### PR TITLE
Feature/configurable paths and a default config 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,14 @@ images go in via `[floppy.df0] path` in the config or `--insert-disk-after`:
 ```
 
 Running with no arguments at all opens an interactive launcher window; any
-flag suppresses it, so headless invocations never block on it.
+flag suppresses it, so headless invocations never block on it. A
+configuration saved with the launcher's Save default button auto-loads into
+any run that names no `--config` and finds no `./copperline.toml` -- so for
+reproducible results on a machine you do not control, pass `--factory` (or
+an explicit `--config`) to pin the machine to a known configuration. A
+config's optional `[paths]` section moves where unspecified outputs land;
+explicit flag paths (`--screenshot-after SECS PATH` and friends) are always
+used exactly as written.
 
 WHDLoad game packages boot directly -- `--whdload game.lha` (or a directory
 holding a `.slave`) stages a boot volume around the real WHDLoad program,

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -13,6 +13,27 @@ rom = "kickstart.rom"
 # identify = false           # drop it from the Zorro chain (default: present)
 
 
+# [paths] -- where Copperline writes what it produces, and where its file
+# dialogs open when the field they were launched from is empty. Every key is
+# optional; the defaults are folders of these names under the host-data
+# directory (~/.config/copperline, %APPDATA%\copperline, or the executable's
+# folder in a portable install). Relative paths hang off `base`, absolute
+# paths are used as given. Entries naming folders this machine cannot reach
+# are ignored with a log warning and the default is used instead.
+# [paths]
+# base = "/somewhere/else"    # move the whole tree in one line
+# states = "states"           # save states, incl. the quick-save slots
+# screenshots = "screenshots"
+# recordings = "recordings"   # video captures and recorded input scripts
+# nvram = "nvram"             # battery-backed RAMs, incl. CD32 game saves
+# traces = "traces"           # debugger traces and waveform captures
+# configs = "configs"         # configurations saved from the launcher
+# roms = "roms"               # dialog folders: only used if the folder exists
+# mt32_roms = "roms/mt32"
+# floppies = "floppies"
+# harddrives = "harddrives"
+# cds = "cds"
+
 [emulation]
 
 # The CPU, chipset, CIA, audio, floppy, and chip-bus timing all advance on

--- a/docs/debugger/waveform.md
+++ b/docs/debugger/waveform.md
@@ -51,7 +51,8 @@ defaults) and click Arm.
 
 Everything is optional: the default trigger is `now`, the default duration
 one video frame, the default signal set `all`, and an omitted path becomes
-`copperline-wave-<timestamp>.vcd` in the working directory.
+`copperline-wave-<timestamp>.vcd` in the traces folder (see the guide's
+[Where files go](../guide/ui.md#where-files-go)).
 
 ## Triggers
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,9 +1,15 @@
 # Configuration reference
 
-Copperline is configured by a TOML file: `./copperline.toml` by default, or
-any file passed with `--config`. Every field is optional; missing fields use
-the defaults documented here. `copperline.example.toml` in the repository
-root is a commented companion to this reference.
+Copperline is configured by a TOML file: the file passed with `--config`,
+else `./copperline.toml` if present, else the configuration saved with the
+configuration screen's **Save default** button (see [](ui.md)). Every field
+is optional; missing fields use the defaults documented here.
+`copperline.example.toml` in the repository root is a commented companion to
+this reference.
+
+`--factory` ignores the saved default and starts from Copperline's own
+settings; `--config` and `./copperline.toml` always win over it anyway. With
+no default saved, the flag changes nothing.
 
 The configuration is validated up front and the emulator refuses to start
 with a clear error message rather than guessing (unknown CPU or chipset
@@ -138,6 +144,48 @@ is fitted from the menu, and under each path row of the machine-configuration
 screen's ROM tab. The bundled AROS ROM reports itself as `bundled AROS`; any
 other image the table does not carry -- DiagROM, a ROM you built yourself --
 simply goes unnamed and boots as usual.
+
+## `[paths]` -- where files go
+
+```toml
+[paths]
+# base = "/somewhere/else"   # move the whole tree; the rest are under it
+# states = "states"          # save states, incl. the quick-save slots
+# screenshots = "screenshots"
+# recordings = "recordings"  # video captures and recorded input scripts
+# nvram = "nvram"            # battery-backed RAMs, incl. CD32 game saves
+# traces = "traces"          # debugger traces and waveform captures
+# configs = "configs"        # configurations saved from the launcher
+# roms = "roms"              # the rest set where an empty file dialog opens:
+# mt32_roms = "roms/mt32"    # MT-32 control and PCM ROMs
+# floppies = "floppies"
+# harddrives = "harddrives"
+# cds = "cds"
+```
+
+Where Copperline writes what it produces, and where its file dialogs open
+when the field they were launched from is empty. Every key is optional and
+an omitted key uses the default shown, so the section only needs to exist
+once something is moved. The launcher edits the same keys on its **A/V &
+Emu -> Paths** page.
+
+Each default is a folder of that name under the host-data directory --
+`~/.config/copperline` on macOS and Linux, `%APPDATA%\copperline` on
+Windows, or the executable's own folder in a [portable
+installation](ui.md#where-files-go). A relative path is taken from
+`base` (itself taken from the host-data directory when relative or unset),
+an absolute path is used as given. Output folders are created on first
+write; the dialog folders are never created, and a dialog only starts in
+one that exists.
+
+These name folders on the machine that runs the configuration, so a config
+copied to another machine may name folders that are not there. At startup
+each entry set here is checked and one that cannot be found is ignored with
+a warning in the log, falling back to its default -- the check waits no
+more than a moment, so a dead network mount delays starting rather than
+preventing it. Explicit output paths on the command line
+(`--screenshot-after`, `--save-state-after`, and so on) are used exactly as
+written and never consult this section.
 
 ## `[machine]` -- machine profiles
 
@@ -1617,8 +1665,9 @@ The disc mounts on the machine's CD controller: Akiko on CD32, the DMAC on
 CDTV. `insert_delay` inserts the disc some emulated seconds after power-on
 with the proper media-change notification; some CDTV discs only boot when
 inserted after the boot screen appears. CD32 NVRAM
-persists to `cd32-nvram.bin` next to the working directory unless
-overridden; without a path the EEPROM is session-only.
+persists to `cd32-nvram.bin` in the `[paths]` nvram folder unless
+overridden with `[cd] nvram`; a `cd32-nvram.bin` already in the working
+directory from an earlier Copperline keeps being used from there.
 
 ## `[[zorro]]` -- expansion boards
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -125,7 +125,9 @@ With no arguments and no `./copperline.toml` in the current directory,
 Copperline opens the **configuration screen** -- a launcher that lets you pick
 a machine, configure everything about it, load and save `.toml` configs, and
 press **Run** to boot. See [](ui#machine-configuration-screen) for a full tour.
-The screen starts from the built-in defaults: the A500 Rev 6A -- the most
+The screen starts from the configuration saved with its **Save default**
+button, if you have saved one; otherwise from the built-in defaults: the
+A500 Rev 6A -- the most
 common and most-targeted Amiga: a 68000 at ~7.09 MHz, the ECS "Fatter" 8372A
 Agnus (1 MiB chip reach plus the software PAL/NTSC switch) with the original
 OCS 8362 Denise, 512 KiB chip RAM plus 512 KiB of trapdoor slow RAM, PAL, and
@@ -135,8 +137,10 @@ that ships with it -- see [](configuration#top-level)).
 Copperline boots directly, skipping the configuration screen, whenever a
 machine is specified: a `./copperline.toml` in the current directory, an
 explicit `--config` file, a ROM or override on the command line, or any
-headless/scripted run. You can reopen the configuration screen at any time from
-the menu (see [](ui#machine-configuration-screen)).
+headless/scripted run. Those runs also start from the saved default when
+neither `--config` nor `./copperline.toml` names a machine; `--factory`
+ignores it (see [](configuration)). You can reopen the configuration screen
+at any time from the menu (see [](ui#machine-configuration-screen)).
 
 You can boot your own ROM with a positional argument, or point at a specific
 config file:

--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -170,7 +170,8 @@ Run it with `--script FILE` (combines freely with the other flags).
 Rather than writing scripts by hand, record one: in the window,
 `Cmd+Shift+R` on macOS or `Alt+Shift+R` on Linux/Windows starts and stops a
 live-input recording, written to
-`copperline-input-<YYYYMMDDHHmmSS>.clscript` in the working directory; the
+`copperline-input-<YYYYMMDDHHmmSS>.clscript` in the recordings folder (see
+[](ui.md#where-files-go)); the
 headless equivalent `--record-input PATH` records the whole run and
 writes the file on exit. Every input event that reaches the emulated
 machine is captured with its emulated timestamp -- key holds, mouse

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -12,10 +12,10 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 |---|---|---|
 | `Cmd+Q` | `Alt+Q` | Quit |
 | `Cmd+E` | `Alt+E` | Open / close the menu (also the status bar's hamburger button); releases a captured mouse |
-| `Cmd+S` | `Alt+S` | Save a screenshot (`copperline-screenshot-<YYYYMMDDHHmmSS>.png` in the working directory; the on-screen confirmation overlay is not part of the saved image) |
+| `Cmd+S` | `Alt+S` | Save a screenshot (`copperline-screenshot-<YYYYMMDDHHmmSS>.png` in the [screenshots folder](#where-files-go); the on-screen confirmation overlay is not part of the saved image) |
 | `Cmd+R` | `Alt+R` | Start / stop a video-with-audio recording (below) |
 | `Cmd+Shift+R` | `Alt+Shift+R` | Start / stop an input recording (below) |
-| `Cmd+Shift+S` | `Alt+Shift+S` | Save a state (`copperline-state-<YYYYMMDDHHmmSS>.clstate` in the working directory) |
+| `Cmd+Shift+S` | `Alt+Shift+S` | Save a state (`copperline-state-<YYYYMMDDHHmmSS>.clstate` in the [states folder](#where-files-go)) |
 | `Cmd+Shift+L` | `Alt+Shift+L` | Load a save state from a file dialog |
 | `Cmd+1`..`Cmd+9`, `Cmd+0` | `Alt+1`..`Alt+9`, `Alt+0` | Quick-save to numbered slot 1-10 |
 | `Cmd+Shift+1`..`Cmd+Shift+0` | `Alt+Shift+1`..`Alt+Shift+0` | Quick-load from that slot |
@@ -557,9 +557,17 @@ The layout is:
   style,
   perf overlay, menu size, overscan, pixel aspect, scaling, deinterlace,
   screen tint, phosphor, CRT shader and shader strength),
-  and **Emulation**
-  (power-on, realtime priority, pacing, warp speed) -- opening on Audio, and
-  switched freely between the three.
+  **Emulation**
+  (power-on, realtime priority, pacing, warp speed),
+  and **Paths** -- opening on Audio, and switched freely between the four.
+  The Paths page edits the `[paths]` section of the configuration (see
+  [](configuration.md)): the base folder on top, then one row per folder.
+  A row reads `(default)` until a folder is chosen for it; **Browse** picks
+  one and a **Reset** button then appears to put the row back to inheriting.
+  The base folder always shows its full path, and swaps Browse for Reset
+  once set. Changes take effect immediately -- a screenshot taken after
+  moving the row lands where the row now says -- and are written to the
+  configuration by **Save As** or **Save default** like everything else.
 - **Settings rows** (right pane). `[<]`/`[>]` step through a value, On/Off
   buttons flip a toggle, and the **Browse** and **Clear** buttons set or remove
   a file path through a native file dialog. On the *Storage* tab, once an IDE
@@ -589,14 +597,21 @@ The layout is:
   keeps it, and one that just names a device with no `bootpri` stays at 0. See
   [](configuration.md) for how the priority ranks against Kickstart's DF0: boot
   node at 5.
-- **Action bar** (bottom). **Load...** and **Save...** read and write a `.toml`
-  config
-  through a file dialog (Save writes a minimal file, only the settings that
-  differ from the chosen profile's defaults, so it reads like the example
-  configs). **Defaults** resets to the selected profile. **Run** validates the
-  configuration and boots it; if anything is wrong -- an unusable RAM size, a
-  missing disk image, a ROM file that cannot be read, an option the chosen
-  machine cannot use -- the reason is
+- **Action bar** (bottom). **Load...** reads a `.toml` config through a file
+  dialog. **Save...** opens a small dialog of three buttons, each described
+  in the dialog as the pointer moves over it: **Save As** writes a `.toml`
+  through a file dialog (a minimal file, only the settings that differ from
+  the chosen profile's defaults, so it reads like the example configs);
+  **Save default** saves the running configuration as the one Copperline
+  starts with: this screen opens showing it, and a run with no `--config`
+  and no `./copperline.toml` boots it (see [](configuration.md));
+  **Reset default** deletes that saved default after
+  an "Are you sure?", returning Copperline to factory settings. The close
+  gadget, or a click anywhere else, puts the dialog away.
+  **Defaults** resets the screen to the selected profile. **Run** validates
+  the configuration and boots it; if anything is wrong -- an unusable RAM
+  size, a missing disk image, a ROM file that cannot be read, an option the
+  chosen machine cannot use -- the reason is
   shown on the status line and you stay on the screen to fix it.
 
 ```{figure} ../images/ui-preview-launcher-boot-priority.png
@@ -708,7 +723,7 @@ names` needs a filesystem no Kickstart provides.
 
 `Cmd+R` on macOS or `Alt+R` on Linux/Windows (or the menu's "Record Video")
 starts capturing the emulated display and sound to
-`copperline-video-<YYYYMMDDHHmmSS>.avi` in the working directory; pressing it again
+`copperline-video-<YYYYMMDDHHmmSS>.avi` in the [recordings folder](#where-files-go); pressing it again
 stops and finalizes the file. A red REC
 badge sits in the display's top-right corner while a recording runs --
 like the screenshot overlay, the badge, status bar, and menus are never
@@ -739,7 +754,7 @@ machine by the same path), mouse buttons and motion, joystick / CD32-pad
 controls, analogue pot positions, and floppy inserts,
 on whichever port carries each device -- each stamped
 with its emulated time. Pressing it again stops the recording and writes
-`copperline-input-<YYYYMMDDHHmmSS>.clscript` in the working directory: a plain
+`copperline-input-<YYYYMMDDHHmmSS>.clscript` in the [recordings folder](#where-files-go): a plain
 text file of scripted-input directives that
 `copperline --script FILE` replays exactly, because the core is
 deterministic and the events re-fire at the same emulated timestamps.
@@ -756,7 +771,7 @@ headless `--record-input` variant are described in
 
 `Cmd+Shift+S` on macOS or `Alt+Shift+S` on Linux/Windows (or the menu's
 "Save State") writes a snapshot of the whole emulated machine to
-`copperline-state-<YYYYMMDDHHmmSS>.clstate` in the working directory: CPU,
+`copperline-state-<YYYYMMDDHHmmSS>.clstate` in the [states folder](#where-files-go): CPU,
 chip/slow/fast RAM, ROM, the full chipset and CIA state, floppy images
 (including unsaved in-memory changes), expansion boards, and CD/NVRAM
 state. `Cmd+Shift+L` / `Alt+Shift+L` (or "Load State...") restores one; the
@@ -798,26 +813,10 @@ as empty.
 A quick save overwrites its slot without asking -- that is the point of it --
 and loading a slot that has never been written reports "Slot N is empty"
 rather than failing. Slots are ordinary `.clstate` files, identical in format
-to a named save, kept per user rather than per working directory so they are
-reachable however Copperline was launched:
-
-| Host | Location |
-|---|---|
-| Linux/BSD | `$XDG_CONFIG_HOME/copperline/states/`, else `~/.config/copperline/states/` |
-| macOS | `~/.config/copperline/states/` |
-| Windows | `%APPDATA%\copperline\states\` |
-
-For a self-contained installation, create an empty file named `portable.txt`
-beside the Copperline executable (or beside the downloaded `.AppImage`) and
-restart Copperline. That folder then becomes the host-data directory, so
-quick-save slots live in its `states/` subdirectory. Gamepad calibration,
-keyboard mappings, the default WHDLoad library and other per-user host data are
-stored in that folder too. Delete `portable.txt` to return to the platform
-location above; Copperline does not move existing files in either direction.
-
-Because they are per user and not per machine, a slot may hold a state from
-a different Amiga than the one running. That is safe: as above, the state
-carries its own machine and the load reconfigures to match it and says so.
+to a named save, kept in the states folder below. And because they are per
+user and not per machine, a slot may hold a state from a different Amiga
+than the one running. That is safe: as above, the state carries its own
+machine and the load reconfigures to match it and says so.
 
 The headless flags `--save-state-after SECS PATH` and `--load-state PATH`
 script the same feature for [debugging workflows](headless.md): snapshot a
@@ -825,6 +824,42 @@ long-running program just before the scene under investigation once, then
 iterate from the state in seconds instead of re-emulating minutes. The
 file format and what exactly is (and is not) captured are specified in
 [the internals chapter](../internals/savestate.md).
+
+### Where files go
+
+Everything Copperline produces is kept per user rather than per working
+directory, so it is reachable however Copperline was launched. The host-data
+directory is:
+
+| Host | Location |
+|---|---|
+| Linux/BSD | `$XDG_CONFIG_HOME/copperline/`, else `~/.config/copperline/` |
+| macOS | `~/.config/copperline/` |
+| Windows | `%APPDATA%\copperline\` |
+
+with a folder inside it for each kind of file: `screenshots/`, `states/`
+(named saves and the quick-save slots), `recordings/` (video captures and
+recorded input scripts), `nvram/` (battery-backed clock RAM and CD32 game
+saves), `traces/` (debugger traces and waveform captures), and `configs/`
+(configurations saved from the configuration screen). Each folder is created
+on first use, and each can be moved with the `[paths]` section of the
+configuration or the configuration screen's **A/V & Emu -> Paths** page --
+see [](configuration.md). Headless flags that take an explicit path
+(`--screenshot-after` and friends) write exactly where they are told and
+ignore all of this.
+
+A `battmem.nvram` or `cd32-nvram.bin` left in the working directory by an
+earlier Copperline keeps being used from there -- they hold real game saves,
+so nothing is moved or abandoned behind your back.
+
+For a self-contained installation, create an empty file named `portable.txt`
+beside the Copperline executable (or beside the downloaded `.AppImage`) and
+restart Copperline. That folder then becomes the host-data directory, and all
+of the folders above -- plus gamepad calibration, keyboard mappings, the
+default WHDLoad library and other per-user host data -- live inside it, so
+the whole installation moves as one folder. Delete `portable.txt` to return
+to the platform location above; Copperline does not move existing files in
+either direction.
 
 ## Controller ports
 

--- a/src/akiko.rs
+++ b/src/akiko.rs
@@ -328,7 +328,9 @@ impl Nvram {
         self.phase = I2cPhase::DeviceAddress;
         if self.dirty {
             if let Some(path) = &self.path {
-                if let Err(e) = std::fs::write(path, &self.memory) {
+                if let Err(e) = crate::paths::ensure_parent(path)
+                    .and_then(|()| std::fs::write(path, &self.memory))
+                {
                     // Stay dirty so the next STOP retries: a transient
                     // host error must not lose the EEPROM contents (save
                     // games) until the guest happens to write them again.
@@ -1686,17 +1688,21 @@ mod tests {
             std::process::id()
         ));
         let _ = std::fs::remove_dir_all(&dir);
-        let path = dir.join("cd32-nvram.bin"); // parent dir missing
+        let path = dir.join("cd32-nvram.bin");
+        // A directory where the file goes: the write fails, and unlike a
+        // missing parent it stays failing, since the flush makes its own
+        // directories now.
+        std::fs::create_dir_all(&path).unwrap();
         akiko.set_nvram_path(path.clone());
 
         i2c::start(&mut akiko, &mut chip);
         assert!(!i2c::write_byte(&mut akiko, &mut chip, 0xA2));
         assert!(!i2c::write_byte(&mut akiko, &mut chip, 0x42));
         assert!(!i2c::write_byte(&mut akiko, &mut chip, 0xDE));
-        i2c::stop(&mut akiko, &mut chip); // flush fails
-        assert!(!path.exists());
+        i2c::stop(&mut akiko, &mut chip); // flush fails: a directory is in the way
+        assert!(path.is_dir(), "nothing should have been written over it");
 
-        std::fs::create_dir(&dir).unwrap();
+        std::fs::remove_dir(&path).unwrap();
         i2c::start(&mut akiko, &mut chip);
         i2c::stop(&mut akiko, &mut chip); // still dirty: retried and lands
         let bytes = std::fs::read(&path).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -6386,9 +6386,14 @@ mod tests {
         // The big boxes get the default backing file with their Ricoh part.
         for profile in ["A3000", "A4000"] {
             let cfg = parse_config(&format!("[machine]\nprofile = \"{profile}\"\n"))?;
+            // The file's name, not its directory: where it sits is
+            // `paths`' business and moves with the host-data directory.
             assert_eq!(
-                cfg.battmem_path.as_deref(),
-                Some(std::path::Path::new("battmem.nvram")),
+                cfg.battmem_path
+                    .as_deref()
+                    .and_then(|p| p.file_name())
+                    .and_then(|n| n.to_str()),
+                Some("battmem.nvram"),
                 "{profile}"
             );
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -275,6 +275,11 @@ pub struct Config {
     /// (`[display] bezel`). The `Cmd+M` / `Alt+M` toggle turns it off and
     /// back on live without affecting this start-up value.
     pub bezel: BezelStyle,
+    /// Where this machine's output goes and where its file dialogs open
+    /// (`[paths]`). Empty until somebody moves something; put in force by
+    /// [`crate::paths::adopt`], which drops whatever this host cannot
+    /// reach so a configuration written elsewhere still starts.
+    pub paths: crate::pathconf::Paths,
     /// Folder of PNG stickers drawn onto the monitor bezel
     /// (`[display] bezel_stickers`). Each PNG in the folder becomes a
     /// decal on the drawn front; an optional `stickers.toml` in the folder
@@ -2158,6 +2163,7 @@ impl Default for Config {
             port_devices: [PortDevice::Mouse, PortDevice::Joystick],
             serial: SerialConfig::default(),
             parallel: ParallelConfig::default(),
+            paths: crate::pathconf::Paths::default(),
         }
     }
 }
@@ -2793,6 +2799,13 @@ pub struct RawConfig {
     /// `[[zorro]]` board entries, configured in file order.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) zorro: Vec<RawZorroBoard>,
+    /// `[paths]`: where this machine's output goes and where its file
+    /// dialogs open. Absent until somebody moves something, and every
+    /// entry within it optional, so a configuration that never mentions
+    /// directories behaves exactly as one written before the section
+    /// existed.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub(crate) paths: crate::pathconf::Paths,
 }
 
 impl RawConfig {
@@ -4662,6 +4675,7 @@ impl TryFrom<RawConfig> for Config {
             port_devices,
             serial,
             parallel: resolve_parallel(raw.parallel)?,
+            paths: raw.paths,
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4528,7 +4528,7 @@ impl TryFrom<RawConfig> for Config {
                  rtc_chip = \"RP5C01\" or drop battmem"
             ),
             Some(path) => Some(PathBuf::from(path)),
-            None => rp5c01_fitted.then(|| PathBuf::from("battmem.nvram")),
+            None => rp5c01_fitted.then(crate::paths::battery_ram_file),
         };
 
         // A SCSI unit exists when something answers on it: a Zorro board
@@ -4613,7 +4613,7 @@ impl TryFrom<RawConfig> for Config {
                 .cd
                 .nvram
                 .map(PathBuf::from)
-                .or_else(|| defaults.akiko.then(|| PathBuf::from("cd32-nvram.bin"))),
+                .or_else(|| defaults.akiko.then(crate::paths::akiko_nvram_file)),
             rtc_present,
             rtc_chip,
             rtc_seed_unix,

--- a/src/config.rs
+++ b/src/config.rs
@@ -2818,6 +2818,13 @@ impl RawConfig {
         toml::to_string_pretty(self).context("serializing configuration to TOML")
     }
 
+    /// The `[paths]` section, for the startup that must put it in force
+    /// before building a [`Config`] -- the conversion resolves the implicit
+    /// battery-RAM files through the paths already in force.
+    pub fn paths(&self) -> crate::pathconf::Paths {
+        self.paths.clone()
+    }
+
     /// The configured menu size, for the paths that put a window up before a
     /// whole [`Config`] has been built.
     pub fn menu_scale(&self) -> MenuScale {
@@ -6393,6 +6400,31 @@ mod tests {
 
         let err = parse_config("[machine]\nrtc_chip = \"DS1307\"\n").unwrap_err();
         assert!(err.to_string().contains("rtc_chip"), "{err:#}");
+    }
+
+    /// `Config::try_from` resolves the implicit battery-RAM files through
+    /// the paths in force, so a startup that adopted `[paths]` *after* the
+    /// conversion would site this run's NVRAM by the previous answer. The
+    /// conversion is exercised here with a section already in force, which
+    /// is the order `load_config` uses.
+    #[test]
+    fn the_battery_ram_follows_the_paths_in_force() -> Result<()> {
+        let _guard = crate::paths::adopted_store_lock();
+        crate::paths::adopt(crate::pathconf::Paths {
+            nvram: Some(PathBuf::from("elsewhere")),
+            ..Default::default()
+        });
+        let cfg = parse_config("[machine]\nprofile = \"A4000\"\n")?;
+        let battmem = cfg.battmem_path.expect("an A4000 fits an RP5C01");
+        // No host-data directory at all leaves the bare name, which is the
+        // documented degradation and has no directory to check.
+        if crate::paths::config_dir().is_some() {
+            assert!(
+                battmem.parent().is_some_and(|p| p.ends_with("elsewhere")),
+                "the section in force did not site the battery RAM: {battmem:?}"
+            );
+        }
+        Ok(())
     }
 
     #[test]

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -2280,11 +2280,7 @@ fn push_id(entry: &mut Value, id: Option<u32>) {
 }
 
 fn default_trace_path() -> PathBuf {
-    let stamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_secs())
-        .unwrap_or(0);
-    PathBuf::from(format!("copperline-trace-{stamp}.txt"))
+    crate::paths::trace_file()
 }
 
 fn trace_status_value(emu: &Emulator) -> Value {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1607,6 +1607,7 @@ impl M68kMachine {
     /// cap-stop). Costs a disassembly and a buffered write per retired
     /// instruction while active.
     pub fn ui_trace_start(&mut self, path: std::path::PathBuf, cap: u64) -> std::io::Result<()> {
+        crate::paths::ensure_parent(&path)?;
         let file = std::fs::File::create(&path)?;
         self.ui_trace = Some(UiTrace {
             writer: std::io::BufWriter::new(file),

--- a/src/inputrec.rs
+++ b/src/inputrec.rs
@@ -102,8 +102,7 @@ fn pot_positions(p: &ControllerPort) -> Option<(u8, u8)> {
 /// Default recording file name, timestamped like the screenshot/recorder
 /// names.
 pub fn auto_filename() -> PathBuf {
-    let ts = crate::timestamp::compact_now();
-    PathBuf::from(format!("copperline-input-{ts}.clscript"))
+    crate::paths::input_recording_file()
 }
 
 pub struct InputRecorder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub mod mt32;
 pub mod net;
 pub mod package;
 pub mod parallel;
+pub mod pathconf;
 pub mod paths;
 pub mod picasso2;
 pub mod pointer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,10 @@ pub struct CliArgs {
     /// Applied on top of the config file (or the built-in defaults) before
     /// validation.
     pub overrides: ConfigOverrides,
+    /// `--factory`: start from Copperline's own defaults, ignoring a
+    /// configuration saved with Save default. An explicit `--config` still
+    /// wins -- this says "not the saved default", not "no configuration".
+    pub factory: bool,
 }
 
 use copperline::video::window::{JoyButtonKind, MouseButtonKind};
@@ -341,6 +345,7 @@ where
     let mut wave_signals: Option<copperline::waveform::SignalSet> = None;
     let mut disk_insert_after: Vec<CliDiskInsert> = Vec::new();
     let mut cd_insert_after: Vec<(f32, PathBuf)> = Vec::new();
+    let mut factory = false;
     let mut audio_live = true;
     let mut explicit_audio_live = false;
     let mut explicit_noaudio = false;
@@ -1016,6 +1021,7 @@ where
                 audio_live = true;
                 explicit_audio_live = true;
             }
+            "--factory" => factory = true,
             "--noaudio" | "--no-audio" => {
                 audio_live = false;
                 explicit_noaudio = true;
@@ -1178,6 +1184,7 @@ where
         net_helper_action,
         list_sampler_inputs,
         overrides,
+        factory,
     })
 }
 
@@ -1225,7 +1232,10 @@ fn print_help() {
          Usage: copperline [--config FILE] [--screenshot-after SECS PATH] [ROM]\n\
          \n\
          Options:\n  \
-         -c, --config FILE              load configuration from FILE (default: ./copperline.toml)\n  \
+         -c, --config FILE              load configuration from FILE (default: ./copperline.toml,\n  \
+         \x20                            then the configuration saved with Save default)\n  \
+         --factory                      ignore the saved default and start from Copperline's own\n  \
+         \x20                            settings\n  \
          --whdload GAME                 boot a WHDLoad game package: an .lha archive or a\n  \
          \x20                            directory holding a .slave (see docs/guide/whdload.md)\n  \
          --model NAME                   machine profile: A1000, A500, A500OCS, A500Plus, A600,\n  \
@@ -1992,7 +2002,7 @@ fn main() -> Result<()> {
     if cli.list_sampler_inputs {
         return print_sampler_input_devices();
     }
-    let (cfg, mut raw_cfg) = load_config(cli.config_path.as_deref(), &cli.overrides)?;
+    let (cfg, mut raw_cfg) = load_config(cli.config_path.as_deref(), &cli.overrides, cli.factory)?;
     if let Some(p) = &cli.rom_path {
         raw_cfg.rom = Some(p.to_string_lossy().into_owned());
     }
@@ -2374,6 +2384,12 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
 /// interactive launch with nothing specified (no config file, ROM, overrides,
 /// scripted input, headless capture, or save-state load), and with live audio
 /// (the launcher's Run path uses the live audio sink).
+///
+/// `--factory` is deliberately not in the list. It is the flag for somebody
+/// whose saved default is not what they want any more, and sending them
+/// straight into a machine rather than into the launcher would be the
+/// opposite of helpful. A saved default does not suppress the launcher
+/// either -- it says what the launcher opens showing, not what to run.
 fn launcher_requested(cli: &CliArgs) -> bool {
     cli.config_path.is_none()
         && cli.rom_path.is_none()
@@ -2506,21 +2522,39 @@ fn read_profile_audio_word(chip_ram: &[u8], address: u32) -> u16 {
 fn load_config(
     explicit: Option<&Path>,
     overrides: &ConfigOverrides,
+    factory: bool,
 ) -> Result<(Config, config::RawConfig)> {
     // Resolve which file (if any) backs the config: the explicit --config
-    // path, then ./copperline.toml if present, otherwise the built-in
-    // defaults. CLI overrides layer on top of whichever it is.
-    let default = Path::new("copperline.toml");
+    // path, then ./copperline.toml if present, then the configuration saved
+    // with Save default, otherwise the built-in defaults. CLI overrides
+    // layer on top of whichever it is.
+    let cwd = Path::new("copperline.toml");
+    // Only if it was actually saved: most installations have no default, so
+    // this is normally one `stat` that finds nothing.
+    let saved = (!factory)
+        .then(copperline::paths::default_config_file)
+        .flatten()
+        .filter(|path| path.is_file());
     let path = if explicit.is_some() {
         explicit
-    } else if default.exists() {
-        info!("loading config from {}", default.display());
-        Some(default)
+    } else if cwd.exists() {
+        info!("loading config from {}", cwd.display());
+        Some(cwd)
+    } else if let Some(saved) = saved.as_deref() {
+        info!(
+            "loading the saved default configuration {}",
+            saved.display()
+        );
+        Some(saved)
     } else {
         None
     };
     let raw = Config::load_raw(path, overrides)?;
     let cfg = Config::try_from(raw.clone())?;
+    // Put `[paths]` in force before anything asks where it should write.
+    // Whatever this host cannot reach is dropped here and inherits instead,
+    // so a config that names somebody else's memory stick still starts.
+    copperline::paths::adopt(cfg.paths.clone());
     Ok((cfg, raw))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2550,11 +2550,13 @@ fn load_config(
         None
     };
     let raw = Config::load_raw(path, overrides)?;
+    // Before the conversion, not after: `Config::try_from` resolves the
+    // implicit battery-RAM backing files through the paths in force, so
+    // adopting afterwards would site this run's NVRAM by the previous
+    // answer. Whatever this host cannot reach is dropped here and inherits
+    // instead, so a config naming somebody else's memory stick still starts.
+    copperline::paths::adopt(raw.paths());
     let cfg = Config::try_from(raw.clone())?;
-    // Put `[paths]` in force before anything asks where it should write.
-    // Whatever this host cannot reach is dropped here and inherits instead,
-    // so a config that names somebody else's memory stick still starts.
-    copperline::paths::adopt(cfg.paths.clone());
     Ok((cfg, raw))
 }
 
@@ -3021,6 +3023,44 @@ mod tests {
     /// The flag means "this bay is a real drive", so it displaces an image the
     /// config file put there rather than colliding with it -- a bay cannot
     /// hold both, and the command line wins.
+    /// `load_config` must put `[paths]` in force *before* building the
+    /// machine: the conversion resolves the implicit battery-RAM backing
+    /// files through the paths in force, so adopting afterwards would site
+    /// this run's NVRAM by the previous answer. Adopting after the
+    /// conversion fails this.
+    ///
+    /// No lock is taken: this is the binary's own test process, and it is
+    /// the only test in it that adopts.
+    #[test]
+    fn a_configs_paths_are_in_force_before_the_machine_is_built() -> Result<()> {
+        let path = std::env::temp_dir().join(format!(
+            "copperline-paths-order-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(
+            &path,
+            "[machine]\nprofile = \"A4000\"\n\n[paths]\nnvram = \"elsewhere\"\n",
+        )?;
+        let loaded = load_config(Some(&path), &ConfigOverrides::default(), true);
+        let _ = std::fs::remove_file(&path);
+        let (cfg, _) = loaded?;
+        let battmem = cfg.battmem_path.expect("an A4000 fits an RP5C01");
+        // A host with no per-user directory keeps the bare name, which is
+        // the documented degradation and has no directory to check.
+        if copperline::paths::config_dir().is_some() {
+            assert!(
+                battmem.parent().is_some_and(|p| p.ends_with("elsewhere")),
+                "the config's [paths] was adopted too late: {battmem:?}"
+            );
+        }
+        copperline::paths::adopt(Default::default());
+        Ok(())
+    }
+
     // The flags only exist in a build that can attach a physical drive.
     #[cfg(feature = "fluxbridge")]
     #[test]

--- a/src/pathconf.rs
+++ b/src/pathconf.rs
@@ -98,27 +98,27 @@ pub struct Paths {
     pub cds: Option<PathBuf>,
 }
 
-/// Whether a directory is one Copperline can use: it is there, or it is one
-/// Copperline would make for itself inside `root`.
+/// Whether a directory is one Copperline can use: it is there, or it is
+/// inside `root`, which is Copperline's own tree and made on demand.
 ///
-/// The second half is what makes a fresh installation work. `screenshots =
-/// "shots"` names a directory that will not exist until the first screenshot
-/// is taken, and it must not inherit in the meantime -- but the same
-/// generosity extended to *any* missing directory would be worse than
-/// useless: `/Volumes/STICK/Copperline` with the stick unplugged has a
-/// perfectly good parent, and treating it as creatable would quietly build
-/// a shadow copy of somebody's library on the internal disk. So a missing
-/// directory counts only inside the root everything else already hangs off,
-/// which a removed volume is not.
+/// The second half is what makes a fresh installation work. Nothing under
+/// the host-data directory exists until something is written to it, so a
+/// check that insisted on finding `screenshots = "shots"` -- or the
+/// host-data directory containing it -- would drop every relative entry on
+/// a machine that had not run Copperline before. Everything inside the root
+/// is created with the write that needs it, so being missing says nothing.
 ///
