### PR TITLE
Add configurable RAM power-on fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ model = "68000"       # 68000, 68010, 68EC020, 68020, 68030, 68040, 68060
 chip = "512K"         # OCS 512K, ECS/AGA up to 2M
 fast = "0"            # Zorro II autoconfig fast RAM, up to 8M
 slow = "512K"         # A500 trapdoor RAM at $C00000, up to 512K
+# init = "random"     # deterministic garbage fill; or fixed "pattern:0x5555"
 
 [chipset]
 revision = "OCS"      # OCS, ECS, or AGA (picks the Agnus/Denise revisions)

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -210,6 +210,15 @@ fast = "0"
 # Set to 0 to disable.
 slow = "512K"
 
+# Cold power-on contents for writable system RAM. "zero" is the compatibility
+# default. "random" fills chip, slow, motherboard, accelerator, WCS, and Zorro
+# RAM with a deterministic pseudo-random pattern to expose guest reads before
+# writes; use "random:SEED" (decimal or 0x hexadecimal) to vary the pattern.
+# A fixed 16-bit word can be repeated in Amiga byte order with
+# "pattern:0x5555" (a bare "0x5555" is also accepted).
+# The same seed produces byte-identical RAM on every run and cold reset.
+# init = "random"
+
 # Zorro III autoconfig RAM. Kickstart assigns the base address (usually
 # $40000000). Needs a CPU with a 32-bit address bus (68020 and later;
 # not the 24-bit 68000/68010/68EC020). Must be 0 or a power of two from

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -44,6 +44,7 @@ range checks as the equivalent TOML fields:
 | `--chip SIZE` | `[memory] chip` | `512K`, `1M`, `2M`, ... |
 | `--fast SIZE` | `[memory] fast` | `0`, `1M`, `4M`, `8M`, ... |
 | `--slow SIZE` | `[memory] slow` | `0`, up to `512K` |
+| `--ram-init MODE` | `[memory] init` | `zero` (default), `random[:SEED]`, `pattern:WORD`, or `0xWORD` |
 | `--motherboard SIZE` | `[memory] motherboard` | Ramsey RAM (A3000/A4000): `0`, `1M`..`4M`, `8M`, `12M`, `16M`; A4000 up to `64M` |
 | `--accelerator SIZE` | `[memory] accelerator` | CPU-slot RAM at `$08000000` (32-bit CPUs): `0` to `128M` |
 | `--floppy-drives COUNT` | `[floppy] drives` | `1` to `4` wired drives (`DF0:` plus external drives) |
@@ -301,7 +302,8 @@ carried no information.)
 
 - `power_on = false` starts the machine powered off showing a test screen
   until you click the status-bar power button -- useful for arming video
-  capture first. The power button cold-boots (clears RAM).
+  capture first. The power button cold-boots (reinitialising RAM according to
+  `[memory] init`).
 - `pacing_budget` selects how real-time pacing budgets CPU work per frame:
   `"cycles"` (default) charges each instruction its actual 68000 cycle cost
   plus chip-bus waits, matching real hardware speed; `"instructions"` uses a
@@ -426,6 +428,7 @@ clock_mhz = 14.0    # optional; defaults to the model's stock speed
 chip = "512K"        # OCS max 512K; ECS/AGA max 2M
 fast = "0"           # Zorro II fast RAM at $200000: 64K..8M board sizes
 slow = "512K"        # A500 trapdoor RAM at $C00000: 0 or up to 512K
+init = "zero"         # or "random[:SEED]" / "pattern:0x5555" for read testing
 motherboard = "0"    # Ramsey motherboard RAM (A3000/A4000): up to 16M (A4000: 64M)
 accelerator = "0"    # CPU-slot RAM at $08000000 (32-bit CPUs): up to 128M
 z3   = "0"           # Zorro III RAM (needs a 32-bit CPU): 64K..1G, power of two
@@ -433,6 +436,26 @@ z3   = "0"           # Zorro III RAM (needs a 32-bit CPU): 64K..1G, power of two
 
 Sizes accept `K`/`KB`/`M`/`MB` (and `G`/`GB` for Zorro III) suffixes or
 plain byte counts, and must be multiples of 4 KiB.
+
+`init` controls cold power-on contents for writable system RAM. The default,
+`"zero"`, preserves Copperline's normal compatibility behaviour. `"random"`
+fills chip, slow, motherboard, accelerator, A1000 WCS, and RAM-backed Zorro
+boards with deterministic pseudo-random bytes, which helps expose guest code
+that reads memory before initialising it. The fixed default seed is identical
+across hosts and repeated cold resets; `"random:SEED"` selects another decimal
+or `0x` hexadecimal 64-bit seed for test matrices. `"pattern:WORD"` instead
+repeats one decimal or `0x` hexadecimal 16-bit word in big-endian Amiga byte
+order; for convenience a bare value such as `"0x5555"` means the same thing as
+`"pattern:0x5555"`. The Machine Configuration screen exposes these as
+**Power-on fill** and **Fill pattern** on its Memory page. Warm keyboard resets
+still preserve RAM, and save-state restores reproduce the saved bytes exactly.
+
+For a one-off developer run:
+
+```sh
+./target/release/copperline --ram-init random --config game.toml --noaudio \
+  --screenshot-after 20 /tmp/game-random-ram.png
+```
 
 - **Chip RAM** is range-checked against the chipset: 512K on OCS, 2M on
   ECS/AGA (also bounded by the selected Agnus revision's address reach).

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -97,8 +97,9 @@ Status Bar*):
 - **Camera button**: saves a screenshot (same as `Cmd+S` on macOS or
   `Alt+S` on Linux/Windows).
 - **Pause / power / reboot buttons.** Pause freezes emulation while staying
-  powered; power cold-boots (clears RAM) or powers off back to the test
-  screen; reboot is a warm reset.
+  powered; power cold-boots (reinitialising RAM with the Memory page's
+  Power-on fill policy) or powers off back to the test screen; reboot is a
+  warm reset.
 
 (on-screen-keyboard)=
 ## On-screen keyboard
@@ -484,7 +485,8 @@ The layout is:
   overrides, video standard, RTC, identify board, RTG card), *CPU* (model,
   FPU, clock, caches, and the experimental not-cycle-exact JIT mode --
   see `[cpu] jit` in [](configuration)),
