### PR TITLE
launcher: let the Storage Browse dialog pick a directory too

### DIFF
--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -577,8 +577,14 @@ The layout is:
   configuration by **Save As** or **Save default** like everything else.
 - **Settings rows** (right pane). `[<]`/`[>]` step through a value, On/Off
   buttons flip a toggle, and the **Browse** and **Clear** buttons set or remove
-  a file path through a native file dialog. On the *Storage* tab, once an IDE
-  or SCSI drive has an image a small editable box appears next to **Browse**:
+  a file path through a native file dialog. On the *Storage* tab (IDE master/
+  slave, a SCSI unit, or a lide drive), **Browse** lets you pick a directory as
+  well as a file -- on macOS -- since any of those slots can be a host
+  directory mounted as an in-memory FFS volume instead of a raw image; on
+  other platforms the dialog is file-only there too, matching the rest of the
+  launcher, and a directory target still has to be set some other way (e.g.
+  editing the config file directly). Once an IDE, SCSI, or lide drive has an
+  image a small editable box appears next to **Browse**:
   click it and type to set the volume name for a directory mount (left blank, a
   directory mount inherits the host directory's name; the box has no effect on a
   raw HDF).

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -8082,7 +8082,39 @@ impl App {
         if let Some(dir) = start_dir {
             dialog = dialog.set_directory(dir);
         }
-        let picked = dialog.pick_file();
+        // A hard-drive slot can be a raw image or a host directory (built
+        // into an in-memory FFS volume at open time; see `HardDriveImage`,
+        // shared by IdeDrive/ScsiDisk/lide's own open call) -- so its dialog
+        // should let the user pick either, not just a file. `rfd` only
+        // offers a combined file-or-folder picker on macOS; elsewhere this
+        // falls back to the file-only dialog it already had, unchanged.
+        let hard_drive_slot = matches!(
+            field,
+            LauncherField::ScsiUnit0
+                | LauncherField::ScsiUnit1
+                | LauncherField::ScsiUnit2
+                | LauncherField::ScsiUnit3
+                | LauncherField::ScsiUnit4
+                | LauncherField::ScsiUnit5
+                | LauncherField::ScsiUnit6
+                | LauncherField::IdeMaster
+                | LauncherField::IdeSlave
+                | LauncherField::LideDrive0
+                | LauncherField::LideDrive1
+                | LauncherField::LideDrive2
+                | LauncherField::LideDrive3
+        );
+        #[cfg(target_os = "macos")]
+        let picked = if hard_drive_slot {
+            dialog.pick_file_or_folder()
+        } else {
+            dialog.pick_file()
+        };
+        #[cfg(not(target_os = "macos"))]
+        let picked = {
+            let _ = hard_drive_slot;
+            dialog.pick_file()
+        };
         if let Some(mut path) = picked {
             if field == LauncherField::WhdloadGame {
                 path = whdload_game_config_path(path);

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -8023,7 +8023,37 @@ impl App {
             .and_then(|p| p.parent().map(|d| d.to_path_buf()))
             .or_else(|| Self::media_start_dir(field));
         self.suspend_live_audio_for_host_io();
-        let mut dialog = rfd::FileDialog::new().set_title("Select file");
+        // A hard-drive slot can be a raw image or a host directory (built
+        // into an in-memory FFS/OFS volume at open time; see
+        // `HardDriveImage`, shared by IdeDrive/ScsiDisk/lide's own open
+        // call) -- so its dialog should let the user pick either, not just
+        // a file, and should say so rather than inheriting the plain
+        // "Select file" title every other field uses. `rfd` only offers a
+        // combined file-or-folder picker on macOS; elsewhere this falls
+        // back to the file-only dialog (and title) it already had,
+        // unchanged.
+        let hard_drive_slot = matches!(
+            field,
+            LauncherField::ScsiUnit0
+                | LauncherField::ScsiUnit1
+                | LauncherField::ScsiUnit2
+                | LauncherField::ScsiUnit3
+                | LauncherField::ScsiUnit4
+                | LauncherField::ScsiUnit5
+                | LauncherField::ScsiUnit6
+                | LauncherField::IdeMaster
+                | LauncherField::IdeSlave
+                | LauncherField::LideDrive0
+                | LauncherField::LideDrive1
+                | LauncherField::LideDrive2
+                | LauncherField::LideDrive3
+        );
+        let title = if hard_drive_slot && cfg!(target_os = "macos") {
+            "Select file or folder"
+        } else {
+            "Select file"
+        };
+        let mut dialog = rfd::FileDialog::new().set_title(title);
         dialog = match field {
             LauncherField::Rom
             | LauncherField::ExtendedRom
@@ -8082,28 +8112,6 @@ impl App {
         if let Some(dir) = start_dir {
             dialog = dialog.set_directory(dir);
         }
-        // A hard-drive slot can be a raw image or a host directory (built
-        // into an in-memory FFS volume at open time; see `HardDriveImage`,
-        // shared by IdeDrive/ScsiDisk/lide's own open call) -- so its dialog
-        // should let the user pick either, not just a file. `rfd` only
-        // offers a combined file-or-folder picker on macOS; elsewhere this
-        // falls back to the file-only dialog it already had, unchanged.
-        let hard_drive_slot = matches!(
-            field,
-            LauncherField::ScsiUnit0
-                | LauncherField::ScsiUnit1
-                | LauncherField::ScsiUnit2
-                | LauncherField::ScsiUnit3
-                | LauncherField::ScsiUnit4
-                | LauncherField::ScsiUnit5
-                | LauncherField::ScsiUnit6
-                | LauncherField::IdeMaster
-                | LauncherField::IdeSlave
-                | LauncherField::LideDrive0
-                | LauncherField::LideDrive1
-                | LauncherField::LideDrive2
-                | LauncherField::LideDrive3
-        );
         #[cfg(target_os = "macos")]
         let picked = if hard_drive_slot {
             dialog.pick_file_or_folder()


### PR DESCRIPTION
## Summary

`IdeMaster`/`IdeSlave`, `ScsiUnit0-6`, and the lide drive fields all accept a host directory as a drive target — `HardDriveImage::open` (shared by `IdeDrive`, `ScsiDisk`, and lide's own open call) builds it into an in-memory FFS volume, and the Storage tab's volume-name box exists specifically for this case. But their **Browse** dialog called `rfd::FileDialog::pick_file()`, a file-only native picker, so on macOS a directory couldn't be selected at all — only files.

`rfd` 0.17 already has `pick_file_or_folder()` for exactly this, so this PR switches to it for those fields.

**Why macOS-only**: this isn't a scope choice, it's the ceiling of what `rfd` can offer. Its own docs mark `pick_file_or_folder()` (and `pick_files_or_folders()`) explicitly `Supported only on: macos`, because macOS's `NSOpenPanel` genuinely supports combined file-or-folder selection natively — it's just two independent booleans (`canChooseFiles`, `canChooseDirectories`) with no restriction on setting both `true`. GTK's `GtkFileChooser` (Linux) and Windows' native file dialog don't have an equivalent combined mode; each is fundamentally either a file picker or a folder picker, so there's nothing for `rfd` to wrap on those platforms. Other platforms keep the existing file-only dialog for these fields, unchanged — a directory-backed drive there still needs another way in (e.g. editing the config file directly). Offering folder selection on Linux/Windows too would need a custom in-app picker bypassing the native dialog, which is a separate, larger piece of work.

## Test plan

- `cargo build --release`, `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — all clean.
- Manually verified in the launcher on macOS: Storage tab → IDE/SCSI/lide drive → Browse now opens a picker that accepts either a file or a folder.