-/// Two `stat`s at most, and nothing is created here. Whether the eventual
-/// write succeeds is the write's business to report; this only answers
-/// whether the place named still exists on this machine.
+/// Outside the root, existing is the whole test. `/Volumes/STICK/Copperline`
+/// with the stick unplugged is not there and inherits, rather than being
+/// treated as creatable and quietly built as a shadow copy of somebody's
+/// library on the internal disk.
+///
+/// One `stat` at most, and only for a path outside the root -- the inside
+/// case is a lexical prefix test that touches no disk and cannot block.
+/// Nothing is created here; whether the eventual write succeeds is the
+/// write's business to report.
 fn is_reachable(dir: &Path, root: &Path) -> bool {
-    dir.is_dir()
-        || dir
-            .parent()
-            .is_some_and(|parent| parent.starts_with(root) && parent.is_dir())
+    dir.starts_with(root) || dir.is_dir()
 }
 
 /// Check each directory, giving up at `deadline`.
@@ -514,6 +514,30 @@ mod tests {
         .reachable(&host());
         assert_eq!(paths.base, None);
         assert!(paths.screenshots.is_some());
+    }
+
+    /// A fresh installation has written nothing yet, so nothing under the
+    /// host-data directory is there -- including the host-data directory.
+    /// Relative entries must still stand: they name folders Copperline
+    /// makes when it writes to them, and dropping them would mean `[paths]`
+    /// quietly did nothing until the first screenshot had been taken
+    /// somewhere else. This is what CI caught and a developer's own machine,
+    /// which has all of these directories already, cannot.
+    #[test]
+    fn a_relative_entry_stands_before_anything_has_been_written() {
+        let untouched = std::env::temp_dir().join("copperline-never-created-7b2e");
+        assert!(
+            !untouched.is_dir(),
+            "the test needs a root that is not there"
+        );
+        let paths = Paths {
+            screenshots: Some(PathBuf::from("shots")),
+            base: Some(PathBuf::from("tree")),
+            ..Default::default()
+        }
+        .reachable(&untouched);
+        assert_eq!(paths.base.as_deref(), Some(Path::new("tree")));
+        assert_eq!(paths.screenshots.as_deref(), Some(Path::new("shots")));
     }
 
     /// Nothing set means nothing to check, so the common case never touches

--- a/src/pathconf.rs
+++ b/src/pathconf.rs
@@ -2,35 +2,43 @@
 
 //! Where Copperline puts what it produces, and where its file dialogs start.
 //!
-//! A host preference, kept in `paths.toml` beside `keymap.toml` and
-//! `gamepads.toml` rather than in a machine TOML. Which chipset a machine
-//! has is a property of that machine and travels with its config; which
-//! folder *this* person keeps screenshots in is not, and a machine config
-//! carrying it would stop being something you can hand to someone else.
+//! The `[paths]` section of a configuration, and no file of its own: one
+//! TOML says what the machine is and where its output goes, which is one
+//! thing to keep, copy or hand over rather than two that have to be kept
+//! in step.
 //!
-//! Every entry is optional and every unset entry inherits, so the file is
-//! only ever as long as the person writing it wants it to be. An empty
-//! `paths.toml`, or none at all, behaves exactly as Copperline does today.
+//! Every entry is optional and every unset entry inherits, so the section
+//! only exists at all once somebody moves something. No `[paths]`, or an
+//! empty one, behaves exactly as Copperline does with no configuration.
 //!
 //! Relative entries are taken from [`base`](Paths::base), which is itself
 //! taken from the host-data directory when it is relative or unset. That is
 //! what makes the whole tree move together: a portable install sets nothing
 //! and everything follows the marker, because nothing ever said where it
 //! was in absolute terms.
+//!
+//! A configuration written on one machine will happily name directories the
+//! next one has never heard of, so [`Paths::reachable`] drops the entries
+//! whose directories are not there and lets them inherit. It is bounded in
+//! time as well as in work: a directory on a network share that has gone
+//! away does not fail, it *hangs*, and Copperline starting is not something
+//! to make conditional on a file server answering.
 
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
-/// The file's name in the host-data directory.
-pub const FILE: &str = "paths.toml";
+/// How long the whole reachability check may take before Copperline stops
+/// waiting and inherits the rest. Long enough that a busy disk still
+/// answers, short enough that a stale mount is a pause and not a hang.
+const PROBE_BUDGET: Duration = Duration::from_millis(1500);
 
 /// Directories Copperline writes into, and the directories its file
 /// dialogs open at. Serialised with `skip_serializing_if` throughout so a
-/// saved file records only what was actually set -- an inherited entry is
-/// absent rather than written out with its computed value, which would
-/// freeze today's default into a file that then stops following it.
+/// saved configuration records only what was actually set -- an inherited
+/// entry is absent rather than written out with its computed value, which
+/// would freeze today's default into a file that then stops following it.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Paths {
@@ -85,6 +93,76 @@ pub struct Paths {
     pub cds: Option<PathBuf>,
 }
 
