### PR TITLE
Add OFS support for directory-mounted hard drives

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -430,15 +430,21 @@ video = "PAL"
 # compressed hardfile (.hdz, or a gzipped .hdf: it is the content that decides,
 # not the name) is unpacked into memory at open time, so the guest may write to
 # it but nothing goes back to the compressed file. A path may also name a host
-# directory, mounted as an in-memory FFS volume (guest writes are likewise not
-# synced back to the host).
+# directory, mounted as an in-memory FFS or OFS volume (guest writes are
+# likewise not synced back to the host).
 #
-# A drive may be given as a table instead of a bare path, to set the FFS volume
-# label of a directory mount (name) and/or the boot priority of the synthesized
-# RDB partition (bootpri, -128..127, default 0). Kickstart enters DF0: at 5, so
-# bootpri = 6 boots the hard disk ahead of a floppy; -128 mounts the volume
-# without ever offering it for boot. Neither applies to an image carrying its
-# own RDB, which keeps the label and priorities recorded inside it.
+# A drive may be given as a table instead of a bare path, to set the volume
+# label of a directory mount (name), the boot priority of the synthesized RDB
+# partition (bootpri, -128..127, default 0), and/or the directory mount's
+# filesystem (filesystem = "ofs" or "ffs", default "ffs"). Kickstart enters
+# DF0: at 5, so bootpri = 6 boots the hard disk ahead of a floppy; -128 mounts
+# the volume without ever offering it for boot. filesystem = "ofs" is worth
+# setting for a drive meant to work under Kickstart 1.3, whose ROM has no FFS
+# handler built in (real hardware needs one loaded from disk or an RDB
+# FileSystemHeader chain, neither of which Copperline bundles); OFS needs no
+# guest-side setup at all. None of these three apply to an image carrying its
+# own RDB, which keeps its label, priorities, and filesystem recorded inside
+# it.
 #
 # A path ending in .cue, .iso, or .chd attaches an ATAPI CD-ROM drive at
 # that slot instead of a hard disk (see [scsi], above, for the read-only
@@ -447,6 +453,7 @@ video = "PAL"
 # master = "workbench.hdf"
 # slave = "data.hdf"
 # master = { path = "workbench.hdf", bootpri = 6 }
+# master = { path = "/host/Games", filesystem = "ofs" }
 
 
 # Direct WHDLoad boot (docs/guide/whdload.md): boot straight into a

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1396,18 +1396,18 @@ file, and changes are lost at exit. An image that unpacks to more than
 plain hardfile and attach it instead.
 
 A path may also name a **host directory**: its tree is built into an
-in-memory FFS volume at startup (volume name = directory name, files and
+in-memory volume at startup (volume name = directory name, files and
 subdirectories included; entries whose names cannot exist on an Amiga
 volume are skipped with a warning). The guest sees an ordinary bootable
-FFS disk and may write to it, but the volume lives only in memory --
-nothing is written back to the host directory, and changes are lost at
-exit. Note that the stock A1200/A600 Kickstart `scsi.device` only probes
-the IDE master; a slave drive needs a guest OS or driver that supports
-two units (e.g. Kickstart 3.1.4).
+disk and may write to it, but the volume lives only in memory -- nothing
+is written back to the host directory, and changes are lost at exit. Note
+that the stock A1200/A600 Kickstart `scsi.device` only probes the IDE
+master; a slave drive needs a guest OS or driver that supports two units
+(e.g. Kickstart 3.1.4).
 
-To override the volume name (instead of inheriting the directory name) or
-the boot priority, give the drive as a table with `path` plus `name`
-and/or `bootpri`:
+To override the volume name (instead of inheriting the directory name),
+the boot priority, or the filesystem, give the drive as a table with
+`path` plus `name`, `bootpri`, and/or `filesystem`:
 
 ```toml
 [ide]
@@ -1416,9 +1416,26 @@ slave = { path = "wb.hdf", bootpri = 6 }
 # slave = "scratch.hdf"        # the bare-string form still works
 ```
 
-The name sets the FFS volume label of a directory mount; AmigaDOS volume
+The name sets the volume label of a directory mount; AmigaDOS volume
 names hold up to 30 characters and cannot contain `:` or `/`. It has no
 effect on a raw HDF, which carries its own label inside the image.
+
+`filesystem` (`"ffs"`, the default, or `"ofs"`) picks the filesystem a
+directory mount's in-memory volume is built with; it only applies to a
+directory (an HDF/gzip image already carries its own filesystem inside
+it, and Copperline refuses the key on one at config-parse time). FFS is
+the default because it is the more modern, more capacious choice, but
+Kickstart 1.3's ROM has no FFS handler built in -- real 1.3 hardware needs
+`L:FastFileSystem` loaded from disk, or an RDB `FileSystemHeader` chain,
+neither of which Copperline can bundle (it is Commodore-copyrighted). OFS
+(`DOS\x00`) is built into every Kickstart ROM from 1.2 onward, so a
+directory mount meant to work under 1.3 with no guest-side setup should
+set `filesystem = "ofs"`:
+
+```toml
+[ide]
+master = { path = "/host/Games", filesystem = "ofs" }
+```
 
 `bootpri` (-128..127, default 0) is the `de_BootPri` written into the
 **synthesized** RDB's partition, which is what the ROM's strap ranks boot
@@ -1495,10 +1512,11 @@ A2091 is Commodore product 3, with its DiagArea vector at `$2000`).
 Each `unitN` accepts everything `[ide]` paths do: RDB images, bare
 partition hardfiles (a synthesized RDB advertises a bootable `DHn`
 partition, named after the SCSI ID), gzip-compressed hardfiles (`.hdz`),
-and host directories built into in-memory FFS volumes -- including the
-`{ path = "...", name = "...", bootpri = N }` table form that overrides a
-directory mount's volume name and the synthesized partition's boot
-priority. The HDD activity LED covers SCSI traffic too.
+and host directories built into in-memory FFS/OFS volumes -- including the
+`{ path = "...", name = "...", bootpri = N, filesystem = "..." }` table
+form that overrides a directory mount's volume name, filesystem, and the
+synthesized partition's boot priority. The HDD activity LED covers SCSI
+traffic too.
 
 A `unitN` path ending in `.cue`, `.iso`, or `.chd` attaches a **SCSI
 CD-ROM drive** at that ID instead of a hard disk: a read-only removable
