### PR TITLE
bezel: sticker decals from a user folder, desktop + web

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -481,6 +481,12 @@ video = "PAL"
 # Copperline drew first). Cmd/Alt+M turns the chosen one off and back on.
 # Composes with any shader setting, and like it is a window-display effect
 # only: captures never include the frame.
+# bezel_stickers: folder of PNG stickers drawn onto the bezel, the way
+# owners dress a real monitor (unset by default: none). Every *.png in
+# the folder becomes a die-cut decal; without further instruction they
+# line up along the cabinet's top band, and an optional stickers.toml in
+# the folder places each one (see the configuration guide). Drawn only
+# while a bezel is; captures never include them.
 # perf_overlay: show the performance overlay at start (default false; also
 # --perf-overlay, and Cmd/Alt+P toggles it live): emulated fps, speed
 # factor, per-frame emulation cost, host utilisation, audio health, and
@@ -506,6 +512,7 @@ video = "PAL"
 # shader = "none"
 # shader_strength = 1.0
 # bezel = "off"
+# bezel_stickers = "/data/amiga/stickers"
 # perf_overlay = false
 # tint = "none"
 # menu_scale = "1x"

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -5625,6 +5625,55 @@ void main() {
 }
 `;
 
+  // Sticker decals over the drawn bezel, ported from
+  // shaders/bezel_stickers.wgsl (the desktop's [display] bezel_stickers):
+  // one pass per sticker over the rotated quad's bounding viewport,
+  // sampling the sticker image with a soft drop shadow off its own
+  // silhouette and a slight vertical tone so a die-cut logo reads as
+  // stuck to the lit plastic. The desktop packs an atlas and instances
+  // the quads; here each sticker is its own texture and draw call, but
+  // the fragment arithmetic is the same -- keep them in step.
+  const FS_STICKER = `#version 300 es
+${FS_COMMON}
+uniform vec4 u_geo; // xy: sticker centre in viewport px, zw: half-size px
+uniform vec4 u_rot; // xy: cos/sin of the tilt, z: opacity, w: shadow px
+
+// The sticker's texels at a quad position ([-1, 1] spans the sticker),
+// transparent outside its bounds.
+vec4 decal(vec2 local) {
+  vec2 t = clamp(local * 0.5 + 0.5, 0.0, 1.0);
+  float inside = step(abs(local.x), 1.0) * step(abs(local.y), 1.0);
+  return texture(u_tex, t) * inside;
+}
+
+void main() {
+  vec2 p = v_uv * u_size.xy - u_geo.xy;
+  // Un-rotate into sticker space: the inverse of the clockwise tilt.
+  vec2 q = vec2(p.x * u_rot.x + p.y * u_rot.y, p.y * u_rot.x - p.x * u_rot.y);
+  vec2 half_size = max(u_geo.zw, vec2(0.5));
+  vec2 local = q / half_size;
+  vec4 c = decal(local);
+  // The shadow is the silhouette dropped down-right, softened by taps
+  // at the offset and half again beyond it.
+  vec2 o = vec2(u_rot.w) / half_size;
+  float sh = decal(local - o).a
+    + decal(local - o - vec2(o.x * 0.5, 0.0)).a
+    + decal(local - o - vec2(0.0, o.y * 0.5)).a
+    + decal(local - o * 1.5).a;
+  float shadow = sh * 0.25 * 0.38;
+  // Stuck to lit plastic: a touch brighter toward the light at the top.
+  // The sRGB texture sampled to linear, toned, and encoded back, like
+  // the desktop's sRGB target.
+  float tone = 1.04 - 0.07 * clamp(local.y * 0.5 + 0.5, 0.0, 1.0);
+  float a_decal = c.a * u_rot.z;
+  float a_shadow = shadow * u_rot.z;
+  // Premultiplied out (the pass blends ONE, ONE_MINUS_SRC_ALPHA): the
+  // decal over its own shadow.
+  fragColor = vec4(srgb_encode(c.rgb * tone) * a_decal,
+                   a_decal + a_shadow * (1.0 - a_decal));
+}
+`;
+
   const program = (fsSrc, label) => {
     const compile = (type, src) => {
       const sh = gl.createShader(type);
@@ -5660,12 +5709,18 @@ void main() {
     crt: null,
     bezel1084: null,
     bezelClassic: null,
+    sticker: null,
+    // Bumped by every (re)build, so per-sticker textures uploaded on a
+    // lost context are told apart from live ones (bezelStickerTexture).
+    gen: 0,
   };
   const build = () => {
     renderer.plain = program(FS_PLAIN, 'monitor plain');
     renderer.crt = program(FS_CRT, 'monitor crt');
     renderer.bezel1084 = program(FS_BEZEL_1084, 'monitor 1084 bezel');
     renderer.bezelClassic = program(FS_BEZEL_CLASSIC, 'monitor classic bezel');
+    renderer.sticker = program(FS_STICKER, 'monitor stickers');
+    renderer.gen += 1;
     renderer.tex = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, renderer.tex);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
@@ -5869,11 +5924,158 @@ function monitorDraw(width, rows, crtLines) {
         crtOn ? 1.0 : 0.0,
       );
     });
+    if (bezelStickers.length && monitorGl.sticker) {
+      // Decals stick to the plastic, so they ride the bezel pass; the
+      // slot walk mirrors the desktop's stickers.rs instances(): placed
+      // entries at their fractions of the canvas, the rest rowed along
+      // the cabinet's top band (its bottom is the opening's top, oy).
+      const band = Math.max(oy, 0);
+      const autoH = Math.max(band * 0.52, 8);
+      const margin = w * 0.055;
+      const gap = autoH * 0.45;
+      const shadow = Math.min(Math.max(h * 0.004, 1), 6);
+      let cursor = margin;
+      let tilt = 0;
+      gl.enable(gl.BLEND);
+      gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+      for (const s of bezelStickers) {
+        if (!s.ready || s.failed) continue;
+        const aspect = s.img.naturalHeight / Math.max(s.img.naturalWidth, 1);
+        let cx, cy, wPx, rot;
+        if (s.x != null) {
+          wPx = (s.width ?? 0.08) * w;
+          cx = s.x * w;
+          cy = s.y * h;
+          rot = s.rotate ?? 0;
+        } else {
+          wPx = s.width != null ? s.width * w : autoH / Math.max(aspect, 1e-3);
+          rot = s.rotate ?? BEZEL_STICKER_TILT[tilt % BEZEL_STICKER_TILT.length];
+          tilt += 1;
+          if (cursor + wPx > w - margin) break;
+          cx = cursor + wPx * 0.5;
+          cy = band * 0.5;
+          cursor += wPx + gap;
+        }
+        if (wPx < 1) continue;
+        const tex = bezelStickerTexture(s);
+        if (!tex) continue;
+        const rad = (rot * Math.PI) / 180;
+        const rc = Math.cos(rad);
+        const rs = Math.sin(rad);
+        const hx = wPx * 0.5;
+        const hy = wPx * aspect * 0.5;
+        // The pass's viewport is the rotated, shadow-padded quad's
+        // bounding box, like the desktop's padded instance quad.
+        const ex = Math.abs((hx + shadow * 2) * rc) + Math.abs((hy + shadow * 2) * rs);
+        const ey = Math.abs((hx + shadow * 2) * rs) + Math.abs((hy + shadow * 2) * rc);
+        const vx = Math.round(cx - ex);
+        const vy = Math.round(cy - ey);
+        gl.bindTexture(gl.TEXTURE_2D, tex);
+        draw(monitorGl.sticker, vx, vy, Math.ceil(ex * 2), Math.ceil(ey * 2), (p) => {
+          gl.uniform4f(p.u.u_geo, cx - vx, cy - vy, hx, hy);
+          gl.uniform4f(p.u.u_rot, rc, rs, s.opacity, shadow);
+        });
+      }
+      gl.disable(gl.BLEND);
+      // Leave the picture texture bound, as every other path here does.
+      gl.bindTexture(gl.TEXTURE_2D, monitorGl.tex);
+    }
   } else if (crtOn) {
     draw(monitorGl.crt, 0, 0, w, h, crtUniforms);
   } else {
     draw(monitorGl.plain, 0, 0, w, h);
   }
+}
+
+// --- bezel stickers (#bezel-stickers page hook) ---------------------------
+// Community logos as die-cut stickers on the drawn monitor front, the
+// desktop's `[display] bezel_stickers` for the page: a shell-provided
+// <script type="application/json" id="bezel-stickers"> holds an array of
+// {image, x, y, width, rotate, opacity} entries -- the same keys as the
+// desktop folder's stickers.toml (docs/guide/browser.md), with `image` a
+// URL resolved against the page. Entries with x/y (fractions of the
+// canvas) are placed there; the rest line up along the cabinet's top band
+// with a slight alternating tilt, exactly as the desktop lays a bare
+// folder out. Drawn only while a bezel mode is up, and never in
+// screenshots, which capture the presentation buffer. This supersedes the
+// CSS overlay hack early Retro32 pages carried: these decals live on the
+// canvas, so they track the plastic in fullscreen too.
+const BEZEL_STICKER_TILT = [-3.0, 2.2, -1.6, 2.8];
+const bezelStickers = (() => {
+  const tag = document.getElementById('bezel-stickers');
+  if (!tag || !monitorGl) return [];
+  let list;
+  try {
+    list = JSON.parse(tag.textContent);
+  } catch (e) {
+    console.error('bezel-stickers: bad JSON:', e);
+    return [];
+  }
+  if (!Array.isArray(list)) return [];
+  const out = [];
+  for (const raw of list.slice(0, 16)) {
+    if (!raw || typeof raw.image !== 'string') continue;
+    if ((raw.x == null) !== (raw.y == null)) {
+      console.error(`bezel-stickers: ${raw.image}: x and y place a sticker together`);
+      continue;
+    }
+    const img = new Image();
+    // Lets a CORS-enabled host serve the images without tainting the GL
+    // upload; same-origin images are unaffected.
+    img.crossOrigin = 'anonymous';
+    const entry = {
+      img,
+      ready: false,
+      failed: false,
+      tex: null,
+      gen: 0,
+      x: raw.x,
+      y: raw.y,
+      width: raw.width,
+      rotate: raw.rotate,
+      opacity: Math.min(Math.max(raw.opacity ?? 1, 0), 1),
+    };
+    img.onload = () => {
+      entry.ready = true;
+      // The picture did not change, so redraw the held texture; with no
+      // machine the sticker lands on the powered-off monitor.
+      if (emu && running) presentFrame(true);
+      else if (!emu) presentMonitorOff();
+    };
+    img.onerror = () => {
+      entry.failed = true;
+      console.error(`bezel-stickers: ${raw.image} failed to load`);
+    };
+    img.src = raw.image;
+    out.push(entry);
+  }
+  return out;
+})();
+
+// A sticker's GL texture on the current context, uploaded on first use
+// and again after a context restore (initMonitorGl's build() bumps the
+// renderer generation, orphaning uploads the lost context took with it).
+function bezelStickerTexture(entry) {
+  const gl = monitorGl.gl;
+  if (entry.tex && entry.gen === monitorGl.gen) return entry.tex;
+  const tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  try {
+    // sRGB like the picture texture, so the shader tones linear light.
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.SRGB8_ALPHA8, gl.RGBA, gl.UNSIGNED_BYTE, entry.img);
+  } catch (e) {
+    // A tainted image (cross-origin without CORS) cannot reach WebGL.
+    entry.failed = true;
+    console.error('bezel-stickers:', e);
+    return null;
+  }
+  entry.tex = tex;
+  entry.gen = monitorGl.gen;
+  return tex;
 }
 
 // The monitor select, the display-settings pattern: hostable by the page

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -5951,7 +5951,9 @@ function monitorDraw(width, rows, crtLines) {
           wPx = s.width != null ? s.width * w : autoH / Math.max(aspect, 1e-3);
           rot = s.rotate ?? BEZEL_STICKER_TILT[tilt % BEZEL_STICKER_TILT.length];
           tilt += 1;
-          if (cursor + wPx > w - margin) break;
+          // Only this slot is dropped when the row is full: a narrower one
+          // after it may still fit, and placed entries never use the row.
+          if (cursor + wPx > w - margin) continue;
           cx = cursor + wPx * 0.5;
           cy = band * 0.5;
           cursor += wPx + gap;

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -723,6 +723,24 @@ elements, and pages without them are untouched:
   the other modes; a shell that wants no part of that can simply not
   style a border. It hides itself -- and the page keeps its
   plain 2D blit -- in a browser without WebGL2.
+- `#bezel-stickers` (a `<script type="application/json">` element): PNG
+  stickers drawn onto the monitor front while a bezel mode is up, the
+  desktop's `[display] bezel_stickers` for a hosting page -- community
+  logos as die-cut decals on the plastic, with a soft drop shadow and the
+  plastic's lighting. The element's content is a JSON array of up to 16
+  entries with the same keys as the desktop folder's `stickers.toml`
+  ([the configuration chapter](configuration.md)): `image` (a URL,
+  resolved against the page -- typically a `stickers/` folder beside it),
+  optional `x`/`y` (the sticker's centre as fractions of the canvas, as a
+  pair), `width` (fraction of the canvas width; height follows the
+  image's aspect), `rotate` (degrees clockwise) and `opacity`. Entries
+  without `x`/`y` line up along the cabinet's top band in written order
+  with a slight alternating tilt, exactly as the desktop lays a bare
+  folder out. The decals are drawn on the canvas itself, so they follow
+  the plastic through resizes and fullscreen, and never appear in
+  screenshots, which capture the presentation buffer. Cross-origin images
+  are requested with CORS and skipped (with a console note) when the host
+  refuses. Without the element, or without WebGL2, no stickers are drawn.
 - `#floppy-speed` (a `<select>` with option values `100`, `200`, `400`,
   `800`, and `0` for turbo): hosts the floppy drive speed control, letting
   the page place and style it. Unlike the other hooks this one is always

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -730,6 +730,45 @@ never include it, and it is skipped while a menu or overlay panel is open
 and for RTG scanout frames. Unlike the shader it does stay on for
 programmable multisync scans -- a frame has no line structure to get wrong.
 
+`bezel_stickers` names a folder of PNG images to draw onto the bezel as
+die-cut stickers, the way owners dress a real monitor with community and
+maker logos. Unset (the default) draws none. Every `*.png` in the folder
+becomes one decal (up to 16, alpha respected, large sources scaled down),
+laid along the cabinet's top band in file-name order with a slight
+alternating tilt; each picks up a soft drop shadow and the plastic's
+lighting so it reads as stuck on rather than pasted over. The folder is
+re-read when a machine starts, so editing it and restarting (or switching
+machine in the launcher) picks up changes; a folder that fails to load
+reports on the on-screen display and falls back to bare plastic.
+
+An optional `stickers.toml` in the folder chooses and places the images
+instead, one `[[sticker]]` table per decal, drawn in written order:
+
+```toml
+[[sticker]]
+image = "retro32.png"   # file name in the folder
+x = 0.32                # sticker centre, fraction of the front's width
+y = 0.935               # and of its height (down from the top)
+width = 0.11            # width as a fraction of the front's width
+rotate = -2.5           # degrees clockwise
+opacity = 1.0
+
+[[sticker]]
+image = "badge.png"     # no x/y: an auto slot on the top band
+```
+
+`x` and `y` come as a pair; a table without them takes the next automatic
+top-band slot (where `width` and `rotate` still override that slot's own).
+Height always follows the image's aspect. The same keys, as JSON, drive
+the web player's `#bezel-stickers` page hook
+([the browser chapter](browser.md)), so one sheet lays out identically in
+the app and on a hosting page.
+
+Stickers ride the bezel: they draw only while a front does, follow it
+through Cmd+M / Alt+M, and are presentation only -- captures never include
+them. `COPPERLINE_BEZEL_STICKERS` (a folder path, or empty for none)
+overrides the config for a single run.
+
 `perf_overlay` (default `false`) shows the performance overlay at start: a
 live readout of emulated fps, speed factor, per-frame emulation cost, host
 utilisation, audio health, and pacer slips in the top-right corner of the

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -351,7 +351,10 @@ belongs to the Amiga.
   on; it never changes which. Session-only; the start-up value is
   `[display] bezel` (see [Configuration](configuration.md)). A window
   effect only, like the shader: screenshots, frame dumps and recordings
-  never include it.
+  never include it. A folder of PNG stickers can be drawn onto either
+  front -- die-cut decals on the plastic, riding the same toggle -- via
+  `[display] bezel_stickers` (no menu item; see
+  [Configuration](configuration.md)).
 - **Performance** (also `Cmd+P` / `Alt+P`): show or hide the
   [performance overlay](#performance-overlay). Session-only; the start-up
   value is `[display] perf_overlay` (see

--- a/src/config.rs
+++ b/src/config.rs
@@ -275,6 +275,12 @@ pub struct Config {
     /// (`[display] bezel`). The `Cmd+M` / `Alt+M` toggle turns it off and
     /// back on live without affecting this start-up value.
     pub bezel: BezelStyle,
+    /// Folder of PNG stickers drawn onto the monitor bezel
+    /// (`[display] bezel_stickers`). Each PNG in the folder becomes a
+    /// decal on the drawn front; an optional `stickers.toml` in the folder
+    /// places each one, and without it they line up along the cabinet's
+    /// top band. Drawn only while a bezel is; never in captures.
+    pub bezel_stickers: Option<PathBuf>,
     /// Show the performance overlay at start (`[display] perf_overlay`, or
     /// `--perf-overlay`): a live emulation-performance readout in the
     /// top-right of the display. The `Cmd+P` / `Alt+P` toggle flips it live
@@ -2139,6 +2145,7 @@ impl Default for Config {
             shader: ShaderMode::None,
             shader_strength: 1.0,
             bezel: BezelStyle::None,
+            bezel_stickers: None,
             perf_overlay: false,
             tint: Tint::None,
             menu_scale: MenuScale::Normal,
@@ -2877,6 +2884,10 @@ pub(crate) struct RawDisplay {
     /// the one frame to turn on.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) bezel: Option<RawBezel>,
+    /// Folder of PNG stickers drawn onto the bezel; unset or empty draws
+    /// none. An optional `stickers.toml` inside places them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) bezel_stickers: Option<String>,
     /// Performance overlay in the top-right of the display (default false).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) perf_overlay: Option<bool>,
@@ -4036,6 +4047,11 @@ impl TryFrom<RawConfig> for Config {
                 }
             },
         };
+        let bezel_stickers = match raw.display.bezel_stickers.as_deref().map(str::trim) {
+            None => defaults.bezel_stickers.clone(),
+            Some("") => None,
+            Some(p) => Some(PathBuf::from(p)),
+        };
         let perf_overlay = raw.display.perf_overlay.unwrap_or(defaults.perf_overlay);
         let tint = match raw.display.tint.as_deref() {
             None => defaults.tint,
@@ -4633,6 +4649,7 @@ impl TryFrom<RawConfig> for Config {
             shader,
             shader_strength,
             bezel,
+            bezel_stickers,
             perf_overlay,
             tint,
             menu_scale,
@@ -6045,6 +6062,17 @@ pub fn resolve_bezel(from_config: BezelStyle) -> BezelStyle {
     }
 }
 
+/// Resolve the bezel sticker folder: the `COPPERLINE_BEZEL_STICKERS` env
+/// var overrides the `[display] bezel_stickers` config for one run; an
+/// empty value disables stickers the config turned on.
+pub fn resolve_bezel_stickers(from_config: Option<PathBuf>) -> Option<PathBuf> {
+    match crate::envcfg::var("COPPERLINE_BEZEL_STICKERS") {
+        Some(v) if v.trim().is_empty() => None,
+        Some(v) => Some(PathBuf::from(v.trim())),
+        None => from_config,
+    }
+}
+
 /// Resolve the performance overlay: the `COPPERLINE_PERF_OVERLAY` env var
 /// (0/false/off/no disables, anything else enables) overrides the
 /// `[display] perf_overlay` config for one run.
@@ -7108,6 +7136,22 @@ mod tests {
             assert_eq!(parse_bezel(style.label())?, style);
         }
         assert!(parse_config("[display]\nbezel = \"1084s\"\n").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn display_bezel_stickers_names_a_folder_and_defaults_to_none() -> Result<()> {
+        assert_eq!(parse_config("")?.bezel_stickers, None);
+        let cfg = parse_config("[display]\nbezel_stickers = \"decals/retro32\"\n")?;
+        assert_eq!(
+            cfg.bezel_stickers.as_deref(),
+            Some(Path::new("decals/retro32"))
+        );
+        // Written but empty means none, not a folder called "".
+        assert_eq!(
+            parse_config("[display]\nbezel_stickers = \"  \"\n")?.bezel_stickers,
+            None
+        );
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2219,6 +2219,7 @@ fn main() -> Result<()> {
         config::resolve_shader(cfg.shader.clone()),
         config::resolve_shader_strength(cfg.shader_strength),
         config::resolve_bezel(cfg.bezel),
+        config::resolve_bezel_stickers(cfg.bezel_stickers.clone()),
         config::resolve_perf_overlay(cfg.perf_overlay),
         config::resolve_tint(cfg.tint),
         cfg.full_screen,
@@ -2346,6 +2347,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         config::resolve_shader(config::ShaderMode::None),
         config::resolve_shader_strength(1.0),
         config::resolve_bezel(config::BezelStyle::None),
+        config::resolve_bezel_stickers(None),
         config::resolve_perf_overlay(false),
         config::resolve_tint(config::Tint::None),
         // The config-screen placeholder is always a normal windowed UI.

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1953,6 +1953,11 @@ pub struct MachineSetup {
     shader_strength: f32,
     /// Which monitor front frames the picture, if any ([display] bezel).
     bezel: BezelStyle,
+    /// Folder of PNG stickers drawn onto the bezel ([display]
+    /// bezel_stickers). No launcher row edits it -- like the custom
+    /// shader, there is no file browser -- but it is carried so a
+    /// configured folder survives the launcher's config round-trip.
+    bezel_stickers: Option<PathBuf>,
     /// Performance overlay in the top-right ([display] perf_overlay).
     perf_overlay: bool,
     /// The MT-32's two ROM images, whether its front panel starts up, and
@@ -2165,6 +2170,7 @@ impl MachineSetup {
             },
             shader_strength: cfg.shader_strength,
             bezel: cfg.bezel,
+            bezel_stickers: cfg.bezel_stickers.clone(),
             perf_overlay: cfg.perf_overlay,
             mt32_control_rom: cfg.serial.mt32_control_rom.clone(),
             mt32_pcm_rom: cfg.serial.mt32_pcm_rom.clone(),
@@ -2572,6 +2578,9 @@ impl MachineSetup {
         if self.bezel != base.bezel {
             raw.display.bezel = Some(crate::config::RawBezel::Named(self.bezel.label().into()));
         }
+        if self.bezel_stickers != base.bezel_stickers {
+            raw.display.bezel_stickers = self.bezel_stickers.as_deref().map(path_string);
+        }
         if self.perf_overlay != base.perf_overlay {
             raw.display.perf_overlay = Some(self.perf_overlay);
         }
@@ -2855,6 +2864,8 @@ impl MachineSetup {
         self.shader = base.shader.clone();
         self.shader_strength = base.shader_strength;
         self.bezel = base.bezel;
+        // The sticker folder survives like the shader path above: it names
+        // a folder of the user's, not anything of the profile's.
         self.perf_overlay = base.perf_overlay;
         self.tint = base.tint;
         self.menu_scale = base.menu_scale;
@@ -9628,6 +9639,32 @@ mod tests {
         }
         // A full turn of the cycle comes back to where it started.
         assert_eq!(s.bezel, BezelStyle::None);
+    }
+
+    #[test]
+    fn the_sticker_folder_survives_a_launcher_round_trip() {
+        let mut raw = RawConfig::default();
+        raw.display.bezel_stickers = Some("/data/amiga/stickers".into());
+        let s = MachineSetup::from_raw(&raw).expect("valid raw");
+        // No launcher row edits the folder, so a straight round-trip must
+        // carry it: a machine saved or started from the launcher keeps its
+        // stickers.
+        assert_eq!(
+            s.to_raw().display.bezel_stickers.as_deref(),
+            Some("/data/amiga/stickers")
+        );
+        assert_eq!(
+            s.build_config()
+                .expect("valid config")
+                .bezel_stickers
+                .as_deref(),
+            Some(Path::new("/data/amiga/stickers"))
+        );
+        // Unset stays unwritten.
+        assert_eq!(
+            MachineSetup::default().to_raw().display.bezel_stickers,
+            None
+        );
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -12084,11 +12084,6 @@ impl App {
         self.tint_lut = tint_lut(tint);
     }
 
-    /// Compile the configured user shader against the live device. The full
-    /// message goes to the log; the returned one-line summary is for the
-    /// caller to fold into whatever overlay it is already showing. A failure
-    /// leaves no pipeline, so the caller falls back to no shader rather than
-    /// to a stale one.
     /// Load the configured sticker folder into the decal pass, or clear it
     /// when none is configured. The full message goes to the log; the
     /// returned one-line summary is for the caller's overlay, exactly as
@@ -12118,6 +12113,11 @@ impl App {
         }
     }
 
+    /// Compile the configured user shader against the live device. The full
+    /// message goes to the log; the returned one-line summary is for the
+    /// caller to fold into whatever overlay it is already showing. A failure
+    /// leaves no pipeline, so the caller falls back to no shader rather than
+    /// to a stale one.
     fn reload_custom_shader(&mut self) -> Result<(), String> {
         let fail = |msg: String| {
             error!("[display] shader: {msg}");

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1116,6 +1116,10 @@ pub struct App {
     /// choosing one. Never [`BezelStyle::None`]: turning the bezel off
     /// leaves this pointing at what was on.
     bezel_last: BezelStyle,
+    /// Folder of PNG stickers drawn onto the bezel ([display]
+    /// bezel_stickers), kept so a machine switch can re-read it. The
+    /// loaded sheet lives in [`Render::sticker_pass`].
+    bezel_stickers_path: Option<std::path::PathBuf>,
     /// Performance overlay in effect ([display] perf_overlay, Cmd/Alt+P):
     /// a live emulation-performance readout in the top-right of the
     /// display. Presentation only, like the OSD: captures never include it.
@@ -1311,6 +1315,10 @@ struct Render {
     /// CRT pass, so switching style or turning it off works live; each
     /// style's shader is compiled the first time that style is drawn.
     bezel_shader: bezel::BezelShader,
+    /// The sticker decals drawn over the bezel pass (see [`stickers`]).
+    /// Built with the window whatever the setting, like the passes above;
+    /// it draws nothing until a sheet is loaded into it.
+    sticker_pass: stickers::StickerPass,
     /// True while the host window is minimized (Windows delivers a 0x0
     /// Resized). Presenting while minimized deadlocks on Windows: DWM stops
     /// consuming swapchain frames, so once the in-flight buffers fill,
@@ -1710,6 +1718,7 @@ impl App {
         shader: crate::config::ShaderMode,
         shader_strength: f32,
         bezel: BezelStyle,
+        bezel_stickers: Option<PathBuf>,
         perf_overlay: bool,
         tint: crate::config::Tint,
         start_fullscreen: bool,
@@ -1899,6 +1908,7 @@ impl App {
             shader_strength,
             bezel,
             bezel_last: last_bezel_style(bezel),
+            bezel_stickers_path: bezel_stickers,
             perf_overlay,
             perf: PerfOverlay::default(),
             tint,
@@ -3042,6 +3052,8 @@ impl ApplicationHandler for App {
         let mut crt_shader =
             crt_shader::CrtShader::new(pixels.device(), pixels.render_texture_format());
         let bezel_shader = bezel::BezelShader::new(pixels.device(), pixels.render_texture_format());
+        let sticker_pass =
+            stickers::StickerPass::new(pixels.device(), pixels.render_texture_format());
         // A user shader can only be compiled once the device exists (too
         // early for `reload_custom_shader`, which needs the built `Render`).
         // A bad one drops back to no shader rather than failing the session:
@@ -3067,12 +3079,18 @@ impl ApplicationHandler for App {
             rtg_texture,
             crt_shader,
             bezel_shader,
+            sticker_pass,
             minimized: false,
             surface_size: (inner.width.max(1), inner.height.max(1)),
         });
         // After the window exists, so the overlay has somewhere to be drawn.
         if let Some(msg) = shader_error {
             self.show_osd(format!("CRT shader: off (custom failed: {msg})"));
+        }
+        // The sticker sheet is CPU-side, but its pass lives in `Render`, so
+        // it loads here too; a bad folder falls back to no stickers.
+        if let Err(msg) = self.reload_bezel_stickers() {
+            self.show_osd(format!("Bezel stickers: off ({msg})"));
         }
         // Paint at least once so the status bar (and power button) is
         // visible immediately, even when the machine starts powered off
@@ -3906,6 +3924,7 @@ impl ApplicationHandler for App {
                         // borrows rather than reached through `r` inside.
                         let crt = &mut r.crt_shader;
                         let bezel_shader = &mut r.bezel_shader;
+                        let sticker_pass = &mut r.sticker_pass;
                         r.pixels.render_with(|encoder, target, ctx| {
                             ctx.scaling_renderer.render(encoder, target);
                             let (uniforms, viewport) = crt_shader::uniforms_for(
@@ -3940,6 +3959,17 @@ impl ApplicationHandler for App {
                                     viewport,
                                     bezel_style,
                                     bezel::uniforms_from(&uniforms, viewport, opening, crt_active),
+                                );
+                                // Decals stick to the plastic, so they ride
+                                // the bezel pass: suspended with it, never
+                                // drawn over a bare picture.
+                                sticker_pass.render(
+                                    &ctx.device,
+                                    &ctx.queue,
+                                    encoder,
+                                    target,
+                                    viewport,
+                                    opening,
                                 );
                             } else {
                                 crt.render(
@@ -9108,6 +9138,9 @@ impl App {
         self.shader_strength = crate::config::resolve_shader_strength(cfg.shader_strength);
         self.bezel = crate::config::resolve_bezel(cfg.bezel);
         self.bezel_last = last_bezel_style(self.bezel);
+        self.bezel_stickers_path =
+            crate::config::resolve_bezel_stickers(cfg.bezel_stickers.clone());
+        let sticker_error = self.reload_bezel_stickers().err();
         self.perf_overlay = crate::config::resolve_perf_overlay(cfg.perf_overlay);
         self.perf = PerfOverlay::default();
         self.set_tint(crate::config::resolve_tint(cfg.tint));
@@ -9135,11 +9168,19 @@ impl App {
         self.paused = false;
         self.reset_render_pipeline();
         // The last overlay set here is the one that gets drawn, so a shader
-        // that failed to load has to travel in this message rather than in
-        // one of its own.
-        self.show_osd(match shader_error {
-            Some(msg) => format!("Machine started (CRT shader: off, custom failed: {msg})"),
-            None => "Machine started".to_string(),
+        // or sticker folder that failed to load has to travel in this
+        // message rather than in one of its own.
+        let mut notes = Vec::new();
+        if let Some(msg) = shader_error {
+            notes.push(format!("CRT shader: off, custom failed: {msg}"));
+        }
+        if let Some(msg) = sticker_error {
+            notes.push(format!("stickers: off, {msg}"));
+        }
+        self.show_osd(if notes.is_empty() {
+            "Machine started".to_string()
+        } else {
+            format!("Machine started ({})", notes.join("; "))
         });
         self.request_redraw();
     }
@@ -12048,6 +12089,35 @@ impl App {
     /// caller to fold into whatever overlay it is already showing. A failure
     /// leaves no pipeline, so the caller falls back to no shader rather than
     /// to a stale one.
+    /// Load the configured sticker folder into the decal pass, or clear it
+    /// when none is configured. The full message goes to the log; the
+    /// returned one-line summary is for the caller's overlay, exactly as
+    /// [`Self::reload_custom_shader`] reports. A failure leaves no sheet,
+    /// so the front falls back to bare plastic rather than a stale set.
+    fn reload_bezel_stickers(&mut self) -> Result<(), String> {
+        let path = self.bezel_stickers_path.clone();
+        let Some(r) = self.render.as_mut() else {
+            return Ok(());
+        };
+        match path {
+            None => {
+                r.sticker_pass.set_sheet(None);
+                Ok(())
+            }
+            Some(dir) => match stickers::load_sheet(&dir) {
+                Ok(sheet) => {
+                    r.sticker_pass.set_sheet(Some(sheet));
+                    Ok(())
+                }
+                Err(msg) => {
+                    r.sticker_pass.set_sheet(None);
+                    error!("[display] bezel_stickers: {msg}");
+                    Err(msg.lines().next().unwrap_or_default().to_string())
+                }
+            },
+        }
+    }
+
     fn reload_custom_shader(&mut self) -> Result<(), String> {
         let fail = |msg: String| {
             error!("[display] shader: {msg}");
@@ -12996,6 +13066,7 @@ mod mt32panel;
 mod present;
 mod rtg_texture;
 mod statusbar;
+mod stickers;
 pub(super) use present::{scale_rect, texture_height, texture_width, Rect};
 pub(super) use statusbar::{draw_rect_bevel, fill_rect, fill_rect_blend};
 

--- a/src/video/window/bezel.rs
+++ b/src/video/window/bezel.rs
@@ -1566,6 +1566,126 @@ mod tests {
         }
     }
 
+    /// The sticker pass draws over the finished front and only there:
+    /// the decal prints where its manifest places it, and every probe
+    /// away from it -- the picture, the case corner, the far chin -- is
+    /// byte-identical to the same render without the pass.
+    #[test]
+    fn sticker_decals_print_on_the_chin_and_touch_nothing_else() {
+        let Some(gpu) = gpu() else {
+            return;
+        };
+        let (device, queue) = (gpu.device(), gpu.queue());
+        let src = source_texture(device, queue, TEX, TEX, DISPLAY_ROWS, &|_, _| {
+            [GREY, GREY, GREY, 255]
+        });
+        let style = BezelStyle::Model1084;
+        let (plain, dim, rows) = render_bezel(device, queue, &src, style, None, 0.0);
+
+        // A folder with one solid red die-cut sticker, placed on the chin
+        // left of the logotype.
+        let dir =
+            std::env::temp_dir().join(format!("copperline-decal-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        {
+            let file = std::fs::File::create(dir.join("red.png")).expect("create png");
+            let mut enc = png::Encoder::new(std::io::BufWriter::new(file), 16, 8);
+            enc.set_color(png::ColorType::Rgba);
+            enc.set_depth(png::BitDepth::Eight);
+            let mut writer = enc.write_header().expect("png header");
+            let px: Vec<u8> = std::iter::repeat_n([255, 0, 0, 255], 16 * 8)
+                .flatten()
+                .collect();
+            writer.write_image_data(&px).expect("png data");
+        }
+        std::fs::write(
+            dir.join("stickers.toml"),
+            "[[sticker]]\nimage = \"red.png\"\nx = 0.30\ny = 0.93\nwidth = 0.12\n",
+        )
+        .expect("manifest");
+        let sheet = super::super::stickers::load_sheet(&dir).expect("load sheet");
+        std::fs::remove_dir_all(&dir).ok();
+
+        // Render exactly as render_bezel does, with the decal pass after
+        // the bezel's, as the window composes them.
+        let target = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("bezel_sticker_test_target"),
+            size: wgpu::Extent3d {
+                width: dim,
+                height: dim,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let view = target.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        let (crt_uniforms, viewport) = crt_shader::uniforms_for(
+            ShaderKind::None,
+            0.0,
+            (0, 0, dim, dim),
+            DISPLAY_ROWS as usize,
+            TEX as usize,
+            (TEX, TEX),
+            DISPLAY_ROWS as f32,
+        );
+        let opening = opening_rect(style, viewport);
+        let mut shader = BezelShader::new(device, FORMAT);
+        shader.render(
+            device,
+            queue,
+            &src,
+            &mut encoder,
+            &view,
+            viewport,
+            style,
+            uniforms_from(&crt_uniforms, viewport, opening, false),
+        );
+        let mut decals = super::super::stickers::StickerPass::new(device, FORMAT);
+        decals.set_sheet(Some(sheet));
+        decals.render(device, queue, &mut encoder, &view, viewport, opening);
+        let px = read_back(device, queue, encoder, &target, (dim, dim));
+
+        // The decal prints where it was placed.
+        let probe = at(
+            &px,
+            dim,
+            (0.30 * dim as f32) as u32,
+            (0.93 * rows as f32) as u32,
+        );
+        assert!(
+            probe[0] > 150 && probe[1] < 80 && probe[2] < 80,
+            "no red decal at its placement, got {probe:?}"
+        );
+        // And it was a change: the plain front's chin is not red there.
+        let before = at(
+            &plain,
+            dim,
+            (0.30 * dim as f32) as u32,
+            (0.93 * rows as f32) as u32,
+        );
+        assert_ne!(probe, before, "the decal pass drew nothing");
+        // Everything away from the decal is untouched, byte for byte:
+        // the picture's centre, the case corner band, and the chin's
+        // far side by the power lamp.
+        for (x, y) in [
+            (dim / 2, rows / 2),
+            (dim / 2, 4),
+            ((0.85 * dim as f32) as u32, (0.93 * rows as f32) as u32),
+        ] {
+            assert_eq!(
+                at(&px, dim, x, y),
+                at(&plain, dim, x, y),
+                "({x}, {y}) changed without a decal on it"
+            );
+        }
+    }
+
     /// Not a check: renders the bezel (optionally with the CRT preset the
     /// window would pair it with) over a source image and writes a PNG for
     /// eyeballing look changes. Runs only when
@@ -1576,7 +1696,9 @@ mod tests {
     /// preset pass; COPPERLINE_BEZEL_PREVIEW_BARE instead renders the
     /// preset alone over the full frame, no bezel, for eyeballing the
     /// preset's own face geometry. COPPERLINE_BEZEL_PREVIEW_STYLE names
-    /// the front to draw, defaulting to 1084.
+    /// the front to draw, defaulting to 1084, and
+    /// COPPERLINE_BEZEL_PREVIEW_STICKERS names a sticker folder to lay
+    /// over it, the [display] bezel_stickers pass.
     #[test]
     #[ignore = "preview dump; set COPPERLINE_BEZEL_PREVIEW_OUT"]
     fn dump_bezel_preview_png() {
@@ -1701,6 +1823,13 @@ mod tests {
                 style,
                 uniforms_from(&crt_uniforms, viewport, opening, with_crt),
             );
+            if let Ok(dir) = std::env::var("COPPERLINE_BEZEL_PREVIEW_STICKERS") {
+                let sheet = super::super::stickers::load_sheet(std::path::Path::new(&dir))
+                    .expect("sticker folder loads");
+                let mut decals = super::super::stickers::StickerPass::new(device, FORMAT);
+                decals.set_sheet(Some(sheet));
+                decals.render(device, queue, &mut encoder, &view, viewport, opening);
+            }
         }
         let px = read_back(device, queue, encoder, &target, (w, h));
         let file = std::fs::File::create(&out).expect("create preview");

--- a/src/video/window/shaders/bezel_stickers.wgsl
+++ b/src/video/window/shaders/bezel_stickers.wgsl
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Sticker decals over the drawn monitor bezel: one rotated quad per
+// sticker, sampling a packed atlas of the user's PNGs (stickers.rs
+// loads and places them; this pass runs after the bezel's, over the
+// same viewport, so the decals land on the finished plastic).
+//
+// Each quad is padded around the sticker so the fragment stage can lay
+// a soft drop shadow off the sticker's own silhouette -- the alpha edge
+// of a die-cut logo -- and the face is toned very slightly brighter
+// toward the top, like the plastic it is stuck to, so it reads as part
+// of the front rather than pasted over the frame. Output is
+// premultiplied: the decal and its shadow are composed in one fragment,
+// which straight alpha cannot carry.
+//
+// try.js carries a GLSL ES port of this pass for the web player's
+// #bezel-stickers page hook; keep them in step.
+
+struct Sticker {
+    // xy: centre in viewport px. zw: half-size in px.
+    geo: vec4<f32>,
+    // xy: cos/sin of the clockwise tilt. z: opacity. w: unused.
+    rot: vec4<f32>,
+    // Atlas sub-rect in UV space: xy origin, zw size.
+    uv: vec4<f32>,
+};
+
+struct Uniforms {
+    // xy: viewport size in px. z: shadow offset in px. w: unused.
+    info: vec4<f32>,
+    st: array<Sticker, 16>,
+};
+
+@group(0) @binding(0) var atlas_tex: texture_2d<f32>;
+@group(0) @binding(1) var atlas_samp: sampler;
+@group(0) @binding(2) var<uniform> u: Uniforms;
+
+struct VsOut {
+    @builtin(position) pos: vec4<f32>,
+    // Quad coordinates with the sticker spanning [-1, 1]; the shadow
+    // padding carries them a little beyond.
+    @location(0) local: vec2<f32>,
+    @location(1) @interpolate(flat) index: u32,
+};
+
+@vertex
+fn vs_main(
+    @builtin(vertex_index) vi: u32,
+    @builtin(instance_index) ii: u32,
+) -> VsOut {
+    var corners = array<vec2<f32>, 6>(
+        vec2(-1.0, -1.0), vec2(1.0, -1.0), vec2(1.0, 1.0),
+        vec2(-1.0, -1.0), vec2(1.0, 1.0), vec2(-1.0, 1.0),
+    );
+    let s = u.st[ii];
+    let half = max(s.geo.zw, vec2(0.5));
+    // Room for the shadow's furthest tap, on every side: the offset and
+    // the half-offset spread beyond it.
+    let padded = half + vec2(u.info.z * 2.0);
+    let local = corners[vi] * padded / half;
+    // The tilt turns clockwise on screen: y runs down, so the plain
+    // rotation matrix already does.
+    let p = corners[vi] * padded;
+    let turned = vec2(
+        p.x * s.rot.x - p.y * s.rot.y,
+        p.x * s.rot.y + p.y * s.rot.x,
+    );
+    let px = s.geo.xy + turned;
+    let ndc = vec2(
+        px.x / u.info.x * 2.0 - 1.0,
+        1.0 - px.y / u.info.y * 2.0,
+    );
+    return VsOut(vec4(ndc, 0.0, 1.0), local, ii);
+}
+
+// The sticker's texels at a quad position, transparent outside its
+// bounds. Sampling is unconditional and by explicit level, so the mask
+// costs no control flow; the clamp keeps the lookup inside the cell,
+// whose transparent padding closes the edge.
+fn decal(s: Sticker, local: vec2<f32>) -> vec4<f32> {
+    let t = clamp(local * 0.5 + vec2(0.5), vec2(0.0), vec2(1.0));
+    let inside = step(abs(local.x), 1.0) * step(abs(local.y), 1.0);
+    let c = textureSampleLevel(atlas_tex, atlas_samp, s.uv.xy + t * s.uv.zw, 0.0);
+    return c * inside;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    let s = u.st[in.index];
+    let half = max(s.geo.zw, vec2(0.5));
+    let colour = decal(s, in.local);
+    // The shadow is the silhouette dropped down-right, softened by taps
+    // at the offset and half again beyond it.
+    let o = vec2(u.info.z) / half;
+    var sh = decal(s, in.local - o).a;
+    sh += decal(s, in.local - o - vec2(o.x * 0.5, 0.0)).a;
+    sh += decal(s, in.local - o - vec2(0.0, o.y * 0.5)).a;
+    sh += decal(s, in.local - o * 1.5).a;
+    let shadow = sh * 0.25 * 0.38;
+    // Stuck to lit plastic: a touch brighter toward the light at the
+    // top, falling off down the face, like the bezel's own tone.
+    let tone = 1.04 - 0.07 * clamp(in.local.y * 0.5 + 0.5, 0.0, 1.0);
+    let a_decal = colour.a * s.rot.z;
+    let a_shadow = shadow * s.rot.z;
+    // Premultiplied out: the decal over its own shadow.
+    return vec4(
+        colour.rgb * tone * a_decal,
+        a_decal + a_shadow * (1.0 - a_decal),
+    );
+}

--- a/src/video/window/stickers.rs
+++ b/src/video/window/stickers.rs
@@ -1,0 +1,914 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Sticker decals over the drawn monitor bezel: user PNGs from
+//! `[display] bezel_stickers`, composited onto the plastic after the
+//! bezel pass so a community logo can be "stuck on" the cabinet the way
+//! owners dress a real monitor.
+//!
+//! The folder is the whole interface. Every `*.png` in it becomes one
+//! decal; an optional `stickers.toml` beside them places each image, and
+//! without one they line up along the cabinet's top band, each with a
+//! slight alternating tilt. Placement coordinates are fractions of the
+//! drawn monitor front (the bezel viewport), so a sheet lays out the same
+//! at any window size and on the web player, whose page hook takes the
+//! same keys as JSON (docs/guide/browser.md).
+//!
+//! Like the bezel it decorates, this is purely a presentation stage:
+//! stickers exist only in the window pass, never in screenshots, frame
+//! dumps, recordings or headless runs, and they are skipped whenever the
+//! bezel itself is (no bezel style, an open overlay, RTG scanout).
+//!
+//! The images are decoded and packed into one atlas on the CPU at load
+//! time; the pass draws one rotated quad per sticker from a single
+//! uniform array, sampling the atlas with a drop shadow and a slight
+//! vertical tone so a die-cut decal reads as stuck to lit plastic rather
+//! than pasted over the frame. `shaders/bezel_stickers.wgsl` holds the
+//! shader; try.js carries a GLSL port of it -- keep them in step.
+
+use std::path::Path;
+
+use pixels::wgpu;
+use serde::Deserialize;
+use zerocopy::{Immutable, IntoBytes};
+
+/// The most stickers a sheet may carry: the uniform array's length, and
+/// past it a front stops reading as a monitor anyway.
+pub(super) const MAX_STICKERS: usize = 16;
+
+/// Longest side an image keeps, in texels. The bands a sticker sits on
+/// are a small fraction of the window, so more source than this is never
+/// visible, and the cap keeps a folder of camera-sized PNGs from costing
+/// a large atlas upload.
+const MAX_DIM: u32 = 512;
+
+/// Transparent padding between atlas cells, so linear sampling at a
+/// sticker's edge fades into clear space instead of the neighbour.
+const PAD: u32 = 2;
+
+/// The atlas shelf width cells wrap at.
+const ATLAS_MAX_W: u32 = 2048;
+
+/// Width an explicitly placed sticker takes when the manifest names none,
+/// as a fraction of the monitor front's width.
+const DEFAULT_WIDTH_FRAC: f32 = 0.08;
+
+/// Tilt cycle for auto-placed stickers, degrees clockwise: a hand puts no
+/// two stickers on straight, so the row alternates a little either way.
+const AUTO_TILT: [f32; 4] = [-3.0, 2.2, -1.6, 2.8];
+
+/// A decoded RGBA image.
+struct Rgba {
+    w: u32,
+    h: u32,
+    px: Vec<u8>,
+}
+
+/// One sticker of a loaded sheet: where its texels sit in the atlas, its
+/// source proportions, and how the manifest asked for it to be placed
+/// (all `None` for a bare folder: an auto slot in the top band).
+#[derive(Debug)]
+struct SheetEntry {
+    /// Atlas sub-rect in UV space: xy origin, zw size.
+    uv: [f32; 4],
+    /// Source size after the [`MAX_DIM`] cap, for the aspect.
+    w: u32,
+    h: u32,
+    /// Explicit centre, fractions of the monitor front; `None` = auto.
+    at: Option<[f32; 2]>,
+    /// Explicit width as a fraction of the front's width.
+    width_frac: Option<f32>,
+    /// Explicit tilt, degrees clockwise; auto slots without one take the
+    /// [`AUTO_TILT`] cycle.
+    rotate: Option<f32>,
+    opacity: f32,
+}
+
+/// A loaded sticker folder: the packed atlas and each image's entry, in
+/// manifest order (or file-name order for a bare folder).
+#[derive(Debug)]
+pub(super) struct StickerSheet {
+    atlas_w: u32,
+    atlas_h: u32,
+    atlas_rgba: Vec<u8>,
+    entries: Vec<SheetEntry>,
+}
+
+/// `stickers.toml` as written: a `[[sticker]]` table per image. The same
+/// keys, as JSON, are the web player's `#bezel-stickers` page hook.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawManifest {
+    #[serde(default)]
+    sticker: Vec<RawManifestSticker>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawManifestSticker {
+    /// File name in the folder.
+    image: String,
+    /// Sticker centre, fractions of the drawn monitor front (x right,
+    /// y down). Both or neither: half a position places nothing.
+    x: Option<f32>,
+    y: Option<f32>,
+    /// Width as a fraction of the front's width; height follows the
+    /// image's aspect.
+    width: Option<f32>,
+    /// Degrees clockwise.
+    rotate: Option<f32>,
+    /// 0.0 to 1.0, default fully opaque.
+    opacity: Option<f32>,
+}
+
+/// Load a sticker folder into a sheet. Any problem fails the whole load
+/// with a message naming the file, the way a bad custom shader does: the
+/// caller falls back to no stickers, never to a stale or partial sheet.
+pub(super) fn load_sheet(dir: &Path) -> Result<StickerSheet, String> {
+    let manifest_path = dir.join("stickers.toml");
+    let picks: Vec<RawManifestSticker> = if manifest_path.is_file() {
+        let text = std::fs::read_to_string(&manifest_path)
+            .map_err(|e| format!("{}: {e}", manifest_path.display()))?;
+        let manifest: RawManifest =
+            toml::from_str(&text).map_err(|e| format!("{}: {e}", manifest_path.display()))?;
+        manifest.sticker
+    } else {
+        scan_folder(dir)?
+            .into_iter()
+            .map(|name| RawManifestSticker {
+                image: name,
+                x: None,
+                y: None,
+                width: None,
+                rotate: None,
+                opacity: None,
+            })
+            .collect()
+    };
+    if picks.is_empty() {
+        return Err(format!("{}: no PNG stickers found", dir.display()));
+    }
+    if picks.len() > MAX_STICKERS {
+        return Err(format!(
+            "{}: {} stickers, the front carries at most {MAX_STICKERS}",
+            dir.display(),
+            picks.len()
+        ));
+    }
+
+    let mut images = Vec::with_capacity(picks.len());
+    for pick in &picks {
+        if pick.x.is_some() != pick.y.is_some() {
+            return Err(format!(
+                "{}: x and y place a sticker together (only one given)",
+                pick.image
+            ));
+        }
+        let path = dir.join(&pick.image);
+        let img = decode_png(&path)?;
+        images.push(cap_size(img));
+    }
+
+    let (atlas_w, atlas_h, cells) = pack(&images);
+    let mut atlas_rgba = vec![0u8; (atlas_w * atlas_h * 4) as usize];
+    let mut entries = Vec::with_capacity(images.len());
+    for (i, img) in images.iter().enumerate() {
+        let (cx, cy) = cells[i];
+        for row in 0..img.h {
+            let src = (row * img.w * 4) as usize;
+            let dst = (((cy + row) * atlas_w + cx) * 4) as usize;
+            atlas_rgba[dst..dst + (img.w * 4) as usize]
+                .copy_from_slice(&img.px[src..src + (img.w * 4) as usize]);
+        }
+        let pick = &picks[i];
+        entries.push(SheetEntry {
+            uv: [
+                cx as f32 / atlas_w as f32,
+                cy as f32 / atlas_h as f32,
+                img.w as f32 / atlas_w as f32,
+                img.h as f32 / atlas_h as f32,
+            ],
+            w: img.w,
+            h: img.h,
+            at: match (pick.x, pick.y) {
+                (Some(x), Some(y)) => Some([x, y]),
+                _ => None,
+            },
+            width_frac: pick.width,
+            rotate: pick.rotate,
+            opacity: pick.opacity.unwrap_or(1.0).clamp(0.0, 1.0),
+        });
+    }
+    Ok(StickerSheet {
+        atlas_w,
+        atlas_h,
+        atlas_rgba,
+        entries,
+    })
+}
+
+/// The folder's PNGs by file name, sorted so a bare folder lays out the
+/// same on every run and every machine. Dot-files are skipped: macOS
+/// leaves AppleDouble `._*.png` companions that are not PNGs at all.
+fn scan_folder(dir: &Path) -> Result<Vec<String>, String> {
+    let listing = std::fs::read_dir(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
+    let mut names = Vec::new();
+    for entry in listing {
+        let entry = entry.map_err(|e| format!("{}: {e}", dir.display()))?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if name.starts_with('.') {
+            continue;
+        }
+        let is_png = Path::new(name)
+            .extension()
+            .is_some_and(|e| e.eq_ignore_ascii_case("png"));
+        if is_png && entry.path().is_file() {
+            names.push(name.to_string());
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+/// Decode one PNG to straight RGBA8. `EXPAND | STRIP_16` normalises
+/// palette, sub-byte greyscale and 16-bit sources, so anything a paint
+/// program saves is taken.
+fn decode_png(path: &Path) -> Result<Rgba, String> {
+    let file = std::fs::File::open(path).map_err(|e| format!("{}: {e}", path.display()))?;
+    let mut decoder = png::Decoder::new(std::io::BufReader::new(file));
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder
+        .read_info()
+        .map_err(|e| format!("{}: {e}", path.display()))?;
+    let mut buf = vec![0; reader.output_buffer_size()];
+    let info = reader
+        .next_frame(&mut buf)
+        .map_err(|e| format!("{}: {e}", path.display()))?;
+    buf.truncate(info.buffer_size());
+    let px = match info.color_type {
+        png::ColorType::Rgba => buf,
+        png::ColorType::Rgb => buf
+            .chunks_exact(3)
+            .flat_map(|c| [c[0], c[1], c[2], 255])
+            .collect(),
+        png::ColorType::Grayscale => buf.iter().flat_map(|&g| [g, g, g, 255]).collect(),
+        png::ColorType::GrayscaleAlpha => buf
+            .chunks_exact(2)
+            .flat_map(|c| [c[0], c[0], c[0], c[1]])
+            .collect(),
+        other => {
+            return Err(format!(
+                "{}: unsupported colour type {other:?}",
+                path.display()
+            ))
+        }
+    };
+    if info.width == 0 || info.height == 0 {
+        return Err(format!("{}: empty image", path.display()));
+    }
+    Ok(Rgba {
+        w: info.width,
+        h: info.height,
+        px,
+    })
+}
+
+/// Cap an image to [`MAX_DIM`] on its longest side, box-filtered so a
+/// large source arrives smooth rather than decimated.
+fn cap_size(img: Rgba) -> Rgba {
+    let longest = img.w.max(img.h);
+    if longest <= MAX_DIM {
+        return img;
+    }
+    let nw = (img.w * MAX_DIM / longest).max(1);
+    let nh = (img.h * MAX_DIM / longest).max(1);
+    let mut px = Vec::with_capacity((nw * nh * 4) as usize);
+    for y in 0..nh {
+        let y0 = y * img.h / nh;
+        let y1 = ((y + 1) * img.h).div_ceil(nh).clamp(y0 + 1, img.h);
+        for x in 0..nw {
+            let x0 = x * img.w / nw;
+            let x1 = ((x + 1) * img.w).div_ceil(nw).clamp(x0 + 1, img.w);
+            let mut sum = [0u32; 4];
+            for sy in y0..y1 {
+                for sx in x0..x1 {
+                    let off = ((sy * img.w + sx) * 4) as usize;
+                    for (acc, &c) in sum.iter_mut().zip(&img.px[off..off + 4]) {
+                        *acc += u32::from(c);
+                    }
+                }
+            }
+            let n = (y1 - y0) * (x1 - x0);
+            px.extend(sum.iter().map(|&s| (s / n) as u8));
+        }
+    }
+    Rgba { w: nw, h: nh, px }
+}
+
+/// Shelf-pack the images left to right, wrapping at [`ATLAS_MAX_W`], with
+/// [`PAD`] clear texels around every cell. Returns the atlas size and each
+/// image's top-left cell.
+fn pack(images: &[Rgba]) -> (u32, u32, Vec<(u32, u32)>) {
+    let mut cells = Vec::with_capacity(images.len());
+    let (mut x, mut y, mut shelf, mut atlas_w) = (PAD, PAD, 0, 1);
+    for img in images {
+        if x + img.w + PAD > ATLAS_MAX_W && x > PAD {
+            x = PAD;
+            y += shelf + PAD;
+            shelf = 0;
+        }
+        cells.push((x, y));
+        x += img.w + PAD;
+        shelf = shelf.max(img.h);
+        atlas_w = atlas_w.max(x);
+    }
+    (atlas_w, y + shelf + PAD, cells)
+}
+
+/// One sticker resolved against a concrete viewport, in physical pixels
+/// relative to the viewport's origin: what the uniform array carries.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct Instance {
+    pub(super) centre: [f32; 2],
+    pub(super) half: [f32; 2],
+    /// cos/sin of the clockwise tilt.
+    pub(super) rot: [f32; 2],
+    pub(super) opacity: f32,
+    pub(super) uv: [f32; 4],
+}
+
+/// Resolve a sheet's placements against one frame's monitor front:
+/// `(vw, vh)` is the bezel viewport in physical pixels and `band_bottom`
+/// the top of the picture opening within it, which bounds the cabinet's
+/// top band. Explicit placements are fraction-of-front; auto slots line
+/// up along the top band in order, tilted by the [`AUTO_TILT`] cycle,
+/// and any that would run past the band's end are left off rather than
+/// drawn over the corner. Pure arithmetic, unit testable on its own.
+pub(super) fn instances(sheet: &StickerSheet, vw: f32, vh: f32, band_bottom: f32) -> Vec<Instance> {
+    let mut out = Vec::new();
+    let band = band_bottom.max(0.0);
+    let auto_h = (band * 0.52).max(8.0);
+    let margin = vw * 0.055;
+    let gap = auto_h * 0.45;
+    let mut cursor = margin;
+    let mut tilt = 0usize;
+    for e in sheet.entries.iter().take(MAX_STICKERS) {
+        let aspect = e.h as f32 / e.w.max(1) as f32;
+        let (centre, w_px, rotate) = match e.at {
+            Some([x, y]) => {
+                let w_px = e.width_frac.unwrap_or(DEFAULT_WIDTH_FRAC) * vw;
+                ([x * vw, y * vh], w_px, e.rotate.unwrap_or(0.0))
+            }
+            None => {
+                let w_px = e
+                    .width_frac
+                    .map(|f| f * vw)
+                    .unwrap_or_else(|| auto_h / aspect.max(1e-3));
+                let rotate = e.rotate.unwrap_or(AUTO_TILT[tilt % AUTO_TILT.len()]);
+                tilt += 1;
+                if cursor + w_px > vw - margin {
+                    break;
+                }
+                let centre = [cursor + w_px * 0.5, band * 0.5];
+                cursor += w_px + gap;
+                (centre, w_px, rotate)
+            }
+        };
+        if w_px < 1.0 {
+            continue;
+        }
+        let rad = rotate.to_radians();
+        out.push(Instance {
+            centre,
+            half: [w_px * 0.5, w_px * aspect * 0.5],
+            rot: [rad.cos(), rad.sin()],
+            opacity: e.opacity,
+            uv: e.uv,
+        });
+    }
+    out
+}
+
+const STICKER_WGSL: &str = include_str!("shaders/bezel_stickers.wgsl");
+
+/// The uniform array's element: mirrors the WGSL `Sticker` struct.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, IntoBytes, Immutable)]
+struct GpuSticker {
+    /// xy: centre in viewport px. zw: half-size in px.
+    geo: [f32; 4],
+    /// xy: cos/sin of the tilt. z: opacity. w: unused.
+    rot: [f32; 4],
+    /// Atlas sub-rect in UV space: xy origin, zw size.
+    uv: [f32; 4],
+}
+
+const ZERO_STICKER: GpuSticker = GpuSticker {
+    geo: [0.0; 4],
+    rot: [0.0; 4],
+    uv: [0.0; 4],
+};
+
+/// The uniform block `shaders/bezel_stickers.wgsl` sees. Mirrors the WGSL
+/// struct exactly; `#[repr(C)]` with 16-byte-aligned members only.
+#[repr(C)]
+#[derive(IntoBytes, Immutable)]
+struct GpuUniforms {
+    /// xy: viewport size in px. z: shadow offset in px. w: unused.
+    info: [f32; 4],
+    st: [GpuSticker; MAX_STICKERS],
+}
+
+const UNIFORM_BYTES: u64 = std::mem::size_of::<GpuUniforms>() as u64;
+
+/// The decal pass: the loaded sheet and the GPU objects that draw it.
+/// Follows [`super::bezel::BezelShader`]'s shape, but with its own bind
+/// group layout: the shared one pins a 64-byte uniform block and has no
+/// vertex-stage binding, and this pass needs both.
+pub(super) struct StickerPass {
+    bind_group_layout: wgpu::BindGroupLayout,
+    sampler: wgpu::Sampler,
+    uniforms: wgpu::Buffer,
+    target_format: wgpu::TextureFormat,
+    pipeline: Option<wgpu::RenderPipeline>,
+    sheet: Option<StickerSheet>,
+    /// The sheet's atlas, uploaded on the first draw after [`Self::set_sheet`]
+    /// (with the bind group viewing it); dropped with the sheet.
+    atlas: Option<wgpu::Texture>,
+    bind_group: Option<wgpu::BindGroup>,
+}
+
+impl StickerPass {
+    pub(super) fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("bezel_stickers_bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(UNIFORM_BYTES),
+                    },
+                    count: None,
+                },
+            ],
+        });
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("bezel_stickers_sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            ..Default::default()
+        });
+        let uniforms = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("bezel_stickers_uniforms"),
+            size: UNIFORM_BYTES,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        Self {
+            bind_group_layout,
+            sampler,
+            uniforms,
+            target_format,
+            pipeline: None,
+            sheet: None,
+            atlas: None,
+            bind_group: None,
+        }
+    }
+
+    /// Install a loaded sheet (or none). The atlas and bind group are
+    /// rebuilt lazily on the next draw, when the device is in hand.
+    pub(super) fn set_sheet(&mut self, sheet: Option<StickerSheet>) {
+        self.sheet = sheet;
+        self.atlas = None;
+        self.bind_group = None;
+    }
+
+    fn pipeline(&mut self, device: &wgpu::Device) -> &wgpu::RenderPipeline {
+        if self.pipeline.is_none() {
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("bezel_stickers"),
+                source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(STICKER_WGSL)),
+            });
+            let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("bezel_stickers_pl"),
+                bind_group_layouts: &[Some(&self.bind_group_layout)],
+                immediate_size: 0,
+            });
+            self.pipeline = Some(
+                device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                    label: Some("bezel_stickers"),
+                    layout: Some(&layout),
+                    vertex: wgpu::VertexState {
+                        module: &shader,
+                        entry_point: Some("vs_main"),
+                        buffers: &[],
+                        compilation_options: wgpu::PipelineCompilationOptions::default(),
+                    },
+                    primitive: wgpu::PrimitiveState {
+                        topology: wgpu::PrimitiveTopology::TriangleList,
+                        ..Default::default()
+                    },
+                    depth_stencil: None,
+                    multisample: wgpu::MultisampleState::default(),
+                    fragment: Some(wgpu::FragmentState {
+                        module: &shader,
+                        entry_point: Some("fs_main"),
+                        targets: &[Some(wgpu::ColorTargetState {
+                            format: self.target_format,
+                            // The shader hands over premultiplied colour:
+                            // the decal and its shadow are composed in one
+                            // fragment, which straight alpha cannot carry.
+                            blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                            write_mask: wgpu::ColorWrites::ALL,
+                        })],
+                        compilation_options: wgpu::PipelineCompilationOptions::default(),
+                    }),
+                    multiview_mask: None,
+                    cache: None,
+                }),
+            );
+        }
+        self.pipeline.as_ref().expect("just built")
+    }
+
+    /// Draw the sheet over the `(x, y, w, h)` viewport rect of `target`
+    /// (physical surface pixels), the same rect the bezel pass just drew,
+    /// with `opening` bounding the picture so the auto row knows the top
+    /// band. A pass with no sheet draws nothing.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn render(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+        viewport: (f32, f32, f32, f32),
+        opening: (f32, f32, f32, f32),
+    ) {
+        let (x, y, w, h) = viewport;
+        if w < 1.0 || h < 1.0 || self.sheet.is_none() {
+            return;
+        }
+        // Resolve the pipeline first: it borrows self mutably, which the
+        // sheet borrow below does not allow.
+        let _ = self.pipeline(device);
+        let Some(sheet) = &self.sheet else { return };
+        let resolved = instances(sheet, w, h, opening.1 - y);
+        if resolved.is_empty() {
+            return;
+        }
+        if self.atlas.is_none() {
+            // sRGB, like the surface: the PNG's bytes are sRGB and the
+            // shader tones them in linear light.
+            let atlas = device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("bezel_stickers_atlas"),
+                size: wgpu::Extent3d {
+                    width: sheet.atlas_w,
+                    height: sheet.atlas_h,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            });
+            queue.write_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &atlas,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                &sheet.atlas_rgba,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(sheet.atlas_w * 4),
+                    rows_per_image: Some(sheet.atlas_h),
+                },
+                wgpu::Extent3d {
+                    width: sheet.atlas_w,
+                    height: sheet.atlas_h,
+                    depth_or_array_layers: 1,
+                },
+            );
+            let view = atlas.create_view(&wgpu::TextureViewDescriptor::default());
+            self.bind_group = Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("bezel_stickers_bg"),
+                layout: &self.bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&self.sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: self.uniforms.as_entire_binding(),
+                    },
+                ],
+            }));
+            self.atlas = Some(atlas);
+        }
+        let (Some(bind_group), Some(pipeline)) = (&self.bind_group, &self.pipeline) else {
+            return;
+        };
+        let mut st = [ZERO_STICKER; MAX_STICKERS];
+        for (slot, inst) in st.iter_mut().zip(&resolved) {
+            *slot = GpuSticker {
+                geo: [inst.centre[0], inst.centre[1], inst.half[0], inst.half[1]],
+                rot: [inst.rot[0], inst.rot[1], inst.opacity, 0.0],
+                uv: inst.uv,
+            };
+        }
+        let uniforms = GpuUniforms {
+            info: [w, h, (h * 0.004).clamp(1.0, 6.0), 0.0],
+            st,
+        };
+        queue.write_buffer(&self.uniforms, 0, uniforms.as_bytes());
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("bezel_stickers_pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, bind_group, &[]);
+        pass.set_viewport(x, y, w, h, 0.0, 1.0);
+        pass.draw(0..6, 0..resolved.len() as u32);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::super::crt_shader;
+    use super::*;
+
+    /// A fresh directory under the target-local tmp dir, unique per test
+    /// so parallel tests never collide on a path.
+    fn scratch_dir(tag: &str) -> PathBuf {
+        static SEQ: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let n = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "copperline-stickers-{tag}-{}-{n}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        dir
+    }
+
+    /// Write a `w x h` RGBA PNG of one solid colour.
+    fn write_png(path: &Path, w: u32, h: u32, colour: [u8; 4]) {
+        let file = std::fs::File::create(path).expect("create png");
+        let mut enc = png::Encoder::new(std::io::BufWriter::new(file), w, h);
+        enc.set_color(png::ColorType::Rgba);
+        enc.set_depth(png::BitDepth::Eight);
+        let mut writer = enc.write_header().expect("png header");
+        let px: Vec<u8> = std::iter::repeat_n(colour, (w * h) as usize)
+            .flatten()
+            .collect();
+        writer.write_image_data(&px).expect("png data");
+    }
+
+    #[test]
+    fn the_sticker_shader_validates() {
+        crt_shader::validate_wgsl_source(STICKER_WGSL).expect("bezel_stickers.wgsl validates");
+    }
+
+    #[test]
+    fn the_uniform_block_matches_the_shader() {
+        // 16-byte info header plus the vec4x3 array the WGSL declares.
+        assert_eq!(UNIFORM_BYTES, 16 + (MAX_STICKERS as u64) * 48);
+    }
+
+    #[test]
+    fn a_bare_folder_loads_every_png_in_name_order() {
+        let dir = scratch_dir("bare");
+        write_png(&dir.join("b.png"), 8, 4, [0, 255, 0, 255]);
+        write_png(&dir.join("a.PNG"), 4, 4, [255, 0, 0, 255]);
+        std::fs::write(dir.join("notes.txt"), "not a sticker").unwrap();
+        std::fs::write(dir.join(".hidden.png"), "apple double junk").unwrap();
+        let sheet = load_sheet(&dir).expect("load");
+        assert_eq!(sheet.entries.len(), 2);
+        // Name order: a.PNG first, then b.png; both auto slots.
+        assert_eq!((sheet.entries[0].w, sheet.entries[0].h), (4, 4));
+        assert_eq!((sheet.entries[1].w, sheet.entries[1].h), (8, 4));
+        assert!(sheet.entries.iter().all(|e| e.at.is_none()));
+        // The atlas holds the first image's colour at its cell.
+        let (cx, cy) = (
+            (sheet.entries[0].uv[0] * sheet.atlas_w as f32) as u32,
+            (sheet.entries[0].uv[1] * sheet.atlas_h as f32) as u32,
+        );
+        let off = ((cy * sheet.atlas_w + cx) * 4) as usize;
+        assert_eq!(&sheet.atlas_rgba[off..off + 4], &[255, 0, 0, 255]);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_manifest_places_names_and_orders_the_sheet() {
+        let dir = scratch_dir("manifest");
+        write_png(&dir.join("logo.png"), 8, 8, [1, 2, 3, 255]);
+        write_png(&dir.join("badge.png"), 8, 2, [4, 5, 6, 255]);
+        std::fs::write(
+            dir.join("stickers.toml"),
+            r#"
+[[sticker]]
+image = "badge.png"
+x = 0.5
+y = 0.93
+width = 0.1
+rotate = -4.0
+opacity = 0.8
+
+[[sticker]]
+image = "logo.png"
+"#,
+        )
+        .unwrap();
+        let sheet = load_sheet(&dir).expect("load");
+        assert_eq!(sheet.entries.len(), 2);
+        let placed = &sheet.entries[0];
+        assert_eq!(placed.at, Some([0.5, 0.93]));
+        assert_eq!(placed.width_frac, Some(0.1));
+        assert_eq!(placed.rotate, Some(-4.0));
+        assert_eq!(placed.opacity, 0.8);
+        assert!(sheet.entries[1].at.is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_manifest_problem_fails_the_whole_load() {
+        let dir = scratch_dir("bad");
+        write_png(&dir.join("logo.png"), 4, 4, [0, 0, 0, 255]);
+        // Half a position.
+        std::fs::write(
+            dir.join("stickers.toml"),
+            "[[sticker]]\nimage = \"logo.png\"\nx = 0.5\n",
+        )
+        .unwrap();
+        assert!(load_sheet(&dir).unwrap_err().contains("x and y"));
+        // A missing image.
+        std::fs::write(
+            dir.join("stickers.toml"),
+            "[[sticker]]\nimage = \"gone.png\"\n",
+        )
+        .unwrap();
+        assert!(load_sheet(&dir).unwrap_err().contains("gone.png"));
+        // An unknown key, so a typo places nothing silently.
+        std::fs::write(
+            dir.join("stickers.toml"),
+            "[[sticker]]\nimage = \"logo.png\"\nrotat = 4.0\n",
+        )
+        .unwrap();
+        assert!(load_sheet(&dir).is_err());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn an_empty_or_overfull_folder_is_refused() {
+        let dir = scratch_dir("empty");
+        assert!(load_sheet(&dir).unwrap_err().contains("no PNG"));
+        for i in 0..=MAX_STICKERS {
+            write_png(&dir.join(format!("s{i:02}.png")), 2, 2, [0, 0, 0, 255]);
+        }
+        assert!(load_sheet(&dir)
+            .unwrap_err()
+            .contains(&format!("at most {MAX_STICKERS}")));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn an_oversized_source_is_capped_smooth() {
+        let dir = scratch_dir("large");
+        write_png(&dir.join("big.png"), 1200, 300, [10, 20, 30, 255]);
+        let sheet = load_sheet(&dir).expect("load");
+        assert_eq!((sheet.entries[0].w, sheet.entries[0].h), (MAX_DIM, 128));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn the_packer_pads_and_never_overlaps() {
+        let images: Vec<Rgba> = [(500, 40), (500, 60), (500, 30), (500, 500), (2, 2)]
+            .iter()
+            .map(|&(w, h)| Rgba {
+                w,
+                h,
+                px: vec![0; (w * h * 4) as usize],
+            })
+            .collect();
+        let (aw, ah, cells) = pack(&images);
+        assert!(aw <= ATLAS_MAX_W);
+        let rects: Vec<(u32, u32, u32, u32)> = cells
+            .iter()
+            .zip(&images)
+            .map(|(&(x, y), img)| (x, y, img.w, img.h))
+            .collect();
+        for (i, a) in rects.iter().enumerate() {
+            assert!(a.0 + a.2 + PAD <= aw && a.1 + a.3 + PAD <= ah, "inside");
+            for b in &rects[i + 1..] {
+                let clear_x = a.0 + a.2 + PAD <= b.0 || b.0 + b.2 + PAD <= a.0;
+                let clear_y = a.1 + a.3 + PAD <= b.1 || b.1 + b.3 + PAD <= a.1;
+                assert!(clear_x || clear_y, "cells {a:?} and {b:?} touch");
+            }
+        }
+    }
+
+    /// A synthetic sheet with `n` entries of one aspect, no manifest.
+    fn auto_sheet(n: usize, w: u32, h: u32) -> StickerSheet {
+        StickerSheet {
+            atlas_w: 1,
+            atlas_h: 1,
+            atlas_rgba: vec![0; 4],
+            entries: (0..n)
+                .map(|_| SheetEntry {
+                    uv: [0.0, 0.0, 1.0, 1.0],
+                    w,
+                    h,
+                    at: None,
+                    width_frac: None,
+                    rotate: None,
+                    opacity: 1.0,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn auto_slots_row_the_top_band_and_stop_at_its_end() {
+        let (vw, vh, band) = (1400.0, 1050.0, 106.0);
+        let sheet = auto_sheet(12, 100, 50);
+        let placed = instances(&sheet, vw, vh, band);
+        // Every slot sits centred in the band, marching right in order.
+        for inst in &placed {
+            assert_eq!(inst.centre[1], band * 0.5);
+            assert_eq!(inst.half[1], inst.half[0] * 0.5);
+        }
+        for pair in placed.windows(2) {
+            assert!(pair[0].centre[0] < pair[1].centre[0]);
+        }
+        // The row ran out before the far corner, and nothing crossed it.
+        assert!(placed.len() < 12);
+        let last = placed.last().expect("some fit");
+        assert!(last.centre[0] + last.half[0] <= vw - vw * 0.055 + 0.5);
+        // The tilt alternates: no two neighbours lean the same way.
+        for pair in placed.windows(2) {
+            assert!(pair[0].rot[1].signum() != pair[1].rot[1].signum());
+        }
+    }
+
+    #[test]
+    fn explicit_placement_maps_fractions_to_the_viewport() {
+        let mut sheet = auto_sheet(1, 200, 100);
+        sheet.entries[0].at = Some([0.25, 0.9]);
+        sheet.entries[0].width_frac = Some(0.1);
+        sheet.entries[0].rotate = Some(90.0);
+        sheet.entries[0].opacity = 0.5;
+        let placed = instances(&sheet, 1000.0, 800.0, 100.0);
+        assert_eq!(placed.len(), 1);
+        let inst = &placed[0];
+        assert_eq!(inst.centre, [250.0, 720.0]);
+        assert_eq!(inst.half, [50.0, 25.0]);
+        assert!((inst.rot[0]).abs() < 1e-6 && (inst.rot[1] - 1.0).abs() < 1e-6);
+        assert_eq!(inst.opacity, 0.5);
+    }
+}

--- a/src/video/window/stickers.rs
+++ b/src/video/window/stickers.rs
@@ -341,9 +341,11 @@ pub(super) struct Instance {
 /// `(vw, vh)` is the bezel viewport in physical pixels and `band_bottom`
 /// the top of the picture opening within it, which bounds the cabinet's
 /// top band. Explicit placements are fraction-of-front; auto slots line
-/// up along the top band in order, tilted by the [`AUTO_TILT`] cycle,
-/// and any that would run past the band's end are left off rather than
-/// drawn over the corner. Pure arithmetic, unit testable on its own.
+/// up along the top band in order, tilted by the [`AUTO_TILT`] cycle.
+/// An auto slot that would run past the band's end is left off rather
+/// than drawn over the corner -- only that one: a narrower slot after it
+/// may still fit, and explicit placements never depend on the row. Pure
+/// arithmetic, unit testable on its own.
 pub(super) fn instances(sheet: &StickerSheet, vw: f32, vh: f32, band_bottom: f32) -> Vec<Instance> {
     let mut out = Vec::new();
     let band = band_bottom.max(0.0);
@@ -367,7 +369,7 @@ pub(super) fn instances(sheet: &StickerSheet, vw: f32, vh: f32, band_bottom: f32
                 let rotate = e.rotate.unwrap_or(AUTO_TILT[tilt % AUTO_TILT.len()]);
                 tilt += 1;
                 if cursor + w_px > vw - margin {
-                    break;
+                    continue;
                 }
                 let centre = [cursor + w_px * 0.5, band * 0.5];
                 cursor += w_px + gap;
@@ -894,6 +896,41 @@ image = "logo.png"
         for pair in placed.windows(2) {
             assert!(pair[0].rot[1].signum() != pair[1].rot[1].signum());
         }
+    }
+
+    #[test]
+    fn a_full_row_drops_only_the_slots_that_do_not_fit() {
+        let (vw, vh, band) = (1400.0, 1050.0, 106.0);
+        let mut sheet = auto_sheet(12, 100, 50);
+        // After the wide slots fill the row: an explicit placement, and a
+        // much narrower auto slot.
+        sheet.entries[10].at = Some([0.5, 0.9]);
+        sheet.entries[10].width_frac = Some(0.1);
+        sheet.entries[11].w = 10;
+        sheet.entries[11].h = 50;
+        let placed = instances(&sheet, vw, vh, band);
+        // The row filled before the wide slots ran out...
+        let on_row = |i: &&Instance| i.centre[1] == band * 0.5;
+        assert!(
+            placed
+                .iter()
+                .filter(on_row)
+                .filter(|i| i.half[0] > 30.0)
+                .count()
+                < 10
+        );
+        // ...but the explicit placement never used the row...
+        assert!(
+            placed.iter().any(|i| i.centre == [0.5 * vw, 0.9 * vh]),
+            "explicit placement dropped with the full row"
+        );
+        // ...and the narrow slot after the oversize ones still fits.
+        assert!(
+            placed
+                .iter()
+                .any(|i| i.half[0] < 30.0 && i.centre[1] == band * 0.5),
+            "a narrow auto slot was dropped with the full row"
+        );
     }
 
     #[test]

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -3584,6 +3584,7 @@ fn test_app_with_audio_cpu_and_program(
         crate::config::ShaderMode::None,
         1.0,
         crate::config::BezelStyle::None,
+        None,
         false,
         crate::config::Tint::None,
         false,


### PR DESCRIPTION
Retro32 asked for community logos as fake stickers on the drawn monitor bezel, customisable from a local folder, on both the app and the hosted page (the `bezel_decals` hook idea). This adds exactly that, drawn by the emulator's own bezel pipeline on both sides.

## Desktop

`[display] bezel_stickers = "/path/to/folder"` names a folder of PNGs. Every image becomes a die-cut decal on the drawn front:

- A bare folder rows its images along the cabinet's top band in file-name order, each with a small alternating tilt, the way a hand sticks them on.
- An optional `stickers.toml` in the folder chooses and places each image instead: centre (`x`/`y`) and `width` as fractions of the front, `rotate` in degrees, `opacity`. Tables without `x`/`y` still take auto slots, so the two styles mix.
- The pass (`src/video/window/stickers.rs` + `shaders/bezel_stickers.wgsl`) runs after the bezel's over the same viewport: one atlas upload, rotated instanced quads in premultiplied alpha, a soft drop shadow off each sticker's alpha silhouette and a slight vertical tone so decals read as stuck to lit plastic.
- Stickers ride the bezel: they follow Cmd/Alt+M, are suspended with the pass for overlays and RTG scanout, and never appear in screenshots, dumps or recordings. `COPPERLINE_BEZEL_STICKERS` overrides for a run; a folder that fails to load reports on the OSD and falls back to bare plastic, never a stale or partial sheet.
- Limits: 16 stickers, oversized sources box-filtered to 512 px, PNG only (palette/greyscale/16-bit all normalised).

## Web

The same sheet drives the hosted page through a new `#bezel-stickers` shell hook: a `<script type="application/json">` element listing `{image, x, y, width, rotate, opacity}` entries, the manifest's keys with `image` a URL resolved against the page. try.js carries a GLSL port of the WGSL (kept in step like the other monitor shaders) and draws each sticker over its rotated quad's bounding viewport in `monitorDraw`'s bezel branch, with per-sticker textures re-uploaded after a context restore. Decals live on the canvas, so they track the plastic through resizes and fullscreen, and screenshots stay clean; this supersedes the page-side CSS overlay hack the early Retro32 pages carried, along with its gating script and fullscreen-hide CSS.

## Preview

The new `COPPERLINE_BEZEL_PREVIEW_STICKERS` knob on the bezel preview dump renders a sheet over the drawn front for look-tuning without a build; a demo sheet (auto-rowed badges on the top band, one manifest-placed label on the chin) was verified there and on the /try page staged against the live site shell.

## Tests

- Loader/manifest unit tests: bare-folder order, manifest placement, every refusal path (half a position, missing image, unknown key, empty and overfull folders), oversize capping, atlas packing overlap-freedom, auto-row walk and explicit placement arithmetic, WGSL validation, uniform-block size.
- GPU regression: a placed decal prints where asked and every probe away from it is byte-identical to the sticker-less front.
- `cargo test` (2509 passed), `cargo clippy`, `cargo fmt --check`, and the wasm32 web-crate check are clean; `node --check` and the www node tests pass.

Docs: `docs/guide/configuration.md` (key + `stickers.toml` format), `docs/guide/browser.md` (page hook contract), `docs/guide/ui.md`, `copperline.example.toml`.