### PR TITLE
bus: float write-only custom register reads to the chip data bus

### DIFF
--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -228,7 +228,10 @@ own values -- e.g. the A2091 board's unpopulated XT-interface bytes read
 Write-only and unmapped custom-register offsets float the same way: the
 chips decode the address but drive no data, so `move.w $DFF106,d0` returns
 the bus residue rather than the register's internal latch (which the
-debugger still inspects separately). Reading a write-only register back
+debugger still inspects separately). Each driven word cycle recharges the
+bus, so a longword read pairing a readable register with a write-only one
+floats the second word to the first -- `move.l $DFF01E,d0` reads INTREQR
+in both halves. Reading a write-only register back
 and OR-ing the result into a fresh write therefore picks up garbage bits
 exactly as on real hardware -- a floating BPLCON3 LOCT bit, for example,
 misroutes AGA palette writes into the low nibbles and darkens the whole

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -225,6 +225,17 @@ on silicon. Device windows that decode their own floating bus keep their
 own values -- e.g. the A2091 board's unpopulated XT-interface bytes read
 `$FF` from its own model, not the chip data bus.
 
+Write-only and unmapped custom-register offsets float the same way: the
+chips decode the address but drive no data, so `move.w $DFF106,d0` returns
+the bus residue rather than the register's internal latch (which the
+debugger still inspects separately). Reading a write-only register back
+and OR-ing the result into a fresh write therefore picks up garbage bits
+exactly as on real hardware -- a floating BPLCON3 LOCT bit, for example,
+misroutes AGA palette writes into the low nibbles and darkens the whole
+palette. The one deliberate exception is DENISEID (`$07C`) on OCS Denise,
+held at `$FFFF` so ECS-detection code (low byte `$FC`) cannot false-match
+a residue; see the TODO in `read_custom_word`.
+
 ## Determinism and the host boundary
 
 The core's only inputs are the config, the loaded images, and the

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -9,7 +9,7 @@ use super::*;
 
 impl Bus {
     pub(super) fn read_custom_word(&mut self, off: u16) -> u16 {
-        match off & 0xFFE {
+        let value = match off & 0xFFE {
             0x002 => {
                 // DMACONR. Bit 14 = BBUSY (blitter busy), bit 13 = BZERO
                 // (last blit's D was all zero). BBUSY is the early-dropping
@@ -96,20 +96,32 @@ impl Bus {
             // HHPOSR (ECS Agnus): UHRES dual-mode H counter readback. The
             // counter is not emulated, so this reads the HHPOSW latch.
             0x1DA if self.agnus.revision().is_ecs() => self.agnus.hhpos(),
-            0x07C => self.denise_revision.id().unwrap_or(0xFFFF),
+            0x07C => match self.denise_revision.id() {
+                Some(id) => id,
+                // Undriven on OCS: return early so the workaround constant
+                // never contaminates the bus residue below.
+                None => return 0xFFFF,
+            },
             _ => {
                 // Write-only and unmapped custom offsets drive nothing, so
                 // the read samples the residue of the last real chip-bus
                 // transfer (`data_bus`, the same floating-bus model unmapped
-                // address space uses). Software that reads a write-only
-                // register back and ORs the result into a fresh write picks
-                // up garbage bits here exactly as on real hardware (e.g. a
-                // floating BPLCON3 LOCT bit misrouting AGA palette writes).
-                // The debugger still inspects the internal latches through
-                // `custom_reg_latch`.
-                self.data_bus
+                // address space uses) and leaves it unchanged. Software that
+                // reads a write-only register back and ORs the result into a
+                // fresh write picks up garbage bits here exactly as on real
+                // hardware (e.g. a floating BPLCON3 LOCT bit misrouting AGA
+                // palette writes). The debugger still inspects the internal
+                // latches through `custom_reg_latch`.
+                return self.data_bus;
             }
-        }
+        };
+        // A driven word cycle recharges the chip data bus, so a following
+        // undriven cycle floats to this word even inside the same CPU
+        // transfer: MOVE.L $DFF01E,Dn reads INTREQR and then the write-only
+        // $020, and the second word must sample the first, not the residue
+        // from before the transfer.
+        self.data_bus = value;
+        value
     }
 
     pub(super) fn pot_pins(&self) -> PotPins {

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -87,19 +87,27 @@ impl Bus {
             }
             // DENISEID: ECS Denise (8373) drives 0xFFFC; software detects ECS
             // via the low byte (0xFC). OCS Denise (8362) has no such register,
-            // so $07C reads the undriven custom bus, which floats high to
-            // 0xFFFF (low byte 0xFF != 0xFC, so software correctly detects OCS).
+            // so $07C reads the undriven custom bus, held here at 0xFFFF (low
+            // byte 0xFF != 0xFC, so software correctly detects OCS).
+            // TODO: the accurate OCS model is the floating-bus residue
+            // (`data_bus`) like the write-only fallback below, but a residue
+            // whose low byte happens to be 0xFC would misdetect ECS; keep the
+            // constant until the detection paths are characterized against it.
             // HHPOSR (ECS Agnus): UHRES dual-mode H counter readback. The
             // counter is not emulated, so this reads the HHPOSW latch.
             0x1DA if self.agnus.revision().is_ecs() => self.agnus.hhpos(),
             0x07C => self.denise_revision.id().unwrap_or(0xFFFF),
             _ => {
-                // Real write-only custom registers leave the CPU reading an
-                // undriven custom bus. Copperline does not model the previous
-                // bus owner yet, so write-only and unmapped custom reads use
-                // deterministic zero. The debugger still inspects the
-                // internal latches through `custom_reg_latch`.
-                0
+                // Write-only and unmapped custom offsets drive nothing, so
+                // the read samples the residue of the last real chip-bus
+                // transfer (`data_bus`, the same floating-bus model unmapped
+                // address space uses). Software that reads a write-only
+                // register back and ORs the result into a fresh write picks
+                // up garbage bits here exactly as on real hardware (e.g. a
+                // floating BPLCON3 LOCT bit misrouting AGA palette writes).
+                // The debugger still inspects the internal latches through
+                // `custom_reg_latch`.
+                self.data_bus
             }
         }
     }

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -1058,6 +1058,22 @@ fn write_only_custom_register_reads_float_to_the_chip_data_bus() {
 }
 
 #[test]
+fn a_driven_word_cycle_recharges_the_bus_for_a_following_undriven_cycle() {
+    // MOVE.L $DFF01E,Dn pairs a driven word with an undriven one: the
+    // INTREQR cycle drives the chip data bus, so the following read of the
+    // write-only DSKPTH ($020) floats to INTREQR's value, not to the
+    // residue from before the transfer.
+    let mut bus = empty_bus();
+    bus.paula.write_intreq(0x8000 | INT_AUD0);
+    bus.data_bus = 0x5A5A;
+
+    let intreqr = INT_AUD0 as u64;
+    assert_eq!(bus.custom_read(0x01E, 4), (intreqr << 16) | intreqr);
+    // The driven cycle's word stays on the bus for later undriven reads.
+    assert_eq!(bus.custom_read(0x106, 2), intreqr);
+}
+
+#[test]
 fn dmacon_masks_stored_bits_and_dmaconr_derives_status() {
     let mut bus = empty_bus();
 

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -1023,8 +1023,38 @@ fn paula_interrupt_write_addresses_use_write_only_custom_bus_readback() {
 
     assert_eq!(bus.custom_read(0x01C, 2), (INT_MASTER | INT_VERTB) as u64);
     assert_eq!(bus.custom_read(0x01E, 2), INT_AUD0 as u64);
-    assert_eq!(bus.custom_read(0x09A, 2), 0);
-    assert_eq!(bus.custom_read(0x09C, 2), 0);
+    // The write addresses drive nothing on a read: they return the floating
+    // chip data bus, never the INTENA/INTREQ latches.
+    bus.data_bus = 0x1234;
+    assert_eq!(bus.custom_read(0x09A, 2), 0x1234);
+    assert_eq!(bus.custom_read(0x09C, 2), 0x1234);
+}
+
+#[test]
+fn write_only_custom_register_reads_float_to_the_chip_data_bus() {
+    // BPLCON3 ($106) and BPL1MOD ($108) drive nothing on a read, so the
+    // CPU samples the residue of the last real chip-bus transfer, not a
+    // fixed zero. Software that reads a write-only register back and ORs
+    // the result into a fresh write must pick up the same garbage bits it
+    // would on real silicon (a floating LOCT bit in a read-back BPLCON3
+    // misroutes AGA palette writes into the low nibbles, collapsing the
+    // palette toward dark).
+    let mut bus = empty_bus();
+    bus.data_bus = 0xA53C;
+
+    assert_eq!(bus.custom_read(0x106, 2), 0xA53C);
+    assert_eq!(bus.custom_read(0x108, 2), 0xA53C);
+    // A 68000 byte read takes the high data-bus lane at even addresses
+    // and the low lane at odd.
+    assert_eq!(bus.custom_read(0x106, 1), 0xA5);
+    assert_eq!(bus.custom_read(0x107, 1), 0x3C);
+    // A longword read spans two undriven word cycles; the residue holds
+    // across both.
+    assert_eq!(bus.custom_read(0x106, 4), 0xA53C_A53C);
+
+    // A readable register still drives the bus with its own value.
+    bus.paula.write_intena(0x8000 | INT_MASTER | INT_VERTB);
+    assert_eq!(bus.custom_read(0x01C, 2), (INT_MASTER | INT_VERTB) as u64);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Reading a write-only or unmapped custom register leaves the chip data bus undriven, so a real machine returns the residue of the last real bus transfer -- not a clean zero. This routes the `read_custom_word` fallback to the existing floating-bus latch (`Bus.data_bus`) that unmapped address space already uses, so both undriven cases now share one model.

## Motivation

A game developer reported (real AGA hardware) that reading BPLCON3 back and OR-ing the result into copper palette writes set mostly-dark colors, while Copperline and WinUAE ran the buggy code cleanly. The mechanism: a floating LOCT bit (bit 9) in the read-back routes the high-nibble palette pass into the low nibbles, so the true high nibbles are never written; floating BANK bits (15-13) scatter writes across wrong banks. With this change the same read returns bus residue in Copperline too, so the guest bug reproduces as on real silicon.

## Notes

- `data_bus` was already latched by 68000 CPU transfers, audio DMA, and bitplane fetches, and stays `#[serde(skip)]` (transient, re-established by DMA after a state load) -- no `STATE_VERSION` bump.
- DENISEID ($07C) on OCS keeps its $FFFF constant so ECS detection (low byte $FC) cannot false-match a residue; a TODO records the more accurate residue model.
- Kickstart slow-RAM sizing through the Gary custom mirror stays correct: 68000 prefetch traffic re-latches the bus between a probe's write and read-back, and 020+ CPUs do not echo into the chip-bus latch at all.
- Copper/sprite/disk DMA fetches still do not latch `data_bus`; the latch sources are unchanged to keep the vAmigaTS uninit calibration intact.

## Testing

- New regression test `write_only_custom_register_reads_float_to_the_chip_data_bus` (word/byte-lane/longword reads plus a readable-register control); strengthened the INTENA/INTREQ write-address readback test to pin the float.
- Full unit suite passes (the one failure, `config::tests::the_battery_ram_follows_the_paths_in_force`, is pre-existing on a clean tree from a stray local `battmem.nvram`).
- `cargo clippy` and `cargo fmt --check` clean; all 28 golden probe renders unchanged.
- Headless boot screenshots verified: AROS factory config, KS1.3 A500 with no slow RAM (insert-Workbench screen, no phantom $C00000 RAM), KS3.1 A1200 AGA.