### PR TITLE
homebrew: fix installation from v0.15.0 archive

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -3,7 +3,8 @@ name: Homebrew formula
 # The repository doubles as its own Homebrew tap (Formula/copperline.rb).
 # Its url/sha256 are hand-edited at each release (see RELEASE.md), which is
 # the error-prone step this workflow guards: a stale checksum, an
-# unreachable tarball, or deprecated formula syntax all fail the audit.
+# unreachable tarball, deprecated formula syntax, or a mismatch between the
+# formula's install steps and the tagged source archive all fail this job.
 # Scoped to formula changes so it does not run on unrelated commits.
 on:
   push:
@@ -36,3 +37,10 @@ jobs:
         run: |
           brew tap copperlinehq/copperline "$GITHUB_WORKSPACE"
           brew audit --strict --online copperlinehq/copperline/copperline
+      - name: Install from source
+        # Audit validates metadata but does not execute `def install`. Build
+        # the stable release tarball so every path copied by the formula is
+        # checked against the archive users actually receive.
+        run: brew install --build-from-source copperlinehq/copperline/copperline
+      - name: Test installed formula
+        run: brew test copperlinehq/copperline/copperline

--- a/Formula/copperline.rb
+++ b/Formula/copperline.rb
@@ -58,10 +58,14 @@ class Copperline < Formula
 
     # WHDLoad support archives: <prefix>/share/copperline/whdboot, where
     # whdload::find_whdboot_assets looks, with the provenance README beside
-    # them.
-    (pkgshare/"whdboot").install "assets/whdboot/README.md"
-    resource("whdload").stage { (pkgshare/"whdboot").install "WHDLoad_usr.lha" }
-    resource("skick").stage { (pkgshare/"whdboot").install "skick346.lha" }
+    # them. The stable formula can briefly point at a release made before a
+    # newly added optional payload, while HEAD already contains it. Use the
+    # source-tree marker so both revisions remain installable.
+    if (buildpath/"assets/whdboot/README.md").exist?
+      (pkgshare/"whdboot").install "assets/whdboot/README.md"
+      resource("whdload").stage { (pkgshare/"whdboot").install "WHDLoad_usr.lha" }
+      resource("skick").stage { (pkgshare/"whdboot").install "skick346.lha" }
+    end
   end
 
   test do


### PR DESCRIPTION
## Summary

- install the optional WHDLoad payload only when the selected source revision contains it
- keep the pre-WHDLoad v0.15.0 stable archive and the WHDLoad-capable HEAD revision installable from the same formula
- make Homebrew CI perform a real stable source install and run the formula test

## Validation

- verified the v0.15.0 archive disables the WHDLoad payload guard
- verified the current source tree enables the payload guard
- ruby -c Formula/copperline.rb
- brew style Formula/copperline.rb
- actionlint .github/workflows/homebrew.yml
- git diff --check

Fixes #439