### PR TITLE
Add opt-in portable host-data directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,9 +320,10 @@ See `docs/README.md` for conventions and PDF output.
 Copperline is distributed from source. On macOS this repository doubles as a
 Homebrew tap (`Formula/`); on Linux it builds as a Flatpak for Flathub
 (`packaging/flatpak/`) and as a portable AppImage (`packaging/appimage/`). It
-is not on crates.io: `Cargo.toml` sets `publish = false` because Copperline is
-distributed as an application rather than a library. Release steps for every
-channel are in
+also supports a `portable.txt` marker beside the executable to keep save-state
+slots and host preferences within the application folder. It is not on
+crates.io: `Cargo.toml` sets `publish = false` because Copperline is distributed
+as an application rather than a library. Release steps for every channel are in
 [`RELEASE.md`](RELEASE.md).
 
 ## What gets emulated

--- a/README.md
+++ b/README.md
@@ -320,10 +320,11 @@ See `docs/README.md` for conventions and PDF output.
 Copperline is distributed from source. On macOS this repository doubles as a
 Homebrew tap (`Formula/`); on Linux it builds as a Flatpak for Flathub
 (`packaging/flatpak/`) and as a portable AppImage (`packaging/appimage/`). It
-also supports a `portable.txt` marker beside the executable to keep save-state
-slots and host preferences within the application folder. It is not on
-crates.io: `Cargo.toml` sets `publish = false` because Copperline is distributed
-as an application rather than a library. Release steps for every channel are in
+also supports a `portable.txt` marker beside the executable (or downloaded
+AppImage) to keep save-state slots and host preferences within the application
+folder. It is not on crates.io: `Cargo.toml` sets `publish = false` because
+Copperline is distributed as an application rather than a library. Release
+steps for every channel are in
 [`RELEASE.md`](RELEASE.md).
 
 ## What gets emulated

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -791,12 +791,12 @@ reachable however Copperline was launched:
 | Windows | `%APPDATA%\copperline\states\` |
 
 For a self-contained installation, create an empty file named `portable.txt`
-beside the Copperline executable and restart Copperline. The executable's
-folder then becomes the host-data directory, so quick-save slots live in its
-`states/` subdirectory. Gamepad calibration, keyboard mappings, the default
-WHDLoad library and other per-user host data are stored in that folder too.
-Delete `portable.txt` to return to the platform location above; Copperline
-does not move existing files in either direction.
+beside the Copperline executable (or beside the downloaded `.AppImage`) and
+restart Copperline. That folder then becomes the host-data directory, so
+quick-save slots live in its `states/` subdirectory. Gamepad calibration,
+keyboard mappings, the default WHDLoad library and other per-user host data are
+stored in that folder too. Delete `portable.txt` to return to the platform
+location above; Copperline does not move existing files in either direction.
 
 Because they are per user and not per machine, a slot may hold a state from
 a different Amiga than the one running. That is safe: as above, the state

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -790,6 +790,14 @@ reachable however Copperline was launched:
 | macOS | `~/.config/copperline/states/` |
 | Windows | `%APPDATA%\copperline\states\` |
 
+For a self-contained installation, create an empty file named `portable.txt`
+beside the Copperline executable and restart Copperline. The executable's
+folder then becomes the host-data directory, so quick-save slots live in its
+`states/` subdirectory. Gamepad calibration, keyboard mappings, the default
+WHDLoad library and other per-user host data are stored in that folder too.
+Delete `portable.txt` to return to the platform location above; Copperline
+does not move existing files in either direction.
+
 Because they are per user and not per machine, a slot may hold a state from
 a different Amiga than the one running. That is safe: as above, the state
 carries its own machine and the load reconfigures to match it and says so.
@@ -924,7 +932,8 @@ cannot bleed into the next binding.
 
 Calibrations are saved per controller UUID in
 `~/.config/copperline/gamepads.toml` (`$XDG_CONFIG_HOME` respected;
-`%APPDATA%\copperline\` on Windows).
+`%APPDATA%\copperline\` on Windows, or beside the executable in
+[portable mode](#quick-save-slots)).
 
 ## Input mapping
 

--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -68,9 +68,11 @@ is fine.
 ## Saves and unpacked games
 
 Each game gets a directory under `whdload/save/` in your configuration
-directory, for example `~/.config/copperline/whdload/save/Turrican/`.
-Everything the game writes -- savegames, high scores, its own settings --
-lands there and stays across runs.
+directory, for example `~/.config/copperline/whdload/save/Turrican/`, or
+`whdload/save/Turrican/` beside the executable when
+[portable mode](ui.md#quick-save-slots) is enabled. Everything the game writes
+-- savegames, high scores, its own settings -- lands there and stays across
+runs.
 
 Delete a game's directory to unpack it fresh. Launching a plain folder
 uses that folder directly, so its saves stay with it.

--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -30,6 +30,16 @@ own Kickstart ROM and disk/hard-disk images, and launch with:
 
 Run "copperline.exe --help" for the full command-line surface.
 
+Portable data
+-------------
+By default, quick-save slots and host preferences are kept under
+%APPDATA%\copperline so they survive replacing or moving this folder. To keep
+them inside this folder instead, create an empty file named portable.txt next
+to copperline.exe and restart Copperline. Quick-save slots will then be in the
+states subfolder; controller mappings, WHDLoad data and other host preferences
+will also stay here. Delete portable.txt to return to %APPDATA%; existing files
+are not moved automatically.
+
 Bridged Ethernet
 ----------------
 User-mode NAT works with no additional software. Direct bridged Ethernet

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -2,7 +2,8 @@
 
 //! Host-data locations, following the platform's config-directory conventions
 //! without pulling in a dependency. An empty `portable.txt` beside the
-//! executable opts into keeping the same data beside the executable instead.
+//! executable (or downloaded AppImage) opts into keeping the same data there
+//! instead.
 //!
 //! These are *host preferences and per-user data* -- gamepad calibration,
 //! keyboard mappings, save-state slots -- not machine configuration. Anything
@@ -23,18 +24,33 @@ use std::path::PathBuf;
 /// switch, so portable archives need no machine-specific configuration.
 pub const PORTABLE_MARKER: &str = "portable.txt";
 
-/// Return the directory containing `executable` when it carries the portable
-/// marker. Split out so the filesystem contract can be tested without trying
-/// to change the process executable.
-fn portable_config_dir(executable: &std::path::Path) -> Option<PathBuf> {
-    let dir = executable.parent()?;
+/// Return the directory containing `program` when it carries the portable
+/// marker.
+fn marked_program_dir(program: &std::path::Path) -> Option<PathBuf> {
+    let dir = program.parent()?;
     dir.join(PORTABLE_MARKER)
         .is_file()
         .then(|| dir.to_path_buf())
 }
 
+/// Resolve portable mode from the program path the user launched. An AppImage
+/// executes its embedded binary from a temporary read-only mount, but the
+/// runtime exposes the downloaded image as `APPIMAGE`; that original path must
+/// win so a marker can sit beside the image and the chosen directory is
+/// writable. Split out so this ordering can be tested without changing the
+/// process environment or executable.
+fn portable_config_dir(
+    appimage: Option<&std::path::Path>,
+    executable: Option<&std::path::Path>,
+) -> Option<PathBuf> {
+    appimage
+        .into_iter()
+        .chain(executable)
+        .find_map(marked_program_dir)
+}
+
 /// Copperline's host-data directory. An empty `portable.txt` beside the
-/// executable selects that directory; otherwise this is
+/// executable or downloaded AppImage selects that directory; otherwise this is
 /// `$XDG_CONFIG_HOME/copperline`, `%APPDATA%\copperline`, or
 /// `$HOME/.config/copperline`, whichever the host offers first.
 ///
@@ -45,10 +61,13 @@ pub fn config_dir() -> Option<PathBuf> {
 }
 
 fn discover_config_dir() -> Option<PathBuf> {
-    if let Ok(executable) = std::env::current_exe() {
-        if let Some(dir) = portable_config_dir(&executable) {
-            return Some(dir);
-        }
+    #[cfg(target_os = "linux")]
+    let appimage = crate::envcfg::var_os("APPIMAGE").map(PathBuf::from);
+    #[cfg(not(target_os = "linux"))]
+    let appimage: Option<PathBuf> = None;
+    let executable = std::env::current_exe().ok();
+    if let Some(dir) = portable_config_dir(appimage.as_deref(), executable.as_deref()) {
+        return Some(dir);
     }
     for var in ["XDG_CONFIG_HOME", "APPDATA"] {
         if let Some(dir) = crate::envcfg::var_os(var) {
@@ -166,12 +185,32 @@ mod tests {
         let root = ScratchDir::new("portable-marker");
         let executable = root.0.join("copperline.exe");
 
-        assert_eq!(portable_config_dir(&executable), None);
+        assert_eq!(portable_config_dir(None, Some(&executable)), None);
         std::fs::write(root.0.join(PORTABLE_MARKER), []).unwrap();
-        assert_eq!(portable_config_dir(&executable), Some(root.0.clone()));
         assert_eq!(
-            portable_config_dir(&executable).map(|dir| dir.join("states")),
+            portable_config_dir(None, Some(&executable)),
+            Some(root.0.clone())
+        );
+        assert_eq!(
+            portable_config_dir(None, Some(&executable)).map(|dir| dir.join("states")),
             Some(root.0.join("states"))
+        );
+    }
+
+    #[test]
+    fn appimage_marker_selects_the_download_location_before_the_mounted_binary() {
+        let root = ScratchDir::new("appimage-marker");
+        let download = root.0.join("download");
+        let mount = root.0.join("mount/usr/bin");
+        std::fs::create_dir_all(&download).unwrap();
+        std::fs::create_dir_all(&mount).unwrap();
+        std::fs::write(download.join(PORTABLE_MARKER), []).unwrap();
+
+        let appimage = download.join("Copperline.AppImage");
+        let executable = mount.join("copperline");
+        assert_eq!(
+            portable_config_dir(Some(&appimage), Some(&executable)),
+            Some(download)
         );
     }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-//! Per-user data locations, following the platform's config-directory
-//! conventions without pulling in a dependency.
+//! Host-data locations, following the platform's config-directory conventions
+//! without pulling in a dependency. An empty `portable.txt` beside the
+//! executable opts into keeping the same data beside the executable instead.
 //!
 //! These are *host preferences and per-user data* -- gamepad calibration,
 //! keyboard mappings, save-state slots -- not machine configuration. Anything
@@ -17,10 +18,38 @@
 
 use std::path::PathBuf;
 
-/// Copperline's per-user configuration directory: `$XDG_CONFIG_HOME/copperline`,
-/// `%APPDATA%\copperline`, or `$HOME/.config/copperline`, whichever the host
-/// offers first. Not created here -- writers call `ensure_parent`.
+/// Marker that opts an installation into keeping host data beside the
+/// executable. Its contents are deliberately ignored: existence is the whole
+/// switch, so portable archives need no machine-specific configuration.
+pub const PORTABLE_MARKER: &str = "portable.txt";
+
+/// Return the directory containing `executable` when it carries the portable
+/// marker. Split out so the filesystem contract can be tested without trying
+/// to change the process executable.
+fn portable_config_dir(executable: &std::path::Path) -> Option<PathBuf> {
+    let dir = executable.parent()?;
+    dir.join(PORTABLE_MARKER)
+        .is_file()
+        .then(|| dir.to_path_buf())
+}
+
+/// Copperline's host-data directory. An empty `portable.txt` beside the
+/// executable selects that directory; otherwise this is
+/// `$XDG_CONFIG_HOME/copperline`, `%APPDATA%\copperline`, or
+/// `$HOME/.config/copperline`, whichever the host offers first.
+///
+/// Not created here -- writers call [`ensure_parent`].
 pub fn config_dir() -> Option<PathBuf> {
+    static DIR: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
+    DIR.get_or_init(discover_config_dir).clone()
+}
+
+fn discover_config_dir() -> Option<PathBuf> {
+    if let Ok(executable) = std::env::current_exe() {
+        if let Some(dir) = portable_config_dir(&executable) {
+            return Some(dir);
+        }
+    }
     for var in ["XDG_CONFIG_HOME", "APPDATA"] {
         if let Some(dir) = crate::envcfg::var_os(var) {
             return Some(PathBuf::from(dir).join("copperline"));
@@ -114,15 +143,46 @@ pub fn ensure_parent(path: &std::path::Path) -> std::io::Result<()> {
 mod tests {
     use super::*;
 
+    struct ScratchDir(PathBuf);
+
+    impl ScratchDir {
+        fn new(name: &str) -> Self {
+            let dir = std::env::temp_dir()
+                .join(format!("copperline-paths-{}-{name}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+    }
+
+    impl Drop for ScratchDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn portable_marker_selects_the_executable_directory() {
+        let root = ScratchDir::new("portable-marker");
+        let executable = root.0.join("copperline.exe");
+
+        assert_eq!(portable_config_dir(&executable), None);
+        std::fs::write(root.0.join(PORTABLE_MARKER), []).unwrap();
+        assert_eq!(portable_config_dir(&executable), Some(root.0.clone()));
+        assert_eq!(
+            portable_config_dir(&executable).map(|dir| dir.join("states")),
+            Some(root.0.join("states"))
+        );
+    }
+
     /// The cascade is read through `envcfg`, which snapshots the environment
     /// once per process, so this asserts the shape of whatever the host
     /// offered rather than driving each branch with a mutated environment.
     #[test]
-    fn per_user_paths_hang_off_one_copperline_directory() {
+    fn host_data_paths_hang_off_one_directory() {
         let Some(dir) = config_dir() else {
             return; // A host with no HOME/APPDATA/XDG_CONFIG_HOME.
         };
-        assert_eq!(dir.file_name().unwrap(), "copperline");
         assert_eq!(
             config_file("gamepads.toml").unwrap(),
             dir.join("gamepads.toml")

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -200,14 +200,15 @@ pub(crate) fn slot_path_in(dir: &Path, slot: usize) -> Option<std::path::PathBuf
 }
 
 /// File backing quick-save slot `slot` (1-based, `1..=SLOT_COUNT`). `None`
-/// when the host offers no per-user directory to keep them in.
+/// when the host offers no directory to keep them in.
 ///
-/// Slots live in the per-user state directory rather than beside a config
-/// file or in the working directory: they are a host convenience, they must
-/// be reachable however the emulator was launched, and a bare relative path
-/// would scatter them across whatever directory happened to be current. A
-/// state carries its own [`MachineDescriptor`], so loading a slot saved from
-/// a different machine is caught and reported rather than silently wrong.
+/// Slots normally live in the per-user state directory rather than beside a
+/// config file or in the working directory: they are a host convenience, they
+/// must be reachable however the emulator was launched, and a bare relative
+/// path would scatter them across whatever directory happened to be current.
+/// Portable mode deliberately roots them beside the executable instead. A
+/// state carries its own [`MachineDescriptor`], so loading a slot saved from a
+/// different machine is caught and reported rather than silently wrong.
 pub fn slot_path(slot: usize) -> Option<std::path::PathBuf> {
     crate::paths::state_slot_dir().and_then(|dir| slot_path_in(&dir, slot))
 }


### PR DESCRIPTION
## Summary

- recognize an empty portable.txt marker beside the executable
- keep quick-save slots, controller mappings, WHDLoad data, and other host preferences in that folder when enabled
- preserve the platform config directory as the default and document that existing files are not migrated
- add regression coverage for marker discovery and the resulting states directory

## Verification

- cargo test --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo fmt --check
- git diff --check

Closes #424