### PR TITLE
web: untangle Esc from fullscreen with the Keyboard Lock API

### DIFF
--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1677,6 +1677,19 @@ window.addEventListener('keydown', (e) => {
     if (consumedKeys.has(e.code)) e.preventDefault();
     return;
   }
+  // Esc with the mouse captured releases it and goes no further. In the
+  // page the browser enforces that gesture itself (this branch never
+  // sees the key); in fullscreen, keyboard lock hands Escape to the page
+  // instead (see the fullscreen section), so the branch recreates it -
+  // one meaning for Esc everywhere, and releasing the mouse no longer
+  // costs the session its fullscreen. The guest only sees Esc while the
+  // pointer is free.
+  if (e.code === 'Escape' && document.pointerLockElement) {
+    document.exitPointerLock?.();
+    consumedKeys.add(e.code);
+    e.preventDefault();
+    return;
+  }
   if (joystickKey(e.code, true) || emu.key_event(e.code, true)) {
     consumedKeys.add(e.code);
     e.preventDefault();
@@ -1697,7 +1710,9 @@ window.addEventListener('keyup', (e) => {
 // --- mouse ---------------------------------------------------------------
 // Unlocked: the cursor drives the Amiga pointer through position deltas
 // (Workbench-friendly). Click to pointer-lock for relative motion (games);
-// Esc releases the lock, as the browser enforces.
+// Esc releases the lock - enforced by the browser in the page, recreated
+// by the keydown handler in fullscreen, where keyboard lock delivers
+// Escape to the page instead (see the fullscreen section).
 
 let lastPos = null;
 // Emulator pixels per CSS pixel, one scale per axis. The picture fills the
@@ -2201,13 +2216,33 @@ $('fullscreen').addEventListener('click', () => {
   }
 });
 
+// Esc is spoken for twice over by browser defaults - it exits fullscreen
+// and it releases pointer lock - and the guest wants it as the Amiga Esc
+// key besides. Fullscreen is where they collide: Esc pressed to put the
+// mouse away also throws the session out of fullscreen. Where the
+// Keyboard Lock API exists (Chromium), lock Escape while really
+// fullscreen: a single press then arrives as an ordinary keydown -
+// releasing the mouse when it is captured (the keydown handler), typing
+// into the guest when it is free - and the browser moves leaving
+// fullscreen to press-and-hold Esc, announcing that itself on entry,
+// alongside the Exit button. Browsers without the API keep the old
+// defaults, and the CSS fallback needs none of this - no browser
+// default is in play there, so Esc already reaches the guest.
+function syncEscapeLock() {
+  const kb = navigator.keyboard;
+  if (!kb?.lock) return;
+  if (document.fullscreenElement !== null) kb.lock(['Escape']).catch(() => {});
+  else kb.unlock();
+}
+
 // Real fullscreen carries the same canvas letterbox as the CSS fallback,
-// applied on the state change so it also covers Esc and any other
+// applied on the state change so it also covers hold-Esc and any other
 // browser-initiated exit. Leaving fullscreen re-syncs the windowed shell
 // chrome (the monitor path's border hiding); entering it is a no-op
 // there, since fullscreen owns the shell's styles.
 document.addEventListener('fullscreenchange', () => {
   setStyles(canvas, CSS_FS_CANVAS, document.fullscreenElement !== null);
+  syncEscapeLock();
   updateFsUi();
   syncShellChrome();
 });

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1671,12 +1671,18 @@ function updatePadStatus(releasedPort1) {
 // default still has to be suppressed on every repeat or holding a cursor
 // key scrolls the page. Track which codes the first keydown consumed.
 const consumedKeys = new Set();
+// Codes whose keydown the page itself spent (Esc releasing the mouse):
+// the guest never saw the down, so the keyup must not reach it either.
+const pageSpentKeys = new Set();
 window.addEventListener('keydown', (e) => {
   if (!emu || !running) return;
   if (e.repeat) {
     if (consumedKeys.has(e.code)) e.preventDefault();
     return;
   }
+  // A fresh keydown supersedes any page-spent claim on the code: if this
+  // press reaches the guest, its release must too.
+  pageSpentKeys.delete(e.code);
   // Esc with the mouse captured releases it and goes no further. In the
   // page the browser enforces that gesture itself (this branch never
   // sees the key); in fullscreen, keyboard lock hands Escape to the page
@@ -1686,6 +1692,7 @@ window.addEventListener('keydown', (e) => {
   // pointer is free.
   if (e.code === 'Escape' && document.pointerLockElement) {
     document.exitPointerLock?.();
+    pageSpentKeys.add(e.code);
     consumedKeys.add(e.code);
     e.preventDefault();
     return;
@@ -1701,7 +1708,14 @@ window.addEventListener('keyup', (e) => {
   // Delete before the running check: a hold that spans an emulator stop
   // or a focus loss must not leave a stale entry behind.
   const consumed = consumedKeys.delete(e.code);
+  const pageSpent = pageSpentKeys.delete(e.code);
   if (!emu || !running) return;
+  // The page spent the down, so the guest never saw it; forwarding the
+  // up would land an unmatched release code.
+  if (pageSpent) {
+    e.preventDefault();
+    return;
+  }
   if (joystickKey(e.code, false) || emu.key_event(e.code, false) || consumed) {
     e.preventDefault();
   }

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -141,7 +141,9 @@ Controls:
 
 - **Mouse**: with the pointer unlocked, the cursor drives the Amiga pointer
   through position deltas (Workbench-friendly); clicking the canvas
-  requests pointer lock for relative motion (games), and Esc releases it.
+  requests pointer lock for relative motion (games), and Esc releases it --
+  also in fullscreen, which releasing the mouse no longer abandons (see
+  the fullscreen section below).
 - **Keyboard**: physical keys map to Amiga raw keycodes with the same table
   as the desktop frontend. The mapping is positional, and the browser does
   not report the host's layout, so the one Amiga key it cannot reach is
@@ -235,6 +237,15 @@ device keyboard is measured from how much of the viewport it covers, which
 is what a browser offers instead of leaving room. On iPhones, where Safari has no element
 fullscreen, the button pins the shell over the page instead -- Safari's
 chrome stays, the page furniture goes, and the same letterbox applies.
+
+Esc carries two browser defaults -- leaving fullscreen and releasing the
+captured mouse -- and the guest wants it as the Amiga Esc key besides. In
+browsers with the Keyboard Lock API (Chromium), the page locks Escape
+while fullscreen, so a press releases the captured mouse without ending
+fullscreen, or types Esc into the guest when the pointer is free; leaving
+fullscreen moves to press-and-hold Esc (the browser announces this on
+entry) or the Exit button. Browsers without the API keep the default,
+where a single Esc leaves fullscreen.
 
 Once a machine boots, a status strip appears below the screen with the
 same front-panel readouts as the desktop [status bar](ui.md): the PWR and


### PR DESCRIPTION
## Problem

On the try page, Esc was spoken for twice over by browser defaults: it releases pointer lock and it exits fullscreen. In a fullscreen game with the mouse captured, one Esc press fired both at once - putting the mouse away also threw the session out of fullscreen - and the guest could never receive its own Esc key while either was active.

Neither default can be rebound directly; the one lever browsers provide is the Keyboard Lock API.

## Change

- On entering real fullscreen (Chromium), the page calls `navigator.keyboard.lock(['Escape'])`, released again on exit. Escape then arrives as an ordinary keydown, and the browser moves leaving fullscreen to press-and-hold Esc, announcing that itself with its own toast on entry. The overlay's Exit button still works.
- The keydown handler gained one branch: Esc while pointer-locked calls `exitPointerLock()` and stops there. Esc keeps its one advertised meaning - release the mouse - and no longer costs the session its fullscreen.
- When the pointer is free, Esc in fullscreen now reaches the guest as the Amiga Esc key (rawkey $45), matching the desktop frontend, where Esc always goes to the guest and the mouse is released with a separate shortcut.
- Firefox and Safari have no Keyboard Lock API and keep the old defaults; the iPhone CSS-pinned fallback never had a browser Esc default in play, so it is unchanged.

docs/guide/browser.md gains a paragraph on the fullscreen Esc behaviour and a note on the mouse bullet.

## Testing

`node --check` passes on try.js. The gesture flow needs trusted user gestures (fullscreen + pointer lock + keyboard lock), so it wants a manual pass in Chrome before merge: fullscreen, click to capture, tap Esc (mouse frees, fullscreen stays), tap Esc again (guest sees Esc), hold Esc (fullscreen exits). Firefox/Safari should behave exactly as before.