-  *Memory* (chip/fast/slow/motherboard/Zorro III RAM),
+  *Memory* (cold power-on fill -- zero, deterministic random, or a typed fixed
+  16-bit word -- plus chip/fast/slow/motherboard/accelerator/Zorro III RAM),
   *ROM*
   (Kickstart and
   extended ROM, each with a greyed line under it naming what the chosen

--- a/docs/zorro.md
+++ b/docs/zorro.md
@@ -425,10 +425,11 @@ zorro II board "Copperline" autoconfigured at 0x00E90000
 Once configured, accesses inside a board's window are routed by
 `ZorroChain::region_at` into the board's backing storage. RAM-backed board
 space is external-bus memory: it runs at the CPU clock and does not contend
-on the chip bus (see [](internals/timing)). A power-on reset
-(`ZorroChain::power_on_reset`) returns every board to the unconfigured
-state and clears its RAM, exactly like real hardware losing its config on
-reset.
+on the chip bus (see [](internals/timing)). The standalone
+`ZorroChain::power_on_reset` API returns every board to the unconfigured state
+and zeroes its RAM by default. A machine-level cold boot returns it to the same
+unconfigured state but uses the selected `[memory] init` fill policy for the
+RAM.
 
 Device-backed boards (`BoardBacking` other than `Ram`) differ in three
 ways:

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -24,7 +24,7 @@ use crate::chipset::paula::{
 };
 use crate::floppy::FloppyController;
 use crate::gayle::Gayle;
-use crate::memory::Memory;
+use crate::memory::{Memory, RamInit};
 use crate::rtc::{Rtc, RtcChip};
 use crate::timebase::{Duration, Instant};
 use crate::video::{beam::BeamEventIndex, FrameGeometry, FB_HEIGHT, FB_WIDTH, MAX_VISIBLE_LINES};
@@ -697,6 +697,10 @@ fn empty_sprite_display_enable_x_by_y() -> [Option<usize>; MAX_VISIBLE_LINES] {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Bus {
     pub mem: Memory,
+    /// Cold-power-on RAM policy. This is machine state rather than a host-side
+    /// presentation preference: a save-state restored and then power-cycled
+    /// must use the same deterministic pattern as the machine that saved it.
+    ram_init: RamInit,
     pub cia_a: Cia,
     pub cia_b: Cia,
     pub paula: Paula,
@@ -2548,6 +2552,7 @@ impl Bus {
 
         let mut bus = Self {
             mem,
+            ram_init: RamInit::Zero,
             cia_a: Cia::new(Which::A),
             cia_b: Cia::new(Which::B),
             paula,
@@ -3862,13 +3867,20 @@ impl Bus {
         self.floppy.write_prb(0xFF);
     }
 
-    /// Full cold boot. Clears RAM to its power-on (zeroed) state and then
-    /// runs the same chip/CIA reset as a keyboard reset. Unlike
-    /// Ctrl-Amiga-Amiga, RAM is not preserved, so the machine comes up as
-    /// if it had been power-cycled. Clear RAM first so the keyboard-reset
-    /// path snapshots the zeroed chip RAM for the renderer.
+    /// Select the RAM pattern used by subsequent cold power-on resets. Initial
+    /// machine construction fills Memory before building the Bus so the
+    /// renderer's first chip-RAM snapshot already sees the selected pattern.
+    pub fn set_ram_init(&mut self, init: RamInit) {
+        self.ram_init = init;
+    }
+
+    /// Full cold boot. Reinitialises RAM according to the configured policy
+    /// and then runs the same chip/CIA reset as a keyboard reset. Unlike
+    /// Ctrl-Amiga-Amiga, RAM is not preserved, so the machine comes up as if
+    /// it had been power-cycled. Fill RAM first so the keyboard-reset path
+    /// snapshots the new chip RAM for the renderer.
     pub fn power_on_reset(&mut self) {
-        self.mem.power_on_reset();
+        self.mem.power_on_reset_with(self.ram_init);
         self.reset_for_keyboard_reset();
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@
 use crate::bus::PortDevice;
 use crate::chipset::agnus::{AgnusRevision, VideoStandard};
 use crate::chipset::denise::DeniseRevision;
+use crate::memory::{RamInit, DEFAULT_RANDOM_RAM_SEED};
 use crate::zorro::{zorro_ii_size_code, zorro_iii_size_bits, BoardSpec, ZorroChain, ZorroVersion};
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -71,6 +72,11 @@ pub struct Config {
     pub chip_ram_bytes: usize,
     pub fast_ram_bytes: usize,
     pub slow_ram_bytes: usize,
+    /// Cold power-on contents for writable system RAM (`[memory] init`). Zero
+    /// is the compatibility default; a fixed word or deterministic random
+    /// data is an opt-in guest-development aid for exposing uninitialised
+    /// reads.
+    pub ram_init: RamInit,
     /// Ramsey-controlled motherboard fast RAM (`[memory] motherboard`):
     /// 32-bit local RAM ending at $08000000 and growing downward, sized by
     /// Kickstart's own probe rather than autoconfig. Needs a Ramsey
@@ -2044,6 +2050,7 @@ impl Default for Config {
             chip_ram_bytes: 512 * 1024,
             fast_ram_bytes: 0,
             slow_ram_bytes: A500_TRAPDOOR_RAM_BYTES,
+            ram_init: RamInit::Zero,
             mb_ram_bytes: 0,
             accel_ram_bytes: 0,
             z3_ram_bytes: 0,
@@ -2252,6 +2259,8 @@ pub struct ConfigOverrides {
     pub chip: Option<String>,
     pub fast: Option<String>,
     pub slow: Option<String>,
+    /// RAM power-on policy (`--ram-init`). Same syntax as `[memory] init`.
+    pub ram_init: Option<String>,
     /// Ramsey motherboard fast RAM size (`--motherboard`). Same parser as
     /// `[memory] motherboard`.
     pub motherboard: Option<String>,
@@ -2390,6 +2399,7 @@ impl ConfigOverrides {
             && self.chip.is_none()
             && self.fast.is_none()
             && self.slow.is_none()
+            && self.ram_init.is_none()
             && self.motherboard.is_none()
             && self.accelerator.is_none()
             && self.floppy_drives.is_none()
@@ -2463,6 +2473,9 @@ impl ConfigOverrides {
         }
         if let Some(slow) = &self.slow {
             raw.memory.slow = Some(slow.clone());
+        }
+        if let Some(init) = &self.ram_init {
+            raw.memory.init = Some(init.clone());
         }
         if let Some(motherboard) = &self.motherboard {
             raw.memory.motherboard = Some(motherboard.clone());
@@ -3396,6 +3409,11 @@ pub(crate) struct RawMemory {
     pub(crate) fast: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) slow: Option<String>,
+    /// Cold-power-on RAM contents: "zero" (default), "random" (the fixed
+    /// reproducible seed), "random:SEED", or a fixed 16-bit
+    /// "pattern:WORD" / bare "0xWORD".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) init: Option<String>,
     /// Ramsey-controlled motherboard fast RAM size (e.g. "16M"); needs a
     /// Ramsey (A3000/A4000 profiles) and a 32-bit CPU. Sizes beyond 16M
     /// (up to 64M) fill the motherboard RAM expansion space and need the
@@ -3783,6 +3801,10 @@ impl TryFrom<RawConfig> for Config {
         let slow_ram_bytes = match raw.memory.slow.as_deref() {
             None => defaults.slow_ram_bytes,
             Some(s) => parse_size(s, "slow RAM")?,
+        };
+        let ram_init = match raw.memory.init.as_deref() {
+            None => defaults.ram_init,
+            Some(s) => parse_ram_init(s)?,
         };
         let mb_ram_bytes = match raw.memory.motherboard.as_deref() {
             None => defaults.mb_ram_bytes,
@@ -4459,6 +4481,7 @@ impl TryFrom<RawConfig> for Config {
             chip_ram_bytes,
             fast_ram_bytes,
             slow_ram_bytes,
+            ram_init,
             mb_ram_bytes,
             accel_ram_bytes,
             z3_ram_bytes,
@@ -5112,6 +5135,67 @@ pub(crate) fn format_size(bytes: usize) -> String {
     } else {
         bytes.to_string()
     }
+}
+
+/// Parse the diagnostic RAM power-on policy shared by `[memory] init` and
+/// `--ram-init`. A named default seed keeps the convenient `random` spelling
+/// reproducible, while a fixed pattern accepts either the explicit
+/// `pattern:WORD` spelling or a bare hexadecimal word such as `0x5555`.
+fn parse_ram_init(s: &str) -> Result<RamInit> {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("zero") {
+        return Ok(RamInit::Zero);
+    }
+    if s.eq_ignore_ascii_case("random") {
+        return Ok(RamInit::Random {
+            seed: DEFAULT_RANDOM_RAM_SEED,
+        });
+    }
+    if s.starts_with("0x") || s.starts_with("0X") {
+        return Ok(RamInit::Pattern {
+            word: parse_ram_pattern(s).with_context(|| format!("[memory] init {s:?}"))?,
+        });
+    }
+    let Some((mode, value)) = s.split_once(':') else {
+        bail!(
+            "unknown [memory] init {s:?}: expected zero, random, random:SEED, pattern:WORD, or 0xWORD"
+        );
+    };
+    if mode.trim().eq_ignore_ascii_case("pattern") {
+        return Ok(RamInit::Pattern {
+            word: parse_ram_pattern(value).with_context(|| format!("[memory] init {s:?}"))?,
+        });
+    }
+    if !mode.trim().eq_ignore_ascii_case("random") {
+        bail!(
+            "unknown [memory] init {s:?}: expected zero, random, random:SEED, pattern:WORD, or 0xWORD"
+        );
+    }
+    let seed = value.trim().replace('_', "");
+    let parsed = if let Some(hex) = seed.strip_prefix("0x").or_else(|| seed.strip_prefix("0X")) {
+        u64::from_str_radix(hex, 16)
+    } else {
+        seed.parse::<u64>()
+    }
+    .with_context(|| {
+        format!("[memory] init {s:?}: seed must be a decimal or 0x hexadecimal 64-bit integer")
+    })?;
+    Ok(RamInit::Random { seed: parsed })
+}
+
+/// Parse the launcher's fixed 16-bit word. Decimal and `0x` hexadecimal
+/// spellings match the seed parser; underscores are accepted for readability.
+pub(crate) fn parse_ram_pattern(s: &str) -> Result<u16> {
+    let value = s.trim().replace('_', "");
+    let parsed = if let Some(hex) = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+    {
+        u16::from_str_radix(hex, 16)
+    } else {
+        value.parse::<u16>()
+    };
+    parsed.with_context(|| "pattern must be a decimal or 0x hexadecimal 16-bit word")
 }
 
 /// Parse a human size like "512K", "1M", "2 MiB" or a raw byte count.
@@ -6298,6 +6382,56 @@ mod tests {
     }
 
     #[test]
+    fn ram_init_parses_zero_random_fixed_patterns_and_explicit_seeds() -> Result<()> {
+        assert_eq!(parse_config("")?.ram_init, RamInit::Zero);
+        assert_eq!(
+            parse_config("[memory]\ninit = \"random\"\n")?.ram_init,
+            RamInit::Random {
+                seed: DEFAULT_RANDOM_RAM_SEED,
+            }
+        );
+        assert_eq!(
+            parse_config("[memory]\ninit = \"random:0x12_34_AB_CD\"\n")?.ram_init,
+            RamInit::Random { seed: 0x1234_ABCD }
+        );
+        assert_eq!(
+            parse_config("[memory]\ninit = \"random:12345\"\n")?.ram_init,
+            RamInit::Random { seed: 12345 }
+        );
+        assert_eq!(
+            parse_config("[memory]\ninit = \"pattern:0x5555\"\n")?.ram_init,
+            RamInit::Pattern { word: 0x5555 }
+        );
+        assert_eq!(
+            parse_config("[memory]\ninit = \"0xDEAD\"\n")?.ram_init,
+            RamInit::Pattern { word: 0xDEAD }
+        );
+        assert_eq!(
+            load_overrides(&ConfigOverrides {
+                ram_init: Some("pattern:0xBEEF".to_string()),
+                ..ConfigOverrides::default()
+            })?
+            .ram_init,
+            RamInit::Pattern { word: 0xBEEF }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ram_init_rejects_unknown_modes_and_bad_seeds() {
+        for value in [
+            "garbage",
+            "random:nope",
+            "random:",
+            "pattern:nope",
+            "pattern:0x10000",
+        ] {
+            let err = parse_config(&format!("[memory]\ninit = {value:?}\n")).unwrap_err();
+            assert!(err.to_string().contains("[memory] init"), "{err:#}");
+        }
+    }
+
+    #[test]
     fn filesys_volume_name_is_validated() {
         use crate::filesys::MountSpec;
         let with_volume = |volume: &str| Config {
@@ -6353,6 +6487,7 @@ mod tests {
                 chip: Some("2M".to_string()),
                 fast: Some("8M".to_string()),
                 slow: None,
+                init: Some("random:0x1234".to_string()),
                 motherboard: None,
                 accelerator: None,
                 z3: None,

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -541,8 +541,9 @@ impl Emulator {
         Ok(())
     }
 
-    /// Cold power-on reset: clears RAM and returns the machine to its
-    /// fresh power-cycled state, distinct from the warm keyboard reset.
+    /// Cold power-on reset: reinitialises RAM with the configured policy and
+    /// returns the machine to its fresh power-cycled state, distinct from the
+    /// warm keyboard reset.
     pub fn power_on_reset(&mut self) -> Result<()> {
         log::info!("cold power-on reset");
         self.bus_mut().power_on_reset();
@@ -2548,6 +2549,21 @@ pub fn build_machine(
             );
         }
     }
+    // System RAM is physically undefined after power is applied. Zero stays
+    // the compatibility default; fixed and deterministic pseudo-random modes
+    // help guest developers expose reads made before their own writes. Do this
+    // before Bus::new so its first renderer snapshot sees the same bytes as
+    // the CPU and DMA engines.
+    mem.power_on_reset_with(cfg.ram_init);
+    match cfg.ram_init {
+        crate::memory::RamInit::Zero => {}
+        crate::memory::RamInit::Pattern { word } => {
+            info!("memory: fixed cold-start fill, word {word:#06X}");
+        }
+        crate::memory::RamInit::Random { seed } => {
+            info!("memory: deterministic pseudo-random cold-start fill, seed {seed:#018X}");
+        }
+    }
     let mut cd_image = match &cfg.cd_image_path {
         Some(path) => {
             let image = crate::cdrom::CdImage::load(path)?;
@@ -2575,6 +2591,7 @@ pub fn build_machine(
         log::warn!("[audio] stereo_separation is ignored while channel_mode is mono");
     }
     let mut bus = Bus::new(mem, paula, floppy);
+    bus.set_ram_init(cfg.ram_init);
     // The printer attaches here (its byte sink is `Send`). A sampler owns a
     // cpal capture stream that is `!Send` on some hosts, so the frontend builds
     // and attaches it on the main thread from a `SamplerRequest` instead.

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,7 @@ pub struct CliArgs {
     pub list_sampler_inputs: bool,
     /// Command-line machine overrides (`--model`, `--chipset`, `--cpu`,
     /// `--fpu`/`--no-fpu`, `--cpu-clock`, `--chip`, `--fast`, `--slow`,
-    /// `--floppy-drives`).
+    /// `--ram-init`, `--floppy-drives`).
     /// Applied on top of the config file (or the built-in defaults) before
     /// validation.
     pub overrides: ConfigOverrides,
@@ -534,6 +534,11 @@ where
                     args.next()
                         .ok_or_else(|| anyhow!("--slow requires a size (e.g. 0, 512K)"))?,
                 );
+            }
+            "--ram-init" => {
+                overrides.ram_init = Some(args.next().ok_or_else(|| {
+                    anyhow!("--ram-init requires zero, random[:SEED], pattern:WORD, or 0xWORD")
+                })?);
             }
             "--motherboard" => {
                 overrides.motherboard =
@@ -1234,6 +1239,8 @@ fn print_help() {
          --chip SIZE                    chip RAM size, e.g. 512K, 1M, 2M\n  \
          --fast SIZE                    Zorro II fast RAM size, e.g. 0, 1M, 4M, 8M\n  \
          --slow SIZE                    trapdoor slow RAM at $C00000, e.g. 0, 512K\n  \
+         --ram-init MODE                cold-start RAM contents: zero (default), random[:SEED],\n  \
+         \x20                            pattern:WORD, or 0xWORD (uninitialised-read testing)\n  \
          --motherboard SIZE             Ramsey motherboard fast RAM (A3000/A4000), e.g. 0, 4M,\n  \
          \x20                            16M; the A4000 extends to 64M\n  \
          --accelerator SIZE             CPU-slot accelerator fast RAM at $08000000 (32-bit\n  \
@@ -3207,6 +3214,8 @@ mod tests {
             "8M",
             "--slow",
             "512K",
+            "--ram-init",
+            "pattern:0x5555",
             "--floppy-drives",
             "3",
             "--chipset",
@@ -3221,6 +3230,7 @@ mod tests {
         assert_eq!(args.overrides.chip.as_deref(), Some("2M"));
         assert_eq!(args.overrides.fast.as_deref(), Some("8M"));
         assert_eq!(args.overrides.slow.as_deref(), Some("512K"));
+        assert_eq!(args.overrides.ram_init.as_deref(), Some("pattern:0x5555"));
         assert_eq!(args.overrides.floppy_drives, Some(3));
         assert_eq!(args.overrides.chipset.as_deref(), Some("AGA"));
         Ok(())

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -59,6 +59,73 @@ pub const WCS_SIZE: usize = 256 * 1024;
 pub const A1000_BOOT_ROM_SIZE: usize = 64 * 1024;
 pub use crate::zorro::{AUTOCONFIG_BASE, AUTOCONFIG_SIZE};
 
+/// Default seed for the opt-in deterministic pseudo-random RAM power-on
+/// pattern. Keeping the seed fixed makes a failing headless run exactly
+/// reproducible; developers can select another seed in the config or CLI to
+/// exercise the same program against a different set of stale-looking bytes.
+pub const DEFAULT_RANDOM_RAM_SEED: u64 = 0x434F_5050_4552_4C49;
+/// Initial value offered by the launcher's fixed-pattern RAM fill control.
+pub const DEFAULT_RAM_PATTERN: u16 = 0x5555;
+
+/// How writable system memory is initialised at a cold power-on.
+///
+/// Zero remains the compatibility default. `Pattern` repeats one big-endian
+/// 16-bit word, while `Random` is a development aid for finding guest code
+/// that reads allocations or statics before initialising them. Random data is
+/// deliberately deterministic rather than host entropy, so the same seed is
+/// byte-identical on every host and run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum RamInit {
+    #[default]
+    Zero,
+    Pattern {
+        word: u16,
+    },
+    Random {
+        seed: u64,
+    },
+}
+
+impl RamInit {
+    /// Config/CLI spelling for this policy.
+    pub fn config_value(self) -> String {
+        match self {
+            Self::Zero => "zero".to_string(),
+            Self::Pattern { word } => format!("pattern:0x{word:04X}"),
+            Self::Random {
+                seed: DEFAULT_RANDOM_RAM_SEED,
+            } => "random".to_string(),
+            Self::Random { seed } => format!("random:0x{seed:016X}"),
+        }
+    }
+
+    /// Fill one independently-seeded RAM bank. SplitMix64 is small, stable,
+    /// and fully specified by integer operations; it is not cryptographic and
+    /// does not need to be for an uninitialised-read detector.
+    pub(crate) fn fill(self, bytes: &mut [u8], stream: u64) {
+        match self {
+            Self::Zero => bytes.fill(0),
+            Self::Pattern { word } => {
+                let pattern = word.to_be_bytes();
+                for (offset, byte) in bytes.iter_mut().enumerate() {
+                    *byte = pattern[offset & 1];
+                }
+            }
+            Self::Random { seed } => {
+                let mut state = seed ^ stream.wrapping_mul(0xD6E8_FEB8_6659_FD93);
+                for chunk in bytes.chunks_mut(8) {
+                    state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+                    let mut word = state;
+                    word = (word ^ (word >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+                    word = (word ^ (word >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+                    word ^= word >> 31;
+                    chunk.copy_from_slice(&word.to_be_bytes()[..chunk.len()]);
+                }
+            }
+        }
+    }
+}
+
 /// Restore big-endian byte order in a byte-swapped ROM image.
 ///
 /// Every bootable Amiga ROM -- Kickstart parts of both sizes, the CDTV/CD32
@@ -303,22 +370,32 @@ impl Memory {
         self.extended_rom_base = 0;
     }
 
-    /// Return memory to its cold power-on state: clear all RAM and restore
-    /// the boot-time ROM overlay and Zorro autoconfig state. Unlike a
-    /// warm (keyboard) reset, this does not preserve RAM contents, so the
-    /// machine boots as if power had been cycled.
+    /// Return memory to its default cold power-on state: zero all RAM and
+    /// restore the boot-time ROM overlay and Zorro autoconfig state. Tests and
+    /// fixtures use this directly; the live Bus calls
+    /// [`Memory::power_on_reset_with`] with its configured policy.
     pub fn power_on_reset(&mut self) {
-        self.chip_ram.fill(0);
-        self.slow_ram.fill(0);
-        self.mb_ram.fill(0);
-        self.accel_ram.fill(0);
+        self.power_on_reset_with(RamInit::Zero);
+    }
+
+    /// Return memory to its configured cold power-on state. Random fills give
+    /// each bank a separate stream, so fitting or resizing fast RAM does not
+    /// change the bytes generated for chip RAM. Warm resets never call this
+    /// and continue to preserve every RAM bank.
+    pub(crate) fn power_on_reset_with(&mut self, init: RamInit) {
+        let mb_ram_base = self.mb_ram_base();
+        init.fill(&mut self.chip_ram, CHIP_RAM_BASE);
+        init.fill(&mut self.slow_ram, SLOW_RAM_BASE);
+        init.fill(&mut self.mb_ram, mb_ram_base);
+        init.fill(&mut self.accel_ram, ACCEL_RAM_BASE);
         // Cold boot loses the WCS contents and returns the latch to boot mode
         // (WCS writable), so the A1000 reloads Kickstart from disk. A warm
         // (keyboard) reset preserves the WCS, as the real machine does.
-        self.wcs.fill(0);
+        init.fill(&mut self.wcs, WCS_BASE);
         self.wcs_write_protected = false;
         self.overlay = true;
-        self.zorro.power_on_reset();
+        self.zorro
+            .power_on_reset_with(|idx, ram| init.fill(ram, 0x5A00_0000_0000_0000 | idx as u64));
     }
 }
 
@@ -431,6 +508,81 @@ mod tests {
         assert_eq!(&mem.rom[0..4], &0x0000_4000u32.to_be_bytes()); // initial SP
         assert_eq!(&mem.rom[4..8], &0x00F8_0010u32.to_be_bytes()); // initial PC
         assert_eq!(&mem.rom[0x10..0x12], &0x60FEu16.to_be_bytes()); // bra.s self
+    }
+
+    #[test]
+    fn random_ram_initialisation_is_repeatable_and_seeded() {
+        let mut first = [0u8; 37];
+        let mut repeated = [0u8; 37];
+        let mut other_seed = [0u8; 37];
+        let init = RamInit::Random {
+            seed: DEFAULT_RANDOM_RAM_SEED,
+        };
+        init.fill(&mut first, CHIP_RAM_BASE);
+        init.fill(&mut repeated, CHIP_RAM_BASE);
+        RamInit::Random {
+            seed: DEFAULT_RANDOM_RAM_SEED + 1,
+        }
+        .fill(&mut other_seed, CHIP_RAM_BASE);
+
+        assert_eq!(first, repeated);
+        assert_ne!(first, [0; 37]);
+        assert_ne!(first, other_seed);
+    }
+
+    #[test]
+    fn fixed_ram_initialisation_repeats_a_big_endian_word() {
+        let mut bytes = [0u8; 7];
+        RamInit::Pattern { word: 0xDEAD }.fill(&mut bytes, CHIP_RAM_BASE);
+        assert_eq!(bytes, [0xDE, 0xAD, 0xDE, 0xAD, 0xDE, 0xAD, 0xDE]);
+        assert_eq!(
+            RamInit::Pattern { word: 0x5555 }.config_value(),
+            "pattern:0x5555"
+        );
+    }
+
+    #[test]
+    fn random_ram_banks_use_independent_streams() {
+        let init = RamInit::Random {
+            seed: DEFAULT_RANDOM_RAM_SEED,
+        };
+        let mut chip = [0u8; 32];
+        let mut slow = [0u8; 32];
+        init.fill(&mut chip, CHIP_RAM_BASE);
+        init.fill(&mut slow, SLOW_RAM_BASE);
+        assert_ne!(chip, slow);
+    }
+
+    #[test]
+    fn random_cold_start_covers_every_system_ram_bank_and_repeats() {
+        let mut zorro = ZorroChain::default();
+        zorro
+            .add_board(crate::zorro::BoardSpec::fast_ram(64 * 1024))
+            .unwrap();
+        let mut mem = Memory::placeholder(64, 32, zorro);
+        mem.fit_mb_ram(64);
+        mem.fit_accel_ram(64);
+        mem.wcs = vec![0; 64];
+        let init = RamInit::Random { seed: 0x1234 };
+
+        mem.power_on_reset_with(init);
+        assert_ne!(mem.chip_ram, vec![0; mem.chip_ram.len()]);
+        assert_ne!(mem.slow_ram, vec![0; mem.slow_ram.len()]);
+        assert_ne!(mem.mb_ram, vec![0; mem.mb_ram.len()]);
+        assert_ne!(mem.accel_ram, vec![0; mem.accel_ram.len()]);
+        assert_ne!(mem.wcs, vec![0; mem.wcs.len()]);
+        assert_ne!(
+            mem.zorro.board_ram(0),
+            vec![0; mem.zorro.board_ram(0).len()]
+        );
+
+        let first_chip = mem.chip_ram.clone();
+        let first_zorro = mem.zorro.board_ram(0).to_vec();
+        mem.chip_ram.fill(0xFF);
+        mem.zorro.board_ram_mut(0).fill(0xFF);
+        mem.power_on_reset_with(init);
+        assert_eq!(mem.chip_ram, first_chip);
+        assert_eq!(mem.zorro.board_ram(0), first_zorro);
     }
 
     #[test]

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -174,7 +174,10 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      acquisition until the complete state has decoded. Wasmtime also moved
 //      from 36.0.12 to the security-fixed 36.0.13; plugin snapshots replay
 //      through that runtime, so states from the older codegen are refused.
-pub const STATE_VERSION: u32 = 50;
+//  51: Bus gained the cold-power-on RAM initialisation policy, so a state
+//      restored and later power-cycled repeats its zero or seeded pseudo-random
+//      pattern.
+pub const STATE_VERSION: u32 = 51;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {
@@ -298,7 +301,7 @@ mod tests {
     use crate::chipset::paula::Paula;
     use crate::config::CpuModel;
     use crate::floppy::FloppyController;
-    use crate::memory::{Memory, ROM_SIZE};
+    use crate::memory::{Memory, RamInit, CHIP_RAM_BASE, ROM_SIZE};
     use crate::serial::NullSerialSink;
     use crate::zorro::ZorroChain;
 
@@ -583,6 +586,24 @@ mod tests {
             "the restored timeline must resume where the save left off"
         );
         assert_eq!(restored.bus().mem.chip_ram, machine.bus().mem.chip_ram);
+    }
+
+    #[test]
+    fn ram_initialisation_policy_survives_a_save_state() {
+        let init = RamInit::Random { seed: 0x1234_5678 };
+        let mut machine = test_machine();
+        machine.bus_mut().set_ram_init(init);
+        let descriptor = MachineDescriptor::default();
+        let mut blob = Vec::new();
+        save_to_writer(&machine, &descriptor, &mut blob).unwrap();
+
+        let mut restored = test_machine();
+        load_from_reader(&mut restored, blob.as_slice()).unwrap();
+        restored.bus_mut().power_on_reset();
+
+        let mut expected = vec![0; restored.bus().mem.chip_ram.len()];
+        init.fill(&mut expected, CHIP_RAM_BASE);
+        assert_eq!(restored.bus().mem.chip_ram, expected);
     }
 
     #[test]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -30,6 +30,7 @@ use crate::config::{
     RawFloppyDrive, RawHostDisk, RawZorroBoard, RtgCard, ScsiController, SerialMode, ShaderMode,
     Tint, WarpSpeed, BOOT_PRI_NEVER,
 };
+use crate::memory::{RamInit, DEFAULT_RAM_PATTERN, DEFAULT_RANDOM_RAM_SEED};
 use crate::net::NetConfig;
 use crate::zorro::{ConfigOption, ConfigOptionKind, LoadedZorroBoard};
 use anyhow::Result;
@@ -453,6 +454,8 @@ pub enum LauncherField {
     ChipRam,
     FastRam,
     SlowRam,
+    RamInit,
+    RamPattern,
     MbRam,
     AccelRam,
     Z3Ram,
@@ -826,7 +829,9 @@ const CPU_ROWS: [Row; 6] = [
     row(F::Dcache, "Data cache", Toggle),
     row(F::Jit, "JIT accelerator", Toggle),
 ];
-const MEMORY_ROWS: [Row; 6] = [
+const MEMORY_ROWS: [Row; 8] = [
+    row(F::RamInit, "Power-on fill", Cycle),
+    row(F::RamPattern, "Fill pattern", RowKind::Text),
     row(F::ChipRam, "Chip RAM", Cycle),
     row(F::FastRam, "Fast RAM", Cycle),
     row(F::SlowRam, "Slow RAM", Cycle),
@@ -1731,6 +1736,12 @@ pub struct MachineSetup {
     chip_ram: usize,
     fast_ram: usize,
     slow_ram: usize,
+    /// Diagnostic cold-start policy selected by the Memory page.
+    ram_init: RamInit,
+    /// Values remembered while another fill mode is selected, so cycling away
+    /// from a loaded/custom mode and back does not silently replace its value.
+    ram_pattern: u16,
+    ram_random_seed: u64,
     mb_ram: usize,
     accel_ram: usize,
     z3_ram: usize,
@@ -2016,6 +2027,15 @@ impl MachineSetup {
             chip_ram: cfg.chip_ram_bytes,
             fast_ram: cfg.fast_ram_bytes,
             slow_ram: cfg.slow_ram_bytes,
+            ram_init: cfg.ram_init,
+            ram_pattern: match cfg.ram_init {
+                RamInit::Pattern { word } => word,
+                _ => DEFAULT_RAM_PATTERN,
+            },
+            ram_random_seed: match cfg.ram_init {
+                RamInit::Random { seed } => seed,
+                _ => DEFAULT_RANDOM_RAM_SEED,
+            },
             mb_ram: cfg.mb_ram_bytes,
             accel_ram: cfg.accel_ram_bytes,
             z3_ram: cfg.z3_ram_bytes,
@@ -2363,6 +2383,9 @@ impl MachineSetup {
         }
         if self.slow_ram != base.slow_ram_bytes {
             raw.memory.slow = Some(format_size(self.slow_ram));
+        }
+        if self.ram_init != base.ram_init {
+            raw.memory.init = Some(self.ram_init.config_value());
         }
         if self.mb_ram != base.mb_ram_bytes {
             raw.memory.motherboard = Some(format_size(self.mb_ram));
@@ -2963,6 +2986,10 @@ impl MachineSetup {
                 !matches!(self.cpu, CpuModel::M68000 | CpuModel::M68010),
                 "needs 68020+",
             ),
+            F::RamPattern => reason(
+                matches!(self.ram_init, RamInit::Pattern { .. }),
+                "select Fixed fill",
+            ),
             F::Z3Ram => reason(cpu_is_32bit(self.cpu), "needs 32-bit CPU"),
             // The CPU-slot space at $08000000 is beyond a 24-bit bus too.
             F::AccelRam => reason(cpu_is_32bit(self.cpu), "needs 32-bit CPU"),
@@ -3341,6 +3368,12 @@ impl MachineSetup {
             F::ChipRam => size_label(self.chip_ram),
             F::FastRam => size_label(self.fast_ram),
             F::SlowRam => size_label(self.slow_ram),
+            F::RamInit => match self.ram_init {
+                RamInit::Zero => "Zero".to_string(),
+                RamInit::Pattern { .. } => "Fixed".to_string(),
+                RamInit::Random { .. } => "Random".to_string(),
+            },
+            F::RamPattern => format!("0x{:04X}", self.ram_pattern),
             F::MbRam => size_label(self.mb_ram),
             F::AccelRam => size_label(self.accel_ram),
             F::Z3Ram => size_label(self.z3_ram),
@@ -3596,6 +3629,14 @@ impl MachineSetup {
         }
     }
 
+    /// Change the fixed power-on word and make it the active policy. The text
+    /// box only applies in Fixed mode, but setting both here keeps this method
+    /// correct if another frontend reuses it directly.
+    pub fn set_ram_pattern(&mut self, word: u16) {
+        self.ram_pattern = word;
+        self.ram_init = RamInit::Pattern { word };
+    }
+
     fn path_label(&self, field: LauncherField, empty: &str) -> String {
         match self.path(field) {
             Some(p) => p
@@ -3689,6 +3730,19 @@ impl MachineSetup {
             F::ChipRam => self.chip_ram = cycle_slice(&CHIP_PRESETS, self.chip_ram, forward),
             F::FastRam => self.fast_ram = cycle_nearest(&FAST_PRESETS, self.fast_ram, forward),
             F::SlowRam => self.slow_ram = cycle_nearest(&SLOW_PRESETS, self.slow_ram, forward),
+            F::RamInit => {
+                self.ram_init = match (self.ram_init, forward) {
+                    (RamInit::Zero, true) | (RamInit::Pattern { .. }, false) => RamInit::Random {
+                        seed: self.ram_random_seed,
+                    },
+                    (RamInit::Random { .. }, true) | (RamInit::Zero, false) => RamInit::Pattern {
+                        word: self.ram_pattern,
+                    },
+                    (RamInit::Pattern { .. }, true) | (RamInit::Random { .. }, false) => {
+                        RamInit::Zero
+                    }
+                };
+            }
             F::MbRam => {
                 // Only the A4000's Ramsey-07 extends past its four banks
                 // into the $04000000-$06FFFFFF expansion space.
@@ -4980,6 +5034,8 @@ pub enum EditTarget {
     NewImageText(LauncherField),
     /// A `host:port` typed into the Serial section's Connect or Listen box.
     SerialAddr(LauncherField),
+    /// The fixed 16-bit RAM power-on word on the Memory page.
+    RamPattern,
 }
 
 /// Where typing goes in a text field, as a character index into it.
@@ -6455,7 +6511,7 @@ impl LauncherState {
         matches!(
             self.editing,
             Some(EditTarget::NewImageText(f) | EditTarget::SerialAddr(f)) if f == field
-        )
+        ) || field == F::RamPattern && self.editing == Some(EditTarget::RamPattern)
     }
 
     /// The filesystem a Create Image row is about: the floppy page's or the
@@ -6773,6 +6829,18 @@ impl LauncherState {
         self.status = None;
     }
 
+    /// Focus the fixed RAM word, using the canonical hexadecimal spelling the
+    /// configuration writer will emit.
+    pub fn begin_edit_ram_pattern(&mut self) {
+        if !self.setup.applies(F::RamPattern) {
+            return;
+        }
+        self.edit_buffer = self.setup.value_label(F::RamPattern);
+        self.editing = Some(EditTarget::RamPattern);
+        self.edit_caret = Caret::end_of(&self.edit_buffer);
+        self.status = None;
+    }
+
     pub fn new(setup: MachineSetup) -> Self {
         let mut setup = setup;
         // Read the host devices as the screen opens so the pickers show what is
@@ -6933,6 +7001,15 @@ impl LauncherState {
             if !c.is_ascii_graphic() || self.edit_buffer.chars().count() >= SERIAL_ADDR_MAX {
                 return;
             }
+        }
+        // A fixed fill is a 16-bit word. The parser accepts decimal too, so
+        // admit decimal digits and the hexadecimal prefix/digits while keeping
+        // the buffer no wider than `0xFFFF`.
+        if target == EditTarget::RamPattern
+            && (self.edit_buffer.chars().count() >= 6
+                || !(c.is_ascii_hexdigit() || matches!(c, 'x' | 'X')))
+        {
+            return;
         }
         // A boot priority is a signed integer: digits, and a leading minus.
         if let EditTarget::DriveBootpri(_) = target {
@@ -7109,6 +7186,18 @@ impl LauncherState {
                 self.edit_buffer.clear();
                 return;
             }
+            EditTarget::RamPattern => {
+                match crate::config::parse_ram_pattern(&self.edit_buffer) {
+                    Ok(word) => self.setup.set_ram_pattern(word),
+                    Err(err) => {
+                        self.status = Some(StatusMessage::err(err.to_string()));
+                        return;
+                    }
+                }
+                self.editing = None;
+                self.edit_buffer.clear();
+                return;
+            }
             EditTarget::BoardOption { .. } => {}
         }
         self.editing = None;
@@ -7121,7 +7210,8 @@ impl LauncherState {
             // These commit above and return, so nothing is left to do here.
             EditTarget::DriveBootpri(_)
             | EditTarget::NewImageText(_)
-            | EditTarget::SerialAddr(_) => {}
+            | EditTarget::SerialAddr(_)
+            | EditTarget::RamPattern => {}
         }
     }
 
@@ -7690,6 +7780,72 @@ fn pacing_name(pacing: PacingBudget) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ram_initialisation_controls_cycle_and_round_trip() {
+        let raw: RawConfig = toml::from_str("[memory]\ninit = \"random:0xBEEF\"\n").unwrap();
+        let mut setup = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(setup.value_label(F::RamInit), "Random");
+        assert_eq!(
+            setup.to_raw().memory.init.as_deref(),
+            Some("random:0x000000000000BEEF")
+        );
+
+        setup.cycle(F::RamInit, true);
+        assert_eq!(setup.value_label(F::RamInit), "Fixed");
+        assert_eq!(setup.value_label(F::RamPattern), "0x5555");
+        assert!(setup.applies(F::RamPattern));
+        setup.set_ram_pattern(0xDEAD);
+        assert_eq!(
+            setup.to_raw().memory.init.as_deref(),
+            Some("pattern:0xDEAD")
+        );
+
+        setup.cycle(F::RamInit, true);
+        assert_eq!(setup.value_label(F::RamInit), "Zero");
+        assert!(!setup.applies(F::RamPattern));
+        setup.cycle(F::RamInit, false);
+        assert_eq!(setup.value_label(F::RamPattern), "0xDEAD");
+
+        setup.cycle(F::RamInit, false);
+        assert_eq!(setup.value_label(F::RamInit), "Random");
+        assert_eq!(
+            setup.to_raw().memory.init.as_deref(),
+            Some("random:0x000000000000BEEF")
+        );
+    }
+
+    #[test]
+    fn fixed_ram_pattern_text_box_validates_and_commits() {
+        let mut setup = MachineSetup::default();
+        setup.cycle(F::RamInit, false); // Zero -> Fixed
+        let mut state = LauncherState::new(setup);
+        state.begin_edit_ram_pattern();
+        assert_eq!(state.editing(), Some(EditTarget::RamPattern));
+        assert_eq!(state.edit_buffer(), "0x5555");
+
+        state.edit_buffer.clear();
+        for c in "0x1234".chars() {
+            state.edit_push(c);
+        }
+        state.edit_commit();
+        assert_eq!(state.setup.value_label(F::RamPattern), "0x1234");
+        assert_eq!(
+            state.setup.to_raw().memory.init.as_deref(),
+            Some("pattern:0x1234")
+        );
+
+        state.begin_edit_ram_pattern();
+        state.edit_buffer = "0x10000".to_string();
+        state.edit_caret = Caret::end_of(&state.edit_buffer);
+        state.edit_commit();
+        assert_eq!(state.editing(), Some(EditTarget::RamPattern));
+        assert!(state
+            .status
+            .as_ref()
+            .is_some_and(|s| s.kind == StatusKind::Error));
+        assert_eq!(state.setup.value_label(F::RamPattern), "0x1234");
+    }
 
     /// The page greys what an interface does not honour, exactly as the
     /// library's own driver table reports it: the launcher carries no driver

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -767,6 +767,8 @@ pub enum UiControl {
     LauncherNewImageEdit(LauncherField),
     /// A serial TCP address box on the I/O Ports tab (Connect or Listen).
     LauncherSerialAddrEdit(LauncherField),
+    /// The fixed RAM power-on word on the Memory tab.
+    LauncherRamPatternEdit,
     /// The Create button on a Create Image page.
     LauncherNewImageCreate(LauncherField),
     /// The MB/GB written beside the hard-drive size, which swaps on click.
@@ -5753,7 +5755,9 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                     if launcher_text_rect(rect, row_y, r.field).contains(pos) {
                         // The same widget serves two stores: a Create Image
                         // word, and a serial address on the machine.
-                        return Some(if LauncherState::is_serial_addr(r.field) {
+                        return Some(if r.field == LauncherField::RamPattern {
+                            UiControl::LauncherRamPatternEdit
+                        } else if LauncherState::is_serial_addr(r.field) {
                             UiControl::LauncherSerialAddrEdit(r.field)
                         } else {
                             UiControl::LauncherNewImageEdit(r.field)
@@ -7213,9 +7217,11 @@ fn greyed_presentation(r: &launcher::Row, setup: &launcher::MachineSetup) -> Gre
     }
     match r.field {
         F::MouseSensitivity | F::MouseCapture | F::ShaderStrength => GreyedAs::DimmedReason,
-        F::FloppySpeed | F::AudioChannelMode | F::AudioFilter | F::AudioStereoSeparation => {
-            GreyedAs::DimmedValue
-        }
+        F::RamPattern
+        | F::FloppySpeed
+        | F::AudioChannelMode
+        | F::AudioFilter
+        | F::AudioStereoSeparation => GreyedAs::DimmedValue,
         // Drive select is shaped by the interface, so it only shows a
         // selection while there is one to shape it: an attached DrawBridge
         // has no drive-select line, but with no interface at all there is
@@ -10253,6 +10259,39 @@ mod tests {
             Some(UiControl::LauncherSerialAddrEdit(
                 LauncherField::SerialConnect
             ))
+        );
+    }
+
+    #[test]
+    fn fixed_ram_pattern_box_hit_tests_to_its_own_edit() {
+        let mut state = LauncherState::new(launcher::MachineSetup::default());
+        state.tab = LauncherTab::Memory;
+        state.setup.cycle(LauncherField::RamInit, false); // Zero -> Fixed
+        let ui = UiState {
+            menu_open: false,
+            menu_rows: Vec::new(),
+            menu_nav: menu::MenuNav::default(),
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        let Some(Panel::Launcher(state)) = ui.panel.as_ref() else {
+            unreachable!()
+        };
+        let rect = panel_rect(ui.panel.as_ref().unwrap());
+        let index = launcher::rows(
+            state.tab,
+            state.setup.parallel_device(),
+            state.setup.serial_mode(),
+            state.setup.midi_out_is_mt32(),
+        )
+        .iter()
+        .filter(|r| !state.setup.row_hidden(r.field))
+        .position(|r| r.field == LauncherField::RamPattern)
+        .expect("no fixed RAM pattern row on Memory page");
+        let row_y = launcher_row_y(rect, index);
+        let box_rect = launcher_text_rect(rect, row_y, LauncherField::RamPattern);
+        assert_eq!(
+            ui.control_at((box_rect.x as i32 + 4, box_rect.y as i32 + 4)),
+            Some(UiControl::LauncherRamPatternEdit)
         );
     }
 

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6311,6 +6311,14 @@ impl App {
                     }
                 }
             }
+            UiControl::LauncherRamPatternEdit => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.edit_commit();
+                    if state.editing().is_none() {
+                        state.begin_edit_ram_pattern();
+                    }
+                }
+            }
             UiControl::LauncherNewImageCreate(field) => self.launcher_create_image(field),
             #[cfg(feature = "game-library")]
             UiControl::LauncherWhdloadDownload(field) => self.whdload_download(field),

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -528,9 +528,16 @@ impl ZorroChain {
 
     /// Return all boards to unconfigured with zeroed RAM (cold power-on).
     pub fn power_on_reset(&mut self) {
+        self.power_on_reset_with(|_, ram| ram.fill(0));
+    }
+
+    /// Return all boards to unconfigured and initialise each RAM-backed
+    /// aperture through `fill`. The bank index gives a deterministic caller a
+    /// stable stream discriminator without exposing the private Board layout.
+    pub(crate) fn power_on_reset_with(&mut self, mut fill: impl FnMut(usize, &mut [u8])) {
         self.warm_reset();
-        for board in &mut self.boards {
-            board.ram.fill(0);
+        for (idx, board) in self.boards.iter_mut().enumerate() {
+            fill(idx, &mut board.ram);
         }
     }
 


### PR DESCRIPTION
## Summary

- add deterministic zero, seeded-random, and fixed 16-bit RAM power-on fill policies
- expose Power-on fill and Fill pattern controls on the Machine Configuration Memory page
- apply the policy to writable system RAM on cold boots while preserving warm-reset and save-state behaviour
- document the config and CLI forms, including pattern:0x5555 and the 0x5555 shorthand

## Testing

- cargo test --all-features --locked (2,567 passed; hardware/asset-dependent tests ignored)
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo fmt --check
- cargo build --release --locked
- headless bundled-AROS boot through 20 emulated seconds with a 0x5555 fixed fill
- canonical and shorthand fixed-fill forms produced byte-identical deterministic screenshots