@@ -1551,7 +1569,8 @@ one channel, no ROM banking. None of the three wire an interrupt line --
 
 `drives` takes the same bare-path/table form as `[ide]`/`[scsi]` (RDB images,
 bare partition hardfiles, `.hdz`, host directories, and the `{ path = "...",
-name = "...", bootpri = N }` table), in (channel, master/slave) order:
+name = "...", bootpri = N, filesystem = "..." }` table), in (channel,
+master/slave) order:
 entries 0 and 1 are channel 0's master and slave, entries 2 and 3 are channel
 1's (`"ripple"` only -- `"ride"` and `"atbus2008"` have one channel).
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1644,8 +1644,8 @@ Each `[[filesys]]` entry exports a host directory to the guest as an
 AmigaDOS volume on its own `HOSTFS<n>:` device, served live by the
 emulator: no disk image is built, and guest reads always see the current
 host contents. This differs from giving `[ide]`/`[scsi]` a directory
-path, which snapshots the tree into an in-memory FFS volume at startup.
-Up to 8 mounts.
+path, which snapshots the tree into an in-memory FFS or OFS volume at
+startup (see `filesystem` above). Up to 8 mounts.
 
 The volumes are read-write by default: the guest creates, writes, renames,
 and deletes the host's files directly, and changes land in the directory

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -581,7 +581,10 @@ The layout is:
   or SCSI drive has an image a small editable box appears next to **Browse**:
   click it and type to set the volume name for a directory mount (left blank, a
   directory mount inherits the host directory's name; the box has no effect on a
-  raw HDF).
+  raw HDF). Once that image is a host **directory** specifically, an **FFS/OFS**
+  button appears just left of the volume-name box: click it to flip the
+  in-memory volume's filesystem (FFS by default; OFS is the one every
+  Kickstart from 1.2 onward can read with no guest-side setup).
   A setting that does not apply to the chosen machine is greyed and
   shows why in place of its control -- "needs 32-bit CPU" for Zorro III RAM
   and the RTG card, "needs 68020+" for the FPU, "needs A600/A1200/A4000" for

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -50,7 +50,7 @@ src/
   scsi.rs           # WD33C93A SBIC + SCSI-2 disk targets
   sdmac.rs          # A3000 Super DMAC fronting the WD33C93
   harddrive.rs      # shared hard-drive image backend (IDE + SCSI)
-  dirfs.rs          # host directory -> in-memory FFS partition image
+  dirfs.rs          # host directory -> in-memory FFS/OFS partition image
   filesys.rs        # host directories mounted live as AmigaDOS volumes
   a2065.rs          # A2065 Zorro II Ethernet board (Am7990 LANCE)
   net/              # loopback, userspace NAT, and host-adapter bridge backends

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -174,9 +174,13 @@ HDF images, bare partition hardfiles wrapped in a synthesized RDB
 (bootable `DHn` named after the unit), gzip-compressed hardfiles (`.hdz`,
 sniffed by gzip magic and unpacked by `gzip.rs` into memory at open time
 because deflate has no random access, which is what makes their writes
-session-only), and host directories built into in-memory FFS volumes by
-`dirfs.rs` (whose volume label defaults to the directory name, or a `name`
-override configured on the drive). The SCSI-2 target layer in
+session-only), and host directories built into in-memory FFS or OFS volumes by
+`dirfs.rs` (FFS by default; `filesystem = "ofs"` on the drive picks OFS,
+the one every Kickstart from 1.2 onward can read with no guest-side
+setup -- FFS needs a handler loaded from disk or an RDB `FileSystemHeader`
+chain, neither of which Copperline bundles). The volume label defaults to
+the directory name, or a `name` override configured on the drive. The
+SCSI-2 target layer in
 `scsi.rs` answers INQUIRY, MODE SENSE pages 3/4, READ CAPACITY,
 READ/WRITE(6)/(10), REQUEST SENSE, and the no-op housekeeping commands,
 with sense state kept per target.
@@ -266,7 +270,7 @@ dispatch in `IdeZorro::read()` (see `ide_zorro.rs`'s tests).
 `[[filesys]]` mounts export host directories as live AmigaDOS volumes
 (`HOSTFS0:` ... up to 8 mounts), with no disk image in between -- distinct
 from the `dirfs.rs` path above, which snapshots a directory into an
-in-memory FFS volume behind a virtual drive. The guest side is a tiny
+in-memory FFS or OFS volume behind a virtual drive. The guest side is a tiny
 handler (see `guest/services/`) mapped into the Copperline services board
 with a mount table and a hand-built DiagArea. DiagPoint only patches a
 Romtag into the retained diag copy; Kickstart's cold-start resident scan

--- a/src/a2091.rs
+++ b/src/a2091.rs
@@ -501,7 +501,11 @@ mod tests {
     fn board_with_disk(sectors: u64) -> (A2091, PathBuf) {
         let mut board = A2091::new(fake_rom()).unwrap();
         let path = temp_image(sectors);
-        board.attach_drive(0, crate::scsi::ScsiDisk::open(&path, 0, None, 0).unwrap());
+        board.attach_drive(
+            0,
+            crate::scsi::ScsiDisk::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS)
+                .unwrap(),
+        );
         (board, path)
     }
 
@@ -611,7 +615,11 @@ mod tests {
         std::fs::write(&path, &img).unwrap();
         let (mut board2, _) = (board, ());
         // Reopen the drive so the new image content is seen.
-        board2.attach_drive(0, crate::scsi::ScsiDisk::open(&path, 0, None, 0).unwrap());
+        board2.attach_drive(
+            0,
+            crate::scsi::ScsiDisk::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS)
+                .unwrap(),
+        );
         let mut board = board2;
         let mut mem = test_memory();
 

--- a/src/ata.rs
+++ b/src/ata.rs
@@ -145,16 +145,25 @@ impl IdeDrive {
     /// bus (e.g. a multi-channel `[lide]` board) must pass a value that is
     /// unique across every drive on the bus, not just channel-relative
     /// master=0/slave=1. The path may be a raw HDF image file, or a host
-    /// directory, which is built into an in-memory FFS volume at open time;
-    /// `volume_name` labels that volume (directory mounts only). `boot_pri`
-    /// is the synthesized partition's `de_BootPri`.
+    /// directory, which is built into an in-memory FFS or OFS volume at open
+    /// time (`filesystem` picks which; directory mounts only -- ignored for
+    /// every other path form). `volume_name` labels that volume (directory
+    /// mounts only). `boot_pri` is the synthesized partition's `de_BootPri`.
     pub fn open(
         path: &Path,
         unit: usize,
         volume_name: Option<&str>,
         boot_pri: i8,
+        filesystem: crate::diskimage::FileSystem,
     ) -> anyhow::Result<Self> {
-        let disk = HardDriveImage::open(path, &format!("DH{unit}"), "ide", volume_name, boot_pri)?;
+        let disk = HardDriveImage::open(
+            path,
+            &format!("DH{unit}"),
+            "ide",
+            volume_name,
+            boot_pri,
+            filesystem,
+        )?;
         // The classic Amiga HDF geometry: 16 surfaces, 32 sectors per track
         // (what HDToolBox/RDB tooling defaults to), so the CHS the host
         // computes from an RDB's physical-drive block agrees with what the
@@ -1502,7 +1511,10 @@ mod tests {
         // The same command against a plain disk slot aborts.
         let disk_path = temp_disk_image(64);
         let mut disk_bus = AtaBus::new();
-        disk_bus.attach_drive(0, IdeDrive::open(&disk_path, 0, None, 0).unwrap());
+        disk_bus.attach_drive(
+            0,
+            IdeDrive::open(&disk_path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+        );
         disk_bus.command(0xA1);
         assert_ne!(disk_bus.status & ST_ERR, 0);
         assert_eq!(disk_bus.error, ERR_ABRT);
@@ -1527,7 +1539,10 @@ mod tests {
 
         let disk_path = temp_disk_image(64);
         let mut disk_bus = AtaBus::new();
-        disk_bus.attach_drive(0, IdeDrive::open(&disk_path, 0, None, 0).unwrap());
+        disk_bus.attach_drive(
+            0,
+            IdeDrive::open(&disk_path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+        );
         disk_bus.reset();
         assert_eq!(disk_bus.cyl_low, 0);
         assert_eq!(disk_bus.cyl_high, 0);
@@ -1541,7 +1556,10 @@ mod tests {
         let disk_path = temp_disk_image(64);
         let cd_path = temp_cd_image(2);
         let mut bus = AtaBus::new();
-        bus.attach_drive(0, IdeDrive::open(&disk_path, 0, None, 0).unwrap());
+        bus.attach_drive(
+            0,
+            IdeDrive::open(&disk_path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+        );
         bus.attach_drive(1, AtapiDrive::open(&cd_path).unwrap());
         bus.reset();
 
@@ -1618,7 +1636,10 @@ mod tests {
         let disk_path = temp_disk_image(64);
         let cd_path = temp_cd_image(2);
         let mut bus = AtaBus::new();
-        bus.attach_drive(0, IdeDrive::open(&disk_path, 0, None, 0).unwrap());
+        bus.attach_drive(
+            0,
+            IdeDrive::open(&disk_path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+        );
         bus.attach_drive(1, AtapiDrive::open(&cd_path).unwrap());
 
         // Master (disk) selected: IDENTIFY DEVICE succeeds.
@@ -1686,7 +1707,10 @@ mod tests {
     fn device_reset_aborts_against_a_plain_ata_slot() {
         let disk_path = temp_disk_image(64);
         let mut bus = AtaBus::new();
-        bus.attach_drive(0, IdeDrive::open(&disk_path, 0, None, 0).unwrap());
+        bus.attach_drive(
+            0,
+            IdeDrive::open(&disk_path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+        );
         bus.command(0x08);
         assert_ne!(bus.status & ST_ERR, 0);
         assert_eq!(bus.error, ERR_ABRT);
@@ -1748,7 +1772,7 @@ mod tests {
         fn bare_partition_image(name: &str) -> PathBuf {
             const CYL_BYTES: usize = 16 * 32 * 512; // RDB_HEADS * RDB_SPT * SECTOR_SIZE
             let mut data = vec![0u8; CYL_BYTES];
-            data[..4].copy_from_slice(b"DOS\x01"); // OFS boot block signature
+            data[..4].copy_from_slice(b"DOS\x01"); // FFS boot block signature
             let path = std::env::temp_dir().join(format!(
                 "copperline-ata-test-{}-{}-{name}",
                 std::process::id(),
@@ -1772,8 +1796,10 @@ mod tests {
         // master is idx 2.
         let path0 = bare_partition_image("ch0.hdf");
         let path2 = bare_partition_image("ch1.hdf");
-        let mut drive0 = IdeDrive::open(&path0, 0, None, 0).unwrap();
-        let mut drive2 = IdeDrive::open(&path2, 2, None, 0).unwrap();
+        let mut drive0 =
+            IdeDrive::open(&path0, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap();
+        let mut drive2 =
+            IdeDrive::open(&path2, 2, None, 0, crate::diskimage::FileSystem::FFS).unwrap();
         let name0 = dh_name(&mut drive0);
         let name2 = dh_name(&mut drive2);
         assert_eq!(name0, "DH0");

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -10995,7 +10995,10 @@ fn gayle_int2_level_keeps_setting_paula_ports_intreq() {
 
     let mut bus = empty_bus();
     let mut gayle = Gayle::new(0xD0);
-    gayle.attach_drive(0, IdeDrive::open(&image, 0, None, 0).unwrap());
+    gayle.attach_drive(
+        0,
+        IdeDrive::open(&image, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+    );
     bus.attach_gayle(gayle);
 
     // Enable the IDE interrupt at $DAA000 and issue a READ SECTORS via

--- a/src/config.rs
+++ b/src/config.rs
@@ -975,9 +975,9 @@ impl Default for ParallelConfig {
 
 /// A configured hard-drive image: the host path plus an optional volume-name
 /// override. The override only changes a host *directory* mounted as an
-/// in-memory FFS volume -- it sets the FFS volume label instead of deriving it
-/// from the directory name. A raw HDF carries its own label inside the image
-/// and ignores the override.
+/// in-memory FFS/OFS volume -- it sets the volume label instead of deriving
+/// it from the directory name. A raw HDF carries its own label inside the
+/// image and ignores the override.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DriveImage {
     pub path: PathBuf,
@@ -986,6 +986,23 @@ pub struct DriveImage {
     /// bare hardfile. Only reaches the guest for such images: an HDF that
     /// carries its own RDB keeps the priorities recorded inside it.
     pub boot_pri: i8,
+    /// The filesystem an in-memory directory-mount volume is built with.
+    /// Only meaningful for a host *directory* mount (an HDF/gzip image
+    /// already carries its own filesystem). Defaults to FFS; Kickstart
+    /// 1.3's ROM has no FFS handler built in, so OFS is the choice for a
+    /// directory mount meant to work under 1.3 with no guest-side setup.
+    pub filesystem: crate::diskimage::FileSystem,
+}
+
+impl Default for DriveImage {
+    fn default() -> Self {
+        DriveImage {
+            path: PathBuf::new(),
+            volume_name: None,
+            boot_pri: HARDFILE_DEFAULT_BOOT_PRI,
+            filesystem: crate::diskimage::FileSystem::FFS,
+        }
+    }
 }
 
 /// Priority a synthesized hard-disk partition boots at when the config says
@@ -3226,6 +3243,9 @@ pub(crate) struct RawDrive {
     /// (-128..=127); defaults to 0, the priority HDToolBox gives a hard-disk
     /// boot partition. -128 mounts the partition without offering it for boot.
     pub(crate) bootpri: Option<i8>,
+    /// "ofs" or "ffs"; only valid on a host-directory mount. Defaults to FFS
+    /// when absent.
+    pub(crate) filesystem: Option<String>,
 }
 
 impl RawDrive {
@@ -3234,6 +3254,7 @@ impl RawDrive {
             path: path.into(),
             name: None,
             bootpri: None,
+            filesystem: None,
         }
     }
 }
@@ -3243,12 +3264,15 @@ impl Serialize for RawDrive {
     where
         S: serde::Serializer,
     {
-        if self.name.is_none() && self.bootpri.is_none() {
+        if self.name.is_none() && self.bootpri.is_none() && self.filesystem.is_none() {
             // No overrides: a plain string keeps saved configs minimal.
             return serializer.serialize_str(&self.path);
         }
         use serde::ser::SerializeMap;
-        let len = 1 + usize::from(self.name.is_some()) + usize::from(self.bootpri.is_some());
+        let len = 1
+            + usize::from(self.name.is_some())
+            + usize::from(self.bootpri.is_some())
+            + usize::from(self.filesystem.is_some());
         let mut map = serializer.serialize_map(Some(len))?;
         map.serialize_entry("path", &self.path)?;
         if let Some(name) = &self.name {
@@ -3256,6 +3280,9 @@ impl Serialize for RawDrive {
         }
         if let Some(bootpri) = &self.bootpri {
             map.serialize_entry("bootpri", bootpri)?;
+        }
+        if let Some(filesystem) = &self.filesystem {
+            map.serialize_entry("filesystem", filesystem)?;
         }
         map.end()
     }
@@ -3290,6 +3317,7 @@ impl<'de> Deserialize<'de> for RawDrive {
                 let mut path: Option<String> = None;
                 let mut name: Option<String> = None;
                 let mut bootpri: Option<i8> = None;
+                let mut filesystem: Option<String> = None;
                 while let Some(key) = map.next_key::<String>()? {
                     match key.as_str() {
                         "path" => {
@@ -3310,10 +3338,16 @@ impl<'de> Deserialize<'de> for RawDrive {
                             }
                             bootpri = Some(map.next_value()?);
                         }
+                        "filesystem" => {
+                            if filesystem.is_some() {
+                                return Err(serde::de::Error::duplicate_field("filesystem"));
+                            }
+                            filesystem = Some(map.next_value()?);
+                        }
                         other => {
                             return Err(serde::de::Error::unknown_field(
                                 other,
-                                &["path", "name", "bootpri"],
+                                &["path", "name", "bootpri", "filesystem"],
                             ));
                         }
                     }
@@ -3323,6 +3357,7 @@ impl<'de> Deserialize<'de> for RawDrive {
                     path,
                     name,
                     bootpri,
+                    filesystem,
                 })
             }
         }
@@ -3797,10 +3832,11 @@ pub(crate) enum RawReplaySpeed {
     Word(String),
 }
 
-/// Convert a parsed `[ide]`/`[scsi]` drive entry into a `DriveImage`,
-/// validating any volume-name override. An empty/whitespace name is treated as
-/// no override; AmigaDOS volume names cannot contain ':' or '/' and the FFS
-/// root block stores at most 30 characters.
+/// Convert a parsed `[ide]`/`[scsi]`/`[lide]` drive entry into a `DriveImage`,
+/// validating any volume-name override and the `filesystem` key. An
+/// empty/whitespace name is treated as no override; AmigaDOS volume names
+/// cannot contain ':' or '/' and the FFS/OFS root block stores at most 30
+/// characters.
 fn drive_image(raw: RawDrive) -> Result<DriveImage> {
     let volume_name = match raw.name {
         None => None,
@@ -3815,10 +3851,28 @@ fn drive_image(raw: RawDrive) -> Result<DriveImage> {
             }
         }
     };
+    let path = PathBuf::from(raw.path);
+    let filesystem = match raw.filesystem {
+        None => crate::diskimage::FileSystem::FFS,
+        Some(fs) => {
+            if !path.is_dir() {
+                bail!(
+                    "drive filesystem = {fs:?}: only applies to a host-directory mount, not \
+                     an image file"
+                );
+            }
+            match fs.trim().to_ascii_lowercase().as_str() {
+                "ofs" => crate::diskimage::FileSystem::OFS,
+                "ffs" => crate::diskimage::FileSystem::FFS,
+                _ => bail!("drive filesystem = {fs:?} is not known (expected \"ofs\" or \"ffs\")"),
+            }
+        }
+    };
     Ok(DriveImage {
-        path: PathBuf::from(raw.path),
+        path,
         volume_name,
         boot_pri: raw.bootpri.unwrap_or(HARDFILE_DEFAULT_BOOT_PRI),
+        filesystem,
     })
 }
 
@@ -6564,6 +6618,7 @@ mod tests {
                     path: PathBuf::from("ch0-master.hdf"),
                     volume_name: None,
                     boot_pri: 0,
+                    filesystem: crate::diskimage::FileSystem::FFS,
                 }),
                 None,
                 None,
@@ -8931,6 +8986,82 @@ mod tests {
     }
 
     #[test]
+    fn drive_filesystem_key_selects_ofs_or_ffs_for_a_directory_mount() -> Result<()> {
+        let dir =
+            std::env::temp_dir().join(format!("copperline-config-fs-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let dir_toml = dir.to_string_lossy().replace('\\', "\\\\");
+
+        // Explicit "ofs".
+        let cfg = parse_config(&format!(
+            r#"
+            [machine]
+            profile = "A1200"
+            [ide]
+            master = {{ path = "{dir_toml}", filesystem = "ofs" }}
+            "#,
+        ))?;
+        let master = cfg.ide.master.as_ref().expect("master configured");
+        assert_eq!(master.filesystem, crate::diskimage::FileSystem::OFS);
+
+        // Explicit "ffs" (case-insensitive).
+        let cfg = parse_config(&format!(
+            r#"
+            [machine]
+            profile = "A1200"
+            [ide]
+            master = {{ path = "{dir_toml}", filesystem = "FFS" }}
+            "#,
+        ))?;
+        let master = cfg.ide.master.as_ref().expect("master configured");
+        assert_eq!(master.filesystem, crate::diskimage::FileSystem::FFS);
+
+        // Absent key: defaults to FFS.
+        let cfg = parse_config(&format!(
+            r#"
+            [machine]
+            profile = "A1200"
+            [ide]
+            master = "{dir_toml}"
+            "#,
+        ))?;
+        let master = cfg.ide.master.as_ref().expect("master configured");
+        assert_eq!(master.filesystem, crate::diskimage::FileSystem::FFS);
+
+        // An unknown token is a clear error.
+        let err = parse_config(&format!(
+            r#"
+            [machine]
+            profile = "A1200"
+            [ide]
+            master = {{ path = "{dir_toml}", filesystem = "qfs" }}
+            "#,
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains("qfs"), "{err:#}");
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn drive_filesystem_key_is_rejected_on_a_non_directory_path() {
+        // filesystem only means something for a host-directory mount; an
+        // image file has its own dostype baked into the bytes.
+        let err = parse_config(
+            r#"
+            [machine]
+            profile = "A1200"
+            [ide]
+            master = { path = "data.hdf", filesystem = "ofs" }
+            "#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("filesystem"), "{err:#}");
+        assert!(err.to_string().contains("directory"), "{err:#}");
+    }
+
+    #[test]
     fn the_memory_controller_can_be_selected() -> anyhow::Result<()> {
         let cfg = parse_config(
             r#"
@@ -9052,6 +9183,7 @@ mod tests {
                     path: "work/".to_string(),
                     name: Some("Work".to_string()),
                     bootpri: None,
+                    filesystem: None,
                 }),
                 unit1: Some(RawDrive::from_path("data.hdf")),
                 ..RawScsi::default()
@@ -9079,6 +9211,7 @@ mod tests {
                 path: "games/".to_string(),
                 name: Some("Games".to_string()),
                 bootpri: None,
+                filesystem: None,
             }),
             slave: None,
         };
@@ -9093,6 +9226,7 @@ mod tests {
                 path: "wb.hdf".to_string(),
                 name: None,
                 bootpri: Some(6),
+                filesystem: None,
             }),
             slave: None,
         };

--- a/src/dirfs.rs
+++ b/src/dirfs.rs
@@ -1,17 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-//! Build a bare FFS partition image (a "partition hardfile") from a host
+//! Build a bare partition image (a "partition hardfile") from a host
 //! directory tree, so a directory can be mounted as a Gayle IDE hard disk
 //! with no preparation. The image is built once at startup and lives in
-//! memory: the guest sees an ordinary FFS volume and may write to it, but
-//! nothing is synced back to the host directory.
+//! memory: the guest sees an ordinary AmigaDOS volume and may write to it,
+//! but nothing is synced back to the host directory.
 //!
-//! The on-disk layout is plain AmigaDOS FFS (dostype DOS\x01, 512-byte
-//! blocks, 16x32 cylinder geometry to match the RDB the IDE layer
-//! synthesizes around bare partition images): boot block, root block in the
-//! middle of the partition, bitmap blocks after the root, directory header
-//! blocks with hashed name chains, and file header / extension blocks whose
-//! data pointers reference raw 512-byte data blocks.
+//! The on-disk layout is plain AmigaDOS FFS or OFS (dostype DOS\x01 or
+//! DOS\x00, caller's choice; see [`build_image`]), 512-byte blocks, 16x32
+//! cylinder geometry to match the RDB the IDE layer synthesizes around bare
+//! partition images: boot block, root block in the middle of the partition,
+//! bitmap blocks after the root, directory header blocks with hashed name
+//! chains, and file header / extension blocks whose data pointers reference
+//! either raw 512-byte FFS data blocks or 24-byte-header OFS data blocks
+//! (488 payload bytes apiece, chained through their own `next_data`
+//! pointers). OFS exists alongside FFS because Kickstart 1.3's ROM has no
+//! FFS handler built in -- OFS is the only filesystem a 1.3 guest can read
+//! from a directory mount with no guest-side setup.
 
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
@@ -34,6 +39,7 @@ const BMEXT_PAGES: usize = BSIZE / 4 - 1;
 
 const T_HEADER: u32 = 2;
 const T_LIST: u32 = 16;
+const T_DATA: u32 = 8;
 const ST_ROOT: u32 = 1;
 const ST_USERDIR: u32 = 2;
 const ST_FILE: u32 = 0xFFFF_FFFD; // -3
@@ -44,9 +50,35 @@ const AMIGA_EPOCH_OFFSET: u64 = 252_460_800;
 /// Refuse to build images larger than this; the whole image lives in RAM.
 const MAX_IMAGE_BYTES: u64 = 2 << 30;
 
-pub fn build_ffs_image(dir: &Path, volume_name: &str) -> anyhow::Result<Vec<u8>> {
+/// Data payload bytes per content block: FFS data blocks carry no header
+/// (the full 512 bytes are payload); OFS data blocks reserve the first 24
+/// bytes for type/header_key/seq_num/data_size/next_data/checksum.
+fn data_payload_bytes(filesystem: crate::diskimage::FileSystem) -> u64 {
+    if filesystem.ffs {
+        BSIZE as u64
+    } else {
+        (BSIZE - 24) as u64
+    }
+}
+
+pub fn build_image(
+    dir: &Path,
+    volume_name: &str,
+    filesystem: crate::diskimage::FileSystem,
+) -> anyhow::Result<Vec<u8>> {
+    // Only `ffs`/plain-vs-not matters here: Kickstart 1.3 (the reason OFS
+    // exists as an option at all) has no intl/dircache/longname support
+    // either, so callers are only ever expected to pass FileSystem::OFS or
+    // FileSystem::FFS.
+    debug_assert!(
+        filesystem.variant == crate::diskimage::Variant::Plain,
+        "dirfs only builds plain OFS/FFS volumes"
+    );
     let entries = scan_tree(dir)?;
-    let content_blocks: u64 = 3 + entries.iter().map(EntryPlan::blocks_needed).sum::<u64>();
+    let content_blocks: u64 = 3 + entries
+        .iter()
+        .map(|e| e.blocks_needed(filesystem))
+        .sum::<u64>();
 
     // Fixed-point size estimate: bitmap blocks depend on the total size.
     let slack = (content_blocks / 20).max(64);
@@ -69,7 +101,7 @@ pub fn build_ffs_image(dir: &Path, volume_name: &str) -> anyhow::Result<Vec<u8>>
         );
     }
 
-    let mut b = Builder::new(total as usize, volume_name);
+    let mut b = Builder::new(total as usize, volume_name, filesystem);
     b.write_tree(dir, &entries, b.root_key)?;
     Ok(b.finish())
 }
@@ -85,15 +117,15 @@ struct EntryPlan {
 }
 
 impl EntryPlan {
-    fn blocks_needed(&self) -> u64 {
+    fn blocks_needed(&self, filesystem: crate::diskimage::FileSystem) -> u64 {
         if self.is_dir {
             1 + self
                 .children
                 .iter()
-                .map(EntryPlan::blocks_needed)
+                .map(|c| c.blocks_needed(filesystem))
                 .sum::<u64>()
         } else {
-            let data = self.size.div_ceil(BSIZE as u64);
+            let data = self.size.div_ceil(data_payload_bytes(filesystem));
             let headers = 1 + data.saturating_sub(HT_SIZE as u64).div_ceil(HT_SIZE as u64);
             data + headers
         }
@@ -216,12 +248,19 @@ struct Builder {
     bitmap_keys: Vec<u32>,
     bmext_keys: Vec<u32>,
     /// Header blocks whose checksum (at offset 20) is computed at finish,
-    /// after all hash-chain inserts have settled.
+    /// after all hash-chain inserts have settled. OFS data blocks are pushed
+    /// here too: they carry a checksum at the same offset, computed the
+    /// same way.
     meta_blocks: Vec<u32>,
+    filesystem: crate::diskimage::FileSystem,
 }
 
 impl Builder {
-    fn new(total_blocks: usize, volume_name: &str) -> Self {
+    fn new(
+        total_blocks: usize,
+        volume_name: &str,
+        filesystem: crate::diskimage::FileSystem,
+    ) -> Self {
         let mut b = Builder {
             image: vec![0u8; total_blocks * BSIZE],
             total_blocks,
@@ -231,10 +270,11 @@ impl Builder {
             bitmap_keys: Vec::new(),
             bmext_keys: Vec::new(),
             meta_blocks: Vec::new(),
+            filesystem,
         };
         // Boot block: dostype only, no boot code (hard-disk partitions boot
         // through the RDB, not boot-block code).
-        b.image[..4].copy_from_slice(b"DOS\x01");
+        b.image[..4].copy_from_slice(&filesystem.dos_type().to_be_bytes());
         b.used[0] = true;
         b.used[1] = true;
         let root = b.root_key as usize;
@@ -378,8 +418,9 @@ impl Builder {
         Ok(())
     }
 
-    /// Write a file header (plus extension blocks as needed) and its raw FFS
-    /// data blocks; returns the header key.
+    /// Write a file header (plus extension blocks as needed) and its data
+    /// blocks (raw FFS or header-carrying OFS, per `self.filesystem`);
+    /// returns the header key.
     fn write_file(
         &mut self,
         host_path: &Path,
@@ -401,7 +442,13 @@ impl Builder {
         let mut chunk_block = header;
         let mut in_block = 0usize;
         let mut first_data = 0u32;
-        for chunk in data.chunks(BSIZE) {
+        // OFS-only bookkeeping: the previous data block's key (to backfill
+        // its next_data pointer once the current one's key is known) and a
+        // running 1-based sequence number.
+        let mut prev_data: Option<u32> = None;
+        let mut seq_num = 0u32;
+        let payload = data_payload_bytes(self.filesystem) as usize;
+        for chunk in data.chunks(payload) {
             if in_block == HT_SIZE {
                 // Current header/extension is full: chain a T_LIST block.
                 let ext = self.alloc()?;
@@ -415,8 +462,24 @@ impl Builder {
                 in_block = 0;
             }
             let block = self.alloc()?;
-            let base = block as usize * BSIZE;
-            self.image[base..base + chunk.len()].copy_from_slice(chunk);
+            if self.filesystem.ffs {
+                let base = block as usize * BSIZE;
+                self.image[base..base + chunk.len()].copy_from_slice(chunk);
+            } else {
+                seq_num += 1;
+                self.put32(block, 0, T_DATA);
+                self.put32(block, 4, header); // header_key: the file's header, never an extension
+                self.put32(block, 8, seq_num);
+                self.put32(block, 12, chunk.len() as u32); // data_size
+                self.put32(block, 16, 0); // next_data, backfilled below once known
+                self.meta_blocks.push(block); // checksum at offset 20, deferred to finish()
+                let base = block as usize * BSIZE + 24;
+                self.image[base..base + chunk.len()].copy_from_slice(chunk);
+                if let Some(prev) = prev_data {
+                    self.put32(prev, 16, block);
+                }
+                prev_data = Some(block);
+            }
             if first_data == 0 {
                 first_data = block;
             }
@@ -501,12 +564,27 @@ fn bitmap_overhead(total: u64) -> u64 {
 mod tests {
     use super::*;
 
-    /// Minimal FFS reader used to verify built images.
+    /// Minimal FFS/OFS reader used to verify built images.
     struct Reader<'a> {
         image: &'a [u8],
+        filesystem: crate::diskimage::FileSystem,
     }
 
     impl<'a> Reader<'a> {
+        fn ffs(image: &'a [u8]) -> Self {
+            Reader {
+                image,
+                filesystem: crate::diskimage::FileSystem::FFS,
+            }
+        }
+
+        fn ofs(image: &'a [u8]) -> Self {
+            Reader {
+                image,
+                filesystem: crate::diskimage::FileSystem::OFS,
+            }
+        }
+
         fn get32(&self, block: u32, offset: usize) -> u32 {
             let base = block as usize * BSIZE + offset;
             u32::from_be_bytes(self.image[base..base + 4].try_into().unwrap())
@@ -549,7 +627,14 @@ mod tests {
             None
         }
 
-        /// Read a whole file back through header/extension data pointers.
+        /// Read a whole file back through header/extension data pointers. For
+        /// OFS, each data pointer names a block with its own 24-byte header
+        /// (data_size may be short only on the very last block); the
+        /// `next_data` chain is not consulted here since the header's/
+        /// extension's own pointer table already lists every data block in
+        /// order -- `next_data` exists for OFS readers that don't have that
+        /// table (e.g. real AmigaDOS repairing a damaged header), and is
+        /// checked separately in ofs-specific tests below.
         fn read_file(&self, header: u32) -> Vec<u8> {
             let size = self.get32(header, BSIZE - 188) as usize;
             let mut out = Vec::with_capacity(size);
@@ -558,9 +643,15 @@ mod tests {
                 let count = self.get32(block, 8) as usize;
                 for i in 0..count {
                     let data = self.get32(block, 24 + (HT_SIZE - 1 - i) * 4);
-                    let base = data as usize * BSIZE;
-                    let take = (size - out.len()).min(BSIZE);
-                    out.extend_from_slice(&self.image[base..base + take]);
+                    if self.filesystem.ffs {
+                        let base = data as usize * BSIZE;
+                        let take = (size - out.len()).min(BSIZE);
+                        out.extend_from_slice(&self.image[base..base + take]);
+                    } else {
+                        let data_size = self.get32(data, 12) as usize;
+                        let base = data as usize * BSIZE + 24;
+                        out.extend_from_slice(&self.image[base..base + data_size]);
+                    }
                 }
                 block = self.get32(block, BSIZE - 8);
                 if block == 0 {
@@ -592,11 +683,11 @@ mod tests {
     #[test]
     fn builds_a_valid_ffs_volume_from_a_directory() {
         let dir = temp_tree();
-        let image = build_ffs_image(&dir, "TestVol").unwrap();
+        let image = build_image(&dir, "TestVol", crate::diskimage::FileSystem::FFS).unwrap();
         assert_eq!(image.len() % (CYL_BLOCKS * BSIZE), 0);
         assert_eq!(&image[..4], b"DOS\x01");
 
-        let r = Reader { image: &image };
+        let r = Reader::ffs(&image);
         let root = r.root_key();
         assert!(r.checksum_ok(root, 20), "root checksum");
         assert_eq!(r.get32(root, 0), T_HEADER);
@@ -636,6 +727,122 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
+    #[test]
+    fn builds_a_valid_ofs_volume_from_a_directory() {
+        let dir = temp_tree();
+        let image = build_image(&dir, "TestVol", crate::diskimage::FileSystem::OFS).unwrap();
+        assert_eq!(image.len() % (CYL_BLOCKS * BSIZE), 0);
+        assert_eq!(&image[..4], b"DOS\x00");
+
+        let r = Reader::ofs(&image);
+        let root = r.root_key();
+        assert!(r.checksum_ok(root, 20), "root checksum");
+        assert_eq!(r.name_of(root), b"TestVol");
+
+        // Single small file: one OFS data block whose header fields are
+        // right, and whose next_data is 0 (end of chain).
+        let readme = r.lookup(root, b"ReadMe.txt").expect("ReadMe.txt");
+        assert!(r.checksum_ok(readme, 20));
+        let data_ptr = r.get32(readme, 24 + (HT_SIZE - 1) * 4);
+        assert_ne!(data_ptr, 0, "ReadMe.txt has a data block");
+        assert_eq!(r.get32(data_ptr, 0), T_DATA);
+        assert_eq!(
+            r.get32(data_ptr, 4),
+            readme,
+            "header_key points at the file header"
+        );
+        assert_eq!(r.get32(data_ptr, 8), 1, "seq_num");
+        assert_eq!(
+            r.get32(data_ptr, 12),
+            b"hello amiga\n".len() as u32,
+            "data_size"
+        );
+        assert_eq!(r.get32(data_ptr, 16), 0, "single block: next_data is 0");
+        assert!(r.checksum_ok(data_ptr, 20), "data block checksum");
+        assert_eq!(r.read_file(readme), b"hello amiga\n");
+
+        // A file spanning multiple, non-block-aligned data blocks: exercise
+        // data_size truncation on the last block and the next_data chain.
+        let sub = r.lookup(root, b"Sub").expect("Sub");
+        let data = r.lookup(sub, b"data.bin").expect("data.bin");
+        assert_ne!(
+            r.get32(data, BSIZE - 8),
+            0,
+            "has extension block (>72 OFS data blocks)"
+        );
+        assert_eq!(r.read_file(data), vec![0xA7u8; 100_000]);
+        // Walk the next_data chain directly (rather than through the header's
+        // pointer table) to prove it is intact end to end, including across
+        // the T_LIST extension boundary.
+        let mut block = r.get32(data, 24 + (HT_SIZE - 1) * 4);
+        let mut seen = 0u32;
+        let mut total = 0usize;
+        loop {
+            seen += 1;
+            assert_eq!(
+                r.get32(block, 8),
+                seen,
+                "seq_num increments across extensions"
+            );
+            assert_eq!(
+                r.get32(block, 4),
+                data,
+                "header_key stays the original file header"
+            );
+            total += r.get32(block, 12) as usize;
+            let next = r.get32(block, 16);
+            if next == 0 {
+                break;
+            }
+            block = next;
+        }
+        assert_eq!(total, 100_000);
+        assert!(seen > HT_SIZE as u32, "the file needed a T_LIST extension");
+
+        let empty_dir = r.lookup(sub, b"Deeper").expect("Deeper");
+        let empty = r.lookup(empty_dir, b"empty").expect("empty");
+        assert_eq!(r.get32(empty, 8), 0, "no data blocks");
+        assert!(r.read_file(empty).is_empty());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn ofs_data_block_content_round_trips_on_a_non_aligned_boundary() {
+        // 488*2 + 137 bytes: two full OFS data blocks plus a short last one,
+        // chosen to catch a data_size truncation bug on the final block.
+        let dir = std::env::temp_dir().join(format!(
+            "copperline-dirfs-ofs-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let content: Vec<u8> = (0..(488 * 2 + 137)).map(|i| (i % 251) as u8).collect();
+        std::fs::write(dir.join("odd.bin"), &content).unwrap();
+
+        let image = build_image(&dir, "TestVol", crate::diskimage::FileSystem::OFS).unwrap();
+        let r = Reader::ofs(&image);
+        let root = r.root_key();
+        let file = r.lookup(root, b"odd.bin").expect("odd.bin");
+        assert_eq!(r.read_file(file), content);
+
+        // The last data block's data_size is the short remainder, not 488.
+        let mut block = r.get32(file, 24 + (HT_SIZE - 1) * 4);
+        loop {
+            let next = r.get32(block, 16);
+            if next == 0 {
+                assert_eq!(r.get32(block, 12), 137, "last block keeps its short length");
+                break;
+            }
+            block = next;
+        }
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     /// Utility for cross-checking against external FFS tools (e.g.
     /// amitools' xdftool): builds an image from COPPERLINE_DIRFS_SRC and
     /// writes it to COPPERLINE_DIRFS_OUT.
@@ -654,7 +861,12 @@ mod tests {
             eprintln!("skipping: set COPPERLINE_DIRFS_SRC and COPPERLINE_DIRFS_OUT to run it");
             return;
         };
-        let image = build_ffs_image(Path::new(&src), "DirVolume").unwrap();
+        let image = build_image(
+            Path::new(&src),
+            "DirVolume",
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
         std::fs::write(&out, image).unwrap();
         eprintln!("wrote {out}");
     }
@@ -662,8 +874,8 @@ mod tests {
     #[test]
     fn bitmap_marks_metadata_used_and_tail_free() {
         let dir = temp_tree();
-        let image = build_ffs_image(&dir, "TestVol").unwrap();
-        let r = Reader { image: &image };
+        let image = build_image(&dir, "TestVol", crate::diskimage::FileSystem::FFS).unwrap();
+        let r = Reader::ffs(&image);
         let root = r.root_key();
         let bm0 = r.get32(root, BSIZE - 196);
         let bit = |block: u32| -> bool {

--- a/src/diskimage.rs
+++ b/src/diskimage.rs
@@ -1496,8 +1496,15 @@ mod tests {
 
         // The strongest check available: the emulator's own hardfile
         // support has to recognise it, since that is what will mount it.
-        let opened = crate::harddrive::HardDriveImage::open(s.path(), "DH0", "ide", None, 0)
-            .expect("our own parser opens it");
+        let opened = crate::harddrive::HardDriveImage::open(
+            s.path(),
+            "DH0",
+            "ide",
+            None,
+            0,
+            FileSystem::FFS, // not a directory mount; this image already carries its own dostype
+        )
+        .expect("our own parser opens it");
         assert!(
             opened.has_own_rdb(),
             "our parser did not find the partition table we wrote, and \

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2255,6 +2255,7 @@ fn open_scsi_target(
             unit,
             drive.volume_name.as_deref(),
             drive.boot_pri,
+            drive.filesystem,
         )?;
         info!("scsi: unit {unit} {}", drive.path.display());
         Ok(disk.into())
@@ -2268,12 +2269,13 @@ fn open_ide_target(
     unit: usize,
     volume_name: Option<&str>,
     boot_pri: i8,
+    filesystem: crate::diskimage::FileSystem,
 ) -> Result<crate::ata::AtaDevice> {
     if crate::config::is_cd_image_path(path) {
         let cd = crate::ata::AtapiDrive::open(path)?;
         Ok(cd.into())
     } else {
-        let disk = crate::ata::IdeDrive::open(path, unit, volume_name, boot_pri)?;
+        let disk = crate::ata::IdeDrive::open(path, unit, volume_name, boot_pri, filesystem)?;
         Ok(disk.into())
     }
 }
@@ -2497,6 +2499,7 @@ pub fn build_machine(
                 idx,
                 drive.volume_name.as_deref(),
                 drive.boot_pri,
+                drive.filesystem,
             )?;
             board.attach_drive(ch, unit, target);
         }
@@ -2749,14 +2752,26 @@ pub fn build_machine(
         if let Some(drive) = &cfg.ide.master {
             gayle.attach_drive(
                 0,
-                open_ide_target(&drive.path, 0, drive.volume_name.as_deref(), drive.boot_pri)?,
+                open_ide_target(
+                    &drive.path,
+                    0,
+                    drive.volume_name.as_deref(),
+                    drive.boot_pri,
+                    drive.filesystem,
+                )?,
             );
             info!("ide: master {}", drive.path.display());
         }
         if let Some(drive) = &cfg.ide.slave {
             gayle.attach_drive(
                 1,
-                open_ide_target(&drive.path, 1, drive.volume_name.as_deref(), drive.boot_pri)?,
+                open_ide_target(
+                    &drive.path,
+                    1,
+                    drive.volume_name.as_deref(),
+                    drive.boot_pri,
+                    drive.filesystem,
+                )?,
             );
             info!("ide: slave {}", drive.path.display());
         }
@@ -2777,6 +2792,7 @@ pub fn build_machine(
                     slot,
                     drive.volume_name.as_deref(),
                     drive.boot_pri,
+                    drive.filesystem,
                 )?,
             );
             let which = if slot == 0 { "master" } else { "slave" };

--- a/src/gayle.rs
+++ b/src/gayle.rs
@@ -292,7 +292,10 @@ mod tests {
     fn gayle_with_drive(sectors: u64) -> (Gayle, PathBuf) {
         let path = temp_image(sectors);
         let mut gayle = Gayle::new(0xD0);
-        gayle.attach_drive(0, IdeDrive::open(&path, 0, None, 0).unwrap());
+        gayle.attach_drive(
+            0,
+            IdeDrive::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+        );
         (gayle, path)
     }
 
@@ -341,7 +344,8 @@ mod tests {
         data[SECTOR_SIZE] = 0xA5; // marker in partition sector 1
         std::fs::write(&path, &data).unwrap();
 
-        let mut drive = IdeDrive::open(&path, 0, None, 0).unwrap();
+        let mut drive =
+            IdeDrive::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap();
         // One synthesized RDB cylinder plus the partition cylinder.
         assert_eq!(drive.disk.total_sectors(), 2 * u64::from(CYL_SECTORS));
 
@@ -397,7 +401,8 @@ mod tests {
         let mut data = std::fs::read(&path).unwrap();
         data[..4].copy_from_slice(b"RDSK");
         std::fs::write(&path, &data).unwrap();
-        let mut drive = IdeDrive::open(&path, 0, None, 0).unwrap();
+        let mut drive =
+            IdeDrive::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap();
         assert_eq!(drive.disk.total_sectors(), u64::from(CYL_SECTORS));
         let mut sector = [0u8; SECTOR_SIZE];
         drive.disk.read_sector(0, &mut sector).unwrap();
@@ -412,7 +417,7 @@ mod tests {
         let mut data = std::fs::read(&path).unwrap();
         data[..4].copy_from_slice(b"DOS\x00");
         std::fs::write(&path, &data).unwrap();
-        let err = match IdeDrive::open(&path, 0, None, 0) {
+        let err = match IdeDrive::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS) {
             Ok(_) => panic!("expected open to fail"),
             Err(e) => e.to_string(),
         };

--- a/src/harddrive.rs
+++ b/src/harddrive.rs
@@ -4,11 +4,11 @@
 //! IDE drives and the A2091 SCSI targets.
 //!
 //! A unit opens from a raw HDF image file, from a gzip-compressed one (the
-//! `.hdz` convention), or from a host directory (built into an in-memory FFS
-//! volume at open time, see `dirfs.rs`). Bare partition hardfiles (a
-//! filesystem boot block at sector 0, no RDSK) get a synthesized RDB
-//! cylinder prepended so the ROM boot driver can mount them without
-//! pre-conversion.
+//! `.hdz` convention), or from a host directory (built into an in-memory
+//! FFS or OFS volume at open time, caller's choice; see `dirfs.rs`). Bare
+//! partition hardfiles (a filesystem boot block at sector 0, no RDSK) get a
+//! synthesized RDB cylinder prepended so the ROM boot driver can mount them
+//! without pre-conversion.
 
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
@@ -503,18 +503,21 @@ impl HardDriveImage {
     /// log messages. A synthesized RDB names itself (see
     /// [`default_rdb_identity`]); nothing a caller passes reaches it.
     /// The path may be a raw HDF image file, a gzip-compressed one (`.hdz`),
-    /// or a host directory, which is built into an in-memory FFS volume at
-    /// open time. `volume_override` names that FFS volume; when `None` the
-    /// directory name is used. It has no effect on an HDF, which carries its
-    /// own label inside the image. `boot_pri` is the `de_BootPri` written
-    /// into a synthesized RDB; it too is ignored by an image that carries its
-    /// own RDB.
+    /// or a host directory, which is built into an in-memory FFS or OFS
+    /// volume at open time (`filesystem` picks which; irrelevant to every
+    /// other path form here, since an HDF/gzip image already carries its own
+    /// filesystem inside it). `volume_override` names that volume; when
+    /// `None` the directory name is used. It has no effect on an HDF, which
+    /// carries its own label inside the image. `boot_pri` is the
+    /// `de_BootPri` written into a synthesized RDB; it too is ignored by an
+    /// image that carries its own RDB.
     pub fn open(
         path: &Path,
         device_name: &str,
         bus_name: &'static str,
         volume_override: Option<&str>,
         boot_pri: i8,
+        filesystem: crate::diskimage::FileSystem,
     ) -> anyhow::Result<Self> {
         let mut backing = if path.is_dir() {
             let volume = volume_override.map(str::to_string).unwrap_or_else(|| {
@@ -522,7 +525,7 @@ impl HardDriveImage {
                     .map(|n| n.to_string_lossy().into_owned())
                     .unwrap_or_default()
             });
-            let image = crate::dirfs::build_ffs_image(path, &volume)?;
+            let image = crate::dirfs::build_image(path, &volume, filesystem)?;
             log::warn!(
                 "{bus_name}: {} mounted as an in-memory volume \"{volume}\" built from the \
                  directory; guest writes to it are NOT written back to the host and are lost \
@@ -817,7 +820,15 @@ mod tests {
         bytes[tail..tail + 4].copy_from_slice(b"TAIL");
         let (first, second) = bytes.split_at(bytes.len() / 2);
         let path = temp_image("multi.hdz", &gzip_members(&[first, second]));
-        let mut drive = HardDriveImage::open(&path, "DH0", "ide", None, 0).unwrap();
+        let mut drive = HardDriveImage::open(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
 
         assert_eq!(
             drive.total_sectors(),
@@ -837,7 +848,15 @@ mod tests {
     fn gzip_compressed_hardfile_serves_the_unpacked_sectors() {
         let bytes = bare_partition_bytes(2);
         let path = temp_image("packed.hdz", &gzip(&bytes));
-        let mut drive = HardDriveImage::open(&path, "DH0", "ide", None, 0).unwrap();
+        let mut drive = HardDriveImage::open(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
 
         // The synthesized RDB cylinder still goes in front: the sniff runs on
         // the unpacked image, not on the gzip stream.
@@ -865,7 +884,15 @@ mod tests {
         let bytes = bare_partition_bytes(1);
         let packed = gzip(&bytes);
         let path = temp_image("readonly.hdz", &packed);
-        let mut drive = HardDriveImage::open(&path, "DH0", "ide", None, 0).unwrap();
+        let mut drive = HardDriveImage::open(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
 
         // Writes land in the unpacked copy for the session...
         let written = vec![0x5A; SECTOR_SIZE];
@@ -886,7 +913,15 @@ mod tests {
         // The same bytes under the .hdf name every other emulator expects.
         let bytes = bare_partition_bytes(1);
         let path = temp_image("misnamed.hdf", &gzip(&bytes));
-        let drive = HardDriveImage::open(&path, "DH0", "ide", None, 0).unwrap();
+        let drive = HardDriveImage::open(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
         assert_eq!(
             drive.total_sectors(),
             u64::from(CYL_SECTORS) + (bytes.len() / SECTOR_SIZE) as u64
@@ -900,7 +935,15 @@ mod tests {
         let mut bytes = vec![0u8; 64 * SECTOR_SIZE];
         bytes[..4].copy_from_slice(b"RDSK");
         let path = temp_image("rdb.hdz", &gzip(&bytes));
-        let mut drive = HardDriveImage::open(&path, "DH0", "ide", None, 0).unwrap();
+        let mut drive = HardDriveImage::open(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
 
         assert_eq!(drive.total_sectors(), 64);
         let mut sector = vec![0u8; SECTOR_SIZE];
@@ -914,7 +957,15 @@ mod tests {
     fn gzip_compressed_hardfile_survives_a_save_state_round_trip() {
         let bytes = bare_partition_bytes(1);
         let path = temp_image("state.hdz", &gzip(&bytes));
-        let mut original = HardDriveImage::open(&path, "DH0", "ide", None, 0).unwrap();
+        let mut original = HardDriveImage::open(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
         // A session-only write has nowhere else to live, so the state has to
         // carry the unpacked image rather than reopen the .hdz.
         let written = vec![0xA5; SECTOR_SIZE];
@@ -937,7 +988,14 @@ mod tests {
         // Not a multiple of the sector size once unpacked: the size check
         // runs on the unpacked bytes, so the message names those.
         let path = temp_image("junk.hdz", &gzip(&[0u8; SECTOR_SIZE + 1]));
-        let Err(err) = HardDriveImage::open(&path, "DH0", "ide", None, 0) else {
+        let Err(err) = HardDriveImage::open(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        ) else {
             panic!("a gzip stream of junk is not a hardfile");
         };
         assert!(
@@ -952,7 +1010,14 @@ mod tests {
     fn truncated_gzip_hardfile_reports_the_decompression_failure() {
         let packed = gzip(&bare_partition_bytes(1));
         let path = temp_image("truncated.hdz", &packed[..packed.len() / 2]);
-        let Err(err) = HardDriveImage::open(&path, "DH0", "ide", None, 0) else {
+        let Err(err) = HardDriveImage::open(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        ) else {
             panic!("a truncated gzip stream cannot be unpacked");
         };
         assert!(err.to_string().contains("decompressing"), "{err}");
@@ -965,7 +1030,15 @@ mod tests {
         let mut bytes = vec![0u8; 64 * SECTOR_SIZE];
         bytes[5 * SECTOR_SIZE..5 * SECTOR_SIZE + 4].copy_from_slice(b"MARK");
         let path = temp_image("serde.hdf", &bytes);
-        let mut original = HardDriveImage::open(&path, "DH0", "ide", None, 0).unwrap();
+        let mut original = HardDriveImage::open(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
 
         let encoded = bincode::serialize(&original).unwrap();
         let mut restored: HardDriveImage = bincode::deserialize(&encoded).unwrap();
@@ -1052,7 +1125,15 @@ mod tests {
     #[test]
     fn directory_mount_uses_the_directory_name_as_the_volume_label() {
         let (parent, mount) = temp_mount_dir("Games");
-        let mut disk = HardDriveImage::open(&mount, "DH0", "ide", None, 0).unwrap();
+        let mut disk = HardDriveImage::open(
+            &mount,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
         assert_eq!(volume_label(&mut disk), "Games");
         let _ = std::fs::remove_dir_all(&parent);
     }
@@ -1060,7 +1141,15 @@ mod tests {
     #[test]
     fn directory_mount_volume_override_sets_the_label() {
         let (parent, mount) = temp_mount_dir("Games");
-        let mut disk = HardDriveImage::open(&mount, "DH0", "ide", Some("Workbench"), 0).unwrap();
+        let mut disk = HardDriveImage::open(
+            &mount,
+            "DH0",
+            "ide",
+            Some("Workbench"),
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
         assert_eq!(volume_label(&mut disk), "Workbench");
         let _ = std::fs::remove_dir_all(&parent);
     }
@@ -1068,7 +1157,15 @@ mod tests {
     #[test]
     fn serde_errors_when_backing_file_is_missing() {
         let path = temp_image("gone.hdf", &vec![0u8; 8 * SECTOR_SIZE]);
-        let original = HardDriveImage::open(&path, "DH0", "ide", None, 0).unwrap();
+        let original = HardDriveImage::open(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
         let encoded = bincode::serialize(&original).unwrap();
         let _ = std::fs::remove_file(&path);
         let Err(err) = bincode::deserialize::<HardDriveImage>(&encoded) else {
@@ -1113,7 +1210,15 @@ mod tests {
     fn synthesized_partition_carries_the_configured_boot_priority() {
         let path = bare_partition_image("bootpri.hdf");
         for pri in [0i8, 6, 20, -5, 127] {
-            let mut disk = HardDriveImage::open(&path, "DH0", "ide", None, pri).unwrap();
+            let mut disk = HardDriveImage::open(
+                &path,
+                "DH0",
+                "ide",
+                None,
+                pri,
+                crate::diskimage::FileSystem::FFS,
+            )
+            .unwrap();
             let part = part_block(&mut disk);
             assert_eq!(
                 be32(&part, DE_BOOT_PRI_OFF) as i32,
@@ -1128,9 +1233,15 @@ mod tests {
     #[test]
     fn boot_pri_never_mounts_the_partition_without_making_it_bootable() {
         let path = bare_partition_image("neverboot.hdf");
-        let mut disk =
-            HardDriveImage::open(&path, "DH1", "scsi", None, crate::config::BOOT_PRI_NEVER)
-                .unwrap();
+        let mut disk = HardDriveImage::open(
+            &path,
+            "DH1",
+            "scsi",
+            None,
+            crate::config::BOOT_PRI_NEVER,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
         let part = part_block(&mut disk);
         assert_eq!(
             be32(&part, DE_BOOT_PRI_OFF) as i32,
@@ -1151,7 +1262,15 @@ mod tests {
     fn part_block_checksum_stays_valid_for_every_boot_priority() {
         let path = bare_partition_image("checksum.hdf");
         for pri in [i8::MIN, -1, 0, 1, i8::MAX] {
-            let mut disk = HardDriveImage::open(&path, "DH0", "ide", None, pri).unwrap();
+            let mut disk = HardDriveImage::open(
+                &path,
+                "DH0",
+                "ide",
+                None,
+                pri,
+                crate::diskimage::FileSystem::FFS,
+            )
+            .unwrap();
             let part = part_block(&mut disk);
             let sum = (0..64).fold(0u32, |acc, i| acc.wrapping_add(be32(&part, i * 4)));
             assert_eq!(sum, 0, "RDB checksum rule broken for bootpri {pri}");

--- a/src/harddrive.rs
+++ b/src/harddrive.rs
@@ -1087,8 +1087,9 @@ mod tests {
         assert_eq!(image.total_sectors(), 1234);
     }
 
-    /// Read every sector of an image and return the FFS volume label found in
-    /// its root block (block type 2 / secondary type 1). The directory mount
+    /// Read every sector of an image and return the volume label found in
+    /// its root block (block type 2 / secondary type 1; the same for FFS
+    /// and OFS). The directory mount
     /// prepends a synthesized RDB, so the root block is not at a fixed LBA;
     /// scan for it instead.
     fn volume_label(disk: &mut HardDriveImage) -> String {

--- a/src/ide_a4000.rs
+++ b/src/ide_a4000.rs
@@ -199,7 +199,10 @@ mod tests {
         ));
         std::fs::write(&path, vec![0u8; 64 * crate::ata::SECTOR_SIZE]).unwrap();
         let mut ide = IdeA4000::new();
-        ide.attach_drive(0, IdeDrive::open(&path, 0, None, 0).unwrap());
+        ide.attach_drive(
+            0,
+            IdeDrive::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+        );
 
         assert_eq!(
             ide.read(IDE_IRQ, 1) as u8 & IRQ_IDE,

--- a/src/ide_zorro.rs
+++ b/src/ide_zorro.rs
@@ -676,7 +676,11 @@ mod tests {
     fn release_host_disks_on_a_board_with_only_image_drives_returns_zero() {
         let path = temp_image(64);
         let mut board = IdeZorro::new(LidePersonality::Ripple, Vec::new()).unwrap();
-        board.attach_drive(0, 0, IdeDrive::open(&path, 0, None, 0).unwrap());
+        board.attach_drive(
+            0,
+            0,
+            IdeDrive::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+        );
         assert_eq!(board.release_host_disks(), 0);
 
         let mut empty = IdeZorro::new(LidePersonality::AtBus2008, Vec::new()).unwrap();
@@ -687,7 +691,11 @@ mod tests {
     fn byte_lanes_put_registers_on_the_upper_byte_and_float_the_dead_lane() {
         let path = temp_image(64);
         let mut board = IdeZorro::new(LidePersonality::Ride, Vec::new()).unwrap();
-        board.attach_drive(0, 0, IdeDrive::open(&path, 0, None, 0).unwrap());
+        board.attach_drive(
+            0,
+            0,
+            IdeDrive::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+        );
         board.write(0x1000 + 6 * 0x200, 1, 0xE0); // drive/head, even (upper) lane
         assert_eq!(board.read(0x1000 + 6 * 0x200, 1) as u8, 0xE0);
         assert_eq!(board.read(0x1000 + 6 * 0x200 + 1, 1) as u8, 0xFF);
@@ -707,7 +715,11 @@ mod tests {
         }
         std::fs::write(&path, &img).unwrap();
         let mut board = IdeZorro::new(LidePersonality::Ride, Vec::new()).unwrap();
-        board.attach_drive(0, 0, IdeDrive::open(&path, 0, None, 0).unwrap());
+        board.attach_drive(
+            0,
+            0,
+            IdeDrive::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+        );
 
         // Select LBA 7, one sector, READ SECTORS ($20).
         board.write(0x1000 + 6 * 0x200, 1, 0xE0); // drive/head: LBA, drive 0
@@ -744,7 +756,11 @@ mod tests {
         let mut board = IdeZorro::new(LidePersonality::Ripple, Vec::new()).unwrap();
         // Channel 0 has a drive; channel 1 has none at all.
         let path = temp_image(64);
-        board.attach_drive(0, 0, IdeDrive::open(&path, 0, None, 0).unwrap());
+        board.attach_drive(
+            0,
+            0,
+            IdeDrive::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+        );
 
         // Channel 1's device/head register: AtaBus alone would answer 0
         // (write lands in the register file, but nothing is selected so a
@@ -822,8 +838,30 @@ mod tests {
         // cable), so attach a master on each channel; both values below
         // clear DH_DRV (bit 4) and so select that master.
         let mut ripple = IdeZorro::new(LidePersonality::Ripple, Vec::new()).unwrap();
-        ripple.attach_drive(0, 0, IdeDrive::open(&temp_image(64), 0, None, 0).unwrap());
-        ripple.attach_drive(1, 0, IdeDrive::open(&temp_image(64), 0, None, 0).unwrap());
+        ripple.attach_drive(
+            0,
+            0,
+            IdeDrive::open(
+                &temp_image(64),
+                0,
+                None,
+                0,
+                crate::diskimage::FileSystem::FFS,
+            )
+            .unwrap(),
+        );
+        ripple.attach_drive(
+            1,
+            0,
+            IdeDrive::open(
+                &temp_image(64),
+                0,
+                None,
+                0,
+                crate::diskimage::FileSystem::FFS,
+            )
+            .unwrap(),
+        );
         ripple.write(0x1000, 1, 0); // latch via a task-file write
         ripple.write(0x1000 + 6 * 0x200, 1, 0xA0); // ch0 drive/head
         ripple.write(0x2000 + 6 * 0x200, 1, 0xE0); // ch1 drive/head

--- a/src/scsi.rs
+++ b/src/scsi.rs
@@ -182,15 +182,24 @@ impl ScsiDisk {
     /// Open a SCSI unit. `unit` is the SCSI ID, which picks the DHn device
     /// name a synthesized RDB advertises (so a bare hardfile on unit 0
     /// boots as DH0 exactly as it would on the IDE bus). `volume_name`
-    /// labels a directory mounted as an in-memory FFS volume; `boot_pri` is
-    /// the synthesized partition's `de_BootPri`.
+    /// labels a directory mounted as an in-memory volume; `filesystem`
+    /// picks FFS or OFS for that volume (directory mounts only). `boot_pri`
+    /// is the synthesized partition's `de_BootPri`.
     pub fn open(
         path: &Path,
         unit: usize,
         volume_name: Option<&str>,
         boot_pri: i8,
+        filesystem: crate::diskimage::FileSystem,
     ) -> anyhow::Result<Self> {
-        let disk = HardDriveImage::open(path, &format!("DH{unit}"), "scsi", volume_name, boot_pri)?;
+        let disk = HardDriveImage::open(
+            path,
+            &format!("DH{unit}"),
+            "scsi",
+            volume_name,
+            boot_pri,
+            filesystem,
+        )?;
         Ok(Self {
             disk,
             sense: [0u8; SENSE_LEN],
@@ -1471,7 +1480,10 @@ mod tests {
     fn chip_with_disk(sectors: u64) -> (Wd33c93, PathBuf) {
         let path = temp_image(sectors);
         let mut wd = Wd33c93::new();
-        wd.attach_target(0, ScsiDisk::open(&path, 0, None, 0).unwrap());
+        wd.attach_target(
+            0,
+            ScsiDisk::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap(),
+        );
         (wd, path)
     }
 
@@ -1665,7 +1677,8 @@ mod tests {
         // so `execute()` can be handed a truncated `cdb` slice. It must
         // reject that as a malformed CDB rather than indexing past the end.
         let path = temp_image(64);
-        let mut disk = ScsiDisk::open(&path, 0, None, 0).unwrap();
+        let mut disk =
+            ScsiDisk::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap();
 
         // Empty CDB.
         let (exec, status) = disk.execute(&[], 0);
@@ -1689,7 +1702,8 @@ mod tests {
     #[test]
     fn complete_out_rejects_short_cdb_instead_of_panicking() {
         let path = temp_image(64);
-        let mut disk = ScsiDisk::open(&path, 0, None, 0).unwrap();
+        let mut disk =
+            ScsiDisk::open(&path, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap();
         assert_eq!(disk.complete_out(&[], &[0u8; SECTOR_SIZE]), GOOD);
         assert_eq!(disk.complete_out(&[0x2A, 0, 0], &[0u8; SECTOR_SIZE]), GOOD);
         std::fs::remove_file(&path).ok();

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1932,10 +1932,15 @@ pub struct MachineSetup {
     // store one or the other, so a save of a disabled drive still writes -128).
     ide_master: Option<PathBuf>,
     ide_master_name: Option<String>,
+    /// The filesystem an in-memory directory-mount volume is built with
+    /// (meaningless, and never emitted, unless the path is a directory);
+    /// paralleling `*_name` above.
+    ide_master_fs: crate::diskimage::FileSystem,
     ide_master_bootpri: Option<i8>,
     ide_master_boot_off: bool,
     ide_slave: Option<PathBuf>,
     ide_slave_name: Option<String>,
+    ide_slave_fs: crate::diskimage::FileSystem,
     ide_slave_bootpri: Option<i8>,
     ide_slave_boot_off: bool,
     /// Which SCSI host adapter is fitted, or `None` for no board. Shares the
@@ -1945,6 +1950,7 @@ pub struct MachineSetup {
     scsi_rom_odd: Option<PathBuf>,
     scsi_units: [Option<PathBuf>; 7],
     scsi_unit_names: [Option<String>; 7],
+    scsi_unit_fs: [crate::diskimage::FileSystem; 7],
     scsi_unit_bootpri: [Option<i8>; 7],
     scsi_unit_boot_off: [bool; 7],
     /// Which lide personality is fitted, or `None` for no board. Unlike
@@ -1961,6 +1967,7 @@ pub struct MachineSetup {
     /// after it, keeping this array always representable as a config.
     lide_drives: [Option<PathBuf>; 4],
     lide_drive_names: [Option<String>; 4],
+    lide_drive_fs: [crate::diskimage::FileSystem; 4],
     lide_drive_bootpri: [Option<i8>; 4],
     lide_drive_boot_off: [bool; 4],
     // Host FS mounts. The GUI edits the first FILESYS_GUI_SLOTS entries
@@ -2212,10 +2219,22 @@ impl MachineSetup {
             host_disks_attached: raw_host_disks(raw),
             ide_master: cfg.ide.master.as_ref().map(|d| d.path.clone()),
             ide_master_name: cfg.ide.master.as_ref().and_then(|d| d.volume_name.clone()),
+            ide_master_fs: cfg
+                .ide
+                .master
+                .as_ref()
+                .map(|d| d.filesystem)
+                .unwrap_or(crate::diskimage::FileSystem::FFS),
             ide_master_bootpri: boot_priority_of(raw.ide.master.as_ref().and_then(|d| d.bootpri)),
             ide_master_boot_off: boot_is_off(raw.ide.master.as_ref().and_then(|d| d.bootpri)),
             ide_slave: cfg.ide.slave.as_ref().map(|d| d.path.clone()),
             ide_slave_name: cfg.ide.slave.as_ref().and_then(|d| d.volume_name.clone()),
+            ide_slave_fs: cfg
+                .ide
+                .slave
+                .as_ref()
+                .map(|d| d.filesystem)
+                .unwrap_or(crate::diskimage::FileSystem::FFS),
             ide_slave_bootpri: boot_priority_of(raw.ide.slave.as_ref().and_then(|d| d.bootpri)),
             ide_slave_boot_off: boot_is_off(raw.ide.slave.as_ref().and_then(|d| d.bootpri)),
             scsi_controller: cfg.scsi.enabled().then_some(cfg.scsi.controller),
@@ -2226,6 +2245,12 @@ impl MachineSetup {
                 cfg.scsi.units[i]
                     .as_ref()
                     .and_then(|d| d.volume_name.clone())
+            }),
+            scsi_unit_fs: std::array::from_fn(|i| {
+                cfg.scsi.units[i]
+                    .as_ref()
+                    .map(|d| d.filesystem)
+                    .unwrap_or(crate::diskimage::FileSystem::FFS)
             }),
             scsi_unit_bootpri: std::array::from_fn(|i| {
                 boot_priority_of(raw_scsi_unit(&raw.scsi, i).and_then(|d| d.bootpri))
@@ -2243,6 +2268,12 @@ impl MachineSetup {
                 cfg.lide.drives[i]
                     .as_ref()
                     .and_then(|d| d.volume_name.clone())
+            }),
+            lide_drive_fs: std::array::from_fn(|i| {
+                cfg.lide.drives[i]
+                    .as_ref()
+                    .map(|d| d.filesystem)
+                    .unwrap_or(crate::diskimage::FileSystem::FFS)
             }),
             lide_drive_bootpri: std::array::from_fn(|i| {
                 boot_priority_of(raw.lide.drives.get(i).and_then(|d| d.bootpri))
@@ -2595,11 +2626,13 @@ impl MachineSetup {
             self.ide_master.as_deref(),
             self.ide_master_name.as_deref(),
             self.effective_bootpri(F::IdeMasterBoot),
+            self.ide_master_fs,
         );
         raw.ide.slave = drive_raw(
             self.ide_slave.as_deref(),
             self.ide_slave_name.as_deref(),
             self.effective_bootpri(F::IdeSlaveBoot),
+            self.ide_slave_fs,
         );
         // Only emit `[scsi]` when a controller is fitted, so an unset board
         // leaves the section absent rather than writing dangling ROM/units.
@@ -2629,36 +2662,43 @@ impl MachineSetup {
                 self.scsi_units[0].as_deref(),
                 self.scsi_unit_names[0].as_deref(),
                 self.effective_bootpri(F::ScsiUnit0Boot),
+                self.scsi_unit_fs[0],
             );
             raw.scsi.unit1 = drive_raw(
                 self.scsi_units[1].as_deref(),
                 self.scsi_unit_names[1].as_deref(),
                 self.effective_bootpri(F::ScsiUnit1Boot),
+                self.scsi_unit_fs[1],
             );
             raw.scsi.unit2 = drive_raw(
                 self.scsi_units[2].as_deref(),
                 self.scsi_unit_names[2].as_deref(),
                 self.effective_bootpri(F::ScsiUnit2Boot),
+                self.scsi_unit_fs[2],
             );
             raw.scsi.unit3 = drive_raw(
                 self.scsi_units[3].as_deref(),
                 self.scsi_unit_names[3].as_deref(),
                 self.effective_bootpri(F::ScsiUnit3Boot),
+                self.scsi_unit_fs[3],
             );
             raw.scsi.unit4 = drive_raw(
                 self.scsi_units[4].as_deref(),
                 self.scsi_unit_names[4].as_deref(),
                 self.effective_bootpri(F::ScsiUnit4Boot),
+                self.scsi_unit_fs[4],
             );
             raw.scsi.unit5 = drive_raw(
                 self.scsi_units[5].as_deref(),
                 self.scsi_unit_names[5].as_deref(),
                 self.effective_bootpri(F::ScsiUnit5Boot),
+                self.scsi_unit_fs[5],
             );
             raw.scsi.unit6 = drive_raw(
                 self.scsi_units[6].as_deref(),
                 self.scsi_unit_names[6].as_deref(),
                 self.effective_bootpri(F::ScsiUnit6Boot),
+                self.scsi_unit_fs[6],
             );
         }
         // Only emit `[lide]` when a board is fitted, matching `[scsi]` above.
@@ -2686,6 +2726,7 @@ impl MachineSetup {
                         self.lide_drives[i].as_deref(),
                         self.lide_drive_names[i].as_deref(),
                         self.effective_bootpri(LIDE_DRIVE_BOOT_FIELDS[i]),
+                        self.lide_drive_fs[i],
                     )
                 })
                 .collect();
@@ -3657,6 +3698,62 @@ impl MachineSetup {
             _ => return None,
         };
         name.as_deref()
+    }
+
+    /// The in-memory volume's filesystem for a directory-mount drive field
+    /// (FFS by default). Meaningless -- but still tracked, so a toggle made
+    /// before Browse is not lost -- for a field whose path is not currently
+    /// a directory; `to_raw` only emits it once the path actually is one.
+    pub fn drive_filesystem(&self, field: LauncherField) -> crate::diskimage::FileSystem {
+        match field {
+            F::IdeMaster => self.ide_master_fs,
+            F::IdeSlave => self.ide_slave_fs,
+            F::ScsiUnit0 => self.scsi_unit_fs[0],
+            F::ScsiUnit1 => self.scsi_unit_fs[1],
+            F::ScsiUnit2 => self.scsi_unit_fs[2],
+            F::ScsiUnit3 => self.scsi_unit_fs[3],
+            F::ScsiUnit4 => self.scsi_unit_fs[4],
+            F::ScsiUnit5 => self.scsi_unit_fs[5],
+            F::ScsiUnit6 => self.scsi_unit_fs[6],
+            F::LideDrive0 => self.lide_drive_fs[0],
+            F::LideDrive1 => self.lide_drive_fs[1],
+            F::LideDrive2 => self.lide_drive_fs[2],
+            F::LideDrive3 => self.lide_drive_fs[3],
+            _ => crate::diskimage::FileSystem::FFS,
+        }
+    }
+
+    /// Set a drive field's directory-mount filesystem.
+    pub fn set_drive_filesystem(&mut self, field: LauncherField, fs: crate::diskimage::FileSystem) {
+        let slot = match field {
+            F::IdeMaster => &mut self.ide_master_fs,
+            F::IdeSlave => &mut self.ide_slave_fs,
+            F::ScsiUnit0 => &mut self.scsi_unit_fs[0],
+            F::ScsiUnit1 => &mut self.scsi_unit_fs[1],
+            F::ScsiUnit2 => &mut self.scsi_unit_fs[2],
+            F::ScsiUnit3 => &mut self.scsi_unit_fs[3],
+            F::ScsiUnit4 => &mut self.scsi_unit_fs[4],
+            F::ScsiUnit5 => &mut self.scsi_unit_fs[5],
+            F::ScsiUnit6 => &mut self.scsi_unit_fs[6],
+            F::LideDrive0 => &mut self.lide_drive_fs[0],
+            F::LideDrive1 => &mut self.lide_drive_fs[1],
+            F::LideDrive2 => &mut self.lide_drive_fs[2],
+            F::LideDrive3 => &mut self.lide_drive_fs[3],
+            _ => return,
+        };
+        *slot = fs;
+    }
+
+    /// Flip a drive field's directory-mount filesystem between FFS and OFS
+    /// -- the Storage tab's filesystem button is a two-way toggle, not a
+    /// stepper, so it needs no forward/backward direction.
+    pub fn cycle_drive_filesystem(&mut self, field: LauncherField) {
+        let next = if self.drive_filesystem(field).ffs {
+            crate::diskimage::FileSystem::OFS
+        } else {
+            crate::diskimage::FileSystem::FFS
+        };
+        self.set_drive_filesystem(field, next);
     }
 
     /// Set (or, with a blank string, clear) a drive field's volume-name
@@ -4640,10 +4737,11 @@ impl MachineSetup {
                 }
             }
         }
-        // A drive's volume name and boot priority are meaningless once its
-        // image is gone.
+        // A drive's volume name, filesystem, and boot priority are
+        // meaningless once its image is gone.
         if Self::is_drive_field(field) {
             self.set_drive_name(field, String::new());
+            self.set_drive_filesystem(field, crate::diskimage::FileSystem::FFS);
             self.clear_drive_bootpri(field);
         }
         // `[lide] drives` is a positional list in the config file -- a hole
@@ -7835,7 +7933,12 @@ fn path_string(path: &Path) -> String {
 /// Build a `[ide]`/`[scsi]` drive entry from an editable path + optional
 /// volume-name override. A blank name emits the bare path string so saved
 /// configs stay minimal.
-fn drive_raw(path: Option<&Path>, name: Option<&str>, bootpri: Option<i8>) -> Option<RawDrive> {
+fn drive_raw(
+    path: Option<&Path>,
+    name: Option<&str>,
+    bootpri: Option<i8>,
+    filesystem: crate::diskimage::FileSystem,
+) -> Option<RawDrive> {
     path.map(|p| RawDrive {
         path: path_string(p),
         name: name
@@ -7843,6 +7946,10 @@ fn drive_raw(path: Option<&Path>, name: Option<&str>, bootpri: Option<i8>) -> Op
             .filter(|s| !s.is_empty())
             .map(str::to_string),
         bootpri,
+        // OFS is only meaningful (and only valid, config-side) on a
+        // directory mount; FFS is the default, so it too stays unwritten,
+        // keeping a saved config minimal exactly like `name` above.
+        filesystem: (p.is_dir() && !filesystem.ffs).then(|| "ofs".to_string()),
     })
 }
 
@@ -12663,6 +12770,82 @@ mod tests {
         assert_eq!(s.drive_name(LauncherField::IdeMaster), Some("Games"));
         s.clear_path(LauncherField::IdeMaster);
         assert_eq!(s.drive_name(LauncherField::IdeMaster), None);
+    }
+
+    #[test]
+    fn drive_filesystem_round_trips_through_raw_for_a_directory_mount() {
+        let dir = std::env::temp_dir().join(format!(
+            "copperline-launcher-fs-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut s = MachineSetup::default();
+        s.select_model(Some(MachineModel::A1200)); // Gayle, so IDE applies.
+        s.set_path(LauncherField::IdeMaster, dir.clone());
+        // FFS by default, and an FFS default is not written out at all.
+        assert_eq!(
+            s.drive_filesystem(LauncherField::IdeMaster),
+            crate::diskimage::FileSystem::FFS
+        );
+        let raw = s.to_raw();
+        assert_eq!(raw.ide.master.as_ref().unwrap().filesystem, None);
+
+        s.cycle_drive_filesystem(LauncherField::IdeMaster);
+        assert_eq!(
+            s.drive_filesystem(LauncherField::IdeMaster),
+            crate::diskimage::FileSystem::OFS
+        );
+        let raw = s.to_raw();
+        assert_eq!(
+            raw.ide.master.as_ref().unwrap().filesystem.as_deref(),
+            Some("ofs")
+        );
+
+        let back = MachineSetup::from_raw(&raw).unwrap();
+        assert_eq!(
+            back.drive_filesystem(LauncherField::IdeMaster),
+            crate::diskimage::FileSystem::OFS
+        );
+
+        // Toggling back to FFS and clearing the path both drop it again.
+        s.cycle_drive_filesystem(LauncherField::IdeMaster);
+        assert_eq!(
+            s.to_raw().ide.master.as_ref().unwrap().filesystem,
+            None,
+            "FFS is the default and is not written out"
+        );
+        s.cycle_drive_filesystem(LauncherField::IdeMaster);
+        s.clear_path(LauncherField::IdeMaster);
+        assert_eq!(
+            s.drive_filesystem(LauncherField::IdeMaster),
+            crate::diskimage::FileSystem::FFS,
+            "clearing the image resets the filesystem choice, like the volume name"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn drive_filesystem_is_not_emitted_for_a_non_directory_path() {
+        // A raw HDF/image path already carries its own filesystem; even if
+        // the field is toggled (e.g. leftover session state from an earlier
+        // directory at the same slot), `to_raw` must never write a
+        // `filesystem` key config.rs would then reject at parse time.
+        let mut s = MachineSetup::default();
+        s.select_model(Some(MachineModel::A1200));
+        s.set_path(LauncherField::IdeMaster, PathBuf::from("/host/games.hdf"));
+        s.cycle_drive_filesystem(LauncherField::IdeMaster);
+        assert_eq!(
+            s.drive_filesystem(LauncherField::IdeMaster),
+            crate::diskimage::FileSystem::OFS
+        );
+        let raw = s.to_raw();
+        assert_eq!(raw.ide.master.as_ref().unwrap().filesystem, None);
     }
 
     #[test]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1936,11 +1936,19 @@ pub struct MachineSetup {
     /// (meaningless, and never emitted, unless the path is a directory);
     /// paralleling `*_name` above.
     ide_master_fs: crate::diskimage::FileSystem,
+    /// Whether `ide_master`'s path is a host directory, sampled whenever
+    /// the path is set or loaded rather than on every frame the row is
+    /// drawn: `Path::is_dir()` is a host filesystem call that can stall on
+    /// a slow or disconnected mount, and the FFS/OFS toggle's visibility
+    /// (`launcher_drive_fs_applies`, `ui.rs`) needs it every frame that row
+    /// is on screen.
+    ide_master_is_dir: bool,
     ide_master_bootpri: Option<i8>,
     ide_master_boot_off: bool,
     ide_slave: Option<PathBuf>,
     ide_slave_name: Option<String>,
     ide_slave_fs: crate::diskimage::FileSystem,
+    ide_slave_is_dir: bool,
     ide_slave_bootpri: Option<i8>,
     ide_slave_boot_off: bool,
     /// Which SCSI host adapter is fitted, or `None` for no board. Shares the
@@ -1951,6 +1959,8 @@ pub struct MachineSetup {
     scsi_units: [Option<PathBuf>; 7],
     scsi_unit_names: [Option<String>; 7],
     scsi_unit_fs: [crate::diskimage::FileSystem; 7],
+    /// Paralleling `ide_master_is_dir`, per unit.
+    scsi_unit_is_dir: [bool; 7],
     scsi_unit_bootpri: [Option<i8>; 7],
     scsi_unit_boot_off: [bool; 7],
     /// Which lide personality is fitted, or `None` for no board. Unlike
@@ -1968,6 +1978,8 @@ pub struct MachineSetup {
     lide_drives: [Option<PathBuf>; 4],
     lide_drive_names: [Option<String>; 4],
     lide_drive_fs: [crate::diskimage::FileSystem; 4],
+    /// Paralleling `ide_master_is_dir`, per drive.
+    lide_drive_is_dir: [bool; 4],
     lide_drive_bootpri: [Option<i8>; 4],
     lide_drive_boot_off: [bool; 4],
     // Host FS mounts. The GUI edits the first FILESYS_GUI_SLOTS entries
@@ -2225,6 +2237,7 @@ impl MachineSetup {
                 .as_ref()
                 .map(|d| d.filesystem)
                 .unwrap_or(crate::diskimage::FileSystem::FFS),
+            ide_master_is_dir: cfg.ide.master.as_ref().is_some_and(|d| d.path.is_dir()),
             ide_master_bootpri: boot_priority_of(raw.ide.master.as_ref().and_then(|d| d.bootpri)),
             ide_master_boot_off: boot_is_off(raw.ide.master.as_ref().and_then(|d| d.bootpri)),
             ide_slave: cfg.ide.slave.as_ref().map(|d| d.path.clone()),
@@ -2235,6 +2248,7 @@ impl MachineSetup {
                 .as_ref()
                 .map(|d| d.filesystem)
                 .unwrap_or(crate::diskimage::FileSystem::FFS),
+            ide_slave_is_dir: cfg.ide.slave.as_ref().is_some_and(|d| d.path.is_dir()),
             ide_slave_bootpri: boot_priority_of(raw.ide.slave.as_ref().and_then(|d| d.bootpri)),
             ide_slave_boot_off: boot_is_off(raw.ide.slave.as_ref().and_then(|d| d.bootpri)),
             scsi_controller: cfg.scsi.enabled().then_some(cfg.scsi.controller),
@@ -2251,6 +2265,9 @@ impl MachineSetup {
                     .as_ref()
                     .map(|d| d.filesystem)
                     .unwrap_or(crate::diskimage::FileSystem::FFS)
+            }),
+            scsi_unit_is_dir: std::array::from_fn(|i| {
+                cfg.scsi.units[i].as_ref().is_some_and(|d| d.path.is_dir())
             }),
             scsi_unit_bootpri: std::array::from_fn(|i| {
                 boot_priority_of(raw_scsi_unit(&raw.scsi, i).and_then(|d| d.bootpri))
@@ -2274,6 +2291,9 @@ impl MachineSetup {
                     .as_ref()
                     .map(|d| d.filesystem)
                     .unwrap_or(crate::diskimage::FileSystem::FFS)
+            }),
+            lide_drive_is_dir: std::array::from_fn(|i| {
+                cfg.lide.drives[i].as_ref().is_some_and(|d| d.path.is_dir())
             }),
             lide_drive_bootpri: std::array::from_fn(|i| {
                 boot_priority_of(raw.lide.drives.get(i).and_then(|d| d.bootpri))
@@ -3723,6 +3743,55 @@ impl MachineSetup {
         }
     }
 
+    /// Whether a disk-backed drive field's current path is a host directory
+    /// (as opposed to an image file) -- sampled when the path was last set
+    /// or loaded, not by statting it here: see `ide_master_is_dir`'s doc
+    /// comment. `false` for any field that is not one of the drive fields
+    /// this applies to, matching `drive_filesystem`'s fallback above.
+    pub fn drive_is_directory(&self, field: LauncherField) -> bool {
+        match field {
+            F::IdeMaster => self.ide_master_is_dir,
+            F::IdeSlave => self.ide_slave_is_dir,
+            F::ScsiUnit0 => self.scsi_unit_is_dir[0],
+            F::ScsiUnit1 => self.scsi_unit_is_dir[1],
+            F::ScsiUnit2 => self.scsi_unit_is_dir[2],
+            F::ScsiUnit3 => self.scsi_unit_is_dir[3],
+            F::ScsiUnit4 => self.scsi_unit_is_dir[4],
+            F::ScsiUnit5 => self.scsi_unit_is_dir[5],
+            F::ScsiUnit6 => self.scsi_unit_is_dir[6],
+            F::LideDrive0 => self.lide_drive_is_dir[0],
+            F::LideDrive1 => self.lide_drive_is_dir[1],
+            F::LideDrive2 => self.lide_drive_is_dir[2],
+            F::LideDrive3 => self.lide_drive_is_dir[3],
+            _ => false,
+        }
+    }
+
+    /// Refresh a drive field's cached directory flag from its current path
+    /// (the one host-filesystem stat the field's `_is_dir` companion is
+    /// allowed: on the path actually changing, not on every draw). A no-op
+    /// for a field this doesn't apply to.
+    fn refresh_drive_is_dir(&mut self, field: LauncherField) {
+        let is_dir = self.path(field).is_some_and(|p| p.is_dir());
+        let slot = match field {
+            F::IdeMaster => &mut self.ide_master_is_dir,
+            F::IdeSlave => &mut self.ide_slave_is_dir,
+            F::ScsiUnit0 => &mut self.scsi_unit_is_dir[0],
+            F::ScsiUnit1 => &mut self.scsi_unit_is_dir[1],
+            F::ScsiUnit2 => &mut self.scsi_unit_is_dir[2],
+            F::ScsiUnit3 => &mut self.scsi_unit_is_dir[3],
+            F::ScsiUnit4 => &mut self.scsi_unit_is_dir[4],
+            F::ScsiUnit5 => &mut self.scsi_unit_is_dir[5],
+            F::ScsiUnit6 => &mut self.scsi_unit_is_dir[6],
+            F::LideDrive0 => &mut self.lide_drive_is_dir[0],
+            F::LideDrive1 => &mut self.lide_drive_is_dir[1],
+            F::LideDrive2 => &mut self.lide_drive_is_dir[2],
+            F::LideDrive3 => &mut self.lide_drive_is_dir[3],
+            _ => return,
+        };
+        *slot = is_dir;
+    }
+
     /// Set a drive field's directory-mount filesystem.
     pub fn set_drive_filesystem(&mut self, field: LauncherField, fs: crate::diskimage::FileSystem) {
         let slot = match field {
@@ -4667,6 +4736,7 @@ impl MachineSetup {
                 }
             }
         }
+        self.refresh_drive_is_dir(field);
         if seed_cascade {
             if let Some(boot) = drive_boot_field(field) {
                 if self.drive_bootpri(boot).is_none() && !self.drive_boot_off(boot) {
@@ -4743,6 +4813,7 @@ impl MachineSetup {
             self.set_drive_name(field, String::new());
             self.set_drive_filesystem(field, crate::diskimage::FileSystem::FFS);
             self.clear_drive_bootpri(field);
+            self.refresh_drive_is_dir(field);
         }
         // `[lide] drives` is a positional list in the config file -- a hole
         // cannot be represented -- so clearing a slot also clears every slot
@@ -11839,6 +11910,47 @@ mod tests {
         s.set_path(F::IdeSlave, PathBuf::from("work.hdf"));
         assert_eq!(s.value_label(F::IdeSlave), "work.hdf");
         assert_eq!(s.disabled_reason(F::IdeSlaveBoot), None);
+    }
+
+    /// The FFS/OFS toggle applies only to a directory mount on a
+    /// disk-backed drive field (IDE/SCSI/lide), never to a `Filesys*Dir`
+    /// row -- a live HOSTFS mount is a directory too, but has no filesystem
+    /// of its own to choose. `drive_is_directory` is also the cached flag
+    /// `launcher_drive_fs_applies` (`ui.rs`) reads instead of statting the
+    /// path on every frame; this exercises both that it is scoped correctly
+    /// and that it tracks the real path shape as it changes.
+    #[test]
+    fn drive_filesystem_toggle_applies_only_to_disk_backed_fields_and_tracks_path_shape() {
+        use LauncherField as F;
+        let dir = std::env::temp_dir().join(format!(
+            "copperline-launcher-isdir-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut s = MachineSetup::default();
+        // A live HOSTFS mount points at a real directory too, but the
+        // toggle must never claim to apply there.
+        s.set_path(F::Filesys0Dir, dir.clone());
+        assert!(!s.drive_is_directory(F::Filesys0Dir));
+
+        // A disk-backed field pointed at that same directory: applies.
+        s.set_path(F::IdeMaster, dir.clone());
+        assert!(s.drive_is_directory(F::IdeMaster));
+
+        // Repointed at an ordinary file: does not apply.
+        let file = dir.join("plain.hdf");
+        std::fs::write(&file, b"").unwrap();
+        s.set_path(F::IdeMaster, file);
+        assert!(!s.drive_is_directory(F::IdeMaster));
+
+        // Clearing drops the flag along with the path.
+        s.set_path(F::IdeMaster, dir.clone());
+        assert!(s.drive_is_directory(F::IdeMaster));
+        s.clear_path(F::IdeMaster);
+        assert!(!s.drive_is_directory(F::IdeMaster));
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -790,6 +790,8 @@ pub enum UiControl {
     LauncherClear(LauncherField),
     /// Configuration screen: focus a drive's volume-name field for text entry.
     LauncherDriveNameEdit(LauncherField),
+    /// Configuration screen: flip a directory-mount drive between FFS and OFS.
+    LauncherDriveFilesystemToggle(LauncherField),
     /// A free-text box on a Create Image page (a volume or device name).
     LauncherNewImageEdit(LauncherField),
     /// A serial TCP address box on the I/O Ports tab (Connect or Listen).
@@ -4331,6 +4333,8 @@ const LAUNCH_CLEAR_W: usize = 54;
 const LAUNCH_PATH_VALUE_W: usize = 216;
 /// Width of the editable volume-name box on a drive row.
 const LAUNCH_NAME_W: usize = 96;
+/// Width of the FFS/OFS toggle button on a drive row (just "FFS"/"OFS").
+const LAUNCH_FS_W: usize = 40;
 /// Width of the serial TCP address box. Far wider than a volume name's,
 /// because a host name and a port together are a long string and the port
 /// is at the far end of it -- the part a reader most needs to see.
@@ -5578,12 +5582,34 @@ fn row_archive(field: LauncherField) -> Option<crate::gamelib::support::Archive>
 
 /// The editable volume-name box on a drive row: it sits just left of the
 /// Browse button, with the path text filling the space before it.
+/// Whether a drive row's FFS/OFS toggle applies: only a directory mount has
+/// a filesystem choice to make (an HDF/gzip image already carries its own).
+/// A stricter condition than the volume-name box's (which shows for any
+/// image, directory or not -- a name is at least harmless on an HDF).
+fn launcher_drive_fs_applies(setup: &launcher::MachineSetup, field: LauncherField) -> bool {
+    setup.drive_name_applies(field) && setup.path(field).is_some_and(|p| p.is_dir())
+}
+
 fn launcher_drive_name_rect(rect: Rect, row_y: usize) -> Rect {
     let (browse, _clear) = launcher_path_rects(rect, row_y);
     Rect {
         x: browse.x.saturating_sub(6 + LAUNCH_NAME_W),
         y: browse.y,
         w: LAUNCH_NAME_W,
+        h: LAUNCH_CONTROL_H,
+    }
+}
+
+/// The FFS/OFS toggle button on a drive row: just left of the volume-name
+/// box, shown under the same condition (a directory mount -- see
+/// `MachineSetup::drive_filesystem`/`ui.rs`'s use of `path().is_dir()`
+/// alongside `drive_name_applies`).
+fn launcher_drive_fs_rect(rect: Rect, row_y: usize) -> Rect {
+    let name_box = launcher_drive_name_rect(rect, row_y);
+    Rect {
+        x: name_box.x.saturating_sub(6 + LAUNCH_FS_W),
+        y: name_box.y,
+        w: LAUNCH_FS_W,
         h: LAUNCH_CONTROL_H,
     }
 }
@@ -6306,6 +6332,14 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                         && launcher_drive_name_rect(rect, row_y).contains(pos)
                     {
                         return Some(UiControl::LauncherDriveNameEdit(r.field));
+                    }
+                    // The filesystem toggle only matters for a directory
+                    // mount: an HDF/gzip image already carries its own
+                    // filesystem inside it.
+                    if launcher_drive_fs_applies(&state.setup, r.field)
+                        && launcher_drive_fs_rect(rect, row_y).contains(pos)
+                    {
+                        return Some(UiControl::LauncherDriveFilesystemToggle(r.field));
                     }
                 }
             }
@@ -8304,8 +8338,16 @@ fn draw_launcher_row(
             // until then the row reads like a plain path row and the path text
             // fills the full width.
             let has_image = setup.path(r.field).is_some() && setup.drive_name_applies(r.field);
+            let has_fs_toggle = launcher_drive_fs_applies(setup, r.field);
             let name_box = launcher_drive_name_rect(rect, row_y);
-            let text_right = if has_image { name_box.x } else { browse.x };
+            let fs_box = launcher_drive_fs_rect(rect, row_y);
+            let text_right = if has_fs_toggle {
+                fs_box.x
+            } else if has_image {
+                name_box.x
+            } else {
+                browse.x
+            };
             let avail = text_right.saturating_sub(value_x + 8);
             // Host FS mounts and the WHDLoad paths show the whole host path
             // (clipped to keep the final name, with a leading "..." when
@@ -8355,6 +8397,21 @@ fn draw_launcher_row(
                         scale,
                     );
                 }
+            }
+            if has_fs_toggle {
+                let label = if setup.drive_filesystem(r.field).ffs {
+                    "FFS"
+                } else {
+                    "OFS"
+                };
+                draw_text_button(
+                    frame,
+                    fs_box,
+                    label,
+                    true,
+                    hover == Some(UiControl::LauncherDriveFilesystemToggle(r.field)),
+                    scale,
+                );
             }
             draw_text_button(
                 frame,

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -5582,12 +5582,16 @@ fn row_archive(field: LauncherField) -> Option<crate::gamelib::support::Archive>
 
 /// The editable volume-name box on a drive row: it sits just left of the
 /// Browse button, with the path text filling the space before it.
-/// Whether a drive row's FFS/OFS toggle applies: only a directory mount has
-/// a filesystem choice to make (an HDF/gzip image already carries its own).
-/// A stricter condition than the volume-name box's (which shows for any
-/// image, directory or not -- a name is at least harmless on an HDF).
+/// Whether a drive row's FFS/OFS toggle applies: only a directory mount on
+/// one of the disk-backed drive fields (IDE/SCSI/lide) has a filesystem
+/// choice to make -- an HDF/gzip image already carries its own, and a
+/// `Filesys*Dir` row is a live HOSTFS mount, not a disk snapshot, so it has
+/// no filesystem to choose either. `drive_is_directory` restricts to
+/// exactly that field set on its own (returning `false` for anything else,
+/// same as `drive_filesystem`'s fallback) and reads a cached flag rather
+/// than statting the path here on every frame the row is drawn.
 fn launcher_drive_fs_applies(setup: &launcher::MachineSetup, field: LauncherField) -> bool {
-    setup.drive_name_applies(field) && setup.path(field).is_some_and(|p| p.is_dir())
+    setup.drive_is_directory(field)
 }
 
 fn launcher_drive_name_rect(rect: Rect, row_y: usize) -> Rect {
@@ -5601,9 +5605,8 @@ fn launcher_drive_name_rect(rect: Rect, row_y: usize) -> Rect {
 }
 
 /// The FFS/OFS toggle button on a drive row: just left of the volume-name
-/// box, shown under the same condition (a directory mount -- see
-/// `MachineSetup::drive_filesystem`/`ui.rs`'s use of `path().is_dir()`
-/// alongside `drive_name_applies`).
+/// box, shown under the same condition as `launcher_drive_fs_applies`
+/// above (a directory mount on a disk-backed drive field).
 fn launcher_drive_fs_rect(rect: Rect, row_y: usize) -> Rect {
     let name_box = launcher_drive_name_rect(rect, row_y);
     Rect {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6383,6 +6383,12 @@ impl App {
                     state.begin_edit_drive_name(field);
                 }
             }
+            UiControl::LauncherDriveFilesystemToggle(field) => {
+                if let Some(state) = self.launcher_state_mut() {
+                    state.setup.cycle_drive_filesystem(field);
+                    state.status = None;
+                }
+            }
             UiControl::LauncherNewImageEdit(field) => {
                 if let Some(state) = self.launcher_state_mut() {
                     state.begin_edit_new_image(field);


### PR DESCRIPTION
[ide]/[scsi]/[lide] drive slots can point at a host directory instead of an image file; Copperline snapshots the tree into an in-memory volume at open time. That volume was unconditionally FFS, but Kickstart 1.3's ROM has no FFS handler built in -- a real 1.3 machine only gets FFS if a handler is loaded from L:FastFileSystem or an RDB FileSystemHeader chain, and Copperline can't bundle that handler (Commodore/AmigaOS copyrighted). A directory mount meant to boot under 1.3 either needed the user to install FFS themselves, or just couldn't be read.

OFS (DOS\0) is in every Kickstart's ROM from 1.2 onward, so building the same directory mount as OFS instead works everywhere with zero guest-side setup -- the same reason diskimage.rs's floppy formatter already defaults to OFS. A new `filesystem = "ofs" | "ffs"` key (default ffs, so every existing config keeps its current behavior) selects it on a drive's `{ path = ..., name = ..., bootpri = ... }` table form, and a matching Storage-tab control does the same in the launcher.

dirfs.rs's Builder gains a real OFS content-block writer alongside the existing FFS one: T_DATA header blocks (header_key/seq_num/data_size/ next_data/checksum, 488 payload bytes instead of FFS's raw 512) folded into the existing deferred-checksum mechanism, chained via next_data as each following block's key becomes known. The header/extension block chaining (the 72-entry data-pointer table, T_LIST chaining past 72 blocks) is unchanged and shared between both filesystems -- only the blocks it points at differ in shape.

HardDriveImage::open's other path -- wrapping a bare hardfile (no RDB) in a synthesized RDB -- already read the dostype out of the image's own boot-block bytes and threaded it through untouched, so an OFS-formatted bare hardfile already worked before this change; nothing there needed to change.

Verified against real firmware, not just the new unit tests: a directory mounted with filesystem = "ofs" behind an A2091 SCSI controller boots a genuine Kickstart 1.3 ROM straight to the Workbench desktop with the drive mounted, no FFS handler present anywhere in the guest.