+/// Whether a directory is one Copperline can use: it is there, or it is one
+/// Copperline would make for itself inside `root`.
+///
+/// The second half is what makes a fresh installation work. `screenshots =
+/// "shots"` names a directory that will not exist until the first screenshot
+/// is taken, and it must not inherit in the meantime -- but the same
+/// generosity extended to *any* missing directory would be worse than
+/// useless: `/Volumes/STICK/Copperline` with the stick unplugged has a
+/// perfectly good parent, and treating it as creatable would quietly build
+/// a shadow copy of somebody's library on the internal disk. So a missing
+/// directory counts only inside the root everything else already hangs off,
+/// which a removed volume is not.
+///
+/// Two `stat`s at most, and nothing is created here. Whether the eventual
+/// write succeeds is the write's business to report; this only answers
+/// whether the place named still exists on this machine.
+fn is_reachable(dir: &Path, root: &Path) -> bool {
+    dir.is_dir()
+        || dir
+            .parent()
+            .is_some_and(|parent| parent.starts_with(root) && parent.is_dir())
+}
+
+/// Check each directory, giving up at `deadline`.
+///
+/// The checking runs on a thread of its own because it cannot be
+/// interrupted: a `stat` into a network mount whose server has gone away
+/// blocks in the kernel until it decides to time out, which on a default
+/// NFS mount is minutes. Verdicts come back one at a time as they are
+/// reached, so a hang costs only the entries behind it -- everything
+/// already answered still counts. Anything unanswered when the deadline
+/// passes is reported unreachable, and the thread is abandoned: it holds no
+/// lock, touches nothing shared, and ends when the kernel lets it.
+fn probe_within(dirs: &[PathBuf], root: &Path, deadline: Instant) -> Vec<bool> {
+    if dirs.is_empty() {
+        return Vec::new();
+    }
+    let (tx, rx) = std::sync::mpsc::channel();
+    let owned: Vec<PathBuf> = dirs.to_vec();
+    let root = root.to_path_buf();
+    std::thread::Builder::new()
+        .name("paths-probe".to_string())
+        .spawn(move || {
+            for dir in owned {
+                // A closed channel means the deadline passed and nobody is
+                // listening any more; there is nothing left to do.
+                if tx.send(is_reachable(&dir, &root)).is_err() {
+                    return;
+                }
+            }
+        })
+        // A host that cannot spawn a thread has bigger problems than where
+        // its screenshots go; inherit everything and carry on.
+        .map_or_else(
+            |_| vec![false; dirs.len()],
+            |_| {
+                let mut verdicts = Vec::with_capacity(dirs.len());
+                while verdicts.len() < dirs.len() {
+                    let left = deadline.saturating_duration_since(Instant::now());
+                    match rx.recv_timeout(left) {
+                        Ok(verdict) => verdicts.push(verdict),
+                        Err(_) => break,
+                    }
+                }
+                verdicts.resize(dirs.len(), false);
+                verdicts
+            },
+        )
+}
+
 /// The name each entry carries when unset. Stated once so the defaults, the
 /// resolver and anything that lists them cannot disagree.
 mod default_name {
@@ -102,36 +180,102 @@ mod default_name {
 }
 
 impl Paths {
-    /// Read `paths.toml`, or the defaults when there is none.
-    ///
-    /// A malformed file is reported and then ignored. It names only where
-    /// things go, so falling back to the defaults leaves a working
-    /// emulator; refusing to start over it would be a poor trade, and the
-    /// message says which file to look at.
-    pub fn load() -> Self {
-        let Some(path) = crate::paths::config_file(FILE) else {
-            return Self::default();
-        };
-        let Ok(text) = std::fs::read_to_string(&path) else {
-            return Self::default();
-        };
-        match toml::from_str(&text) {
-            Ok(paths) => paths,
-            Err(err) => {
-                log::warn!("{}: {err}; using the default directories", path.display());
-                Self::default()
-            }
-        }
+    /// Whether anything at all was set. Nothing set is the overwhelmingly
+    /// common case and costs nothing to answer, which is what keeps the
+    /// reachability check off the startup path for almost everybody.
+    pub fn is_empty(&self) -> bool {
+        self == &Self::default()
     }
 
-    /// Write the entries that were set.
-    pub fn save(&self) -> Result<()> {
-        let path = crate::paths::config_file(FILE)
-            .ok_or_else(|| anyhow!("no host-data directory for {FILE}"))?;
-        crate::paths::ensure_parent(&path)?;
-        std::fs::write(&path, toml::to_string_pretty(self)?)?;
-        log::info!("saved directories to {}", path.display());
-        Ok(())
+    /// Every entry but the base, destructured rather than listed so a field
+    /// added later cannot quietly escape the check below.
+    fn entries(&mut self) -> [&mut Option<PathBuf>; 11] {
+        let Paths {
+            base: _,
+            states,
+            screenshots,
+            recordings,
+            nvram,
+            traces,
+            configs,
+            roms,
+            mt32_roms,
+            floppies,
+            harddrives,
+            cds,
+        } = self;
+        [
+            states,
+            screenshots,
+            recordings,
+            nvram,
+            traces,
+            configs,
+            roms,
+            mt32_roms,
+            floppies,
+            harddrives,
+            cds,
+        ]
+    }
+
+    /// Drop the entries whose directories are not there, so what is left
+    /// inherits.
+    ///
+    /// A configuration is a portable thing: it gets copied between machines,
+    /// checked in, and handed to other people, and the memory stick one of
+    /// them named is not going to be plugged into the next one. Rather than
+    /// fail, or write somewhere surprising, an entry Copperline cannot reach
+    /// stops applying and that directory goes back to its default.
+    ///
+    /// "There" means the directory itself, or the directory it would be
+    /// created inside: Copperline makes its own output directories on first
+    /// write, so naming one that does not exist yet is normal and only its
+    /// parent has to be real.
+    ///
+    /// Bounded in time. `stat` on a network share whose server has gone away
+    /// blocks in the kernel and cannot be cancelled, so the probing happens
+    /// on a thread of its own and this waits [`PROBE_BUDGET`] for it.
+    /// Whatever has not answered by then is treated as unreachable and
+    /// inherits -- the wrong-but-working answer, arrived at promptly, rather
+    /// than the right one at the cost of a startup that never finishes. The
+    /// thread is left to end in its own time; it holds nothing.
+    pub fn reachable(mut self, host_data: &Path) -> Self {
+        if self.is_empty() {
+            return self;
+        }
+        let deadline = Instant::now() + PROBE_BUDGET;
+        // The base goes first and on its own. Everything relative hangs off
+        // it, so an unreachable base is not one bad entry but a wrong answer
+        // for all of them; dropping it first means the rest are then
+        // measured where they are actually about to be written.
+        if let Some(base) = self.base.clone() {
+            let dir = host_data.join(base);
+            if !probe_within(std::slice::from_ref(&dir), host_data, deadline)[0] {
+                log::warn!("{}: base folder unreachable", dir.display());
+                self.base = None;
+            }
+        }
+        let base = self.base_dir(host_data);
+        let mut entries = self.entries();
+        let resolved: Vec<PathBuf> = entries
+            .iter()
+            .map(|entry| match entry.as_deref() {
+                Some(dir) => base.join(dir),
+                // Unset entries are probed too rather than skipped, so the
+                // verdicts line up with the entries by position and no
+                // index arithmetic stands between the two.
+                None => base.clone(),
+            })
+            .collect();
+        let verdicts = probe_within(&resolved, &base, deadline);
+        for ((entry, dir), reachable) in entries.iter_mut().zip(resolved).zip(verdicts) {
+            if entry.is_some() && !reachable {
+                log::warn!("{}: unreachable, using the default instead", dir.display());
+                **entry = None;
+            }
+        }
+        self
     }
 
     /// The directory everything else is taken from: `base` when it is
@@ -327,5 +471,67 @@ mod tests {
     #[test]
     fn an_empty_file_is_the_defaults() {
         assert_eq!(toml::from_str::<Paths>("").unwrap(), Paths::default());
+        assert!(Paths::default().is_empty());
+    }
+
+    /// The point of the whole check: a configuration written on a machine
+    /// with a memory stick plugged in still starts on one without it, with
+    /// the entries that *are* there left alone.
+    #[test]
+    fn an_entry_that_is_not_there_inherits_and_the_rest_do_not() {
+        let root = std::env::temp_dir();
+        let paths = Paths {
+            // A volume that is not mounted: the case the whole check is for.
+            screenshots: Some(PathBuf::from("/no-such-volume-9f3a/shots")),
+            // A directory that does not exist yet, inside Copperline's own
+            // root: normal on a fresh installation, because it is made on
+            // the first write.
+            states: Some(PathBuf::from("not-yet-created")),
+            // One that is simply there.
+            recordings: Some(root.clone()),
+            ..Default::default()
+        }
+        .reachable(&root);
+        assert_eq!(paths.screenshots, None, "a missing volume should inherit");
+        assert!(paths.states.is_some(), "a creatable directory should stand");
+        assert!(paths.recordings.is_some(), "an existing one should stand");
+    }
+
+    /// An unreachable base takes only itself out: the rest fall back to the
+    /// host directory rather than being condemned along with it.
+    #[test]
+    fn an_unreachable_base_leaves_the_entries_under_the_default_root() {
+        let paths = Paths {
+            base: Some(PathBuf::from("/no-such-volume-4c1d/Copperline")),
+            screenshots: Some(std::env::temp_dir()),
+            ..Default::default()
+        }
+        .reachable(&host());
+        assert_eq!(paths.base, None);
+        assert!(paths.screenshots.is_some());
+    }
+
+    /// Nothing set means nothing to check, so the common case never touches
+    /// the disk at all.
+    #[test]
+    fn nothing_set_is_not_probed() {
+        assert_eq!(Paths::default().reachable(&host()), Paths::default());
+    }
+
+    /// A probe that never answers costs the budget and no more, and the
+    /// entries behind it inherit rather than the whole thing failing.
+    #[test]
+    fn the_check_gives_up_rather_than_waiting() {
+        let started = Instant::now();
+        let verdicts = probe_within(
+            &[PathBuf::from("/"), PathBuf::from("/")],
+            Path::new("/"),
+            started - Duration::from_secs(1),
+        );
+        assert_eq!(verdicts.len(), 2, "one verdict per directory, always");
+        assert!(
+            started.elapsed() < PROBE_BUDGET,
+            "a passed deadline should not be waited out"
+        );
     }
 }

--- a/src/pathconf.rs
+++ b/src/pathconf.rs
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Where Copperline puts what it produces, and where its file dialogs start.
+//!
+//! A host preference, kept in `paths.toml` beside `keymap.toml` and
+//! `gamepads.toml` rather than in a machine TOML. Which chipset a machine
+//! has is a property of that machine and travels with its config; which
+//! folder *this* person keeps screenshots in is not, and a machine config
+//! carrying it would stop being something you can hand to someone else.
+//!
+//! Every entry is optional and every unset entry inherits, so the file is
+//! only ever as long as the person writing it wants it to be. An empty
+//! `paths.toml`, or none at all, behaves exactly as Copperline does today.
+//!
+//! Relative entries are taken from [`base`](Paths::base), which is itself
+//! taken from the host-data directory when it is relative or unset. That is
+//! what makes the whole tree move together: a portable install sets nothing
+//! and everything follows the marker, because nothing ever said where it
+//! was in absolute terms.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+
+/// The file's name in the host-data directory.
+pub const FILE: &str = "paths.toml";
+
+/// Directories Copperline writes into, and the directories its file
+/// dialogs open at. Serialised with `skip_serializing_if` throughout so a
+/// saved file records only what was actually set -- an inherited entry is
+/// absent rather than written out with its computed value, which would
+/// freeze today's default into a file that then stops following it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Paths {
+    /// The directory the rest are taken from. Unset, or relative, means
+    /// the host-data directory -- so portable installs need say nothing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base: Option<PathBuf>,
+
+    // --- what Copperline writes -------------------------------------
+    /// Numbered save-state slots and any state saved outside them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub states: Option<PathBuf>,
+    /// Screenshots.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub screenshots: Option<PathBuf>,
+    /// Video captures and recorded input scripts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recordings: Option<PathBuf>,
+    /// Battery-backed RAMs: the RP5C01's, and the CD32's Akiko NVRAM,
+    /// which holds real game saves.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nvram: Option<PathBuf>,
+    /// Debugger instruction traces and waveform captures. A waveform can
+    /// reach half a gigabyte, which is its own reason to know where it is.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub traces: Option<PathBuf>,
+    /// Machine configurations saved from the launcher.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configs: Option<PathBuf>,
+
+    // --- where the file dialogs start -------------------------------
+    //
+    // These are not Copperline's to write. A dialog already opens beside
+    // whatever is in the field it was launched from, which is better than
+    // any fixed answer; these only decide where it opens when that field
+    // is empty. Nothing is created for them, because a handful of empty
+    // folders nobody asked for is worse than none.
+    /// Kickstart and extended ROM images.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub roms: Option<PathBuf>,
+    /// MT-32 control and PCM ROMs, under the ROMs directory by default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mt32_roms: Option<PathBuf>,
+    /// Floppy images.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub floppies: Option<PathBuf>,
+    /// Hard-disk images and host-filesystem folders.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub harddrives: Option<PathBuf>,
+    /// CD images.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cds: Option<PathBuf>,
+}
+
+/// The name each entry carries when unset. Stated once so the defaults, the
+/// resolver and anything that lists them cannot disagree.
+mod default_name {
+    pub const STATES: &str = "states";
+    pub const SCREENSHOTS: &str = "screenshots";
+    pub const RECORDINGS: &str = "recordings";
+    pub const NVRAM: &str = "nvram";
+    pub const TRACES: &str = "traces";
+    pub const CONFIGS: &str = "configs";
+    pub const ROMS: &str = "roms";
+    pub const MT32: &str = "mt32";
+    pub const FLOPPIES: &str = "floppies";
+    pub const HARDDRIVES: &str = "harddrives";
+    pub const CDS: &str = "cds";
+}
+
+impl Paths {
+    /// Read `paths.toml`, or the defaults when there is none.
+    ///
+    /// A malformed file is reported and then ignored. It names only where
+    /// things go, so falling back to the defaults leaves a working
+    /// emulator; refusing to start over it would be a poor trade, and the
+    /// message says which file to look at.
+    pub fn load() -> Self {
+        let Some(path) = crate::paths::config_file(FILE) else {
+            return Self::default();
+        };
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            return Self::default();
+        };
+        match toml::from_str(&text) {
+            Ok(paths) => paths,
+            Err(err) => {
+                log::warn!("{}: {err}; using the default directories", path.display());
+                Self::default()
+            }
+        }
+    }
+
+    /// Write the entries that were set.
+    pub fn save(&self) -> Result<()> {
+        let path = crate::paths::config_file(FILE)
+            .ok_or_else(|| anyhow!("no host-data directory for {FILE}"))?;
+        crate::paths::ensure_parent(&path)?;
+        std::fs::write(&path, toml::to_string_pretty(self)?)?;
+        log::info!("saved directories to {}", path.display());
+        Ok(())
+    }
+
+    /// The directory everything else is taken from: `base` when it is
+    /// absolute, `base` under the host-data directory when it is relative,
+    /// and the host-data directory itself when it is unset.
+    pub fn base_dir(&self, host_data: &Path) -> PathBuf {
+        match self.base.as_deref() {
+            Some(base) if base.is_absolute() => base.to_path_buf(),
+            Some(base) => host_data.join(base),
+            None => host_data.to_path_buf(),
+        }
+    }
+
+    /// One entry, resolved: absolute as given, relative under the base, and
+    /// the stated default name under the base when unset.
+    fn dir(&self, host_data: &Path, set: Option<&Path>, default: &str) -> PathBuf {
+        match set {
+            Some(dir) if dir.is_absolute() => dir.to_path_buf(),
+            Some(dir) => self.base_dir(host_data).join(dir),
+            None => self.base_dir(host_data).join(default),
+        }
+    }
+
+    /// Save-state slots.
+    pub fn states_dir(&self, host_data: &Path) -> PathBuf {
+        self.dir(host_data, self.states.as_deref(), default_name::STATES)
+    }
+
+    /// Screenshots.
+    pub fn screenshots_dir(&self, host_data: &Path) -> PathBuf {
+        self.dir(
+            host_data,
+            self.screenshots.as_deref(),
+            default_name::SCREENSHOTS,
+        )
+    }
+
+    /// Video and input recordings.
+    pub fn recordings_dir(&self, host_data: &Path) -> PathBuf {
+        self.dir(
+            host_data,
+            self.recordings.as_deref(),
+            default_name::RECORDINGS,
+        )
+    }
+
+    /// Battery-backed RAMs.
+    pub fn nvram_dir(&self, host_data: &Path) -> PathBuf {
+        self.dir(host_data, self.nvram.as_deref(), default_name::NVRAM)
+    }
+
+    /// Traces and waveform captures.
+    pub fn traces_dir(&self, host_data: &Path) -> PathBuf {
+        self.dir(host_data, self.traces.as_deref(), default_name::TRACES)
+    }
+
+    /// Saved machine configurations.
+    pub fn configs_dir(&self, host_data: &Path) -> PathBuf {
+        self.dir(host_data, self.configs.as_deref(), default_name::CONFIGS)
+    }
+
+    /// Where a ROM dialog opens when its field is empty.
+    pub fn roms_dir(&self, host_data: &Path) -> PathBuf {
+        self.dir(host_data, self.roms.as_deref(), default_name::ROMS)
+    }
+
+    /// Where an MT-32 ROM dialog opens. Under the ROMs directory rather
+    /// than beside it: they are ROMs, just not the machine's own.
+    pub fn mt32_roms_dir(&self, host_data: &Path) -> PathBuf {
+        match self.mt32_roms.as_deref() {
+            Some(dir) if dir.is_absolute() => dir.to_path_buf(),
+            Some(dir) => self.base_dir(host_data).join(dir),
+            None => self.roms_dir(host_data).join(default_name::MT32),
+        }
+    }
+
+    /// Where a floppy dialog opens when its field is empty.
+    pub fn floppies_dir(&self, host_data: &Path) -> PathBuf {
+        self.dir(host_data, self.floppies.as_deref(), default_name::FLOPPIES)
+    }
+
+    /// Where a hard-disk dialog opens when its field is empty.
+    pub fn harddrives_dir(&self, host_data: &Path) -> PathBuf {
+        self.dir(
+            host_data,
+            self.harddrives.as_deref(),
+            default_name::HARDDRIVES,
+        )
+    }
+
+    /// Where a CD dialog opens when its field is empty.
+    pub fn cds_dir(&self, host_data: &Path) -> PathBuf {
+        self.dir(host_data, self.cds.as_deref(), default_name::CDS)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn host() -> PathBuf {
+        PathBuf::from("/host/copperline")
+    }
+
+    #[test]
+    fn nothing_set_puts_everything_under_the_host_directory() {
+        let p = Paths::default();
+        let h = host();
+        assert_eq!(p.base_dir(&h), h);
+        assert_eq!(p.states_dir(&h), h.join("states"));
+        assert_eq!(p.screenshots_dir(&h), h.join("screenshots"));
+        assert_eq!(p.recordings_dir(&h), h.join("recordings"));
+        assert_eq!(p.nvram_dir(&h), h.join("nvram"));
+        assert_eq!(p.traces_dir(&h), h.join("traces"));
+        assert_eq!(p.configs_dir(&h), h.join("configs"));
+        assert_eq!(p.roms_dir(&h), h.join("roms"));
+        assert_eq!(p.mt32_roms_dir(&h), h.join("roms").join("mt32"));
+        assert_eq!(p.floppies_dir(&h), h.join("floppies"));
+        assert_eq!(p.harddrives_dir(&h), h.join("harddrives"));
+        assert_eq!(p.cds_dir(&h), h.join("cds"));
+    }
+
+    /// The property the whole design rests on: nothing records where it is
+    /// in absolute terms, so moving the root moves everything with it. This
+    /// is what makes a portable install a folder copy and not a migration.
+    #[test]
+    fn the_whole_tree_follows_the_root() {
+        let p = Paths::default();
+        let stick = PathBuf::from("/Volumes/STICK/Copperline");
+        for (a, b) in [
+            (p.states_dir(&host()), p.states_dir(&stick)),
+            (p.screenshots_dir(&host()), p.screenshots_dir(&stick)),
+            (p.nvram_dir(&host()), p.nvram_dir(&stick)),
+            (p.mt32_roms_dir(&host()), p.mt32_roms_dir(&stick)),
+        ] {
+            assert!(a.starts_with(host()), "{a:?} left the host root");
+            assert!(b.starts_with(&stick), "{b:?} did not follow the root");
+            assert_eq!(
+                a.strip_prefix(host()),
+                b.strip_prefix(&stick),
+                "the same entry sits differently under two roots"
+            );
+        }
+    }
+
+    #[test]
+    fn a_relative_entry_hangs_off_the_base_and_an_absolute_one_does_not() {
+        let h = host();
+        let p = Paths {
+            screenshots: Some(PathBuf::from("shots")),
+            recordings: Some(PathBuf::from("/mnt/scratch/video")),
+            ..Default::default()
+        };
+        assert_eq!(p.screenshots_dir(&h), h.join("shots"));
+        assert_eq!(p.recordings_dir(&h), PathBuf::from("/mnt/scratch/video"));
+    }
+
+    #[test]
+    fn base_moves_the_lot_without_naming_each_one() {
+        let h = host();
+        let p = Paths {
+            base: Some(PathBuf::from("/data/copperline")),
+            ..Default::default()
+        };
+        assert_eq!(p.states_dir(&h), PathBuf::from("/data/copperline/states"));
+        assert_eq!(p.nvram_dir(&h), PathBuf::from("/data/copperline/nvram"));
+        // A relative base is still taken from the host directory, so it
+        // cannot escape a portable root by accident.
+        let rel = Paths {
+            base: Some(PathBuf::from("data")),
+            ..Default::default()
+        };
+        assert_eq!(rel.states_dir(&h), h.join("data").join("states"));
+    }
+
+    /// An inherited entry must not be written out with its computed value:
+    /// a file that recorded today's defaults would stop following them, and
+    /// the person who wrote it never asked for that.
+    #[test]
+    fn saving_records_only_what_was_set() {
+        let p = Paths {
+            screenshots: Some(PathBuf::from("shots")),
+            ..Default::default()
+        };
+        let text = toml::to_string_pretty(&p).unwrap();
+        assert!(text.contains("screenshots"), "{text}");
+        for absent in ["states", "nvram", "traces", "roms", "base"] {
+            assert!(!text.contains(absent), "{absent} written out: {text}");
+        }
+        assert_eq!(toml::from_str::<Paths>(&text).unwrap(), p);
+    }
+
+    #[test]
+    fn an_empty_file_is_the_defaults() {
+        assert_eq!(toml::from_str::<Paths>("").unwrap(), Paths::default());
+    }
+}

--- a/src/pathconf.rs
+++ b/src/pathconf.rs
@@ -80,6 +80,11 @@ pub struct Paths {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub roms: Option<PathBuf>,
     /// MT-32 control and PCM ROMs, under the ROMs directory by default.
+    /// The one entry with no row on the Paths page: they are ROMs, they
+    /// follow the ROMs directory, and a second ROM row for the handful of
+    /// people who keep them apart is a poor trade against a shorter page.
+    /// Still read and still written back, so a configuration that sets it
+    /// keeps it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mt32_roms: Option<PathBuf>,
     /// Floppy images.

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -183,7 +183,7 @@ pub fn library_root() -> PathBuf {
 
 /// Directory holding the numbered save-state slots.
 pub fn state_slot_dir() -> Option<PathBuf> {
-    config_dir().map(|dir| dir.join("states"))
+    config_dir().map(|dir| dirs().states_dir(&dir))
 }
 
 // --- what a run produces ------------------------------------------------
@@ -208,6 +208,29 @@ pub fn state_slot_dir() -> Option<PathBuf> {
 // recognises, so unifying it is a change in its own right and not one to
 // smuggle in here.
 
+/// The configured directories, read once. `paths.toml` says where each of
+/// these goes; absent or empty, it says nothing and the defaults stand.
+fn dirs() -> &'static crate::pathconf::Paths {
+    static DIRS: std::sync::OnceLock<crate::pathconf::Paths> = std::sync::OnceLock::new();
+    DIRS.get_or_init(crate::pathconf::Paths::load)
+}
+
+/// A named file under one of the configured directories.
+///
+/// A host with no per-user directory at all keeps the bare name, which is
+/// the working directory -- the same "degrade to not persisted" the rest of
+/// this module promises, rather than an error at the point somebody presses
+/// the screenshot key.
+fn output(
+    pick: impl Fn(&crate::pathconf::Paths, &std::path::Path) -> PathBuf,
+    name: String,
+) -> PathBuf {
+    match config_dir() {
+        Some(host) => pick(dirs(), &host).join(name),
+        None => PathBuf::from(name),
+    }
+}
+
 /// Seconds since the epoch, for the diagnostic captures.
 fn epoch_stamp() -> u64 {
     std::time::SystemTime::now()
@@ -218,61 +241,98 @@ fn epoch_stamp() -> u64 {
 
 /// Default name for a screenshot taken without one being given.
 pub fn screenshot_file() -> PathBuf {
-    PathBuf::from(format!(
-        "copperline-screenshot-{}.png",
-        crate::timestamp::compact_now()
-    ))
+    output(
+        |p, h| p.screenshots_dir(h),
+        format!(
+            "copperline-screenshot-{}.png",
+            crate::timestamp::compact_now()
+        ),
+    )
 }
 
 /// Default name for a video recording.
 pub fn recording_file() -> PathBuf {
-    PathBuf::from(format!(
-        "copperline-video-{}.avi",
-        crate::timestamp::compact_now()
-    ))
+    output(
+        |p, h| p.recordings_dir(h),
+        format!("copperline-video-{}.avi", crate::timestamp::compact_now()),
+    )
 }
 
 /// Default name for a recorded input script.
 pub fn input_recording_file() -> PathBuf {
-    PathBuf::from(format!(
-        "copperline-input-{}.clscript",
-        crate::timestamp::compact_now()
-    ))
+    output(
+        |p, h| p.recordings_dir(h),
+        format!(
+            "copperline-input-{}.clscript",
+            crate::timestamp::compact_now()
+        ),
+    )
 }
 
 /// Default name for a save state written outside the numbered slots.
 pub fn state_file() -> PathBuf {
-    PathBuf::from(format!(
-        "copperline-state-{}.clstate",
-        crate::timestamp::compact_now()
-    ))
+    output(
+        |p, h| p.states_dir(h),
+        format!(
+            "copperline-state-{}.clstate",
+            crate::timestamp::compact_now()
+        ),
+    )
 }
 
 /// Default name for a waveform capture. Reached from `--waveform` without a
 /// path and from `waveform.start` without one; a capture can run to half a
 /// gigabyte, which is its own argument against the working directory.
 pub fn waveform_file() -> PathBuf {
-    PathBuf::from(format!("copperline-wave-{}.vcd", epoch_stamp()))
+    output(
+        |p, h| p.traces_dir(h),
+        format!("copperline-wave-{}.vcd", epoch_stamp()),
+    )
 }
 
 /// Default name for an instruction trace. The debugger console and the
 /// control protocol both start traces, and each had its own copy of this;
 /// they now cannot drift.
 pub fn trace_file() -> PathBuf {
-    PathBuf::from(format!("copperline-trace-{}.txt", epoch_stamp()))
+    output(
+        |p, h| p.traces_dir(h),
+        format!("copperline-trace-{}.txt", epoch_stamp()),
+    )
+}
+
+/// A battery-backed RAM, under the configured directory -- unless one is
+/// already sitting where Copperline used to put it.
+///
+/// These held their bare names, so they landed in whatever directory the
+/// process happened to start in. Moving where Copperline *looks* is not the
+/// same as moving the file: the CD32's is a memory card holding real game
+/// saves, and a player whose progress silently reverted to blank would have
+/// no way of knowing it was still on disk a directory away. So an existing
+/// file keeps being used where it is, and only a machine that never had one
+/// gets the new place. Nothing is moved behind anyone's back.
+fn battery_ram(name: &str) -> PathBuf {
+    let legacy = PathBuf::from(name);
+    if legacy.is_file() {
+        log::info!(
+            "using the existing {name} in the working directory; new machines keep theirs under the host data directory"
+        );
+        return legacy;
+    }
+    match config_dir() {
+        Some(host) => dirs().nvram_dir(&host).join(name),
+        None => legacy,
+    }
 }
 
 /// The RP5C01's battery-backed RAM, when `[machine] battmem` does not say
 /// otherwise. Fitted to A3000/A4000-class machines.
 pub fn battery_ram_file() -> PathBuf {
-    PathBuf::from("battmem.nvram")
+    battery_ram("battmem.nvram")
 }
 
-/// The CD32's Akiko NVRAM, when nothing else says otherwise. This one holds
-/// real game saves, so wherever it ends up, an existing file has to keep
-/// being found.
+/// The CD32's Akiko NVRAM, when nothing else says otherwise.
 pub fn akiko_nvram_file() -> PathBuf {
-    PathBuf::from("cd32-nvram.bin")
+    battery_ram("cd32-nvram.bin")
 }
 
 /// Create a path's parent directory so a write to it can succeed.
@@ -340,15 +400,49 @@ mod tests {
         epoch(&waveform_file(), "copperline-wave-", ".vcd");
         epoch(&trace_file(), "copperline-trace-", ".txt");
 
-        // The two battery RAMs are fixed names, not stamped.
-        assert_eq!(battery_ram_file().to_str(), Some("battmem.nvram"));
-        assert_eq!(akiko_nvram_file().to_str(), Some("cd32-nvram.bin"));
+        // The two battery RAMs are fixed names, not stamped. Where they
+        // sit is `nvram_dir`'s business and is covered separately; what
+        // matters here is that the names themselves never changed.
+        assert_eq!(
+            battery_ram_file().file_name().and_then(|n| n.to_str()),
+            Some("battmem.nvram")
+        );
+        assert_eq!(
+            akiko_nvram_file().file_name().and_then(|n| n.to_str()),
+            Some("cd32-nvram.bin")
+        );
     }
 
     /// The launcher is handed a root and spells the library paths from it;
     /// the no-argument helpers spell them from the config directory. Those
     /// were two independent descriptions of the same tree, agreeing only by
     /// coincidence, so hold them to each other.
+    /// A battery RAM sitting where Copperline used to put it keeps being
+    /// used from there. The CD32's is a memory card holding real game
+    /// saves; looking somewhere new would present a player with a blank
+    /// card and no hint that their progress was still on disk.
+    #[test]
+    fn an_existing_battery_ram_is_not_abandoned() {
+        let scratch = ScratchDir::new("battery");
+        let here = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&scratch.0).unwrap();
+
+        // Nothing there: the new place, under the host data directory.
+        let fresh = akiko_nvram_file();
+        assert!(
+            fresh.parent().is_some_and(|p| p.ends_with("nvram")) || config_dir().is_none(),
+            "a machine with no card should get the nvram directory: {fresh:?}"
+        );
+
+        // One there: that one, wherever it is.
+        std::fs::write("cd32-nvram.bin", []).unwrap();
+        assert_eq!(akiko_nvram_file(), PathBuf::from("cd32-nvram.bin"));
+        std::fs::write("battmem.nvram", []).unwrap();
+        assert_eq!(battery_ram_file(), PathBuf::from("battmem.nvram"));
+
+        std::env::set_current_dir(here).unwrap();
+    }
+
     #[test]
     fn the_library_layout_is_one_description() {
         let root = std::path::Path::new("/tmp/copperline-root");

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -183,7 +183,7 @@ pub fn library_root() -> PathBuf {
 
 /// Directory holding the numbered save-state slots.
 pub fn state_slot_dir() -> Option<PathBuf> {
-    config_dir().map(|dir| dirs().states_dir(&dir))
+    config_dir().map(|dir| configured().states_dir(&dir))
 }
 
 // --- what a run produces ------------------------------------------------
@@ -208,11 +208,51 @@ pub fn state_slot_dir() -> Option<PathBuf> {
 // recognises, so unifying it is a change in its own right and not one to
 // smuggle in here.
 
-/// The configured directories, read once. `paths.toml` says where each of
-/// these goes; absent or empty, it says nothing and the defaults stand.
-fn dirs() -> &'static crate::pathconf::Paths {
-    static DIRS: std::sync::OnceLock<crate::pathconf::Paths> = std::sync::OnceLock::new();
-    DIRS.get_or_init(crate::pathconf::Paths::load)
+/// The directories in force. A configuration's `[paths]` says where each of
+/// these goes; no section, or an empty one, says nothing and the defaults
+/// stand -- which is the state Copperline runs in until a configuration is
+/// loaded, and the one it stays in for anybody who never moves anything.
+///
+/// Settable rather than read once: the launcher can change these mid-session
+/// and a screenshot taken afterwards must land where the person just said it
+/// should, not where the configuration said at startup.
+fn store() -> &'static std::sync::RwLock<Option<std::sync::Arc<crate::pathconf::Paths>>> {
+    static DIRS: std::sync::RwLock<Option<std::sync::Arc<crate::pathconf::Paths>>> =
+        std::sync::RwLock::new(None);
+    &DIRS
+}
+
+/// The directories in force now.
+pub fn configured() -> std::sync::Arc<crate::pathconf::Paths> {
+    // A poisoned lock still holds a perfectly good `Paths`: the panic that
+    // poisoned it was somebody else's, and refusing to say where screenshots
+    // go because of it would help nobody.
+    let read = store().read().unwrap_or_else(|e| e.into_inner());
+    if let Some(dirs) = read.clone() {
+        return dirs;
+    }
+    drop(read);
+    let mut write = store().write().unwrap_or_else(|e| e.into_inner());
+    write.get_or_insert_with(Default::default).clone()
+}
+
+/// Put a configuration's `[paths]` in force, dropping whatever it names that
+/// this machine cannot reach.
+///
+/// Called once the configuration is settled, and again whenever the launcher
+/// changes it. The reachability check happens here rather than at the point
+/// of use so it happens once and where it can be waited on, not in the
+/// middle of taking a screenshot.
+pub fn adopt(dirs: crate::pathconf::Paths) {
+    let checked = match config_dir() {
+        Some(host) => dirs.reachable(&host),
+        // Nowhere to resolve against, so nothing to check: without a
+        // host-data directory the defaults are bare names in the working
+        // directory and `[paths]` has nothing to hang off.
+        None => dirs,
+    };
+    let mut write = store().write().unwrap_or_else(|e| e.into_inner());
+    *write = Some(std::sync::Arc::new(checked));
 }
 
 /// A named file under one of the configured directories.
@@ -226,7 +266,7 @@ fn output(
     name: String,
 ) -> PathBuf {
     match config_dir() {
-        Some(host) => pick(dirs(), &host).join(name),
+        Some(host) => pick(&configured(), &host).join(name),
         None => PathBuf::from(name),
     }
 }
@@ -319,7 +359,7 @@ fn battery_ram(name: &str) -> PathBuf {
         return legacy;
     }
     match config_dir() {
-        Some(host) => dirs().nvram_dir(&host).join(name),
+        Some(host) => configured().nvram_dir(&host).join(name),
         None => legacy,
     }
 }
@@ -348,7 +388,7 @@ pub fn akiko_nvram_file() -> PathBuf {
 fn media_dir(
     pick: impl Fn(&crate::pathconf::Paths, &std::path::Path) -> PathBuf,
 ) -> Option<PathBuf> {
-    let dir = pick(dirs(), &config_dir()?);
+    let dir = pick(&configured(), &config_dir()?);
     dir.is_dir().then_some(dir)
 }
 
@@ -376,6 +416,25 @@ pub fn harddrives_dir() -> Option<PathBuf> {
 pub fn cds_dir() -> Option<PathBuf> {
     media_dir(|p, h| p.cds_dir(h))
 }
+
+/// Where the launcher saves machine configurations.
+pub fn configs_dir() -> Option<PathBuf> {
+    config_dir().map(|host| configured().configs_dir(&host))
+}
+
+/// The configuration Copperline starts with when nothing on the command
+/// line says otherwise.
+///
+/// Exists only once somebody has pressed Save default, which is what makes
+/// "back to factory settings" a matter of deleting one file: with no
+/// default saved there is nothing to override, so most installations never
+/// have one and `--factory` never has anything to do.
+pub fn default_config_file() -> Option<PathBuf> {
+    configs_dir().map(|dir| dir.join(DEFAULT_CONFIG))
+}
+
+/// The saved default's filename.
+pub const DEFAULT_CONFIG: &str = "default.toml";
 
 /// Create a path's parent directory so a write to it can succeed.
 pub fn ensure_parent(path: &std::path::Path) -> std::io::Result<()> {
@@ -453,6 +512,34 @@ mod tests {
             akiko_nvram_file().file_name().and_then(|n| n.to_str()),
             Some("cd32-nvram.bin")
         );
+    }
+
+    /// The link the rest of the suite does not reach: a configuration's
+    /// `[paths]`, once adopted, is what a run actually writes against.
+    /// Everything in between is covered -- the section parses, the entries
+    /// resolve, the names keep their shape -- and none of it would notice
+    /// if [`output`] stopped consulting the adopted set at all.
+    ///
+    /// The only test that writes the process-wide store. It is safe beside
+    /// the others because they look at file *names*, which this does not
+    /// touch, and it puts the defaults back when it is done.
+    #[test]
+    fn what_a_run_writes_follows_the_adopted_section() {
+        let Some(host) = config_dir() else {
+            // No per-user directory on this host, so every default is a
+            // bare name and there is nothing for a section to move.
+            return;
+        };
+        adopt(crate::pathconf::Paths {
+            screenshots: Some(PathBuf::from("elsewhere")),
+            ..Default::default()
+        });
+        let moved = screenshot_file();
+        adopt(crate::pathconf::Paths::default());
+        let back = screenshot_file();
+
+        assert_eq!(moved.parent(), Some(host.join("elsewhere").as_path()));
+        assert_eq!(back.parent(), Some(host.join("screenshots").as_path()));
     }
 
     /// The launcher is handed a root and spells the library paths from it;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -236,6 +236,17 @@ pub fn configured() -> std::sync::Arc<crate::pathconf::Paths> {
     write.get_or_insert_with(Default::default).clone()
 }
 
+/// Serialises the tests that touch the adopted set. [`adopt`] writes one
+/// process-wide store, `cargo test` runs threads in one process, and a test
+/// that adopts and then asserts can otherwise be clobbered by another
+/// test's adopt landing between the two. Production has no such caller:
+/// adoption happens at startup and on launcher edits, both on one thread.
+#[cfg(test)]
+pub(crate) fn adopted_store_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// Put a configuration's `[paths]` in force, dropping whatever it names that
 /// this machine cannot reach.
 ///
@@ -353,9 +364,7 @@ pub fn trace_file() -> PathBuf {
 fn battery_ram(name: &str) -> PathBuf {
     let legacy = PathBuf::from(name);
     if legacy.is_file() {
-        log::info!(
-            "using the existing {name} in the working directory; new machines keep theirs under the host data directory"
-        );
+        log::info!("using the existing {name} in the working directory");
         return legacy;
     }
     match config_dir() {
@@ -429,8 +438,15 @@ pub fn configs_dir() -> Option<PathBuf> {
 /// "back to factory settings" a matter of deleting one file: with no
 /// default saved there is nothing to override, so most installations never
 /// have one and `--factory` never has anything to do.
+///
+/// Deliberately *not* [`configs_dir`]: this file is found at startup,
+/// before any configuration -- including its own `[paths]` -- has been
+/// adopted, so a location that followed `[paths] configs` could never be
+/// found by the startup that needs it. Saved and looked for in the factory
+/// location always; the `configs` entry steers the file dialogs, not this.
 pub fn default_config_file() -> Option<PathBuf> {
-    configs_dir().map(|dir| dir.join(DEFAULT_CONFIG))
+    let factory = crate::pathconf::Paths::default();
+    config_dir().map(|host| factory.configs_dir(&host).join(DEFAULT_CONFIG))
 }
 
 /// The saved default's filename.
@@ -525,6 +541,7 @@ mod tests {
     /// touch, and it puts the defaults back when it is done.
     #[test]
     fn what_a_run_writes_follows_the_adopted_section() {
+        let _guard = adopted_store_lock();
         let Some(host) = config_dir() else {
             // No per-user directory on this host, so every default is a
             // bare name and there is nothing for a section to move.
@@ -574,10 +591,23 @@ mod tests {
         assert_eq!(cfg.mt32_roms_dir(host), roms.join("mt32"));
     }
 
+    /// Restores the working directory when dropped, so a failing assertion
+    /// cannot leave the rest of the suite running somewhere else: the CWD
+    /// is process state, and `set_current_dir` with no guard holds until
+    /// the process ends, not until the test does.
+    struct CwdGuard(PathBuf);
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
     #[test]
     fn an_existing_battery_ram_is_not_abandoned() {
+        // The no-legacy branch below reads the adopted store.
+        let _store = adopted_store_lock();
         let scratch = ScratchDir::new("battery");
-        let here = std::env::current_dir().unwrap();
+        let _cwd = CwdGuard(std::env::current_dir().unwrap());
         std::env::set_current_dir(&scratch.0).unwrap();
 
         // Nothing there: the new place, under the host data directory.
@@ -592,8 +622,6 @@ mod tests {
         assert_eq!(akiko_nvram_file(), PathBuf::from("cd32-nvram.bin"));
         std::fs::write("battmem.nvram", []).unwrap();
         assert_eq!(battery_ram_file(), PathBuf::from("battmem.nvram"));
-
-        std::env::set_current_dir(here).unwrap();
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -95,7 +95,7 @@ pub fn whdload_dir() -> Option<PathBuf> {
 
 /// Where the support archives are looked for and downloaded to.
 pub fn whdload_support_dir() -> Option<PathBuf> {
-    whdload_dir().map(|dir| dir.join("support"))
+    config_dir().map(|dir| whdload_support_in(&dir))
 }
 
 /// Where games are unpacked and their saves kept, when `[whdload] library`
@@ -132,22 +132,147 @@ fn holds_unpacked_games(dir: &std::path::Path) -> bool {
         .any(|entry| entry.path().join(".source").is_file())
 }
 
+// The same layout, spelled from a root the caller chose. The launcher is
+// handed a root rather than asking for one, so a test can point it
+// somewhere harmless -- and it had grown its own copy of these joins,
+// which meant the tree Copperline writes and the tree `paths` described
+// were two independent claims that happened to agree.
+
+/// The support directory under a given root.
+pub fn whdload_support_in(root: &std::path::Path) -> PathBuf {
+    root.join("whdload").join("support")
+}
+
+/// The scanned library under a given root.
+pub fn whdload_library_db_in(root: &std::path::Path) -> PathBuf {
+    whdload_support_in(root).join("launcher.db")
+}
+
+/// A scan's downloads under a given root.
+pub fn whdload_library_cache_in(root: &std::path::Path) -> PathBuf {
+    whdload_support_in(root).join("cache")
+}
+
 /// The scanned library, when `[whdload] library_db` does not say otherwise.
 /// Beside the support archives, which is the other thing under `whdload/`
 /// that Copperline rather than the guest put there.
 pub fn whdload_library_db() -> Option<PathBuf> {
-    whdload_support_dir().map(|dir| dir.join("launcher.db"))
+    config_dir().map(|dir| whdload_library_db_in(&dir))
 }
 
 /// What a scan downloaded, when `[whdload] library_cache` does not say
 /// otherwise. Safe to delete: it is rebuilt by the next scan.
 pub fn whdload_library_cache() -> Option<PathBuf> {
-    whdload_support_dir().map(|dir| dir.join("cache"))
+    config_dir().map(|dir| whdload_library_cache_in(&dir))
+}
+
+/// The root the launcher takes its library paths from.
+///
+/// A host with no per-user directory at all -- no `HOME`, no `XDG_CONFIG_HOME`,
+/// no `APPDATA`, which is a bare service account or some CI runners -- has
+/// nowhere to put these, and every call site reached for
+/// `config_dir().unwrap_or_default()`. That yields an *empty* path, so the
+/// library quietly becomes `whdload/support/launcher.db` relative to
+/// wherever the process was started. Named here rather than repeated at
+/// eight call sites, with the behaviour unchanged: it is a poor answer, but
+/// changing it is a decision about where data lives and not about who owns
+/// the path.
+pub fn library_root() -> PathBuf {
+    config_dir().unwrap_or_default()
 }
 
 /// Directory holding the numbered save-state slots.
 pub fn state_slot_dir() -> Option<PathBuf> {
     config_dir().map(|dir| dir.join("states"))
+}
+
+// --- what a run produces ------------------------------------------------
+//
+// Screenshots, recordings, save states, traces, waveform captures and the
+// battery-backed RAMs. Each of these had its name and its location written
+// out at the point it was used -- in nine places, two of them identical --
+// so a file's home depended on which code path produced it and no one
+// place knew the whole set.
+//
+// They are gathered here unchanged: every function below still resolves to
+// exactly where its caller put things before, which for most of them is
+// the process's working directory. That is not where they belong, but
+// moving them and re-homing them at once would make a regression in the
+// routing indistinguishable from an argument about the destination. With
+// one owner, the move is an edit to these bodies.
+
+// Two stamp formats are in use and both are kept. What a person opens --
+// screenshots, recordings, states -- is named with a readable local
+// datetime; the diagnostic captures are named with Unix seconds. Nobody
+// chose that split, but a filename is what a script greps and a person
+// recognises, so unifying it is a change in its own right and not one to
+// smuggle in here.
+
+/// Seconds since the epoch, for the diagnostic captures.
+fn epoch_stamp() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Default name for a screenshot taken without one being given.
+pub fn screenshot_file() -> PathBuf {
+    PathBuf::from(format!(
+        "copperline-screenshot-{}.png",
+        crate::timestamp::compact_now()
+    ))
+}
+
+/// Default name for a video recording.
+pub fn recording_file() -> PathBuf {
+    PathBuf::from(format!(
+        "copperline-video-{}.avi",
+        crate::timestamp::compact_now()
+    ))
+}
+
+/// Default name for a recorded input script.
+pub fn input_recording_file() -> PathBuf {
+    PathBuf::from(format!(
+        "copperline-input-{}.clscript",
+        crate::timestamp::compact_now()
+    ))
+}
+
+/// Default name for a save state written outside the numbered slots.
+pub fn state_file() -> PathBuf {
+    PathBuf::from(format!(
+        "copperline-state-{}.clstate",
+        crate::timestamp::compact_now()
+    ))
+}
+
+/// Default name for a waveform capture. Reached from `--waveform` without a
+/// path and from `waveform.start` without one; a capture can run to half a
+/// gigabyte, which is its own argument against the working directory.
+pub fn waveform_file() -> PathBuf {
+    PathBuf::from(format!("copperline-wave-{}.vcd", epoch_stamp()))
+}
+
+/// Default name for an instruction trace. The debugger console and the
+/// control protocol both start traces, and each had its own copy of this;
+/// they now cannot drift.
+pub fn trace_file() -> PathBuf {
+    PathBuf::from(format!("copperline-trace-{}.txt", epoch_stamp()))
+}
+
+/// The RP5C01's battery-backed RAM, when `[machine] battmem` does not say
+/// otherwise. Fitted to A3000/A4000-class machines.
+pub fn battery_ram_file() -> PathBuf {
+    PathBuf::from("battmem.nvram")
+}
+
+/// The CD32's Akiko NVRAM, when nothing else says otherwise. This one holds
+/// real game saves, so wherever it ends up, an existing file has to keep
+/// being found.
+pub fn akiko_nvram_file() -> PathBuf {
+    PathBuf::from("cd32-nvram.bin")
 }
 
 /// Create a path's parent directory so a write to it can succeed.
@@ -177,6 +302,77 @@ mod tests {
     impl Drop for ScratchDir {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// The names a run produces, and which stamp each carries. Gathering
+    /// these into one place is only safe if none of them changed on the way
+    /// -- a filename is what a person recognises and a script greps -- and
+    /// the two stamp formats are easy to swap by accident, because nothing
+    /// but the call site said which was which.
+    #[test]
+    fn the_output_names_keep_their_shape_and_their_stamp() {
+        let readable = |p: &std::path::Path, prefix: &str, ext: &str| {
+            let name = p.file_name().unwrap().to_str().unwrap().to_string();
+            assert!(name.starts_with(prefix), "{name} does not start {prefix}");
+            assert!(name.ends_with(ext), "{name} does not end {ext}");
+            let stamp = &name[prefix.len()..name.len() - ext.len()];
+            // yyyymmddHHMMSS: a local datetime a person can read.
+            assert_eq!(stamp.len(), 14, "{name}: not a compact datetime");
+            assert!(stamp.chars().all(|c| c.is_ascii_digit()), "{name}");
+            assert!(stamp.starts_with("20"), "{name}: not a year");
+        };
+        readable(&screenshot_file(), "copperline-screenshot-", ".png");
+        readable(&recording_file(), "copperline-video-", ".avi");
+        readable(&input_recording_file(), "copperline-input-", ".clscript");
+        readable(&state_file(), "copperline-state-", ".clstate");
+
+        let epoch = |p: &std::path::Path, prefix: &str, ext: &str| {
+            let name = p.file_name().unwrap().to_str().unwrap().to_string();
+            assert!(name.starts_with(prefix), "{name} does not start {prefix}");
+            assert!(name.ends_with(ext), "{name} does not end {ext}");
+            let stamp = &name[prefix.len()..name.len() - ext.len()];
+            let secs: u64 = stamp.parse().unwrap_or_else(|_| panic!("{name}"));
+            // Unix seconds, not a datetime: far past any 14-digit value.
+            assert!(secs > 1_600_000_000, "{name}: not unix seconds");
+            assert!(secs < 4_000_000_000, "{name}: not unix seconds");
+        };
+        epoch(&waveform_file(), "copperline-wave-", ".vcd");
+        epoch(&trace_file(), "copperline-trace-", ".txt");
+
+        // The two battery RAMs are fixed names, not stamped.
+        assert_eq!(battery_ram_file().to_str(), Some("battmem.nvram"));
+        assert_eq!(akiko_nvram_file().to_str(), Some("cd32-nvram.bin"));
+    }
+
+    /// The launcher is handed a root and spells the library paths from it;
+    /// the no-argument helpers spell them from the config directory. Those
+    /// were two independent descriptions of the same tree, agreeing only by
+    /// coincidence, so hold them to each other.
+    #[test]
+    fn the_library_layout_is_one_description() {
+        let root = std::path::Path::new("/tmp/copperline-root");
+        assert_eq!(
+            whdload_library_db_in(root),
+            whdload_support_in(root).join("launcher.db")
+        );
+        assert_eq!(
+            whdload_library_cache_in(root),
+            whdload_support_in(root).join("cache")
+        );
+        assert_eq!(
+            whdload_support_in(root),
+            root.join("whdload").join("support")
+        );
+        // And the no-argument forms are the same layout under the config
+        // directory, whatever that turns out to be on this host.
+        if let Some(dir) = config_dir() {
+            assert_eq!(whdload_support_dir(), Some(whdload_support_in(&dir)));
+            assert_eq!(whdload_library_db(), Some(whdload_library_db_in(&dir)));
+            assert_eq!(
+                whdload_library_cache(),
+                Some(whdload_library_cache_in(&dir))
+            );
         }
     }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -236,15 +236,35 @@ pub fn configured() -> std::sync::Arc<crate::pathconf::Paths> {
     write.get_or_insert_with(Default::default).clone()
 }
 
-/// Serialises the tests that touch the adopted set. [`adopt`] writes one
-/// process-wide store, `cargo test` runs threads in one process, and a test
-/// that adopts and then asserts can otherwise be clobbered by another
-/// test's adopt landing between the two. Production has no such caller:
-/// adoption happens at startup and on launcher edits, both on one thread.
+/// Borrows the adopted set for a test, and puts the defaults back when it
+/// goes out of scope.
+///
+/// [`adopt`] writes one process-wide store and `cargo test` runs threads in
+/// one process, so two tests adopting at once would clobber each other --
+/// hence the lock. Restoring on drop is the other half: without it a test
+/// that adopts leaves its directories in force for every *unguarded* test
+/// that runs afterwards, which the lock alone cannot prevent. Production
+/// has no such caller; adoption happens at startup and on launcher edits,
+/// both on one thread.
 #[cfg(test)]
-pub(crate) fn adopted_store_lock() -> std::sync::MutexGuard<'static, ()> {
+pub(crate) struct AdoptedStore {
+    /// Held for the guard's lifetime; never read.
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl Drop for AdoptedStore {
+    fn drop(&mut self) {
+        adopt(crate::pathconf::Paths::default());
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn adopted_store_lock() -> AdoptedStore {
     static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    AdoptedStore {
+        _lock: LOCK.lock().unwrap_or_else(|e| e.into_inner()),
+    }
 }
 
 /// Put a configuration's `[paths]` in force, dropping whatever it names that
@@ -455,8 +475,10 @@ pub const DEFAULT_CONFIG: &str = "default.toml";
 /// Create a path's parent directory so a write to it can succeed.
 pub fn ensure_parent(path: &std::path::Path) -> std::io::Result<()> {
     match path.parent() {
-        Some(parent) => std::fs::create_dir_all(parent),
-        None => Ok(()),
+        // A bare filename's parent is the empty path, which is the working
+        // directory and needs no creating.
+        Some(parent) if !parent.as_os_str().is_empty() => std::fs::create_dir_all(parent),
+        _ => Ok(()),
     }
 }
 
@@ -554,6 +576,8 @@ mod tests {
         let moved = screenshot_file();
         adopt(crate::pathconf::Paths::default());
         let back = screenshot_file();
+        // `_guard` puts the defaults back either way; the explicit adopt
+        // above is what `back` is measuring.
 
         assert_eq!(moved.parent(), Some(host.join("elsewhere").as_path()));
         assert_eq!(back.parent(), Some(host.join("screenshots").as_path()));

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -335,6 +335,48 @@ pub fn akiko_nvram_file() -> PathBuf {
     battery_ram("cd32-nvram.bin")
 }
 
+// --- where a dialog opens ------------------------------------------------
+//
+// Not Copperline's to write, and not created: these only say where a file
+// dialog starts when the field it was opened from is empty. A field with a
+// value opens beside that value, which beats any fixed answer.
+//
+// Each returns `None` when the directory does not exist, so a dialog is
+// never pointed at somewhere that isn't there. Make the folder and it gets
+// used; don't, and nothing changes. That is the whole of the opt-in.
+
+fn media_dir(
+    pick: impl Fn(&crate::pathconf::Paths, &std::path::Path) -> PathBuf,
+) -> Option<PathBuf> {
+    let dir = pick(dirs(), &config_dir()?);
+    dir.is_dir().then_some(dir)
+}
+
+/// Kickstart and extended ROM images.
+pub fn roms_dir() -> Option<PathBuf> {
+    media_dir(|p, h| p.roms_dir(h))
+}
+
+/// MT-32 control and PCM ROMs.
+pub fn mt32_roms_dir() -> Option<PathBuf> {
+    media_dir(|p, h| p.mt32_roms_dir(h))
+}
+
+/// Floppy images.
+pub fn floppies_dir() -> Option<PathBuf> {
+    media_dir(|p, h| p.floppies_dir(h))
+}
+
+/// Hard-disk images and host-filesystem folders.
+pub fn harddrives_dir() -> Option<PathBuf> {
+    media_dir(|p, h| p.harddrives_dir(h))
+}
+
+/// CD images.
+pub fn cds_dir() -> Option<PathBuf> {
+    media_dir(|p, h| p.cds_dir(h))
+}
+
 /// Create a path's parent directory so a write to it can succeed.
 pub fn ensure_parent(path: &std::path::Path) -> std::io::Result<()> {
     match path.parent() {
@@ -421,6 +463,30 @@ mod tests {
     /// used from there. The CD32's is a memory card holding real game
     /// saves; looking somewhere new would present a player with a blank
     /// card and no hint that their progress was still on disk.
+    /// The dialog directories answer only for a folder that exists. Make
+    /// one and it gets used; leave it and nothing changes -- which is what
+    /// lets these be offered without Copperline creating a handful of empty
+    /// folders nobody asked for.
+    #[test]
+    fn a_dialog_directory_answers_only_when_it_is_there() {
+        let scratch = ScratchDir::new("media");
+        let cfg = crate::pathconf::Paths {
+            base: Some(scratch.0.clone()),
+            ..Default::default()
+        };
+        let host = scratch.0.as_path();
+
+        let roms = cfg.roms_dir(host);
+        assert!(!roms.is_dir(), "nothing made yet");
+        assert_eq!(roms.is_dir().then(|| roms.clone()), None);
+
+        std::fs::create_dir_all(&roms).unwrap();
+        assert_eq!(roms.is_dir().then(|| roms.clone()), Some(roms.clone()));
+
+        // The MT-32 pair sit under the ROMs folder rather than beside it.
+        assert_eq!(cfg.mt32_roms_dir(host), roms.join("mt32"));
+    }
+
     #[test]
     fn an_existing_battery_ram_is_not_abandoned() {
         let scratch = ScratchDir::new("battery");

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -97,6 +97,8 @@ impl VideoRecorder {
     /// RGBA stream. The header's timing fields are placeholders until
     /// [`finish`](Self::finish) patches them.
     pub fn create(path: &Path, width: usize, height: usize) -> Result<Self> {
+        crate::paths::ensure_parent(path)
+            .with_context(|| format!("creating the directory for {}", path.display()))?;
         let file =
             File::create(path).with_context(|| format!("creating recording {}", path.display()))?;
         let mut out = BufWriter::new(file);

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -63,8 +63,7 @@ const HEADER_LEN: usize = 324;
 
 /// Pick a default filename for an interactive recording.
 pub fn auto_filename() -> PathBuf {
-    let ts = crate::timestamp::compact_now();
-    PathBuf::from(format!("copperline-video-{ts}.avi"))
+    crate::paths::recording_file()
 }
 
 struct IndexEntry {

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -616,7 +616,12 @@ impl Rp5c01Rtc {
 
     fn flush_battmem(&mut self, emulated_secs: f64) {
         if let Some(path) = &self.battmem_path {
-            if let Err(e) = std::fs::write(path, self.battmem_bytes(emulated_secs)) {
+            // The directory is Copperline's own and may not exist yet; it
+            // is made here rather than at bind time so a guest that never
+            // writes the clock RAM leaves no empty folder behind.
+            if let Err(e) = crate::paths::ensure_parent(path)
+                .and_then(|()| std::fs::write(path, self.battmem_bytes(emulated_secs)))
+            {
                 // Stay dirty so the next MODE write retries: a transient
                 // host error must not lose the battery state until the
                 // guest happens to change it again.
@@ -1237,17 +1242,21 @@ mod tests {
     /// drop the battery state on a transient host error.
     #[test]
     fn rp5c01_battmem_retries_the_flush_after_a_failed_write() {
-        let dir = battmem_file("retry-dir"); // reserved, not yet created
+        let dir = battmem_file("retry-dir");
         let path = dir.join("battmem.nvram");
+        // A directory where the file goes: the write fails, and unlike a
+        // missing parent it stays failing, since the flush makes its own
+        // directories now.
+        std::fs::create_dir_all(&path).unwrap();
         let mut rtc = seeded_rp5c01(VECTOR_UNIX);
         rtc.set_battmem_path(path.clone());
 
         rp_write(&mut rtc, 0xD, 0xA);
         rp_write(&mut rtc, 0x0, 0x5);
-        rp_write(&mut rtc, 0xD, 0x8); // flush fails: parent dir missing
-        assert!(!path.exists());
+        rp_write(&mut rtc, 0xD, 0x8); // flush fails: a directory is in the way
+        assert!(path.is_dir(), "nothing should have been written over it");
 
-        std::fs::create_dir(&dir).unwrap();
+        std::fs::remove_dir(&path).unwrap();
         rp_write(&mut rtc, 0xD, 0x8); // still dirty: retried and lands
         let bytes = std::fs::read(&path).unwrap();
         assert_eq!(bytes[0x20], 0x05);

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -218,6 +218,8 @@ pub fn slot_path(slot: usize) -> Option<std::path::PathBuf> {
 /// (the shape of the machine that produced it). Call only between emulated
 /// frames.
 pub fn save(machine: &M68kMachine, descriptor: &MachineDescriptor, path: &Path) -> Result<()> {
+    crate::paths::ensure_parent(path)
+        .with_context(|| format!("creating the directory for {}", path.display()))?;
     let file =
         File::create(path).with_context(|| format!("creating save state {}", path.display()))?;
     save_to_writer(machine, descriptor, BufWriter::new(file))

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -183,8 +183,7 @@ pub const STATE_VERSION: u32 = 52;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {
-    let ts = crate::timestamp::compact_now();
-    std::path::PathBuf::from(format!("copperline-state-{ts}.clstate"))
+    crate::paths::state_file()
 }
 
 /// Number of numbered quick-save slots. Ten, so they map onto the host

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -26,6 +26,8 @@ pub fn save(path: &Path, fb: &[u32], width: u32, height: u32) -> Result<()> {
                 .with_context(|| format!("creating {}", parent.display()))?;
         }
     }
+    crate::paths::ensure_parent(path)
+        .with_context(|| format!("creating the directory for {}", path.display()))?;
     let file =
         std::fs::File::create(path).with_context(|| format!("opening {}", path.display()))?;
     let writer = std::io::BufWriter::new(file);

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -217,8 +217,7 @@ pub fn stretch_rows_x_window(fb: &mut [u32], width: usize, rows: usize, src_x0: 
 
 /// Pick a default filename for an interactive screenshot grab.
 pub fn auto_filename() -> PathBuf {
-    let ts = crate::timestamp::compact_now();
-    PathBuf::from(format!("copperline-screenshot-{ts}.png"))
+    crate::paths::screenshot_file()
 }
 
 #[cfg(test)]

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -20,12 +20,6 @@ pub fn save(path: &Path, fb: &[u32], width: u32, height: u32) -> Result<()> {
             expected
         );
     }
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating {}", parent.display()))?;
-        }
-    }
     crate::paths::ensure_parent(path)
         .with_context(|| format!("creating the directory for {}", path.display()))?;
     let file =

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1120,7 +1120,7 @@ const EMULATION_ROWS: [Row; 5] = [
 /// the machine, so none of it round-trips through [`RawConfig`].
 const PATHS_ROWS: [Row; 12] = [
     row(F::PathsBase, "Base folder", PathRow),
-    section_header("Copperline writes:"),
+    section_header("Custom directories:"),
     row(F::PathsStates, "Save states", PathRow),
     row(F::PathsScreenshots, "Screenshots", PathRow),
     row(F::PathsRecordings, "Recordings", PathRow),
@@ -5866,6 +5866,11 @@ pub struct LauncherState {
     /// is three buttons over the action bar, and every click either picks
     /// one or puts it away.
     pub save_menu: bool,
+    /// Whether the "are you sure" over Reset default is up. Only ever set
+    /// when there is a default to delete -- with none saved there is
+    /// nothing to be sure about, and a dialog asking anyway is a dialog
+    /// that teaches people to dismiss dialogs.
+    pub confirm_reset: bool,
     /// What the Create Image pages will make. Not machine configuration, so
     /// it sits beside the setup rather than inside it.
     pub workshop: ImageWorkshop,
@@ -7111,6 +7116,7 @@ impl LauncherState {
         setup.adopt_whdload_defaults();
         let mut state = Self {
             save_menu: false,
+            confirm_reset: false,
             #[cfg(feature = "game-library")]
             library: LibraryPage::default(),
             #[cfg(feature = "game-library")]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -8983,6 +8983,9 @@ mod tests {
     /// wrong entry, or to none, cannot pass.
     #[test]
     fn every_paths_row_reaches_its_own_entry() {
+        // `set_path` on a Paths row adopts, which writes the process-wide
+        // store another test asserts against.
+        let _guard = crate::paths::adopted_store_lock();
         let mut setup = MachineSetup::default();
         let fields: Vec<LauncherField> = PATHS_ROWS
             .iter()

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1129,7 +1129,7 @@ const PATHS_ROWS: [Row; 12] = [
     row(F::PathsRecordings, "  Recordings", PathRow),
     row(F::PathsNvram, "  NVRAM", PathRow),
     row(F::PathsTraces, "  Traces", PathRow),
-    row(F::PathsConfigs, "  Configurations", PathRow),
+    row(F::PathsConfigs, "  Config files", PathRow),
     row(F::PathsRoms, "  ROMs", PathRow),
     row(F::PathsFloppies, "  Floppies", PathRow),
     row(F::PathsHarddrives, "  Hard drives", PathRow),

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1121,16 +1121,19 @@ const EMULATION_ROWS: [Row; 5] = [
 const PATHS_ROWS: [Row; 12] = [
     row(F::PathsBase, "Base folder", PathRow),
     section_header("Custom directories:"),
-    row(F::PathsStates, "Save states", PathRow),
-    row(F::PathsScreenshots, "Screenshots", PathRow),
-    row(F::PathsRecordings, "Recordings", PathRow),
-    row(F::PathsNvram, "NVRAM", PathRow),
-    row(F::PathsTraces, "Traces", PathRow),
-    row(F::PathsConfigs, "Configurations", PathRow),
-    row(F::PathsRoms, "ROMs", PathRow),
-    row(F::PathsFloppies, "Floppies", PathRow),
-    row(F::PathsHarddrives, "Hard drives", PathRow),
-    row(F::PathsCds, "CD images", PathRow),
+    // Indented under the heading, the same as the sections on the I/O
+    // Ports and MT-32 pages: the base above it is not one of these, and
+    // the indent is what says so.
+    row(F::PathsStates, "  Save states", PathRow),
+    row(F::PathsScreenshots, "  Screenshots", PathRow),
+    row(F::PathsRecordings, "  Recordings", PathRow),
+    row(F::PathsNvram, "  NVRAM", PathRow),
+    row(F::PathsTraces, "  Traces", PathRow),
+    row(F::PathsConfigs, "  Configurations", PathRow),
+    row(F::PathsRoms, "  ROMs", PathRow),
+    row(F::PathsFloppies, "  Floppies", PathRow),
+    row(F::PathsHarddrives, "  Hard drives", PathRow),
+    row(F::PathsCds, "  CD images", PathRow),
 ];
 
 /// The floppy page. Every option the format carries is on it; nothing on

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -202,6 +202,10 @@ pub enum LauncherTab {
     AvAudio,
     AvVideo,
     AvEmulation,
+    /// Where Copperline keeps what it produces and where its file dialogs
+    /// open. Its rows are the configuration's `[paths]` section, saved
+    /// with the rest of it and absent until one of them is set.
+    AvPaths,
     /// The Create Image workshop, reached from Storage: two pages that make
     /// fresh images and touch nothing about the machine.
     CreateFloppy,
@@ -285,6 +289,7 @@ impl LauncherTab {
             LauncherTab::AvAudio => "A/V & Emu",
             LauncherTab::AvVideo => "Video",
             LauncherTab::AvEmulation => "Emulation",
+            LauncherTab::AvPaths => "Paths",
             LauncherTab::CreateFloppy => "Floppy Disk",
             LauncherTab::CreateHard => "Hard Disk",
             LauncherTab::CreateGeometry => "Disk Geometry",
@@ -310,7 +315,9 @@ impl LauncherTab {
             | LauncherTab::CreateHard
             | LauncherTab::CreateGeometry => LauncherTab::Storage,
             LauncherTab::FluxBridge => LauncherTab::Floppy,
-            LauncherTab::AvVideo | LauncherTab::AvEmulation => LauncherTab::AvAudio,
+            LauncherTab::AvVideo | LauncherTab::AvEmulation | LauncherTab::AvPaths => {
+                LauncherTab::AvAudio
+            }
             other => other,
         }
     }
@@ -345,7 +352,10 @@ impl LauncherTab {
     pub fn nav_options(self) -> &'static [(&'static str, LauncherTab)] {
         match self {
             LauncherTab::Storage => STORAGE_NAV,
-            LauncherTab::AvAudio | LauncherTab::AvVideo | LauncherTab::AvEmulation => AV_NAV,
+            LauncherTab::AvAudio
+            | LauncherTab::AvVideo
+            | LauncherTab::AvEmulation
+            | LauncherTab::AvPaths => AV_NAV,
             LauncherTab::CreateFloppy | LauncherTab::CreateHard => CREATE_NAV,
             #[cfg(feature = "game-library")]
             LauncherTab::Whdload | LauncherTab::WhdloadLibrary => WHDLOAD_NAV,
@@ -397,6 +407,7 @@ const AV_NAV: &[(&str, LauncherTab)] = &[
     ("Audio", LauncherTab::AvAudio),
     ("Video", LauncherTab::AvVideo),
     ("Emulation", LauncherTab::AvEmulation),
+    ("Paths", LauncherTab::AvPaths),
 ];
 
 /// A single editable setting. Parameter-free variants keep the per-tab row
@@ -405,6 +416,23 @@ const AV_NAV: &[(&str, LauncherTab)] = &[
 /// same reason.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LauncherField {
+    // --- the Paths page ---------------------------------------------
+    //
+    // The configuration's `[paths]` section, edited here and written out
+    // with the rest of it. On `MachineSetup` because that is the
+    // launcher's edit buffer for everything a configuration holds.
+    PathsBase,
+    PathsStates,
+    PathsScreenshots,
+    PathsRecordings,
+    PathsNvram,
+    PathsTraces,
+    PathsConfigs,
+    PathsRoms,
+    PathsMt32Roms,
+    PathsFloppies,
+    PathsHarddrives,
+    PathsCds,
     // Create Image workshop -- these edit no machine setting, only what the
     // next image will be made of.
     NewFloppyDensity,
@@ -748,6 +776,28 @@ impl LauncherField {
         matches!(filesys_slot(self), Some((_, false)))
     }
 
+    /// Whether this field is a row on the Paths page: a directory in
+    /// `[paths]` rather than anything belonging to the machine. They get
+    /// a folder picker, they show the whole path rather than a file name,
+    /// and they take effect the moment they change.
+    pub fn is_paths_field(self) -> bool {
+        matches!(
+            self,
+            LauncherField::PathsBase
+                | LauncherField::PathsStates
+                | LauncherField::PathsScreenshots
+                | LauncherField::PathsRecordings
+                | LauncherField::PathsNvram
+                | LauncherField::PathsTraces
+                | LauncherField::PathsConfigs
+                | LauncherField::PathsRoms
+                | LauncherField::PathsMt32Roms
+                | LauncherField::PathsFloppies
+                | LauncherField::PathsHarddrives
+                | LauncherField::PathsCds
+        )
+    }
+
     /// Whether this field is a WHDLoad staging directory (folder picker):
     /// the Kickstart-image and game-library directories, but not the game
     /// package (an `.lha` file, picked as a file).
@@ -1067,6 +1117,26 @@ const EMULATION_ROWS: [Row; 5] = [
     // doing anything at all -- no database read, no cover worker, no scan.
     row(F::WhdloadEnabled, "WHDLoad", Cycle),
 ];
+/// The Paths page. Every row is optional: cleared, it inherits, and the
+/// value shown is the directory that would be used. Nothing here describes
+/// the machine, so none of it round-trips through [`RawConfig`].
+const PATHS_ROWS: [Row; 14] = [
+    row(F::PathsBase, "Base folder", PathRow),
+    section_header("Copperline writes:"),
+    row(F::PathsStates, "Save states", PathRow),
+    row(F::PathsScreenshots, "Screenshots", PathRow),
+    row(F::PathsRecordings, "Recordings", PathRow),
+    row(F::PathsNvram, "Battery RAM", PathRow),
+    row(F::PathsTraces, "Traces", PathRow),
+    row(F::PathsConfigs, "Configurations", PathRow),
+    section_header("Dialogs open at:"),
+    row(F::PathsRoms, "ROMs", PathRow),
+    row(F::PathsMt32Roms, "MT-32 ROMs", PathRow),
+    row(F::PathsFloppies, "Floppies", PathRow),
+    row(F::PathsHarddrives, "Hard drives", PathRow),
+    row(F::PathsCds, "CD images", PathRow),
+];
+
 /// The floppy page. Every option the format carries is on it; nothing on
 /// it reads or writes the machine's configuration.
 const NEW_FLOPPY_ROWS: [Row; 8] = [
@@ -1181,6 +1251,7 @@ pub fn rows(
         LauncherTab::AvAudio => Cow::Borrowed(&AUDIO_ROWS),
         LauncherTab::AvVideo => Cow::Borrowed(&VIDEO_ROWS),
         LauncherTab::AvEmulation => Cow::Borrowed(&EMULATION_ROWS),
+        LauncherTab::AvPaths => Cow::Borrowed(&PATHS_ROWS),
     }
 }
 
@@ -1986,6 +2057,13 @@ pub struct MachineSetup {
     port_devices: [PortDevice; 2],
     // Extra Zorro boards (metadata path + plugin config schema/overrides)
     zorro_boards: Vec<ZorroBoardSetup>,
+    /// The Paths page: the configuration's `[paths]` section, saved with
+    /// the rest of it. Empty until somebody moves something, so a
+    /// configuration that never mentions directories stays as portable as
+    /// it was -- and one that does still starts on a machine that has
+    /// never seen them, because what cannot be reached is dropped when the
+    /// configuration is adopted.
+    paths: crate::pathconf::Paths,
 }
 
 impl Default for MachineSetup {
@@ -2205,12 +2283,18 @@ impl MachineSetup {
                     board
                 })
                 .collect(),
+            paths: raw.paths.clone(),
         })
     }
 
     /// Load a configuration file into the typed model, validating it.
     pub fn load_from(path: &Path) -> Result<Self> {
-        Self::from_raw(&crate::config::raw_from_path(path)?)
+        let setup = Self::from_raw(&crate::config::raw_from_path(path)?)?;
+        // The loaded configuration is now the one in hand, so its `[paths]`
+        // is where things go from here -- a screenshot taken after loading
+        // it should not still be following the one before.
+        setup.apply_paths();
+        Ok(setup)
     }
 
     /// Re-read the host MIDI endpoints for the device pickers.
@@ -2746,6 +2830,10 @@ impl MachineSetup {
                 }
             })
             .collect();
+        // Written out whole rather than compared against the baseline: every
+        // entry is already optional and skipped when unset, so an untouched
+        // Paths page emits no `[paths]` at all.
+        raw.paths = self.paths.clone();
         raw
     }
 
@@ -3224,7 +3312,149 @@ impl MachineSetup {
             F::WhdloadWhdPackage => self.whdload_whd_package.as_deref(),
             F::WhdloadSkickPackage => self.whdload_skick_package.as_deref(),
             F::WhdloadGames => self.whdload_games.as_deref(),
-            _ => None,
+            // What the entry says, not where it resolves to: this is the
+            // value being edited. `paths_resolved` answers the other
+            // question, and the row shows that one.
+            _ => self.paths_entry_ref(field).and_then(Option::as_deref),
+        }
+    }
+
+    /// The `[paths]` entry a Paths row edits.
+    ///
+    /// `None` for anything that is not a Paths row, which is what keeps the
+    /// twelve directories out of every other path accessor's way.
+    fn paths_entry(
+        paths: &mut crate::pathconf::Paths,
+        field: LauncherField,
+    ) -> Option<&mut Option<PathBuf>> {
+        let p = paths;
+        Some(match field {
+            F::PathsBase => &mut p.base,
+            F::PathsStates => &mut p.states,
+            F::PathsScreenshots => &mut p.screenshots,
+            F::PathsRecordings => &mut p.recordings,
+            F::PathsNvram => &mut p.nvram,
+            F::PathsTraces => &mut p.traces,
+            F::PathsConfigs => &mut p.configs,
+            F::PathsRoms => &mut p.roms,
+            F::PathsMt32Roms => &mut p.mt32_roms,
+            F::PathsFloppies => &mut p.floppies,
+            F::PathsHarddrives => &mut p.harddrives,
+            F::PathsCds => &mut p.cds,
+            _ => return None,
+        })
+    }
+
+    /// The same entry, to read. Written out twice because a borrow cannot
+    /// be handed back from a copy; the test below walks every row through
+    /// both, so the pair cannot drift apart unnoticed.
+    fn paths_entry_ref(&self, field: LauncherField) -> Option<&Option<PathBuf>> {
+        let p = &self.paths;
+        Some(match field {
+            F::PathsBase => &p.base,
+            F::PathsStates => &p.states,
+            F::PathsScreenshots => &p.screenshots,
+            F::PathsRecordings => &p.recordings,
+            F::PathsNvram => &p.nvram,
+            F::PathsTraces => &p.traces,
+            F::PathsConfigs => &p.configs,
+            F::PathsRoms => &p.roms,
+            F::PathsMt32Roms => &p.mt32_roms,
+            F::PathsFloppies => &p.floppies,
+            F::PathsHarddrives => &p.harddrives,
+            F::PathsCds => &p.cds,
+            _ => return None,
+        })
+    }
+
+    /// Where a Paths row points now, resolved -- which for an unset row is
+    /// the directory it inherits. The page is there to say where things
+    /// actually go, so an inherited row still names a directory rather than
+    /// going blank and leaving the answer somewhere else.
+    pub fn paths_resolved(&self, field: LauncherField) -> Option<PathBuf> {
+        let host = crate::paths::config_dir()?;
+        let p = &self.paths;
+        Some(match field {
+            F::PathsBase => p.base_dir(&host),
+            F::PathsStates => p.states_dir(&host),
+            F::PathsScreenshots => p.screenshots_dir(&host),
+            F::PathsRecordings => p.recordings_dir(&host),
+            F::PathsNvram => p.nvram_dir(&host),
+            F::PathsTraces => p.traces_dir(&host),
+            F::PathsConfigs => p.configs_dir(&host),
+            F::PathsRoms => p.roms_dir(&host),
+            F::PathsMt32Roms => p.mt32_roms_dir(&host),
+            F::PathsFloppies => p.floppies_dir(&host),
+            F::PathsHarddrives => p.harddrives_dir(&host),
+            F::PathsCds => p.cds_dir(&host),
+            _ => return None,
+        })
+    }
+
+    /// Whether a Paths row was set rather than inherited.
+    pub fn paths_is_set(&self, field: LauncherField) -> bool {
+        self.paths_entry_ref(field).is_some_and(Option::is_some)
+    }
+
+    /// What a path row shows when the whole path is the point rather than
+    /// the file at the end of it: the printer's capture file, and every row
+    /// on the Paths page. `None` leaves the row to its usual file name.
+    pub fn full_path_label(&self, field: LauncherField) -> Option<String> {
+        if field == F::ParallelOutput {
+            return Some(match self.path(field) {
+                Some(path) => path.display().to_string(),
+                None => "(none)".to_string(),
+            });
+        }
+        if !field.is_paths_field() {
+            return None;
+        }
+        let Some(resolved) = self.paths_resolved(field) else {
+            // No host directory at all, so nothing is resolvable and the
+            // defaults land beside wherever Copperline was started.
+            return Some("(default)".to_string());
+        };
+        let label = resolved.display().to_string();
+        // The marker goes on the end because the column clips from the
+        // front to keep the tail: a leading one would be the first thing
+        // lost on a long path.
+        Some(if self.paths_is_set(field) {
+            label
+        } else {
+            format!("{label} (default)")
+        })
+    }
+
+    /// Put the edited directories in force.
+    ///
+    /// They are saved with the configuration like everything else on these
+    /// pages -- `[paths]` is a section of it, not a file of its own -- but
+    /// they take effect the moment they are changed, so a screenshot taken
+    /// after moving the row lands where the row now says rather than where
+    /// it said when the launcher opened.
+    fn apply_paths(&self) {
+        crate::paths::adopt(self.paths.clone());
+    }
+
+    /// Store a directory a Paths row was pointed at.
+    ///
+    /// A directory under the base is stored relative to it, so a tree that
+    /// was set up as one piece still moves as one piece: point the base at
+    /// a memory stick and everything under it follows, which is the whole
+    /// reason the entries resolve the way they do. The base itself is
+    /// always absolute -- a relative base is taken from the host-data
+    /// directory, and quietly re-anchoring it there is not what somebody
+    /// picking a folder meant.
+    fn set_paths_dir(&mut self, field: LauncherField, dir: PathBuf) {
+        let relative = (field != F::PathsBase)
+            .then(|| {
+                let base = crate::paths::config_dir()?;
+                let base = self.paths.base_dir(&base);
+                dir.strip_prefix(base).ok().map(Path::to_path_buf)
+            })
+            .flatten();
+        if let Some(entry) = Self::paths_entry(&mut self.paths, field) {
+            *entry = Some(relative.unwrap_or(dir));
         }
     }
 
@@ -4084,6 +4314,14 @@ impl MachineSetup {
         // the positional cascade, so drives added in the launcher (with no
         // config priorities of their own) do not all tie at 0. A slot that
         // already held an image keeps whatever priority it had.
+        // A Paths row is a host preference, not part of the machine, and
+        // shares nothing with the rest of this: it stores its directory and
+        // saves, and none of the drive bookkeeping below applies.
+        if field.is_paths_field() {
+            self.set_paths_dir(field, path);
+            self.apply_paths();
+            return;
+        }
         let seed_cascade = Self::is_drive_field(field)
             && self.path(field).is_none()
             && !crate::config::is_cd_image_path(&path);
@@ -4139,6 +4377,14 @@ impl MachineSetup {
 
     /// Clear a path field's value.
     pub fn clear_path(&mut self, field: LauncherField) {
+        // Cleared, a Paths row inherits again rather than pointing
+        // nowhere: the entry goes out of `[paths]` entirely, so it
+        // follows the default from then on instead of freezing today's.
+        if let Some(entry) = Self::paths_entry(&mut self.paths, field) {
+            *entry = None;
+            self.apply_paths();
+            return;
+        }
         match field {
             F::Rom => self.rom = None,
             F::ExtendedRom => self.extended_rom = None,
@@ -5618,6 +5864,10 @@ struct RomNote {
 #[derive(Debug, Clone)]
 pub struct LauncherState {
     pub setup: MachineSetup,
+    /// Whether the Save menu is showing. One flag rather than a dialog: it
+    /// is three buttons over the action bar, and every click either picks
+    /// one or puts it away.
+    pub save_menu: bool,
     /// What the Create Image pages will make. Not machine configuration, so
     /// it sits beside the setup rather than inside it.
     pub workshop: ImageWorkshop,
@@ -6862,6 +7112,7 @@ impl LauncherState {
         #[cfg(feature = "game-library")]
         setup.adopt_whdload_defaults();
         let mut state = Self {
+            save_menu: false,
             #[cfg(feature = "game-library")]
             library: LibraryPage::default(),
             #[cfg(feature = "game-library")]
@@ -8716,6 +8967,84 @@ mod tests {
             Some(Path::new("/whd/library"))
         );
         assert_eq!(setup.to_raw().whdload, raw.whdload);
+    }
+
+    /// Every Paths row must reach an entry, resolve to a directory, and
+    /// come back out in `[paths]`. Three separate matches stand between a
+    /// row and its entry -- one to read, one to write, one to resolve -- so
+    /// this walks all of them for every row on the page: a row wired to the
+    /// wrong entry, or to none, cannot pass.
+    #[test]
+    fn every_paths_row_reaches_its_own_entry() {
+        let mut setup = MachineSetup::default();
+        let fields: Vec<LauncherField> = PATHS_ROWS
+            .iter()
+            .map(|row| row.field)
+            .filter(|field| field.is_paths_field())
+            .collect();
+        assert_eq!(fields.len(), 12, "every entry should have had a row");
+        for (i, &field) in fields.iter().enumerate() {
+            assert!(
+                !setup.paths_is_set(field),
+                "{field:?} starts out set, so nothing here proves anything"
+            );
+            let dir = PathBuf::from(format!("/probe/{i}"));
+            setup.set_path(field, dir.clone());
+            assert_eq!(
+                setup.path(field),
+                Some(dir.as_path()),
+                "{field:?} does not read back what it was given"
+            );
+            assert!(setup.paths_is_set(field), "{field:?} still reads inherited");
+        }
+        // Resolution is checked only once every row is set. Checked as each
+        // one is set, a row resolving through a *later* row's entry would
+        // still land on that row's untouched default and look fine.
+        let mut seen: Vec<PathBuf> = Vec::new();
+        for &field in &fields {
+            let resolved = setup
+                .paths_resolved(field)
+                .expect("a Paths row resolves to a directory");
+            assert!(
+                !seen.contains(&resolved),
+                "{field:?} resolves to {resolved:?}, which another row already claimed"
+            );
+            seen.push(resolved);
+        }
+        // Out through the configuration and back, since that is the only
+        // way any of it survives.
+        let round_tripped = MachineSetup::from_raw(&setup.to_raw()).expect("valid");
+        for row in PATHS_ROWS {
+            if row.field.is_paths_field() {
+                assert_eq!(
+                    round_tripped.path(row.field),
+                    setup.path(row.field),
+                    "{:?} did not survive [paths]",
+                    row.field
+                );
+            }
+        }
+        // And cleared, each one goes back to inheriting rather than to a
+        // frozen copy of today's default.
+        for row in PATHS_ROWS {
+            if row.field.is_paths_field() {
+                setup.clear_path(row.field);
+            }
+        }
+        assert!(
+            setup.to_raw().paths.is_empty(),
+            "a cleared page emits no [paths]"
+        );
+    }
+
+    /// A machine configuration that never mentions directories must not
+    /// grow a `[paths]` section just by passing through the launcher.
+    #[test]
+    fn an_untouched_paths_page_writes_nothing() {
+        let raw = MachineSetup::default().to_raw();
+        assert!(raw.paths.is_empty());
+        let text = raw.to_toml_string().expect("serialises");
+        assert!(!text.contains("[paths]"), "{text}");
     }
 
     #[test]
@@ -10803,13 +11132,18 @@ mod tests {
         assert!(TABS.contains(&LauncherTab::AvAudio));
         assert!(!TABS.contains(&LauncherTab::AvVideo));
         assert!(!TABS.contains(&LauncherTab::AvEmulation));
-        for t in [LauncherTab::AvVideo, LauncherTab::AvEmulation] {
+        assert!(!TABS.contains(&LauncherTab::AvPaths));
+        for t in [
+            LauncherTab::AvVideo,
+            LauncherTab::AvEmulation,
+            LauncherTab::AvPaths,
+        ] {
             // They keep the A/V strip entry lit and have no Back button --
             // categories switch between each other via the top nav row.
             assert_eq!(t.strip_tab(), LauncherTab::AvAudio);
             assert_eq!(t.parent_tab(), None);
         }
-        // Every A/V page offers the same nav buttons: Audio / Video / Emulation.
+        // Every A/V page offers the same nav buttons.
         let nav = LauncherTab::AvAudio.nav_options();
         assert_eq!(
             nav,
@@ -10817,6 +11151,7 @@ mod tests {
                 ("Audio", LauncherTab::AvAudio),
                 ("Video", LauncherTab::AvVideo),
                 ("Emulation", LauncherTab::AvEmulation),
+                ("Paths", LauncherTab::AvPaths),
             ]
         );
         assert_eq!(LauncherTab::AvVideo.nav_options(), nav);

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -5950,12 +5950,12 @@ impl LoginDialog {
 #[cfg(feature = "game-library")]
 const USER_MAX: usize = 64;
 
-/// The support directory under a given configuration directory. The same
-/// place [`crate::paths::whdload_support_dir`] names, spelled from a root
-/// the caller chose so a test can point somewhere else.
+/// The support directory under a given configuration directory, from
+/// `paths` so this and the no-argument helpers cannot describe different
+/// trees. Kept as a name here because the call sites read better for it.
 #[cfg(feature = "game-library")]
 fn whdload_support_under(config_dir: &std::path::Path) -> PathBuf {
-    config_dir.join("whdload").join("support")
+    crate::paths::whdload_support_in(config_dir)
 }
 
 #[cfg(feature = "game-library")]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -5865,10 +5865,10 @@ struct RomNote {
 #[derive(Debug, Clone)]
 pub struct LauncherState {
     pub setup: MachineSetup,
-    /// Whether the Save menu is showing. One flag rather than a dialog: it
-    /// is three buttons over the action bar, and every click either picks
-    /// one or puts it away.
-    pub save_menu: bool,
+    /// Whether the Save dialog is up: Save As, Set default, Reset default.
+    /// One flag, because it holds nothing -- three buttons and a close
+    /// gadget, and every click either picks one or puts it away.
+    pub save_dialog: bool,
     /// Whether the "are you sure" over Reset default is up. Only ever set
     /// when there is a default to delete -- with none saved there is
     /// nothing to be sure about, and a dialog asking anyway is a dialog
@@ -7118,7 +7118,7 @@ impl LauncherState {
         #[cfg(feature = "game-library")]
         setup.adopt_whdload_defaults();
         let mut state = Self {
-            save_menu: false,
+            save_dialog: false,
             confirm_reset: false,
             #[cfg(feature = "game-library")]
             library: LibraryPage::default(),

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -429,7 +429,6 @@ pub enum LauncherField {
     PathsTraces,
     PathsConfigs,
     PathsRoms,
-    PathsMt32Roms,
     PathsFloppies,
     PathsHarddrives,
     PathsCds,
@@ -791,7 +790,6 @@ impl LauncherField {
                 | LauncherField::PathsTraces
                 | LauncherField::PathsConfigs
                 | LauncherField::PathsRoms
-                | LauncherField::PathsMt32Roms
                 | LauncherField::PathsFloppies
                 | LauncherField::PathsHarddrives
                 | LauncherField::PathsCds
@@ -1120,18 +1118,16 @@ const EMULATION_ROWS: [Row; 5] = [
 /// The Paths page. Every row is optional: cleared, it inherits, and the
 /// value shown is the directory that would be used. Nothing here describes
 /// the machine, so none of it round-trips through [`RawConfig`].
-const PATHS_ROWS: [Row; 14] = [
+const PATHS_ROWS: [Row; 12] = [
     row(F::PathsBase, "Base folder", PathRow),
     section_header("Copperline writes:"),
     row(F::PathsStates, "Save states", PathRow),
     row(F::PathsScreenshots, "Screenshots", PathRow),
     row(F::PathsRecordings, "Recordings", PathRow),
-    row(F::PathsNvram, "Battery RAM", PathRow),
+    row(F::PathsNvram, "NVRAM", PathRow),
     row(F::PathsTraces, "Traces", PathRow),
     row(F::PathsConfigs, "Configurations", PathRow),
-    section_header("Dialogs open at:"),
     row(F::PathsRoms, "ROMs", PathRow),
-    row(F::PathsMt32Roms, "MT-32 ROMs", PathRow),
     row(F::PathsFloppies, "Floppies", PathRow),
     row(F::PathsHarddrives, "Hard drives", PathRow),
     row(F::PathsCds, "CD images", PathRow),
@@ -3337,7 +3333,6 @@ impl MachineSetup {
             F::PathsTraces => &mut p.traces,
             F::PathsConfigs => &mut p.configs,
             F::PathsRoms => &mut p.roms,
-            F::PathsMt32Roms => &mut p.mt32_roms,
             F::PathsFloppies => &mut p.floppies,
             F::PathsHarddrives => &mut p.harddrives,
             F::PathsCds => &mut p.cds,
@@ -3359,7 +3354,6 @@ impl MachineSetup {
             F::PathsTraces => &p.traces,
             F::PathsConfigs => &p.configs,
             F::PathsRoms => &p.roms,
-            F::PathsMt32Roms => &p.mt32_roms,
             F::PathsFloppies => &p.floppies,
             F::PathsHarddrives => &p.harddrives,
             F::PathsCds => &p.cds,
@@ -3383,7 +3377,6 @@ impl MachineSetup {
             F::PathsTraces => p.traces_dir(&host),
             F::PathsConfigs => p.configs_dir(&host),
             F::PathsRoms => p.roms_dir(&host),
-            F::PathsMt32Roms => p.mt32_roms_dir(&host),
             F::PathsFloppies => p.floppies_dir(&host),
             F::PathsHarddrives => p.harddrives_dir(&host),
             F::PathsCds => p.cds_dir(&host),
@@ -3409,19 +3402,24 @@ impl MachineSetup {
         if !field.is_paths_field() {
             return None;
         }
-        let Some(resolved) = self.paths_resolved(field) else {
+        // An inheriting row says so and stops there. Where a default goes
+        // is Copperline's business until somebody makes it theirs, and a
+        // page of eleven paths nobody chose is a page nobody reads.
+        //
+        // The base is the exception: it is the root the rest of them hang
+        // off, so it names its directory whether or not it was set. With
+        // it inheriting too, the page would say where nothing goes.
+        if !self.paths_is_set(field) && field != F::PathsBase {
+            return Some("(default)".to_string());
+        }
+        let resolved = self
+            .paths_resolved(field)
+            .or_else(|| self.path(field).map(Path::to_path_buf));
+        Some(match resolved {
+            Some(dir) => dir.display().to_string(),
             // No host directory at all, so nothing is resolvable and the
             // defaults land beside wherever Copperline was started.
-            return Some("(default)".to_string());
-        };
-        let label = resolved.display().to_string();
-        // The marker goes on the end because the column clips from the
-        // front to keep the tail: a leading one would be the first thing
-        // lost on a long path.
-        Some(if self.paths_is_set(field) {
-            label
-        } else {
-            format!("{label} (default)")
+            None => "(default)".to_string(),
         })
     }
 
@@ -8982,7 +8980,7 @@ mod tests {
             .map(|row| row.field)
             .filter(|field| field.is_paths_field())
             .collect();
-        assert_eq!(fields.len(), 12, "every entry should have had a row");
+        assert_eq!(fields.len(), 11, "every entry should have had a row");
         for (i, &field) in fields.iter().enumerate() {
             assert!(
                 !setup.paths_is_set(field),

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -5464,6 +5464,36 @@ fn launcher_bridge_configure_rect(rect: Rect, row_y: usize) -> Rect {
 
 /// (Browse, Clear) buttons for a path row, just after the fixed-width value
 /// column ([`LAUNCH_PATH_VALUE_W`]) rather than out at the panel's right edge.
+/// Which of a path row's two buttons are there, as (browse, reset).
+///
+/// Every path row outside the Paths page has both, always. On the Paths
+/// page a row that is inheriting has nothing to reset, so it offers only
+/// Browse -- and the base swaps the two rather than showing both, because
+/// it is the root the others hang off and moving it is a different act
+/// from picking a folder for one of them.
+///
+/// One function, so what is drawn and what can be clicked cannot disagree:
+/// a Reset that is not there must not still answer, and a Browse that is
+/// not there must not still open a dialog.
+fn launcher_path_buttons(setup: &launcher::MachineSetup, field: LauncherField) -> (bool, bool) {
+    if !field.is_paths_field() {
+        return (true, true);
+    }
+    let set = setup.paths_is_set(field);
+    if field == LauncherField::PathsBase {
+        (!set, set)
+    } else {
+        (true, set)
+    }
+}
+
+/// Whether a row is a Paths row that has not been given a directory of its
+/// own. Its label and value are dimmed to say so: the row is showing
+/// Copperline's answer rather than the person's.
+fn launcher_path_inherits(setup: &launcher::MachineSetup, field: LauncherField) -> bool {
+    field.is_paths_field() && !setup.paths_is_set(field)
+}
+
 fn launcher_path_rects(rect: Rect, row_y: usize) -> (Rect, Rect) {
     let y = row_y + 2;
     let browse = Rect {
@@ -5944,10 +5974,11 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                 }
                 RowKind::Path => {
                     let (browse, clear) = launcher_path_rects(rect, row_y);
-                    if browse.contains(pos) {
+                    let (has_browse, has_clear) = launcher_path_buttons(&state.setup, r.field);
+                    if has_browse && browse.contains(pos) {
                         return Some(UiControl::LauncherBrowse(r.field));
                     }
-                    if clear.contains(pos) {
+                    if has_clear && clear.contains(pos) {
                         return Some(UiControl::LauncherClear(r.field));
                     }
                 }
@@ -7369,7 +7400,7 @@ fn draw_launcher_row(
     } else {
         setup.disabled_reason(r.field)
     };
-    let label_color = if reason.is_none() {
+    let label_color = if reason.is_none() && !launcher_path_inherits(setup, r.field) {
         PANEL_TEXT
     } else {
         PANEL_TEXT_DIM
@@ -7920,23 +7951,42 @@ fn draw_launcher_row(
                 Some(full) => clip_path_keep_name(&full, avail),
                 None => truncate_to_width(&setup.value_label(r.field), avail),
             };
-            draw_panel_text(frame, value_x, browse.y + 6, &text, PANEL_TEXT, 1, scale);
-            draw_text_button(
-                frame,
-                browse,
-                "Browse",
-                true,
-                hover == Some(UiControl::LauncherBrowse(r.field)),
-                scale,
-            );
-            draw_text_button(
-                frame,
-                clear,
-                "Clear",
-                true,
-                hover == Some(UiControl::LauncherClear(r.field)),
-                scale,
-            );
+            let value_color = if launcher_path_inherits(setup, r.field) {
+                PANEL_TEXT_DIM
+            } else {
+                PANEL_TEXT
+            };
+            draw_panel_text(frame, value_x, browse.y + 6, &text, value_color, 1, scale);
+            let (has_browse, has_clear) = launcher_path_buttons(setup, r.field);
+            if has_browse {
+                draw_text_button(
+                    frame,
+                    browse,
+                    "Browse",
+                    true,
+                    hover == Some(UiControl::LauncherBrowse(r.field)),
+                    scale,
+                );
+            }
+            if has_clear {
+                // "Reset" on the Paths page, because that is what it does
+                // there: the row goes back to inheriting rather than being
+                // emptied. Everywhere else the button really does clear a
+                // path, and says so.
+                let label = if r.field.is_paths_field() {
+                    "Reset"
+                } else {
+                    "Clear"
+                };
+                draw_text_button(
+                    frame,
+                    clear,
+                    label,
+                    true,
+                    hover == Some(UiControl::LauncherClear(r.field)),
+                    scale,
+                );
+            }
         }
         #[cfg(feature = "game-library")]
         RowKind::Account => {
@@ -12387,6 +12437,28 @@ mod tests {
             draw(&mut frame, scale, &ui, None, None);
             save(&frame, "launcher-paths");
 
+            // And with two rows given directories of their own, which is
+            // the only state in which a Reset button exists.
+            let mut frame = vec![0u8; w * h * 4];
+            let mut state = LauncherState::new(launcher::MachineSetup::default());
+            state.tab = LauncherTab::AvPaths;
+            state.setup.set_path(
+                LauncherField::PathsBase,
+                std::path::PathBuf::from("/Volumes/AMIGA"),
+            );
+            state.setup.set_path(
+                LauncherField::PathsScreenshots,
+                std::path::PathBuf::from("/Users/someone/Pictures/Amiga screenshots"),
+            );
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: menu::MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            draw(&mut frame, scale, &ui, None, None);
+            save(&frame, "launcher-paths-set");
+
             // Drawn at a scale of more than one, which is where anything
             // handing an unscaled rect to a scaled draw shows up: at scale
             // one the two are the same and the mistake is invisible.
@@ -12403,6 +12475,48 @@ mod tests {
             };
             draw(&mut frame, big, &ui, None, None);
             save_at(&frame, "launcher-save-menu", bw, bh);
+        }
+
+        // A Paths row must offer exactly the buttons it draws. A Reset
+        // that is not there but still answers would put a row back to
+        // inheriting on a click meant for nothing at all, and on the base
+        // -- where Browse and Reset swap places rather than sitting side
+        // by side -- the two would land on each other's rectangles.
+        {
+            let probe = |set: bool, field: LauncherField| {
+                let mut setup = launcher::MachineSetup::default();
+                if set {
+                    setup.set_path(field, std::path::PathBuf::from("/probe/dir"));
+                }
+                let mut state = LauncherState::new(setup);
+                state.tab = LauncherTab::AvPaths;
+                let panel = Panel::Launcher(Box::new(state));
+                let rect = panel_rect(&panel);
+                let row = launcher::rows(
+                    LauncherTab::AvPaths,
+                    Default::default(),
+                    Default::default(),
+                    false,
+                )
+                .iter()
+                .position(|r| r.field == field)
+                .expect("the field has a row");
+                let row_y = launcher_row_y(rect, row) + launcher_nav_block_h(LauncherTab::AvPaths);
+                let (browse, reset) = launcher_path_rects(rect, row_y);
+                let at = |r: Rect| {
+                    panel_control_at(&panel, ((r.x + r.w / 2) as i32, (r.y + r.h / 2) as i32))
+                };
+                (
+                    at(browse) == Some(UiControl::LauncherBrowse(field)),
+                    at(reset) == Some(UiControl::LauncherClear(field)),
+                )
+            };
+            // An ordinary row: Browse always, Reset only once it was set.
+            assert_eq!(probe(false, LauncherField::PathsScreenshots), (true, false));
+            assert_eq!(probe(true, LauncherField::PathsScreenshots), (true, true));
+            // The base swaps them.
+            assert_eq!(probe(false, LauncherField::PathsBase), (true, false));
+            assert_eq!(probe(true, LauncherField::PathsBase), (false, true));
         }
 
         // The Save menu: every item reachable, nothing under it reachable

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -12672,7 +12672,10 @@ mod tests {
             save(&frame, "launcher-paths");
 
             // And with two rows given directories of their own, which is
-            // the only state in which a Reset button exists.
+            // the only state in which a Reset button exists. `set_path` on
+            // a Paths row adopts into the process-wide store that
+            // paths::tests assert against, hence the guard.
+            let _guard = crate::paths::adopted_store_lock();
             let mut frame = vec![0u8; w * h * 4];
             let mut state = LauncherState::new(launcher::MachineSetup::default());
             state.tab = LauncherTab::AvPaths;
@@ -12737,6 +12740,9 @@ mod tests {
         // -- where Browse and Reset swap places rather than sitting side
         // by side -- the two would land on each other's rectangles.
         {
+            // `set_path` on a Paths row adopts into the process-wide store
+            // that paths::tests assert against.
+            let _guard = crate::paths::adopted_store_lock();
             let probe = |set: bool, field: LauncherField| {
                 let mut setup = launcher::MachineSetup::default();
                 if set {

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -5785,13 +5785,42 @@ const SAVE_ACTIONS: [UiControl; 3] = [
 const SAVE_DIALOG_BUTTON: (usize, usize) = (116, 20);
 const SAVE_DIALOG_MARGIN: usize = 12;
 const SAVE_DIALOG_GAP: usize = 6;
+/// Lines kept for the description above the buttons, what one costs, and
+/// the space between the last of them and the row.
+///
+/// Always reserved, whether or not anything is being pointed at: a dialog
+/// that changed size as the pointer crossed it would move the buttons out
+/// from under the pointer that was crossing them.
+const SAVE_DIALOG_HELP_LINES: usize = 2;
+const SAVE_DIALOG_LINE_H: usize = 12;
+const SAVE_DIALOG_HELP_GAP: usize = 16;
+
+/// What each button does, said while the pointer is on it.
+///
+/// Anything that is not one of the three gets the Save line. This is a
+/// Save dialog opened from a Save button, so with the pointer resting
+/// nowhere in particular it should say what saving means rather than go
+/// blank and leave a hole where a sentence was a moment ago.
+fn save_dialog_help(control: UiControl) -> &'static str {
+    match control {
+        UiControl::LauncherSaveDefault => {
+            "Saves the current running configuration as the default when you launch Copperline."
+        }
+        UiControl::LauncherResetDefault => "Resets the current default config to factory settings.",
+        _ => "Save the configuration to a file",
+    }
+}
 
 /// The Save dialog, centred on the panel like the confirm.
 fn launcher_save_dialog_rect(rect: Rect) -> Rect {
     let (bw, bh) = SAVE_DIALOG_BUTTON;
     let (w, h) = (
         2 * SAVE_DIALOG_MARGIN + 3 * bw + 2 * SAVE_DIALOG_GAP,
-        TITLE_H + 2 * SAVE_DIALOG_MARGIN + bh,
+        TITLE_H
+            + 2 * SAVE_DIALOG_MARGIN
+            + SAVE_DIALOG_HELP_LINES * SAVE_DIALOG_LINE_H
+            + SAVE_DIALOG_HELP_GAP
+            + bh,
     );
     Rect {
         x: rect.x + rect.w.saturating_sub(w) / 2,
@@ -5808,7 +5837,8 @@ fn launcher_save_dialog_rects(rect: Rect) -> [(UiControl, Rect); 3] {
     std::array::from_fn(|i| {
         let item = Rect {
             x: dialog.x + SAVE_DIALOG_MARGIN + i * (w + SAVE_DIALOG_GAP),
-            y: dialog.y + TITLE_H + SAVE_DIALOG_MARGIN,
+            // Along the bottom, under the line that says what they do.
+            y: dialog.y + dialog.h - SAVE_DIALOG_MARGIN - h,
             w,
             h,
         };
@@ -5854,6 +5884,25 @@ fn draw_launcher_save_dialog(
             launcher_action_label(control),
             true,
             hover == Some(control),
+            scale,
+        );
+    }
+    // Above the row, where a dialog's own words go, and never blank: with
+    // the pointer on none of the three it says what the dialog is for.
+    let help = save_dialog_help(hover.unwrap_or(UiControl::LauncherSaveAs));
+    let chars = (dialog.w - 2 * SAVE_DIALOG_MARGIN) / font::GLYPH_W;
+    for (i, line) in wrap_text(help, chars, chars)
+        .into_iter()
+        .take(SAVE_DIALOG_HELP_LINES)
+        .enumerate()
+    {
+        draw_panel_text(
+            frame,
+            dialog.x + SAVE_DIALOG_MARGIN,
+            dialog.y + TITLE_H + SAVE_DIALOG_MARGIN + i * SAVE_DIALOG_LINE_H,
+            &line,
+            PANEL_TEXT,
+            1,
             scale,
         );
     }
@@ -12641,7 +12690,15 @@ mod tests {
                 menu_nav: menu::MenuNav::default(),
                 panel: Some(Panel::Launcher(Box::new(state))),
             };
-            draw(&mut frame, big, &ui, None, None);
+            // With the pointer on the button whose description is longest,
+            // which is the one that has to fit.
+            draw(
+                &mut frame,
+                big,
+                &ui,
+                Some(UiControl::LauncherSaveDefault),
+                None,
+            );
             save_at(&frame, "launcher-save-menu", bw, bh);
 
             let mut frame = vec![0u8; w * h * 4];
@@ -12714,7 +12771,17 @@ mod tests {
                 panel_control_at(&panel, centre(yes)),
                 Some(UiControl::LauncherConfirmReset)
             );
-            for elsewhere in [cancel, launcher_action_rects(rect)[3].1, rect] {
+            // Named places again, not the panel's centre: that sits inside
+            // the dialog and would land on a button if it ever resized.
+            let dialog = launcher_confirm_rect(rect);
+            let title = Rect {
+                x: dialog.x,
+                y: dialog.y,
+                w: dialog.w,
+                h: TITLE_H,
+            };
+            let [load, _, _, run] = launcher_action_rects(rect);
+            for elsewhere in [cancel, title, load.1, run.1] {
                 assert_eq!(
                     panel_control_at(&panel, centre(elsewhere)),
                     Some(UiControl::LauncherCancelReset),
@@ -12757,21 +12824,54 @@ mod tests {
                 assert!(a.1.x + a.1.w <= b.1.x, "the buttons overlap each other");
                 assert_eq!(a.1.y, b.1.y, "the buttons should be one row");
             }
-            // The close gadget, and Run underneath it: neither does
-            // anything but put the dialog away.
+            // The close gadget, the dialog's own body below the buttons,
+            // and the bar underneath: none of them does anything but put
+            // the dialog away. Probed at named places rather than at the
+            // panel's centre, which is inside the dialog and moves onto a
+            // button the moment the dialog changes height.
             let close = Rect {
                 x: dialog.x + dialog.w - 18,
                 y: dialog.y + 4,
                 w: 12,
                 h: 12,
             };
-            for elsewhere in [close, launcher_action_rects(rect)[3].1, rect] {
+            let body = Rect {
+                x: dialog.x,
+                y: dialog.y + TITLE_H,
+                w: dialog.w,
+                h: SAVE_DIALOG_MARGIN,
+            };
+            let [load, _, _, run] = launcher_action_rects(rect);
+            for elsewhere in [close, body, load.1, run.1] {
                 assert_eq!(
                     panel_control_at(&panel, centre(elsewhere)),
                     Some(UiControl::LauncherSave),
                     "a click off the three should only put the dialog away"
                 );
             }
+            // Every description fits the two lines reserved for it. The
+            // dialog cannot grow to suit a longer one -- resizing under a
+            // pointer that is crossing the buttons would move them -- so a
+            // sentence that does not fit is silently cut off instead.
+            let chars = (dialog.w - 2 * SAVE_DIALOG_MARGIN) / font::GLYPH_W;
+            for (control, _) in items {
+                let help = save_dialog_help(control);
+                assert!(!help.is_empty(), "{control:?} has nothing to say");
+                let lines = wrap_text(help, chars, chars);
+                assert!(
+                    lines.len() <= SAVE_DIALOG_HELP_LINES,
+                    "{help:?} wraps to {} lines, and there is room for {}",
+                    lines.len(),
+                    SAVE_DIALOG_HELP_LINES
+                );
+            }
+            // With the pointer on nothing, the dialog still says what it
+            // is for rather than leaving the space empty.
+            assert_eq!(
+                save_dialog_help(UiControl::LauncherSave),
+                save_dialog_help(UiControl::LauncherSaveAs)
+            );
+
             // And with it closed, its buttons are not there to be hit.
             let closed = Panel::Launcher(Box::new(LauncherState::new(
                 launcher::MachineSetup::default(),

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -505,8 +505,8 @@ pub fn panel_control_at(panel: &Panel, pos: (i32, i32)) -> Option<UiControl> {
             // something should not be answerable by a stray click.
             return Some(UiControl::LauncherCancelReset);
         }
-        if state.save_menu {
-            return launcher_save_menu_hit(rect, pos).or(Some(UiControl::LauncherSave));
+        if state.save_dialog {
+            return launcher_save_dialog_hit(rect, pos).or(Some(UiControl::LauncherSave));
         }
     }
     if !modal && close_button_rect(rect).contains(pos) {
@@ -5764,50 +5764,99 @@ fn launcher_action_label(control: UiControl) -> &'static str {
         UiControl::LauncherSave => "Save...",
         UiControl::LauncherDefaults => "Defaults",
         UiControl::LauncherRun => "Run",
-        UiControl::LauncherSaveAs => "Save as...",
-        UiControl::LauncherSaveDefault => "Save default",
+        UiControl::LauncherSaveAs => "Save As",
+        UiControl::LauncherSaveDefault => "Set default",
         UiControl::LauncherResetDefault => "Reset default",
         _ => "",
     }
 }
 
-/// The Save menu's items, left to right from the button that opens them.
-/// Nearest first, so the pointer reaches the commonest of the three
-/// without crossing the other two -- and the one that deletes something
-/// ends up furthest away, next to Defaults.
-const SAVE_MENU: [UiControl; 3] = [
+/// What the Save dialog offers, left to right. The one that deletes
+/// something sits furthest from where the pointer comes in.
+const SAVE_ACTIONS: [UiControl; 3] = [
     UiControl::LauncherSaveAs,
     UiControl::LauncherSaveDefault,
     UiControl::LauncherResetDefault,
 ];
 
-/// Where each Save-menu item is drawn: in a row to the right of the Save
-/// button, along the action bar it belongs to.
-///
-/// Each is sized to its own label rather than to a shared width. There are
-/// 336 pixels between Save... and Defaults, and three buttons wide enough
-/// for "Reset default" do not fit in them -- a uniform row is 12 pixels
-/// too long. Sized individually the three come to 324 with their gaps,
-/// which leaves the last of them clear of Defaults by 8. The test below
-/// holds that, because a label growing by two characters is what would
-/// quietly push the row into the button beside it.
-fn launcher_save_menu_rects(rect: Rect) -> [(UiControl, Rect); 3] {
-    let save = launcher_action_rects(rect)[1].1;
-    // Six pixels of clearance either side of the text, which is what a
-    // label of exactly this many characters needs to survive the
-    // truncation `draw_text_button` applies.
-    let width = |control| launcher_action_label(control).chars().count() * font::GLYPH_W + 12;
-    let mut x = save.x + save.w + 4;
+/// One button's size, and the space around them. Every button is as wide
+/// as the longest label so the row is even, and the dialog is then sized
+/// to the row rather than the row fitted into a dialog.
+const SAVE_DIALOG_BUTTON: (usize, usize) = (116, 20);
+const SAVE_DIALOG_MARGIN: usize = 12;
+const SAVE_DIALOG_GAP: usize = 6;
+
+/// The Save dialog, centred on the panel like the confirm.
+fn launcher_save_dialog_rect(rect: Rect) -> Rect {
+    let (bw, bh) = SAVE_DIALOG_BUTTON;
+    let (w, h) = (
+        2 * SAVE_DIALOG_MARGIN + 3 * bw + 2 * SAVE_DIALOG_GAP,
+        TITLE_H + 2 * SAVE_DIALOG_MARGIN + bh,
+    );
+    Rect {
+        x: rect.x + rect.w.saturating_sub(w) / 2,
+        y: rect.y + rect.h.saturating_sub(h) / 2,
+        w,
+        h,
+    }
+}
+
+/// The three buttons in it.
+fn launcher_save_dialog_rects(rect: Rect) -> [(UiControl, Rect); 3] {
+    let dialog = launcher_save_dialog_rect(rect);
+    let (w, h) = SAVE_DIALOG_BUTTON;
     std::array::from_fn(|i| {
         let item = Rect {
-            x,
-            y: save.y,
-            w: width(SAVE_MENU[i]),
-            h: LAUNCH_ACTION_H,
+            x: dialog.x + SAVE_DIALOG_MARGIN + i * (w + SAVE_DIALOG_GAP),
+            y: dialog.y + TITLE_H + SAVE_DIALOG_MARGIN,
+            w,
+            h,
         };
-        x = item.x + item.w + 4;
-        (SAVE_MENU[i], item)
+        (SAVE_ACTIONS[i], item)
     })
+}
+
+fn draw_launcher_save_dialog(
+    frame: &mut [u8],
+    rect: Rect,
+    state: &LauncherState,
+    hover: Option<UiControl>,
+    scale: usize,
+) {
+    if !state.save_dialog {
+        return;
+    }
+    fill_rect_blend(frame, scale_rect(rect, scale), SCRIM, SCRIM_ALPHA, scale);
+    let dialog = launcher_save_dialog_rect(rect);
+    fill_rect(frame, scale_rect(dialog, scale), PANEL_BG, scale);
+    draw_rect_bevel(
+        frame,
+        scale_rect(dialog, scale),
+        BUTTON_EDGE_LIGHT,
+        BUTTON_EDGE_DARK,
+        scale,
+    );
+    // The close gadget in its title bar is how this is dismissed. There is
+    // no Cancel among the three because none of them answers a question --
+    // they are three things you might do, and not doing any of them is
+    // closing the window rather than choosing a fourth.
+    draw_title_bar(
+        frame,
+        dialog,
+        "Save configuration...",
+        hover == Some(UiControl::LauncherSave),
+        scale,
+    );
+    for (control, item) in launcher_save_dialog_rects(rect) {
+        draw_text_button(
+            frame,
+            item,
+            launcher_action_label(control),
+            true,
+            hover == Some(control),
+            scale,
+        );
+    }
 }
 
 /// Hit-test the configuration panel. Returns the control under `pos`, or `None`
@@ -6321,11 +6370,12 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
     None
 }
 
-/// Hit-test the Save menu, which is over everything while it is up. A click
-/// anywhere else closes it without doing anything, which is what a menu is
-/// expected to do and keeps it from being a mode you can get stuck in.
-fn launcher_save_menu_hit(rect: Rect, pos: (i32, i32)) -> Option<UiControl> {
-    launcher_save_menu_rects(rect)
+/// Hit-test the Save dialog, which is over everything while it is up. A
+/// click anywhere else -- its close gadget, its own frame, the panel
+/// behind it -- puts it away without doing anything, so it can never be a
+/// mode you are stuck in.
+fn launcher_save_dialog_hit(rect: Rect, pos: (i32, i32)) -> Option<UiControl> {
+    launcher_save_dialog_rects(rect)
         .into_iter()
         .find_map(|(control, item)| item.contains(pos).then_some(control))
 }
@@ -8785,30 +8835,11 @@ fn draw_launcher(
             button_rect,
             launcher_action_label(control),
             true,
-            hover == Some(control) || (control == UiControl::LauncherSave && state.save_menu),
+            hover == Some(control),
             scale,
         );
     }
-    if state.save_menu {
-        // Dimmed rather than merely covered, the same as a dialog: while
-        // the menu is up it is the only thing being answered, and the page
-        // behind it should look like it is waiting.
-        fill_rect_blend(frame, scale_rect(rect, scale), SCRIM, SCRIM_ALPHA, scale);
-        for (control, item) in launcher_save_menu_rects(rect) {
-            // No backing fill: the button face is opaque across the whole
-            // rect, and a second fill here would have to scale the rect
-            // itself, which is `draw_text_button`'s job and not this
-            // loop's.
-            draw_text_button(
-                frame,
-                item,
-                launcher_action_label(control),
-                true,
-                hover == Some(control),
-                scale,
-            );
-        }
-    }
+    draw_launcher_save_dialog(frame, rect, state, hover, scale);
     draw_launcher_confirm(frame, rect, state, hover, scale);
     // Over everything, because it is the only thing being answered while
     // it is up.
@@ -12603,7 +12634,7 @@ mod tests {
             let (bw, bh) = (texture_width(big), texture_height(big));
             let mut frame = vec![0u8; bw * bh * 4];
             let mut state = LauncherState::new(launcher::MachineSetup::default());
-            state.save_menu = true;
+            state.save_dialog = true;
             let ui = UiState {
                 menu_open: false,
                 menu_rows: Vec::new(),
@@ -12668,47 +12699,6 @@ mod tests {
             assert_eq!(probe(true, LauncherField::PathsBase), (false, true));
         }
 
-        // The Save menu is a row along the action bar, and there is only
-        // just room for it: three buttons at a shared width do not fit
-        // between Save... and Defaults at all. Nothing about that is
-        // obvious from reading the code, so it is held here -- a label
-        // gaining two characters would otherwise push the last button
-        // silently under the one beside it.
-        {
-            let panel = Panel::Launcher(Box::new(LauncherState::new(
-                launcher::MachineSetup::default(),
-            )));
-            let rect = panel_rect(&panel);
-            let [load, save, defaults, run] = launcher_action_rects(rect);
-            let items = launcher_save_menu_rects(rect);
-            assert!(
-                items[0].1.x >= save.1.x + save.1.w,
-                "the menu should start clear of the button that opens it"
-            );
-            for (a, b) in items.iter().zip(items.iter().skip(1)) {
-                assert!(a.1.x + a.1.w <= b.1.x, "menu items overlap each other");
-                assert_eq!(a.1.y, b.1.y, "the menu should be one row");
-            }
-            let last = items[2].1;
-            assert!(
-                last.x + last.w <= defaults.1.x,
-                "the menu runs into Defaults: {} past {}",
-                last.x + last.w,
-                defaults.1.x
-            );
-            // Every label readable rather than truncated by the button it
-            // is drawn in, which is the reason the widths differ at all.
-            for (control, item) in items {
-                let fits = item.w.saturating_sub(8) / font::GLYPH_W;
-                let label = launcher_action_label(control);
-                assert!(
-                    label.chars().count() <= fits,
-                    "{label:?} does not fit its button"
-                );
-            }
-            let _ = (load, run);
-        }
-
         // The confirm over Reset default answers every click on the panel:
         // Yes only on its own button, and anything else -- Run included --
         // cancels. A question about deleting something must not be
@@ -12733,40 +12723,64 @@ mod tests {
             }
         }
 
-        // The Save menu: every item reachable, nothing under it reachable
-        // while it is up, and a click anywhere else putting it away rather
-        // than doing something.
+        // The Save dialog: every button reachable, nothing under it
+        // reachable while it is up, and anything that is not one of the
+        // three -- its close gadget included -- putting it away.
         {
             let mut state = LauncherState::new(launcher::MachineSetup::default());
-            state.save_menu = true;
+            state.save_dialog = true;
             let panel = Panel::Launcher(Box::new(state));
             let rect = panel_rect(&panel);
+            let dialog = launcher_save_dialog_rect(rect);
             let centre = |r: Rect| ((r.x + r.w / 2) as i32, (r.y + r.h / 2) as i32);
-            for (control, item) in launcher_save_menu_rects(rect) {
+            let items = launcher_save_dialog_rects(rect);
+            for (control, item) in items {
                 assert_eq!(
                     panel_control_at(&panel, centre(item)),
                     Some(control),
-                    "{control:?} is not reachable from the Save menu"
+                    "{control:?} is not reachable in the Save dialog"
+                );
+                assert!(
+                    item.x >= dialog.x && item.x + item.w <= dialog.x + dialog.w,
+                    "{control:?} is outside the dialog"
+                );
+                // Readable rather than truncated by the button it sits in,
+                // which is what sizes the dialog in the first place.
+                let fits = item.w.saturating_sub(8) / font::GLYPH_W;
+                let label = launcher_action_label(control);
+                assert!(
+                    label.chars().count() <= fits,
+                    "{label:?} does not fit its button"
                 );
             }
-            // Run sits under the open menu and must not answer: a click
-            // meant for a menu item that lands slightly off should close the
-            // menu, never start a machine.
-            let run = launcher_action_rects(rect)[3].1;
-            assert_eq!(
-                panel_control_at(&panel, centre(run)),
-                Some(UiControl::LauncherSave),
-                "a click off the menu should only put it away"
-            );
-            // And with the menu down, its items are not there to be hit.
-            let mut closed = LauncherState::new(launcher::MachineSetup::default());
-            closed.save_menu = false;
-            let closed = Panel::Launcher(Box::new(closed));
-            for (control, item) in launcher_save_menu_rects(rect) {
+            for (a, b) in items.iter().zip(items.iter().skip(1)) {
+                assert!(a.1.x + a.1.w <= b.1.x, "the buttons overlap each other");
+                assert_eq!(a.1.y, b.1.y, "the buttons should be one row");
+            }
+            // The close gadget, and Run underneath it: neither does
+            // anything but put the dialog away.
+            let close = Rect {
+                x: dialog.x + dialog.w - 18,
+                y: dialog.y + 4,
+                w: 12,
+                h: 12,
+            };
+            for elsewhere in [close, launcher_action_rects(rect)[3].1, rect] {
+                assert_eq!(
+                    panel_control_at(&panel, centre(elsewhere)),
+                    Some(UiControl::LauncherSave),
+                    "a click off the three should only put the dialog away"
+                );
+            }
+            // And with it closed, its buttons are not there to be hit.
+            let closed = Panel::Launcher(Box::new(LauncherState::new(
+                launcher::MachineSetup::default(),
+            )));
+            for (control, item) in items {
                 assert_ne!(
                     panel_control_at(&closed, centre(item)),
                     Some(control),
-                    "{control:?} answers with the menu closed"
+                    "{control:?} answers with the dialog closed"
                 );
             }
         }

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -491,6 +491,13 @@ pub fn panel_control_at(panel: &Panel, pos: (i32, i32)) -> Option<UiControl> {
         matches!(panel, Panel::Launcher(state) if state.login.is_some() || state.meta.is_some());
     #[cfg(not(feature = "game-library"))]
     let modal = false;
+    // The Save menu answers before anything under it, including the close
+    // gadget: while it is up it is the only thing being asked.
+    if let Panel::Launcher(state) = panel {
+        if state.save_menu {
+            return launcher_save_menu_hit(rect, pos).or(Some(UiControl::LauncherSave));
+        }
+    }
     if !modal && close_button_rect(rect).contains(pos) {
         return Some(UiControl::PanelClose);
     }
@@ -897,8 +904,15 @@ pub enum UiControl {
     },
     /// Configuration screen: load a .toml configuration.
     LauncherLoad,
-    /// Configuration screen: save the configuration to a .toml file.
+    /// Configuration screen: open the Save menu.
     LauncherSave,
+    /// Save menu: save the configuration to a .toml file of its own.
+    LauncherSaveAs,
+    /// Save menu: save it as the configuration Copperline starts with.
+    LauncherSaveDefault,
+    /// Save menu: delete the saved default, so Copperline starts from
+    /// factory settings again.
+    LauncherResetDefault,
     /// Configuration screen: reset to the selected profile's defaults.
     LauncherDefaults,
     /// Configuration screen: build and run the configured machine.
@@ -5607,8 +5621,37 @@ fn launcher_action_label(control: UiControl) -> &'static str {
         UiControl::LauncherSave => "Save...",
         UiControl::LauncherDefaults => "Defaults",
         UiControl::LauncherRun => "Run",
+        UiControl::LauncherSaveAs => "Save as...",
+        UiControl::LauncherSaveDefault => "Save default",
+        UiControl::LauncherResetDefault => "Reset default",
         _ => "",
     }
+}
+
+/// The Save menu's items, in the order they are stacked above the button
+/// that opens it. Nearest the button first, so the pointer reaches the
+/// commonest of the three without crossing the other two -- and the one
+/// that deletes something ends up furthest away.
+const SAVE_MENU: [UiControl; 3] = [
+    UiControl::LauncherSaveAs,
+    UiControl::LauncherSaveDefault,
+    UiControl::LauncherResetDefault,
+];
+
+/// Where each Save-menu item is drawn: stacked upward from the Save button,
+/// wide enough for the longest label rather than the button's own width.
+fn launcher_save_menu_rects(rect: Rect) -> [(UiControl, Rect); 3] {
+    let save = launcher_action_rects(rect)[1].1;
+    let w = LAUNCH_ACTION_W + 34;
+    std::array::from_fn(|i| {
+        let item = Rect {
+            x: save.x,
+            y: save.y - (i + 1) * (LAUNCH_ACTION_H + 4),
+            w,
+            h: LAUNCH_ACTION_H,
+        };
+        (SAVE_MENU[i], item)
+    })
 }
 
 /// Hit-test the configuration panel. Returns the control under `pos`, or `None`
@@ -6119,6 +6162,15 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
         }
     }
     None
+}
+
+/// Hit-test the Save menu, which is over everything while it is up. A click
+/// anywhere else closes it without doing anything, which is what a menu is
+/// expected to do and keeps it from being a mode you can get stuck in.
+fn launcher_save_menu_hit(rect: Rect, pos: (i32, i32)) -> Option<UiControl> {
+    launcher_save_menu_rects(rect)
+        .into_iter()
+        .find_map(|(control, item)| item.contains(pos).then_some(control))
 }
 
 /// The Host Disk page: what the host has, and which of it to attach.
@@ -7860,16 +7912,13 @@ fn draw_launcher_row(
             let (browse, clear) = launcher_path_rects(rect, row_y);
             let value_x = launcher_control_x(rect);
             let avail = browse.x.saturating_sub(value_x + 8);
-            // The printer output shows its full path (clipped to keep the file
-            // name if long, so the row never overflows), "(none)" until one is
-            // chosen; other path rows show the image file name.
-            let text = if r.field == LauncherField::ParallelOutput {
-                match setup.path(r.field) {
-                    Some(p) => clip_path_keep_name(&p.to_string_lossy(), avail),
-                    None => "(none)".to_string(),
-                }
-            } else {
-                truncate_to_width(&setup.value_label(r.field), avail)
+            // The printer output and the Paths rows show a whole path
+            // (clipped from the front if long, so the row never overflows
+            // and the end -- which is the part that identifies it -- stays);
+            // other path rows show the image file name.
+            let text = match setup.full_path_label(r.field) {
+                Some(full) => clip_path_keep_name(&full, avail),
+                None => truncate_to_width(&setup.value_label(r.field), avail),
             };
             draw_panel_text(frame, value_x, browse.y + 6, &text, PANEL_TEXT, 1, scale);
             draw_text_button(
@@ -8554,9 +8603,25 @@ fn draw_launcher(
             button_rect,
             launcher_action_label(control),
             true,
-            hover == Some(control),
+            hover == Some(control) || (control == UiControl::LauncherSave && state.save_menu),
             scale,
         );
+    }
+    if state.save_menu {
+        for (control, item) in launcher_save_menu_rects(rect) {
+            // No backing fill: the button face is opaque across the whole
+            // rect, and a second fill here would have to scale the rect
+            // itself, which is `draw_text_button`'s job and not this
+            // loop's.
+            draw_text_button(
+                frame,
+                item,
+                launcher_action_label(control),
+                true,
+                hover == Some(control),
+                scale,
+            );
+        }
     }
     // Over everything, because it is the only thing being answered while
     // it is up.
@@ -10897,7 +10962,7 @@ mod tests {
 
         let scale = 1;
         let (w, h) = (texture_width(scale), texture_height(scale));
-        let save = |frame: &[u8], name: &str| {
+        let save_at = |frame: &[u8], name: &str, w: usize, h: usize| {
             if !crate::envcfg::flag("COPPERLINE_UI_PREVIEW") {
                 return;
             }
@@ -10910,6 +10975,9 @@ mod tests {
             writer.write_image_data(frame).unwrap();
             eprintln!("saved {path}");
         };
+        // Almost every preview is drawn at the base scale into the same
+        // frame size, so most callers need say nothing about it.
+        let save = |frame: &[u8], name: &str| save_at(frame, name, w, h);
         let panel_has_title_bar = |frame: &[u8], panel: &Panel| {
             let rect = panel_rect(panel);
             let probe = ((rect.y + 10) * w + rect.x + 4) * 4;
@@ -12301,6 +12369,76 @@ mod tests {
                     launcher_control_at(rect, state, centre),
                     Some(control),
                     "a mounted disk must not block {control:?}"
+                );
+            }
+        }
+
+        // A preview of the Paths page and of the Save menu, for eyes.
+        {
+            let mut frame = vec![0u8; w * h * 4];
+            let mut state = LauncherState::new(launcher::MachineSetup::default());
+            state.tab = LauncherTab::AvPaths;
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: menu::MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            draw(&mut frame, scale, &ui, None, None);
+            save(&frame, "launcher-paths");
+
+            // Drawn at a scale of more than one, which is where anything
+            // handing an unscaled rect to a scaled draw shows up: at scale
+            // one the two are the same and the mistake is invisible.
+            let big = 2;
+            let (bw, bh) = (texture_width(big), texture_height(big));
+            let mut frame = vec![0u8; bw * bh * 4];
+            let mut state = LauncherState::new(launcher::MachineSetup::default());
+            state.save_menu = true;
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: menu::MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            draw(&mut frame, big, &ui, None, None);
+            save_at(&frame, "launcher-save-menu", bw, bh);
+        }
+
+        // The Save menu: every item reachable, nothing under it reachable
+        // while it is up, and a click anywhere else putting it away rather
+        // than doing something.
+        {
+            let mut state = LauncherState::new(launcher::MachineSetup::default());
+            state.save_menu = true;
+            let panel = Panel::Launcher(Box::new(state));
+            let rect = panel_rect(&panel);
+            let centre = |r: Rect| ((r.x + r.w / 2) as i32, (r.y + r.h / 2) as i32);
+            for (control, item) in launcher_save_menu_rects(rect) {
+                assert_eq!(
+                    panel_control_at(&panel, centre(item)),
+                    Some(control),
+                    "{control:?} is not reachable from the Save menu"
+                );
+            }
+            // Run sits under the open menu and must not answer: a click
+            // meant for a menu item that lands slightly off should close the
+            // menu, never start a machine.
+            let run = launcher_action_rects(rect)[3].1;
+            assert_eq!(
+                panel_control_at(&panel, centre(run)),
+                Some(UiControl::LauncherSave),
+                "a click off the menu should only put it away"
+            );
+            // And with the menu down, its items are not there to be hit.
+            let mut closed = LauncherState::new(launcher::MachineSetup::default());
+            closed.save_menu = false;
+            let closed = Panel::Launcher(Box::new(closed));
+            for (control, item) in launcher_save_menu_rects(rect) {
+                assert_ne!(
+                    panel_control_at(&closed, centre(item)),
+                    Some(control),
+                    "{control:?} answers with the menu closed"
                 );
             }
         }

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -5788,11 +5788,11 @@ fn launcher_save_menu_rects(rect: Rect) -> [(UiControl, Rect); 3] {
     let w = LAUNCH_ACTION_W + 34;
     std::array::from_fn(|i| {
         let item = Rect {
-            // From the middle of the button that opened it, so the stack
-            // reads as hanging off that button rather than as a column
-            // that happens to sit above it.
-            x: save.x + save.w / 2,
-            y: save.y - (i + 1) * (LAUNCH_ACTION_H + 4),
+            // Beside the button rather than over it: the first item lands
+            // level with Save..., so the menu opens out of it instead of
+            // covering the row it came from.
+            x: save.x + save.w + 4,
+            y: save.y - i * (LAUNCH_ACTION_H + 4),
             w,
             h: LAUNCH_ACTION_H,
         };
@@ -8067,12 +8067,18 @@ fn draw_launcher_row(
                 Some(full) => clip_path_keep_name(&full, avail),
                 None => truncate_to_width(&setup.value_label(r.field), avail),
             };
-            let value_color = if launcher_path_inherits(setup, r.field) {
-                PANEL_TEXT_DIM
+            // An inheriting row centres its `(default)`, which reads as a
+            // column of its own rather than as eleven short strings
+            // pretending to be paths. A row with a real path keeps the
+            // left edge every other path on the page is read from.
+            let inherits = launcher_path_inherits(setup, r.field);
+            let (value_color, text_x) = if inherits {
+                let text_w = text.chars().count() * font::GLYPH_W;
+                (PANEL_TEXT_DIM, value_x + avail.saturating_sub(text_w) / 2)
             } else {
-                PANEL_TEXT
+                (PANEL_TEXT, value_x)
             };
-            draw_panel_text(frame, value_x, browse.y + 6, &text, value_color, 1, scale);
+            draw_panel_text(frame, text_x, browse.y + 6, &text, value_color, 1, scale);
             let (has_browse, has_clear) = launcher_path_buttons(setup, r.field);
             if has_browse {
                 draw_text_button(

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -491,9 +491,20 @@ pub fn panel_control_at(panel: &Panel, pos: (i32, i32)) -> Option<UiControl> {
         matches!(panel, Panel::Launcher(state) if state.login.is_some() || state.meta.is_some());
     #[cfg(not(feature = "game-library"))]
     let modal = false;
-    // The Save menu answers before anything under it, including the close
-    // gadget: while it is up it is the only thing being asked.
+    // The confirm, then the Save menu: each answers before anything under
+    // it, including the close gadget, because while one is up it is the
+    // only thing being asked.
     if let Panel::Launcher(state) = panel {
+        if state.confirm_reset {
+            let (yes, _) = launcher_confirm_button_rects(rect);
+            if yes.contains(pos) {
+                return Some(UiControl::LauncherConfirmReset);
+            }
+            // Anywhere else, the dialog's own frame included, is the
+            // answer that changes nothing. A question about deleting
+            // something should not be answerable by a stray click.
+            return Some(UiControl::LauncherCancelReset);
+        }
         if state.save_menu {
             return launcher_save_menu_hit(rect, pos).or(Some(UiControl::LauncherSave));
         }
@@ -913,6 +924,10 @@ pub enum UiControl {
     /// Save menu: delete the saved default, so Copperline starts from
     /// factory settings again.
     LauncherResetDefault,
+    /// The "are you sure" over Reset default: go ahead.
+    LauncherConfirmReset,
+    /// The "are you sure" over Reset default: leave it alone.
+    LauncherCancelReset,
     /// Configuration screen: reset to the selected profile's defaults.
     LauncherDefaults,
     /// Configuration screen: build and run the configured machine.
@@ -5490,8 +5505,12 @@ fn launcher_path_buttons(setup: &launcher::MachineSetup, field: LauncherField) -
 /// Whether a row is a Paths row that has not been given a directory of its
 /// own. Its label and value are dimmed to say so: the row is showing
 /// Copperline's answer rather than the person's.
+///
+/// Not the base. It names a real directory either way, it is the one row
+/// on the page that always says something, and dimming the only line that
+/// tells you where everything is would be the wrong thing to play down.
 fn launcher_path_inherits(setup: &launcher::MachineSetup, field: LauncherField) -> bool {
-    field.is_paths_field() && !setup.paths_is_set(field)
+    field.is_paths_field() && field != LauncherField::PathsBase && !setup.paths_is_set(field)
 }
 
 fn launcher_path_rects(rect: Rect, row_y: usize) -> (Rect, Rect) {
@@ -5645,6 +5664,100 @@ fn launcher_zorro_add_rect(rect: Rect) -> Rect {
     launcher_nav_button_rect(rect, 0)
 }
 
+/// The "are you sure" over Reset default, centred on the panel.
+fn launcher_confirm_rect(rect: Rect) -> Rect {
+    // Sized by its title bar -- the name plus its close gadget -- and its
+    // two buttons, both of which want more room than the one line inside
+    // it does.
+    let (w, h) = (268, TITLE_H + 62);
+    Rect {
+        x: rect.x + rect.w.saturating_sub(w) / 2,
+        y: rect.y + rect.h.saturating_sub(h) / 2,
+        w,
+        h,
+    }
+}
+
+/// Its two buttons, as (yes, cancel). Cancel is the rightmost, where a
+/// dialog's least destructive answer usually sits.
+fn launcher_confirm_button_rects(rect: Rect) -> (Rect, Rect) {
+    let dialog = launcher_confirm_rect(rect);
+    let (w, h) = (66, 20);
+    let y = dialog.y + dialog.h - h - 12;
+    (
+        Rect {
+            x: dialog.x + dialog.w - 2 * w - 20,
+            y,
+            w,
+            h,
+        },
+        Rect {
+            x: dialog.x + dialog.w - w - 12,
+            y,
+            w,
+            h,
+        },
+    )
+}
+
+fn draw_launcher_confirm(
+    frame: &mut [u8],
+    rect: Rect,
+    state: &LauncherState,
+    hover: Option<UiControl>,
+    scale: usize,
+) {
+    if !state.confirm_reset {
+        return;
+    }
+    fill_rect_blend(frame, scale_rect(rect, scale), SCRIM, SCRIM_ALPHA, scale);
+    let dialog = launcher_confirm_rect(rect);
+    fill_rect(frame, scale_rect(dialog, scale), PANEL_BG, scale);
+    draw_rect_bevel(
+        frame,
+        scale_rect(dialog, scale),
+        BUTTON_EDGE_LIGHT,
+        BUTTON_EDGE_DARK,
+        scale,
+    );
+    draw_title_bar(
+        frame,
+        dialog,
+        "Reset default",
+        hover == Some(UiControl::LauncherCancelReset),
+        scale,
+    );
+    // The title bar has already said which default, and the buttons say
+    // what the answers are. Anything more here is a paragraph nobody
+    // reads standing between somebody and a decision they have made.
+    draw_panel_text(
+        frame,
+        dialog.x + 12,
+        dialog.y + TITLE_H + 10,
+        "Are you sure?",
+        PANEL_TEXT,
+        1,
+        scale,
+    );
+    let (yes, cancel) = launcher_confirm_button_rects(rect);
+    draw_text_button(
+        frame,
+        yes,
+        "Yes",
+        true,
+        hover == Some(UiControl::LauncherConfirmReset),
+        scale,
+    );
+    draw_text_button(
+        frame,
+        cancel,
+        "Cancel",
+        true,
+        hover == Some(UiControl::LauncherCancelReset),
+        scale,
+    );
+}
+
 fn launcher_action_label(control: UiControl) -> &'static str {
     match control {
         UiControl::LauncherLoad => "Load...",
@@ -5675,7 +5788,10 @@ fn launcher_save_menu_rects(rect: Rect) -> [(UiControl, Rect); 3] {
     let w = LAUNCH_ACTION_W + 34;
     std::array::from_fn(|i| {
         let item = Rect {
-            x: save.x,
+            // From the middle of the button that opened it, so the stack
+            // reads as hanging off that button rather than as a column
+            // that happens to sit above it.
+            x: save.x + save.w / 2,
             y: save.y - (i + 1) * (LAUNCH_ACTION_H + 4),
             w,
             h: LAUNCH_ACTION_H,
@@ -8658,6 +8774,10 @@ fn draw_launcher(
         );
     }
     if state.save_menu {
+        // Dimmed rather than merely covered, the same as a dialog: while
+        // the menu is up it is the only thing being answered, and the page
+        // behind it should look like it is waiting.
+        fill_rect_blend(frame, scale_rect(rect, scale), SCRIM, SCRIM_ALPHA, scale);
         for (control, item) in launcher_save_menu_rects(rect) {
             // No backing fill: the button face is opaque across the whole
             // rect, and a second fill here would have to scale the rect
@@ -8673,6 +8793,7 @@ fn draw_launcher(
             );
         }
     }
+    draw_launcher_confirm(frame, rect, state, hover, scale);
     // Over everything, because it is the only thing being answered while
     // it is up.
     #[cfg(feature = "game-library")]
@@ -12475,6 +12596,18 @@ mod tests {
             };
             draw(&mut frame, big, &ui, None, None);
             save_at(&frame, "launcher-save-menu", bw, bh);
+
+            let mut frame = vec![0u8; w * h * 4];
+            let mut state = LauncherState::new(launcher::MachineSetup::default());
+            state.confirm_reset = true;
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: menu::MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            draw(&mut frame, scale, &ui, None, None);
+            save(&frame, "launcher-confirm-reset");
         }
 
         // A Paths row must offer exactly the buttons it draws. A Reset
@@ -12517,6 +12650,30 @@ mod tests {
             // The base swaps them.
             assert_eq!(probe(false, LauncherField::PathsBase), (true, false));
             assert_eq!(probe(true, LauncherField::PathsBase), (false, true));
+        }
+
+        // The confirm over Reset default answers every click on the panel:
+        // Yes only on its own button, and anything else -- Run included --
+        // cancels. A question about deleting something must not be
+        // answerable by a click that missed.
+        {
+            let mut state = LauncherState::new(launcher::MachineSetup::default());
+            state.confirm_reset = true;
+            let panel = Panel::Launcher(Box::new(state));
+            let rect = panel_rect(&panel);
+            let centre = |r: Rect| ((r.x + r.w / 2) as i32, (r.y + r.h / 2) as i32);
+            let (yes, cancel) = launcher_confirm_button_rects(rect);
+            assert_eq!(
+                panel_control_at(&panel, centre(yes)),
+                Some(UiControl::LauncherConfirmReset)
+            );
+            for elsewhere in [cancel, launcher_action_rects(rect)[3].1, rect] {
+                assert_eq!(
+                    panel_control_at(&panel, centre(elsewhere)),
+                    Some(UiControl::LauncherCancelReset),
+                    "a click off Yes should cancel"
+                );
+            }
         }
 
         // The Save menu: every item reachable, nothing under it reachable

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -5771,31 +5771,41 @@ fn launcher_action_label(control: UiControl) -> &'static str {
     }
 }
 
-/// The Save menu's items, in the order they are stacked above the button
-/// that opens it. Nearest the button first, so the pointer reaches the
-/// commonest of the three without crossing the other two -- and the one
-/// that deletes something ends up furthest away.
+/// The Save menu's items, left to right from the button that opens them.
+/// Nearest first, so the pointer reaches the commonest of the three
+/// without crossing the other two -- and the one that deletes something
+/// ends up furthest away, next to Defaults.
 const SAVE_MENU: [UiControl; 3] = [
     UiControl::LauncherSaveAs,
     UiControl::LauncherSaveDefault,
     UiControl::LauncherResetDefault,
 ];
 
-/// Where each Save-menu item is drawn: stacked upward from the Save button,
-/// wide enough for the longest label rather than the button's own width.
+/// Where each Save-menu item is drawn: in a row to the right of the Save
+/// button, along the action bar it belongs to.
+///
+/// Each is sized to its own label rather than to a shared width. There are
+/// 336 pixels between Save... and Defaults, and three buttons wide enough
+/// for "Reset default" do not fit in them -- a uniform row is 12 pixels
+/// too long. Sized individually the three come to 324 with their gaps,
+/// which leaves the last of them clear of Defaults by 8. The test below
+/// holds that, because a label growing by two characters is what would
+/// quietly push the row into the button beside it.
 fn launcher_save_menu_rects(rect: Rect) -> [(UiControl, Rect); 3] {
     let save = launcher_action_rects(rect)[1].1;
-    let w = LAUNCH_ACTION_W + 34;
+    // Six pixels of clearance either side of the text, which is what a
+    // label of exactly this many characters needs to survive the
+    // truncation `draw_text_button` applies.
+    let width = |control| launcher_action_label(control).chars().count() * font::GLYPH_W + 12;
+    let mut x = save.x + save.w + 4;
     std::array::from_fn(|i| {
         let item = Rect {
-            // Beside the button rather than over it: the first item lands
-            // level with Save..., so the menu opens out of it instead of
-            // covering the row it came from.
-            x: save.x + save.w + 4,
-            y: save.y - i * (LAUNCH_ACTION_H + 4),
-            w,
+            x,
+            y: save.y,
+            w: width(SAVE_MENU[i]),
             h: LAUNCH_ACTION_H,
         };
+        x = item.x + item.w + 4;
         (SAVE_MENU[i], item)
     })
 }
@@ -12656,6 +12666,47 @@ mod tests {
             // The base swaps them.
             assert_eq!(probe(false, LauncherField::PathsBase), (true, false));
             assert_eq!(probe(true, LauncherField::PathsBase), (false, true));
+        }
+
+        // The Save menu is a row along the action bar, and there is only
+        // just room for it: three buttons at a shared width do not fit
+        // between Save... and Defaults at all. Nothing about that is
+        // obvious from reading the code, so it is held here -- a label
+        // gaining two characters would otherwise push the last button
+        // silently under the one beside it.
+        {
+            let panel = Panel::Launcher(Box::new(LauncherState::new(
+                launcher::MachineSetup::default(),
+            )));
+            let rect = panel_rect(&panel);
+            let [load, save, defaults, run] = launcher_action_rects(rect);
+            let items = launcher_save_menu_rects(rect);
+            assert!(
+                items[0].1.x >= save.1.x + save.1.w,
+                "the menu should start clear of the button that opens it"
+            );
+            for (a, b) in items.iter().zip(items.iter().skip(1)) {
+                assert!(a.1.x + a.1.w <= b.1.x, "menu items overlap each other");
+                assert_eq!(a.1.y, b.1.y, "the menu should be one row");
+            }
+            let last = items[2].1;
+            assert!(
+                last.x + last.w <= defaults.1.x,
+                "the menu runs into Defaults: {} past {}",
+                last.x + last.w,
+                defaults.1.x
+            );
+            // Every label readable rather than truncated by the button it
+            // is drawn in, which is the reason the widths differ at all.
+            for (control, item) in items {
+                let fits = item.w.saturating_sub(8) / font::GLYPH_W;
+                let label = launcher_action_label(control);
+                assert!(
+                    label.chars().count() <= fits,
+                    "{label:?} does not fit its button"
+                );
+            }
+            let _ = (load, run);
         }
 
         // The confirm over Reset default answers every click on the panel:

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -500,13 +500,22 @@ pub fn panel_control_at(panel: &Panel, pos: (i32, i32)) -> Option<UiControl> {
             if yes.contains(pos) {
                 return Some(UiControl::LauncherConfirmReset);
             }
+            if close_button_rect(launcher_confirm_rect(rect)).contains(pos) {
+                return Some(UiControl::LauncherDialogClose);
+            }
             // Anywhere else, the dialog's own frame included, is the
             // answer that changes nothing. A question about deleting
             // something should not be answerable by a stray click.
             return Some(UiControl::LauncherCancelReset);
         }
         if state.save_dialog {
-            return launcher_save_dialog_hit(rect, pos).or(Some(UiControl::LauncherSave));
+            if let Some(control) = launcher_save_dialog_hit(rect, pos) {
+                return Some(control);
+            }
+            if close_button_rect(launcher_save_dialog_rect(rect)).contains(pos) {
+                return Some(UiControl::LauncherDialogClose);
+            }
+            return Some(UiControl::LauncherSave);
         }
     }
     if !modal && close_button_rect(rect).contains(pos) {
@@ -928,6 +937,13 @@ pub enum UiControl {
     LauncherConfirmReset,
     /// The "are you sure" over Reset default: leave it alone.
     LauncherCancelReset,
+    /// The close gadget on whichever launcher dialog is up.
+    ///
+    /// Its own control rather than sharing the one a click anywhere else
+    /// returns. Both mean "put this away", but only one of them is the
+    /// gadget, and the gadget lights up when the pointer is on it -- share
+    /// the control and it lights up for every hover in the dialog.
+    LauncherDialogClose,
     /// Configuration screen: reset to the selected profile's defaults.
     LauncherDefaults,
     /// Configuration screen: build and run the configured machine.
@@ -5666,10 +5682,11 @@ fn launcher_zorro_add_rect(rect: Rect) -> Rect {
 
 /// The "are you sure" over Reset default, centred on the panel.
 fn launcher_confirm_rect(rect: Rect) -> Rect {
-    // Sized by its title bar -- the name plus its close gadget -- and its
-    // two buttons, both of which want more room than the one line inside
-    // it does.
-    let (w, h) = (268, TITLE_H + 62);
+    // Its own width, which its title bar and two buttons decide, but the
+    // Save dialog's height exactly: they are the same window asking two
+    // things, and one being shorter than the other made them look like two
+    // unrelated boxes that happened to open in the same place.
+    let (w, h) = (268, launcher_save_dialog_rect(rect).h);
     Rect {
         x: rect.x + rect.w.saturating_sub(w) / 2,
         y: rect.y + rect.h.saturating_sub(h) / 2,
@@ -5682,8 +5699,8 @@ fn launcher_confirm_rect(rect: Rect) -> Rect {
 /// dialog's least destructive answer usually sits.
 fn launcher_confirm_button_rects(rect: Rect) -> (Rect, Rect) {
     let dialog = launcher_confirm_rect(rect);
-    let (w, h) = (66, 20);
-    let y = dialog.y + dialog.h - h - 12;
+    let (w, h) = (66, SAVE_DIALOG_BUTTON.1);
+    let y = dialog.y + dialog.h - SAVE_DIALOG_MARGIN - h;
     (
         Rect {
             x: dialog.x + dialog.w - 2 * w - 20,
@@ -5724,7 +5741,7 @@ fn draw_launcher_confirm(
         frame,
         dialog,
         "Reset default",
-        hover == Some(UiControl::LauncherCancelReset),
+        hover == Some(UiControl::LauncherDialogClose),
         scale,
     );
     // The title bar has already said which default, and the buttons say
@@ -5732,8 +5749,8 @@ fn draw_launcher_confirm(
     // reads standing between somebody and a decision they have made.
     draw_panel_text(
         frame,
-        dialog.x + 12,
-        dialog.y + TITLE_H + 10,
+        dialog.x + SAVE_DIALOG_MARGIN,
+        dialog.y + TITLE_H + SAVE_DIALOG_MARGIN,
         "Are you sure?",
         PANEL_TEXT,
         1,
@@ -5765,7 +5782,7 @@ fn launcher_action_label(control: UiControl) -> &'static str {
         UiControl::LauncherDefaults => "Defaults",
         UiControl::LauncherRun => "Run",
         UiControl::LauncherSaveAs => "Save As",
-        UiControl::LauncherSaveDefault => "Set default",
+        UiControl::LauncherSaveDefault => "Save default",
         UiControl::LauncherResetDefault => "Reset default",
         _ => "",
     }
@@ -5804,10 +5821,10 @@ const SAVE_DIALOG_HELP_GAP: usize = 16;
 fn save_dialog_help(control: UiControl) -> &'static str {
     match control {
         UiControl::LauncherSaveDefault => {
-            "Saves the current running configuration as the default when you launch Copperline."
+            "Sets the running configuration as the default when you launch Copperline."
         }
         UiControl::LauncherResetDefault => "Resets the current default config to factory settings.",
-        _ => "Save the configuration to a file",
+        _ => "Save the running configuration to a file.",
     }
 }
 
@@ -5874,7 +5891,7 @@ fn draw_launcher_save_dialog(
         frame,
         dialog,
         "Save configuration...",
-        hover == Some(UiControl::LauncherSave),
+        hover == Some(UiControl::LauncherDialogClose),
         scale,
     );
     for (control, item) in launcher_save_dialog_rects(rect) {
@@ -12788,6 +12805,14 @@ mod tests {
                     "a click off Yes should cancel"
                 );
             }
+            // And here too the gadget answers only for itself.
+            assert_eq!(
+                panel_control_at(&panel, centre(close_button_rect(dialog))),
+                Some(UiControl::LauncherDialogClose)
+            );
+            // The two dialogs are the same height, so they read as one
+            // window asking two things rather than two boxes.
+            assert_eq!(dialog.h, launcher_save_dialog_rect(rect).h);
         }
 
         // The Save dialog: every button reachable, nothing under it
@@ -12842,11 +12867,28 @@ mod tests {
                 h: SAVE_DIALOG_MARGIN,
             };
             let [load, _, _, run] = launcher_action_rects(rect);
-            for elsewhere in [close, body, load.1, run.1] {
+            for elsewhere in [body, load.1, run.1] {
                 assert_eq!(
                     panel_control_at(&panel, centre(elsewhere)),
                     Some(UiControl::LauncherSave),
                     "a click off the three should only put the dialog away"
+                );
+            }
+            // The gadget answers as itself, and nothing else does. It is
+            // drawn lit when the pointer is on it, so sharing a control
+            // with "anywhere else" lit it up for every hover in the dialog.
+            assert_eq!(
+                panel_control_at(&panel, centre(close)),
+                Some(UiControl::LauncherDialogClose)
+            );
+            for elsewhere in [body, load.1, run.1]
+                .into_iter()
+                .chain(items.map(|(_, item)| item))
+            {
+                assert_ne!(
+                    panel_control_at(&panel, centre(elsewhere)),
+                    Some(UiControl::LauncherDialogClose),
+                    "something that is not the gadget lights the gadget"
                 );
             }
             // Every description fits the two lines reserved for it. The

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -12596,7 +12596,9 @@ impl App {
                 let events = rec.events_recorded();
                 let script = rec.finish();
                 let path = crate::inputrec::auto_filename();
-                match std::fs::write(&path, script) {
+                match crate::paths::ensure_parent(&path)
+                    .and_then(|()| std::fs::write(&path, script))
+                {
                     Ok(()) => {
                         info!(
                             "input recording saved: {} ({events} events)",

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6330,7 +6330,7 @@ impl App {
                     // is, and the database may have been synced meanwhile.
                     #[cfg(feature = "game-library")]
                     if tab == crate::video::launcher::LauncherTab::WhdloadLibrary {
-                        let at = crate::paths::config_dir().unwrap_or_default();
+                        let at = crate::paths::library_root();
                         state.library.games = crate::gamelib::Library::default();
                         state.refresh_library(&at);
                     }
@@ -6433,7 +6433,7 @@ impl App {
             }
             #[cfg(feature = "game-library")]
             UiControl::LauncherLibraryFavourite(drawn) => {
-                let config = crate::paths::config_dir().unwrap_or_default();
+                let config = crate::paths::library_root();
                 if let Some(state) = self.launcher_state_mut() {
                     let at = state.library.scroll + drawn;
                     state.toggle_library_favourite(at);
@@ -6451,7 +6451,7 @@ impl App {
             }
             #[cfg(feature = "game-library")]
             UiControl::LauncherLibraryFavouriteRemove(drawn) => {
-                let config = crate::paths::config_dir().unwrap_or_default();
+                let config = crate::paths::library_root();
                 if let Some(state) = self.launcher_state_mut() {
                     let at = state.library.favourite_scroll + drawn;
                     state.remove_favourite(at);
@@ -8261,7 +8261,7 @@ impl App {
         else {
             return;
         };
-        let config = crate::paths::config_dir().unwrap_or_default();
+        let config = crate::paths::library_root();
         let Some(state) = self.launcher_state_mut() else {
             return;
         };
@@ -8308,7 +8308,7 @@ impl App {
     /// Commit the editor and write the store.
     #[cfg(feature = "game-library")]
     fn meta_save(&mut self) {
-        let config = crate::paths::config_dir().unwrap_or_default();
+        let config = crate::paths::library_root();
         if let Some(state) = self.launcher_state_mut() {
             state.commit_meta_editor();
             state.save_library_database(&config);
@@ -8408,7 +8408,7 @@ impl App {
     /// the last scan resolved, and asks the service nothing.
     #[cfg(feature = "game-library")]
     fn library_refresh(&mut self) {
-        let config = crate::paths::config_dir().unwrap_or_default();
+        let config = crate::paths::library_root();
         let Some(state) = self.launcher_state_mut() else {
             return;
         };
@@ -8430,7 +8430,7 @@ impl App {
         if self.library_scan.is_some() {
             return;
         }
-        let config = crate::paths::config_dir().unwrap_or_default();
+        let config = crate::paths::library_root();
         let Some(state) = self.launcher_state() else {
             return;
         };
@@ -8534,7 +8534,7 @@ impl App {
         if said.is_empty() {
             return;
         }
-        let config = crate::paths::config_dir().unwrap_or_default();
+        let config = crate::paths::library_root();
         let mut status = None;
         for progress in said {
             let text = progress.message();

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6831,6 +6831,8 @@ impl App {
             UiControl::LauncherSaveAs => self.launcher_save(),
             UiControl::LauncherSaveDefault => self.launcher_save_default(),
             UiControl::LauncherResetDefault => self.launcher_reset_default(),
+            UiControl::LauncherConfirmReset => self.launcher_reset_default_confirmed(),
+            UiControl::LauncherCancelReset => self.launcher_close_confirm(),
             UiControl::LauncherRun => self.launcher_run(),
             UiControl::DropDrive(drive_idx) => self.drop_chooser_route(drive_idx),
             UiControl::AnalyzerTab(_)
@@ -8983,14 +8985,37 @@ impl App {
         }
     }
 
+    /// Ask before deleting the saved default.
+    ///
+    /// Only when there is one. With no default saved there is nothing to be
+    /// sure about, and a dialog that asks anyway is a dialog that teaches
+    /// people to dismiss dialogs without reading them.
+    fn launcher_reset_default(&mut self) {
+        self.launcher_close_save_menu();
+        let saved = crate::paths::default_config_file().is_some_and(|path| path.is_file());
+        if !saved {
+            self.set_launcher_status(StatusMessage::ok("No default saved"));
+            return;
+        }
+        if let Some(state) = self.launcher_state_mut() {
+            state.confirm_reset = true;
+        }
+    }
+
+    fn launcher_close_confirm(&mut self) {
+        if let Some(state) = self.launcher_state_mut() {
+            state.confirm_reset = false;
+        }
+    }
+
     /// Delete the saved default, so Copperline starts from factory settings
     /// again.
     ///
     /// Nothing else goes with it. What it removes is one file that was
     /// written by one button press, and everything the emulator has
     /// produced -- states, screenshots, NVRAM -- is untouched.
-    fn launcher_reset_default(&mut self) {
-        self.launcher_close_save_menu();
+    fn launcher_reset_default_confirmed(&mut self) {
+        self.launcher_close_confirm();
         let Some(path) = crate::paths::default_config_file() else {
             return;
         };

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6833,6 +6833,12 @@ impl App {
             UiControl::LauncherResetDefault => self.launcher_reset_default(),
             UiControl::LauncherConfirmReset => self.launcher_reset_default_confirmed(),
             UiControl::LauncherCancelReset => self.launcher_close_confirm(),
+            // Whichever is up. Only one ever is: opening the confirm puts
+            // the Save dialog away rather than stacking on it.
+            UiControl::LauncherDialogClose => {
+                self.launcher_close_confirm();
+                self.launcher_close_save_dialog();
+            }
             UiControl::LauncherRun => self.launcher_run(),
             UiControl::DropDrive(drive_idx) => self.drop_chooser_route(drive_idx),
             UiControl::AnalyzerTab(_)

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6827,7 +6827,10 @@ impl App {
             UiControl::LauncherBrowse(field) => self.launcher_browse(field),
             UiControl::LauncherZorroAdd => self.launcher_add_zorro(),
             UiControl::LauncherLoad => self.launcher_load(),
-            UiControl::LauncherSave => self.launcher_save(),
+            UiControl::LauncherSave => self.launcher_toggle_save_menu(),
+            UiControl::LauncherSaveAs => self.launcher_save(),
+            UiControl::LauncherSaveDefault => self.launcher_save_default(),
+            UiControl::LauncherResetDefault => self.launcher_reset_default(),
             UiControl::LauncherRun => self.launcher_run(),
             UiControl::DropDrive(drive_idx) => self.drop_chooser_route(drive_idx),
             UiControl::AnalyzerTab(_)
@@ -7991,7 +7994,7 @@ impl App {
         // Host FS mounts and the WHDLoad staging directories are a host
         // directory, not an image file, so they get a folder picker seeded
         // at the current directory itself.
-        if field.is_filesys_dir_field() || field.is_whdload_dir_field() {
+        if field.is_filesys_dir_field() || field.is_whdload_dir_field() || field.is_paths_field() {
             self.launcher_browse_folder(field);
             return;
         }
@@ -8116,10 +8119,16 @@ impl App {
 
     /// Folder picker for a Host FS mount's directory field.
     fn launcher_browse_folder(&mut self, field: LauncherField) {
+        // A Paths row opens where it points now, resolved: its stored value
+        // may be relative to the base, which is not somewhere a dialog can
+        // be pointed at.
         let start_dir = self
             .launcher_state()
-            .and_then(|s| s.setup.path(field))
-            .map(|p| p.to_path_buf())
+            .and_then(|s| {
+                s.setup
+                    .paths_resolved(field)
+                    .or_else(|| s.setup.path(field).map(std::path::Path::to_path_buf))
+            })
             .or_else(crate::paths::harddrives_dir);
         self.suspend_live_audio_for_host_io();
         let mut dialog = rfd::FileDialog::new().set_title("Select host directory");
@@ -8937,35 +8946,117 @@ impl App {
         self.finish_host_io_pause();
     }
 
-    fn launcher_save(&mut self) {
-        // Capture a name/option typed but not yet committed with Enter. A
-        // value the commit refuses keeps the focus and blocks the save:
-        // writing the file anyway would silently save the previous value
-        // while the box shows the rejected one.
+    /// Open or put away the Save menu. Every other click while it is up
+    /// arrives here too, which is how clicking off it closes it.
+    fn launcher_toggle_save_menu(&mut self) {
+        if let Some(state) = self.launcher_state_mut() {
+            state.save_menu = !state.save_menu;
+        }
+    }
+
+    /// Save the configuration as the one Copperline starts with.
+    ///
+    /// The same TOML as Save as..., in a fixed place. It replaces whatever
+    /// was there without asking: pressing Save default is a statement about
+    /// what the default should be now, and the thing it overwrites is a
+    /// previous answer to that same question rather than anything a person
+    /// would have to go and recreate.
+    fn launcher_save_default(&mut self) {
+        self.launcher_close_save_menu();
+        let Some(text) = self.launcher_toml_for_save() else {
+            return;
+        };
+        let Some(path) = crate::paths::default_config_file() else {
+            self.set_launcher_status(StatusMessage::err("No place to save a default"));
+            return;
+        };
+        let written = crate::paths::ensure_parent(&path).and_then(|()| std::fs::write(&path, text));
+        match written {
+            Ok(()) => {
+                info!("saved the default configuration to {}", path.display());
+                self.set_launcher_status(StatusMessage::ok("Saved as the default"));
+            }
+            Err(e) => {
+                warn!("default save failed ({}): {e}", path.display());
+                self.set_launcher_status(StatusMessage::err("Save failed (see log)"));
+            }
+        }
+    }
+
+    /// Delete the saved default, so Copperline starts from factory settings
+    /// again.
+    ///
+    /// Nothing else goes with it. What it removes is one file that was
+    /// written by one button press, and everything the emulator has
+    /// produced -- states, screenshots, NVRAM -- is untouched.
+    fn launcher_reset_default(&mut self) {
+        self.launcher_close_save_menu();
+        let Some(path) = crate::paths::default_config_file() else {
+            return;
+        };
+        if !path.is_file() {
+            self.set_launcher_status(StatusMessage::ok("No default saved"));
+            return;
+        }
+        match std::fs::remove_file(&path) {
+            Ok(()) => {
+                info!("removed the default configuration {}", path.display());
+                self.set_launcher_status(StatusMessage::ok("Default reset"));
+            }
+            Err(e) => {
+                warn!("default reset failed ({}): {e}", path.display());
+                self.set_launcher_status(StatusMessage::err("Reset failed (see log)"));
+            }
+        }
+    }
+
+    fn launcher_close_save_menu(&mut self) {
+        if let Some(state) = self.launcher_state_mut() {
+            state.save_menu = false;
+        }
+    }
+
+    /// The configuration as TOML, with a value typed but not committed
+    /// folded in first. A value the commit refuses keeps the focus and
+    /// blocks the save: writing the file anyway would save the previous
+    /// value while the box still shows the rejected one.
+    fn launcher_toml_for_save(&mut self) -> Option<String> {
         if let Some(state) = self.launcher_state_mut() {
             state.edit_commit();
             if state.editing().is_some() {
                 self.request_redraw();
-                return;
+                return None;
             }
         }
-        let toml = match self.launcher_state().map(|s| s.setup.to_toml()) {
-            Some(Ok(text)) => text,
+        match self.launcher_state().map(|s| s.setup.to_toml()) {
+            Some(Ok(text)) => Some(text),
             Some(Err(e)) => {
                 self.set_launcher_status(StatusMessage::err(format!(
                     "Save failed: {}",
                     short_status_error(&e)
                 )));
-                return;
+                None
             }
-            None => return,
+            None => None,
+        }
+    }
+
+    fn launcher_save(&mut self) {
+        self.launcher_close_save_menu();
+        let Some(toml) = self.launcher_toml_for_save() else {
+            return;
         };
         self.suspend_live_audio_for_host_io();
-        let picked = rfd::FileDialog::new()
+        let mut dialog = rfd::FileDialog::new()
             .set_title("Save configuration")
             .add_filter("Copperline config", &["toml"])
-            .set_file_name("machine.toml")
-            .save_file();
+            .set_file_name("machine.toml");
+        // Where configurations are kept, which is a better first answer than
+        // wherever the last unrelated dialog happened to end up.
+        if let Some(dir) = crate::paths::configs_dir() {
+            dialog = dialog.set_directory(dir);
+        }
+        let picked = dialog.save_file();
         if let Some(path) = picked {
             match std::fs::write(&path, toml) {
                 Ok(()) => self.set_launcher_status(StatusMessage::ok(format!(

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6827,7 +6827,7 @@ impl App {
             UiControl::LauncherBrowse(field) => self.launcher_browse(field),
             UiControl::LauncherZorroAdd => self.launcher_add_zorro(),
             UiControl::LauncherLoad => self.launcher_load(),
-            UiControl::LauncherSave => self.launcher_toggle_save_menu(),
+            UiControl::LauncherSave => self.launcher_toggle_save_dialog(),
             UiControl::LauncherSaveAs => self.launcher_save(),
             UiControl::LauncherSaveDefault => self.launcher_save_default(),
             UiControl::LauncherResetDefault => self.launcher_reset_default(),
@@ -8950,9 +8950,9 @@ impl App {
 
     /// Open or put away the Save menu. Every other click while it is up
     /// arrives here too, which is how clicking off it closes it.
-    fn launcher_toggle_save_menu(&mut self) {
+    fn launcher_toggle_save_dialog(&mut self) {
         if let Some(state) = self.launcher_state_mut() {
-            state.save_menu = !state.save_menu;
+            state.save_dialog = !state.save_dialog;
         }
     }
 
@@ -8964,7 +8964,7 @@ impl App {
     /// previous answer to that same question rather than anything a person
     /// would have to go and recreate.
     fn launcher_save_default(&mut self) {
-        self.launcher_close_save_menu();
+        self.launcher_close_save_dialog();
         let Some(text) = self.launcher_toml_for_save() else {
             return;
         };
@@ -8991,7 +8991,7 @@ impl App {
     /// sure about, and a dialog that asks anyway is a dialog that teaches
     /// people to dismiss dialogs without reading them.
     fn launcher_reset_default(&mut self) {
-        self.launcher_close_save_menu();
+        self.launcher_close_save_dialog();
         let saved = crate::paths::default_config_file().is_some_and(|path| path.is_file());
         if !saved {
             self.set_launcher_status(StatusMessage::ok("No default saved"));
@@ -9035,9 +9035,9 @@ impl App {
         }
     }
 
-    fn launcher_close_save_menu(&mut self) {
+    fn launcher_close_save_dialog(&mut self) {
         if let Some(state) = self.launcher_state_mut() {
-            state.save_menu = false;
+            state.save_dialog = false;
         }
     }
 
@@ -9067,7 +9067,7 @@ impl App {
     }
 
     fn launcher_save(&mut self) {
-        self.launcher_close_save_menu();
+        self.launcher_close_save_dialog();
         let Some(toml) = self.launcher_toml_for_save() else {
             return;
         };

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -8001,10 +8001,16 @@ impl App {
             self.launcher_browse_save(field, "printer.txt");
             return;
         }
+        // Beside whatever the field already holds; failing that, the
+        // directory kept for that kind of media. A field with a value is
+        // the better answer of the two -- somebody editing df1 after df0
+        // wants the folder df0 came from, not a fixed one -- so the
+        // configured directory is only ever the fallback.
         let start_dir = self
             .launcher_state()
             .and_then(|s| s.setup.path(field))
-            .and_then(|p| p.parent().map(|d| d.to_path_buf()));
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+            .or_else(|| Self::media_start_dir(field));
         self.suspend_live_audio_for_host_io();
         let mut dialog = rfd::FileDialog::new().set_title("Select file");
         dialog = match field {
@@ -8072,12 +8078,49 @@ impl App {
         self.finish_host_io_pause();
     }
 
+    /// The directory a dialog opens at when its field is empty, by what the
+    /// field holds. The same grouping the filters use just below, so a field
+    /// cannot be offered ROM filters and opened in the floppy folder.
+    ///
+    /// `None` throughout when the directory has not been made -- `paths` only
+    /// answers for one that exists -- which is what keeps this opt-in.
+    fn media_start_dir(field: LauncherField) -> Option<std::path::PathBuf> {
+        match field {
+            LauncherField::Mt32ControlRom | LauncherField::Mt32PcmRom => {
+                crate::paths::mt32_roms_dir().or_else(crate::paths::roms_dir)
+            }
+            LauncherField::Rom
+            | LauncherField::ExtendedRom
+            | LauncherField::ScsiRom
+            | LauncherField::ScsiRomOdd => crate::paths::roms_dir(),
+            LauncherField::Df0Image
+            | LauncherField::Df1Image
+            | LauncherField::Df2Image
+            | LauncherField::Df3Image => crate::paths::floppies_dir(),
+            LauncherField::CdImage => crate::paths::cds_dir(),
+            // A SCSI unit takes either, and the hard-disk folder is the more
+            // likely of the two; a CD there is the exception.
+            LauncherField::ScsiUnit0
+            | LauncherField::ScsiUnit1
+            | LauncherField::ScsiUnit2
+            | LauncherField::ScsiUnit3
+            | LauncherField::ScsiUnit4
+            | LauncherField::ScsiUnit5
+            | LauncherField::ScsiUnit6 => crate::paths::harddrives_dir(),
+            // The WHDLoad game folder and the NVRAM image have homes of their
+            // own that the launcher already knows; nothing to add here.
+            LauncherField::WhdloadGame | LauncherField::Cd32Nvram => None,
+            _ => crate::paths::harddrives_dir(),
+        }
+    }
+
     /// Folder picker for a Host FS mount's directory field.
     fn launcher_browse_folder(&mut self, field: LauncherField) {
         let start_dir = self
             .launcher_state()
             .and_then(|s| s.setup.path(field))
-            .map(|p| p.to_path_buf());
+            .map(|p| p.to_path_buf())
+            .or_else(crate::paths::harddrives_dir);
         self.suspend_live_audio_for_host_io();
         let mut dialog = rfd::FileDialog::new().set_title("Select host directory");
         if let Some(dir) = start_dir {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -8964,7 +8964,7 @@ impl App {
 
     /// Save the configuration as the one Copperline starts with.
     ///
-    /// The same TOML as Save as..., in a fixed place. It replaces whatever
+    /// The same TOML as Save As, in a fixed place. It replaces whatever
     /// was there without asking: pressing Save default is a statement about
     /// what the default should be now, and the thing it overwrites is a
     /// previous answer to that same question rather than anything a person
@@ -8975,18 +8975,27 @@ impl App {
             return;
         };
         let Some(path) = crate::paths::default_config_file() else {
-            self.set_launcher_status(StatusMessage::err("No place to save a default"));
+            // No host-data directory at all (no HOME, XDG_CONFIG_HOME or
+            // APPDATA), so there is nowhere the next launch would look.
+            warn!("no host data directory to save a default configuration in");
+            self.set_launcher_status(StatusMessage::err(
+                "Failed to set the default config (see log)",
+            ));
             return;
         };
         let written = crate::paths::ensure_parent(&path).and_then(|()| std::fs::write(&path, text));
         match written {
             Ok(()) => {
                 info!("saved the default configuration to {}", path.display());
-                self.set_launcher_status(StatusMessage::ok("Saved as the default"));
+                self.set_launcher_status(StatusMessage::ok(
+                    "Saved the running config as the default",
+                ));
             }
             Err(e) => {
                 warn!("default save failed ({}): {e}", path.display());
-                self.set_launcher_status(StatusMessage::err("Save failed (see log)"));
+                self.set_launcher_status(StatusMessage::err(
+                    "Failed to set the default config (see log)",
+                ));
             }
         }
     }
@@ -9000,7 +9009,7 @@ impl App {
         self.launcher_close_save_dialog();
         let saved = crate::paths::default_config_file().is_some_and(|path| path.is_file());
         if !saved {
-            self.set_launcher_status(StatusMessage::ok("No default saved"));
+            self.set_launcher_status(StatusMessage::ok("No default config currently set"));
             return;
         }
         if let Some(state) = self.launcher_state_mut() {
@@ -9026,17 +9035,21 @@ impl App {
             return;
         };
         if !path.is_file() {
-            self.set_launcher_status(StatusMessage::ok("No default saved"));
+            self.set_launcher_status(StatusMessage::ok("No default config currently set"));
             return;
         }
         match std::fs::remove_file(&path) {
             Ok(()) => {
                 info!("removed the default configuration {}", path.display());
-                self.set_launcher_status(StatusMessage::ok("Default reset"));
+                self.set_launcher_status(StatusMessage::ok(
+                    "Reset the current default config to factory settings",
+                ));
             }
             Err(e) => {
                 warn!("default reset failed ({}): {e}", path.display());
-                self.set_launcher_status(StatusMessage::err("Reset failed (see log)"));
+                self.set_launcher_status(StatusMessage::err(
+                    "Unable to reset the default config (see log)",
+                ));
             }
         }
     }

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -755,13 +755,7 @@ impl App {
                     Some("START") => {
                         let path = match args.get(1) {
                             Some(path) => std::path::PathBuf::from(path),
-                            None => {
-                                let stamp = std::time::SystemTime::now()
-                                    .duration_since(std::time::UNIX_EPOCH)
-                                    .map(|d| d.as_secs())
-                                    .unwrap_or(0);
-                                std::path::PathBuf::from(format!("copperline-trace-{stamp}.txt"))
-                            }
+                            None => crate::paths::trace_file(),
                         };
                         match self
                             .emu

--- a/src/waveform.rs
+++ b/src/waveform.rs
@@ -597,6 +597,7 @@ impl WaveCapture {
     /// Create the output file and write the declaration section. The
     /// capture starts in the Armed state.
     pub fn create(opts: WaveOptions) -> io::Result<Self> {
+        crate::paths::ensure_parent(&opts.path)?;
         let file = std::fs::File::create(&opts.path)?;
         let mut writer = VcdWriter::new(io::BufWriter::new(file));
         writer.header(&[format!(
@@ -960,7 +961,14 @@ mod tests {
             }
         );
         assert_eq!(opts.duration, WaveDuration::Cck(500));
-        assert!(opts.path.to_string_lossy().starts_with("copperline-wave-"));
+        assert!(
+            opts.path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("copperline-wave-")),
+            "{:?}",
+            opts.path
+        );
         // Defaults with no arguments at all.
         let opts = parse_wave_args([]).unwrap();
         assert_eq!(opts.trigger, Trigger::Now);

--- a/src/waveform.rs
+++ b/src/waveform.rs
@@ -295,13 +295,10 @@ where
     Ok(opts)
 }
 
-/// Timestamped default output path in the working directory.
+/// Timestamped default output path. Named by `paths`, with every other
+/// default a run produces.
 pub fn default_wave_path() -> PathBuf {
-    let stamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    PathBuf::from(format!("copperline-wave-{stamp}.vcd"))
+    crate::paths::waveform_file()
 }
 
 /// Snapshot of a capture's state for the console/debugger UI.


### PR DESCRIPTION
## Configurable paths, portable outputs, and a default config

The purpose of this PR is to give the Copperline and its launcher a more “grown up” feel more akin to other emulators, but without affecting today's behaviour unless you want it to. 

Everything Copperline produces — screenshots, save states, video/input recordings, NVRAM, traces, waveform captures — now lands in named folders under the host-data directory instead of the process working directory, and a new optional `[paths]` section in the config moves any of them (plus where empty file dialogs open). Nothing set behaves as before, minus the stray files in the CWD.

- **`[paths]`** — 12 optional keys, relative entries resolve under a movable `base`, so the whole tree follows `portable.txt` untouched. Entries a machine can't reach (unplugged stick, dead network mount) fall back to defaults with a log warning; the check is time-bounded so a stale mount delays startup by moments, never hangs it.
- **Launcher: A/V & Emu → Paths** — one row per folder, `(default)` until set, Browse/Reset, changes take effect immediately.
- **Save default / `--factory`** — the Save button now offers Save As / Save default / Reset default. A saved `configs/default.toml` is what Copperline starts with when `--config`/`./copperline.toml` name nothing (the launcher opens showing it); `--factory` ignores it.
- Legacy `battmem.nvram` / `cd32-nvram.bin` in the CWD keep being used from there — real game saves are never silently relocated.
- Explicit CLI paths (`--screenshot-after` etc.) are used exactly as written and never consult `[paths]`.

Docs: `[paths]` reference, a "Where files go" section, example TOML block (keys asserted against the struct in a test).

Testing: full suite green incl. the ROM-gated integration tests, with identical results on this branch and upstream main (`image_regression` 10/10 both sides); portable mode and unreachable-path fallback verified end-to-end.

<img width="724" height="623" alt="Screenshot 2026-08-14 at 14 13 13" src="https://github.com/user-attachments/assets/0fa153f9-94ae-4b0a-a8f7-6f88e70759d7" />
<img width="725" height="616" alt="Screenshot 2026-08-14 at 14 13 29" src="https://github.com/user-attachments/assets/829ee035-5aff-46ac-86c0-671e8e60db6c" />
