### PR TITLE
toccata: add MacroSystem Toccata AD1848 sound board support (AHI, playback)

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1807,6 +1807,21 @@ bridge adapter identifier and must be restored on a host where that adapter can
 be opened. See [](../zorro) for board details, platform bridge setup, and the
 NAT's limitations.
 
+## `[toccata]` -- AD1848 sound board
+
+```toml
+[toccata]
+enabled = true
+```
+
+Fits a MacroSystem Toccata sound board (an AD1848 codec) on the Zorro
+chain. Its stock, open-source AHI driver (`toccata.audio`) works unmodified,
+so any AHI-aware guest application gets 16-bit sound with no
+Copperline-specific setup. No other options exist yet. Omit the section
+(or `enabled = false`) for no board. The board's output joins the mixer as
+the `toccata` source for `--audio-stems` (see [](headless)); see
+[](../zorro) and [](../internals/toccata) for the register model.
+
 ## `[hostsocket]` -- bsdsocket.library without a guest TCP/IP stack
 
 ```toml

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ running in Copperline.
   contributors.
 - [](internals/picasso2) -- the Picasso II/II+ and CL-GD5426/5428 RTG model.
 - [](internals/audio) -- the audio mixer/sink service and stem capture.
+- [](internals/toccata) -- the MacroSystem Toccata AD1848 sound board model.
 
 ## Design principles
 

--- a/docs/internals/audio.md
+++ b/docs/internals/audio.md
@@ -20,24 +20,25 @@ is now an `AudioMux` instead of a bare `Box<dyn AudioSink>`, and
 `push_mixed_frame`'s tail calls `push_master`/`push_source`/
 `push_source_channel` instead of pushing straight into the sink. This is
 what lets `--audio-stems` capture the same signal at finer granularity
-with no change to the mixing math, and is the seam a future board (a
-MacroSystem Toccata AHI card, for instance) will register through as
-just another named source -- see the project's Toccata proposal for the
-board work itself, which this milestone only prepares for.
+with no change to the mixing math, and is the seam boards register
+through as just another named source: the MacroSystem Toccata
+(`src/toccata.rs`, [](toccata)) is the first, feeding a fifth `"toccata"`
+tap the same way CD-DA and MT-32 do.
 
 ## The taps
 
-`push_mixed_frame` pushes four named sources, each at the point in the
+`push_mixed_frame` pushes five named sources, each at the point in the
 signal chain described below (not necessarily the point that ends up in
 the master mix -- see each entry):
 
 | Source | Tap point | Notes |
 |---|---|---|
-| `paula` | Post-LED-filter, pre-drive/CD/MT-32 | The pure Paula-channel sum |
+| `paula` | Post-LED-filter, pre-drive/CD/MT-32/Toccata | The pure Paula-channel sum |
 | `paula` sub-channels `0`..`3` | `channel_mixed_sample(i)`, scaled | **Not** LED-filtered -- real hardware's filter sits after the channel mixer's summation, so a per-channel stem naturally excludes it |
 | `drivesounds` | The synthesized drive-noise sample | Mono; written to a stem as `(sample, sample)` |
 | `cdda` | Post `cd_muted` gate | Reflects audible content -- unlike the debugger's CD scope tap, which stays pre-mute for visibility |
 | `mt32` | The in-process MT-32 synth frame | Silence (`0.0, 0.0`) once the serial sink has latched `synth_silent` |
+| `toccata` | One frame popped from `ToccataAudioRing` | Already resampled to the mixer rate by the board's own tick; see [](toccata) |
 
 The **master** signal (`push_master`) is the final `out_left`/`out_right`
 after master volume and stereo width -- unchanged from what every sink has

--- a/docs/internals/toccata.md
+++ b/docs/internals/toccata.md
@@ -1,0 +1,122 @@
+# Toccata and the AD1848 model
+
+Copperline's Toccata is a hardware model of the MacroSystem Zorro II sound
+board, not an AHI-aware audio API: the guest enumerates the real
+manufacturer/product identity, programs the AD1848 codec's indexed
+registers, pushes/pulls bytes through the board's own 1024-byte FIFO, and
+polls the board's status/control register exactly as the stock
+`toccata.audio` AHI driver does. See [](../zorro) for the autoconfig window
+and [](audio) for how the board's output joins the mixer and stem capture.
+
+Modelled against WinUAE/amiberry's `sndboard.cpp` (byte-identical in both
+trees) as a **behavioural oracle**: register offsets, bit semantics, the
+FIFO's threshold and byte-order quirks, and the interrupt condition are
+transcribed from what that reference does, not from the AD1848 datasheet
+alone -- several of the board's most consequential behaviours (reg 12
+pinned to plain-AD1848 mode, the FIFO's little-endian-vs-big-endian byte
+order, underrun repeating rather than silencing) are MacroSystem-specific
+or emulator-specific choices a datasheet alone would not predict.
+
+## Implemented controller surface
+
+`Ad1848` (`src/toccata/ad1848.rs`) owns all chip state: the 16 reachable
+indexed registers, the 1024-byte play FIFO, the board's own status/control
+register, the auto-calibration countdown, and DAC output volume. It has no
+Zorro/bus coupling -- `Toccata` (`src/toccata.rs`) is the board wrapper:
+autoconfig identity (`BoardSpec::toccata`), the 64 KB window's four-port
+address decode, and the mixer-rate cadence.
+
+- **Autoconfig**: manufacturer 18260 (MacroSystem), product 12, Zorro II,
+  single 64 KB I/O window, no autoboot ROM (the real board's `romtype` is
+  `ROMTYPE_NOT`).
+- **Register window**: status/control, FIFO data, and the AD1848
+  index/data ports are decoded by address-line pattern (`A14`/`A13`/`A11`/
+  `A0`), matching the reference's own decode rather than exact-address
+  matching -- each port mirrors across several KB of the window, and the
+  AD1848 ports only respond on odd byte addresses. Anything the pattern
+  doesn't match is open bus within the board's own window (reads 0, writes
+  drop), distinct from the Zorro chain's open bus (0xFF) outside any
+  configured board.
+- **AD1848**: reg 12 is pinned to `0x0A` regardless of what's written,
+  which locks the codec to plain-AD1848 mode -- no CS4231 extensions, and
+  since format bits 5/7 of reg 8 are never decoded, no µ-law/A-law, only
+  8-bit unsigned linear and 16-bit signed linear PCM. Reg 8's crystal-select
+  and divider bits produce the codec's 14 legal rates (5512-48000 Hz,
+  rounded to the nearest 100 Hz the way the reference rounds); reg 6/7 are
+  DAC output attenuation, applied to every produced sample including
+  underrun repeats.
+- **FIFO**: 1024 bytes, half-empty threshold 512, edge-triggered on the
+  downward crossing only. Overflow silently drops bytes (matching the
+  IDT7202LA's own can't-overflow guarantee). Underrun repeats the last
+  decoded sample rather than emitting silence -- real silicon holds its
+  last DAC value, and the reference models that exactly.
+- **16-bit byte order**: a native `move.w` decomposes into big-endian byte
+  pokes at the FIFO port, but the FIFO reads back little-endian, so writing
+  word `0x1234` is actually heard by the codec as `0x3412`. This is a real
+  hardware quirk real Toccata drivers byte-swap around, not something
+  Copperline "corrects" -- see the test named for it in
+  `src/toccata/ad1848.rs`.
+
+## Mixer cadence and resampling
+
+The codec's own programmed rate is independent of Copperline's fixed
+44.1 kHz mixer rate (established by the audio sink service, [](audio)).
+`Toccata::tick` runs its own exact-ratio accumulator -- identical in shape
+to `Paula::advance_audio`'s own -- and on each mixer-rate frame boundary
+pulls one sample through a polyphase windowed-sinc resampler
+(`src/audio/resample.rs`, shared with the MT-32 engine) that converts the
+AD1848's rate to the mixer's.
+
+The resampler's pull API (`next(refill)`) does double duty: `refill()` is
+called exactly once per actual codec-rate sample the resampler needs, so
+it *is* the per-sample unit the reference's own `audio_state_sndboard_toccata`
+callback performs -- draining the FIFO, applying volume, evaluating the
+half-empty/interrupt condition. No separate codec-rate accumulator exists
+in the board's own state; the resampler's phase counter is the cadence.
+Resamplers are cached per codec rate (`Toccata`'s `resamplers` map, at most
+14 entries, the AD1848's legal rate count) so returning to an
+already-programmed rate never rebuilds its kernel table.
+
+Produced frames push into `ToccataAudioRing` (`src/chipset/paula.rs`,
+alongside `CdAudioRing`), which `push_mixed_frame` pops one frame from per
+mixer tick -- a plain per-frame pop, not a rate conversion, since the
+board already resampled before pushing. Unlike CD-DA's bursty per-sector
+delivery, the board's own tick cadence matches the mixer's, so the ring
+stays near-empty in steady state; its fixed capacity is a safety margin
+against a stalled consumer, not a buffering requirement.
+
+## Interrupt
+
+INT6/EXTER, level-sensitive (`Toccata::int6_line` reads `Ad1848::int6_pending`).
+The condition requires the codec to have been started (reg 9's playback/
+record enable bits), the board's own `STATUS_FIFO_CODEC` gate, the
+relevant direction's FIFO-enable bit, that direction's INTENA bit, and the
+edge-latched half-empty/half-full flag -- all evaluated once per produced
+sample. Reading the status register acknowledges (clears) pending
+interrupt bits; the half-empty/half-full latch itself is cleared by FIFO
+port access instead, so a status-read ack with the latch still set
+re-raises the interrupt on the next produced sample.
+
+## Determinism
+
+Every board-side computation -- register writes, FIFO drains, interrupt
+evaluation, the resampler's phase -- is driven purely by `tick`'s `cck`
+argument or by CPU register accesses, both already deterministic inputs.
+Nothing reads wall-clock time, so a Toccata-fitted machine is warp-safe
+and reproducible exactly like the rest of the emulated audio path (see
+[](audio)'s determinism section) -- two runs of the same scripted
+scenario produce byte-identical `toccata.wav` stem captures.
+
+## What's out of scope for M1-M3
+
+- **Record** (the board's capture FIFO/interrupt path) is modelled only as
+  inert stubs: the record port exists and acknowledges correctly, but
+  never has data, since nothing ever sets `STATUS_FIFO_RECORD`.
+- **The "Paula/CD audio mixer" board setting** (reg 2-5's AUX1/AUX2 input
+  gain feeding the board's own analog mixer) is not modelled: Copperline's
+  Paula and CD-DA already reach the master mix directly, so replicating
+  the board's own internal mixing would add no user-visible capability.
+- The launcher's machine-configuration screen does not yet have a Toccata
+  row; `[toccata] enabled = true` in a config file loaded directly (`--config`)
+  works, but loading that config into the launcher and saving from there
+  drops the setting until a GUI row is added.

--- a/docs/internals/toccata.md
+++ b/docs/internals/toccata.md
@@ -61,37 +61,52 @@ address decode, and the mixer-rate cadence.
 
 The codec's own programmed rate is independent of Copperline's fixed
 44.1 kHz mixer rate (established by the audio sink service, [](audio)).
-`Toccata::tick` runs its own exact-ratio accumulator -- identical in shape
-to `Paula::advance_audio`'s own -- and on each mixer-rate frame boundary
-pulls one sample through a polyphase windowed-sinc resampler
-(`src/audio/resample.rs`, shared with the MT-32 engine) that converts the
-AD1848's rate to the mixer's.
+`Toccata::tick` runs **two** independent exact-ratio accumulators --
+each the same shape as `Paula::advance_audio`'s own -- rather than one:
+`advance_codec` at the AD1848's own active rate, and `advance_mixer` at
+the mixer's fixed rate. Splitting them is deliberate, not incidental: a
+polyphase windowed-sinc resampler (`src/audio/resample.rs`, shared with
+the MT-32 engine) is inherently non-causal, since it needs taps on both
+sides of the output instant and primes by pulling a full window's worth
+of input before its first output. If the resampler pulled straight from
+the chip (calling `Ad1848::produce_one_sample` directly from inside its
+own `refill` closure), its first use after startup or a rate change
+would drain dozens of FIFO bytes and evaluate the half-empty/interrupt
+condition all at once, decades ahead of when a real codec would reach
+them -- the resampler's own lookahead would leak into hardware-state
+timing correctness.
 
-The resampler's pull API (`next(refill)`) does double duty: `refill()` is
-called exactly once per actual codec-rate sample the resampler needs, so
-it *is* the per-sample unit the reference's own `audio_state_sndboard_toccata`
-callback performs -- draining the FIFO, applying volume, evaluating the
-half-empty/interrupt condition. No separate codec-rate accumulator exists
-in the board's own state; the resampler's phase counter is the cadence.
-Resamplers are cached per codec rate (`Toccata`'s `resamplers` map, at most
-14 entries, the AD1848's legal rate count) so returning to an
-already-programmed rate never rebuilds its kernel table.
+`advance_codec` is what actually drains the FIFO and evaluates the
+half-empty/interrupt condition (the reference's own
+`audio_state_sndboard_toccata` per-sample body, transplanted verbatim),
+paced causally by `cck` at the codec's own rate; each produced sample is
+queued into `decoded`, a plain FIFO of raw pre-resample frames.
+`advance_mixer` pulls from that passive queue through the resampler --
+never from the chip directly -- repeating the chip's last known sample
+(via the side-effect-free `Ad1848::peek_last_sample`) if `decoded` is
+momentarily empty. This keeps the resampler's non-causal lookahead
+confined to shaping the interpolated *waveform*; it can never reorder
+when a FIFO byte drains or an interrupt raises. Resamplers are cached per
+codec rate (`Toccata`'s `resamplers` map, at most 14 entries, the
+AD1848's legal rate count) so returning to an already-programmed rate
+never rebuilds its kernel table.
 
 Produced frames push into `ToccataAudioRing` (`src/chipset/paula.rs`,
 alongside `CdAudioRing`), which `push_mixed_frame` pops one frame from per
 mixer tick -- a plain per-frame pop, not a rate conversion, since the
 board already resampled before pushing. Unlike CD-DA's bursty per-sector
-delivery, the board's own tick cadence matches the mixer's, so the ring
-stays near-empty in steady state; its fixed capacity is a safety margin
-against a stalled consumer, not a buffering requirement.
+delivery, the board's own tick cadence matches the mixer's, so both the
+`decoded` queue and the ring stay near-empty in steady state; their fixed
+capacities are a safety margin against a stalled consumer, not a
+buffering requirement.
 
 A cached resampler's `history` buffer holds the last ~64 input frames it
 convolves over, so `Toccata::reset()` (a guest CPU reset, matching every
 other in-tree board's `ZorroDevice::reset()` -- a full hardware reinit)
-also zeroes the mixer accumulator and clears the whole resampler cache,
-not just `Ad1848`'s own registers/FIFO. Without that, a few dozen
-milliseconds of pre-reset audio would bleed through the stale kernel
-window into what should be post-reset silence -- covered by
+zeroes both accumulators, clears `decoded`, and clears the whole
+resampler cache, not just `Ad1848`'s own registers/FIFO. Without that, a
+few dozen milliseconds of pre-reset audio would bleed through the stale
+kernel window into what should be post-reset silence -- covered by
 `reset_clears_stale_resampler_history_so_silence_follows_immediately` in
 `src/toccata.rs`.
 
@@ -116,6 +131,23 @@ Nothing reads wall-clock time, so a Toccata-fitted machine is warp-safe
 and reproducible exactly like the rest of the emulated audio path (see
 [](audio)'s determinism section) -- two runs of the same scripted
 scenario produce byte-identical `toccata.wav` stem captures.
+
+## Savestates
+
+`Toccata` derives `Serialize`/`Deserialize` directly (`Box`ed as
+`BoardDevice::Toccata`, like `Picasso2`) with no `#[serde(skip)]` fields:
+`codec_acc`/`decoded` are genuine machine state for the reason given
+above, and the `resamplers` cache -- despite only shaping the waveform,
+never FIFO/IRQ timing -- is serialized too, via `Resampler`'s own manual
+`Serialize`/`Deserialize` in `src/audio/resample.rs` (its derived
+`kernels` table is rebuilt from `l`/`m` on load rather than stored, since
+it is a pure function of the reduced rate ratio). This makes a
+save-state load reproduce an uninterrupted run's *output* exactly, not
+just its FIFO/IRQ timing -- a resumed run's `toccata.wav` stem is
+byte-identical to what an uninterrupted run would have produced at the
+same point, covered by
+`savestate_round_trip_reproduces_an_uninterrupted_runs_output` in
+`src/toccata.rs`.
 
 ## What's out of scope for M1-M3
 

--- a/docs/internals/toccata.md
+++ b/docs/internals/toccata.md
@@ -85,6 +85,16 @@ delivery, the board's own tick cadence matches the mixer's, so the ring
 stays near-empty in steady state; its fixed capacity is a safety margin
 against a stalled consumer, not a buffering requirement.
 
+A cached resampler's `history` buffer holds the last ~64 input frames it
+convolves over, so `Toccata::reset()` (a guest CPU reset, matching every
+other in-tree board's `ZorroDevice::reset()` -- a full hardware reinit)
+also zeroes the mixer accumulator and clears the whole resampler cache,
+not just `Ad1848`'s own registers/FIFO. Without that, a few dozen
+milliseconds of pre-reset audio would bleed through the stale kernel
+window into what should be post-reset silence -- covered by
+`reset_clears_stale_resampler_history_so_silence_follows_immediately` in
+`src/toccata.rs`.
+
 ## Interrupt
 
 INT6/EXTER, level-sensitive (`Toccata::int6_line` reads `Ad1848::int6_pending`).

--- a/docs/zorro.md
+++ b/docs/zorro.md
@@ -21,10 +21,10 @@ There are two board kinds:
   forking and recompiling Copperline. See
   [WASM plugin boards](#wasm-plugin-boards) below.
 
-Functional boards (the A2091, the A4091, the A2065, the CDTV DMAC, and WASM
-plugins) all implement the `ZorroDevice` trait (`src/zorro_device.rs`): the
-bus drives every board through that one boundary for register access,
-ticking, interrupts, and DMA.
+Functional boards (the A2091, the A4091, the A2065, the CDTV DMAC, the
+Toccata, and WASM plugins) all implement the `ZorroDevice` trait
+(`src/zorro_device.rs`): the bus drives every board through that one
+boundary for register access, ticking, interrupts, and DMA.
 
 ## Describing a board in TOML
 
@@ -312,6 +312,25 @@ plugin) breaks Copperline's byte-identical replay and save-state reproducibility
 while traffic flows -- the emulator logs this when the board is attached. Save
 states record only the chosen backend and bring up a fresh one on load
 (in-flight frames are dropped; the guest's TCP retransmits).
+
+## Audio: the Toccata sound board
+
+`[toccata]` fits an in-tree MacroSystem Toccata (`src/toccata.rs`), a Zorro
+II AD1848-based sound board with a mature, open-source AHI driver
+(`toccata.audio`), so AHI-aware guest software gets 16-bit sound with no
+Copperline-specific driver work:
+
+```toml
+[toccata]
+enabled = true
+```
+
+No other options exist yet. Unlike the A2065/HostSocket boards above,
+Toccata's guest interface is purely register-and-FIFO, not bus-mastering
+DMA, and its output joins Copperline's own mixer as a named source (the
+`toccata` stem in `--audio-stems`) rather than talking to a host device
+directly -- see [](internals/toccata) for the register model and
+[](internals/audio) for the mixer/stem-capture integration.
 
 ## Networking: the bundled HostSocket board
 

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -6,6 +6,7 @@
 //! on CLI flags.
 
 pub mod mux;
+pub(crate) mod resample;
 
 #[cfg(feature = "frontend")]
 use crate::timebase::Instant;

--- a/src/audio/resample.rs
+++ b/src/audio/resample.rs
@@ -31,7 +31,9 @@ pub struct Resampler {
     m: u32,
     /// Where between input frames the next output falls, in `1/l`ths.
     phase: u32,
-    /// One windowed-sinc kernel per phase, phase-major.
+    /// One windowed-sinc kernel per phase, phase-major. A pure function of
+    /// `l`/`m`, so it is never serialized -- see the manual `Serialize`/
+    /// `Deserialize` impls below, which rebuild it from `l`/`m` instead.
     kernels: Vec<f32>,
     /// The last [`TAPS`] input frames, written twice [`TAPS`] apart so
     /// the window starting at `head` is always one contiguous slice,
@@ -41,34 +43,41 @@ pub struct Resampler {
     primed: bool,
 }
 
+/// One windowed-sinc kernel per output phase, phase-major -- the part of
+/// [`Resampler`] that depends only on the reduced `l`/`m` ratio, shared by
+/// `Resampler::new` and its `Deserialize` impl.
+fn build_kernels(l: u32, m: u32) -> Vec<f32> {
+    // Downsampling, the output's own Nyquist is the ceiling; the kernel is
+    // stretched to cut there instead.
+    let cutoff = CUTOFF_MARGIN * (f64::from(l) / f64::from(m)).min(1.0);
+    let mut kernels = Vec::with_capacity(l as usize * TAPS);
+    for phase in 0..l {
+        // The output instant sits `frac` past the newest-but-HALF input
+        // frame; each tap is the sinc at its distance from it.
+        let frac = f64::from(phase) / f64::from(l);
+        let mut kernel = [0f64; TAPS];
+        let mut sum = 0.0;
+        for (j, tap) in kernel.iter_mut().enumerate() {
+            let x = frac - (j as f64 - (HALF as f64 - 1.0));
+            *tap = cutoff * sinc(cutoff * x) * blackman(x / HALF as f64);
+            sum += *tap;
+        }
+        // Unity gain at DC exactly, so the window's ripple cannot shade
+        // the level from one phase to the next.
+        kernels.extend(kernel.iter().map(|&t| (t / sum) as f32));
+    }
+    kernels
+}
+
 impl Resampler {
     pub fn new(from: u32, to: u32) -> Resampler {
         let g = gcd(from, to);
         let (l, m) = (to / g, from / g);
-        // Downsampling, the output's own Nyquist is the ceiling; the
-        // kernel is stretched to cut there instead.
-        let cutoff = CUTOFF_MARGIN * (f64::from(l) / f64::from(m)).min(1.0);
-        let mut kernels = Vec::with_capacity(l as usize * TAPS);
-        for phase in 0..l {
-            // The output instant sits `frac` past the newest-but-HALF
-            // input frame; each tap is the sinc at its distance from it.
-            let frac = f64::from(phase) / f64::from(l);
-            let mut kernel = [0f64; TAPS];
-            let mut sum = 0.0;
-            for (j, tap) in kernel.iter_mut().enumerate() {
-                let x = frac - (j as f64 - (HALF as f64 - 1.0));
-                *tap = cutoff * sinc(cutoff * x) * blackman(x / HALF as f64);
-                sum += *tap;
-            }
-            // Unity gain at DC exactly, so the window's ripple cannot
-            // shade the level from one phase to the next.
-            kernels.extend(kernel.iter().map(|&t| (t / sum) as f32));
-        }
         Resampler {
             l,
             m,
             phase: 0,
-            kernels,
+            kernels: build_kernels(l, m),
             history: vec![(0.0, 0.0); 2 * TAPS],
             head: 0,
             primed: false,
@@ -109,6 +118,41 @@ impl Resampler {
             self.push(frame);
         }
         (left, right)
+    }
+}
+
+/// `l`/`m`/`phase`/`history`/`head`/`primed` -- everything except the
+/// derived `kernels` table, which `Deserialize` rebuilds from `l`/`m` via
+/// [`build_kernels`] instead of carrying it in the savestate. Needed so a
+/// Toccata savestate reproduces an uninterrupted run's output exactly
+/// (not just its FIFO/IRQ timing): the resampler's phase and tap history
+/// are what shape the interpolated waveform at the instant of a resume.
+impl serde::Serialize for Resampler {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        (
+            self.l,
+            self.m,
+            self.phase,
+            &self.history,
+            self.head,
+            self.primed,
+        )
+            .serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Resampler {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let (l, m, phase, history, head, primed) = serde::Deserialize::deserialize(deserializer)?;
+        Ok(Resampler {
+            l,
+            m,
+            phase,
+            kernels: build_kernels(l, m),
+            history,
+            head,
+            primed,
+        })
     }
 }
 

--- a/src/audio/resample.rs
+++ b/src/audio/resample.rs
@@ -1,15 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-//! The one rate conversion between the module and the mix.
+//! Rate conversion between an emulated audio source's native rate and the
+//! mixer's rate ([`crate::audio::MIX_SAMPLE_RATE`]).
 //!
-//! The engine renders at the analogue model's rate; the mixer runs at
-//! [`crate::audio::MIX_SAMPLE_RATE`]. The two are in a fixed rational
-//! ratio, so the conversion is a polyphase windowed-sinc filter: a bank
-//! of one kernel per output phase, computed once, each output frame one
-//! pass of taps over the input history. Band-limited at whichever
-//! Nyquist is lower, so raising a rate adds no images and lowering one
-//! folds none back; the phase advances by an exact integer counter, so
-//! a run never drifts.
+//! A source with its own clock (the MT-32 engine's 48 kHz output, a
+//! Toccata's AD1848 codec at one of its 14 programmable rates) and the
+//! mixer are in a fixed rational ratio at any moment, so the conversion is
+//! a polyphase windowed-sinc filter: a bank of one kernel per output phase,
+//! computed once per (from, to) pair, each output frame one pass of taps
+//! over the input history. Band-limited at whichever Nyquist is lower, so
+//! raising a rate adds no images and lowering one folds none back; the
+//! phase advances by an exact integer counter, so a run never drifts --
+//! deterministic and warp-safe like everything else in the emulated audio
+//! path.
 
 /// Taps each side of the output instant. Sixty-four in all keeps the
 /// passband flat to the top of what the module produces and the

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -5837,10 +5837,12 @@ impl Bus {
                 ..
             } = self;
             for (slot, dev) in devices.iter_mut().enumerate() {
-                let mut host = crate::zorro_device::DeviceHost::for_slot_with_cd_audio(
+                let (cd_audio, toccata_audio) = paula.audio_rings_mut();
+                let mut host = crate::zorro_device::DeviceHost::for_slot_with_audio(
                     &mut *mem,
                     slot,
-                    paula.cd_audio_mut(),
+                    cd_audio,
+                    toccata_audio,
                 );
                 crate::zorro_device::ZorroDevice::tick(dev, cck, &mut host);
                 if crate::zorro_device::ZorroDevice::int2_line(dev) {

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -315,6 +315,39 @@ impl CdAudioRing {
     }
 }
 
+/// Toccata audio stream from the board to the host mixer. Unlike CD-DA's
+/// bursty per-sector delivery, the board's own tick accumulates emulated
+/// time the same way `Paula::advance_audio` does (see
+/// `Toccata::tick`/`push_mixed_frame`'s fifth tap), so the two sides stay
+/// in near-lockstep -- a small fixed capacity is a safety margin, not a
+/// buffering requirement.
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct ToccataAudioRing {
+    samples: std::collections::VecDeque<(f32, f32)>,
+}
+
+/// A generous safety margin (well beyond what near-lockstep production
+/// ever needs) so a stalled consumer cannot grow the ring unbounded.
+const TOCCATA_AUDIO_RING_LIMIT: usize = 4096;
+
+impl ToccataAudioRing {
+    pub fn push_frame(&mut self, left: f32, right: f32) -> bool {
+        if self.samples.len() >= TOCCATA_AUDIO_RING_LIMIT {
+            return false;
+        }
+        self.samples.push_back((left, right));
+        true
+    }
+
+    pub fn next_sample(&mut self) -> (f32, f32) {
+        self.samples.pop_front().unwrap_or((0.0, 0.0))
+    }
+
+    pub fn clear(&mut self) {
+        self.samples.clear();
+    }
+}
+
 /// Push one sample into a debugger oscilloscope ring, evicting the oldest
 /// once the ring is full so it always holds the most recent AUDIO_SCOPE_LEN.
 fn scope_push(ring: &mut std::collections::VecDeque<i8>, sample: i8) {
@@ -417,6 +450,10 @@ pub struct Paula {
     // CD audio samples streamed by the CD controller (CD32 Akiko), mixed
     // into the host output at the shared 44.1 kHz mixer rate.
     cd_audio: CdAudioRing,
+    // Toccata board audio, already resampled to the mixer rate by the
+    // board's own tick before it reaches this ring -- see
+    // `ToccataAudioRing`'s doc comment.
+    toccata_audio: ToccataAudioRing,
     // Set once the device on the serial port has said it makes no sound
     // here, which is the usual answer: a machine with nothing on its MIDI
     // port then costs one predictable branch a sample and nothing else.
@@ -494,6 +531,7 @@ impl Paula {
             mono_output: false,
             stereo_separation: 1.0,
             cd_audio: CdAudioRing::default(),
+            toccata_audio: ToccataAudioRing::default(),
             synth_silent: false,
             drive_sounds: DriveSounds::new(),
             dma_addr_mask: 0x001F_FFFF,
@@ -734,6 +772,17 @@ impl Paula {
 
     pub fn cd_audio_mut(&mut self) -> &mut CdAudioRing {
         &mut self.cd_audio
+    }
+
+    pub fn toccata_audio_mut(&mut self) -> &mut ToccataAudioRing {
+        &mut self.toccata_audio
+    }
+
+    /// Both rings together, as disjoint field borrows -- the bus's generic
+    /// Zorro-board tick host needs both at once (`DeviceHost::for_slot_with_audio`),
+    /// which two separate `&mut self` accessor calls cannot express.
+    pub fn audio_rings_mut(&mut self) -> (&mut CdAudioRing, &mut ToccataAudioRing) {
+        (&mut self.cd_audio, &mut self.toccata_audio)
     }
 
     pub fn output_volume_percent(&self) -> u8 {
@@ -1837,6 +1886,14 @@ impl Paula {
             }
         }
         self.audio.push_source("mt32", synth_left, synth_right);
+        // A Toccata board resamples its own codec-rate output to the mixer
+        // rate before pushing here (see `Toccata::tick`), so this is a
+        // plain per-frame pop like CD-DA, not a rate conversion.
+        let (toccata_left, toccata_right) = self.toccata_audio.next_sample();
+        left += toccata_left;
+        right += toccata_right;
+        self.audio
+            .push_source("toccata", toccata_left, toccata_right);
         if let Some(capture) = &mut self.capture {
             capture.push((left, right));
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -211,6 +211,11 @@ pub struct Config {
     /// the Zorro chain using the named host network backend. Networking is
     /// non-deterministic, so a fitted A2065 breaks byte-identical replay.
     pub a2065_net: Option<crate::net::NetConfig>,
+    /// MacroSystem Toccata sound board (`[toccata] enabled = true`): when
+    /// true, a Toccata autoconfigs on the Zorro chain and its AD1848 output
+    /// joins the mixer as the `toccata` audio source. No other options
+    /// exist yet (see docs/internals/toccata.md).
+    pub toccata: bool,
     /// HostSocket board backend (`[hostsocket] net`): when set, the bundled
     /// bsdsocket.library plugin board is fitted with this backend. The board
     /// itself travels in [`Config::wasm_boards`]; this field records the
@@ -2215,6 +2220,7 @@ impl Default for Config {
             scsi: ScsiConfig::default(),
             lide: LideConfig::default(),
             a2065_net: None,
+            toccata: false,
             hostsocket_net: None,
             hostsocket_transport: None,
             rtg: RtgCard::None,
@@ -2858,6 +2864,8 @@ pub struct RawConfig {
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) a2065: RawA2065,
     #[serde(default, skip_serializing_if = "is_default")]
+    pub(crate) toccata: RawToccata,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) hostsocket: RawHostSocket,
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) rtg: RawRtg,
@@ -3445,6 +3453,15 @@ pub(crate) struct RawA2065 {
     /// Host adapter identifier used by `net = "bridge"`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) interface: Option<String>,
+}
+
+/// `[toccata]` MacroSystem Toccata sound board.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RawToccata {
+    /// Fit the board. Absent/false means no Toccata is on the chain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) enabled: Option<bool>,
 }
 
 /// `[hostsocket]` bundled bsdsocket.library board: a host-side TCP/IP stack
@@ -4490,6 +4507,8 @@ impl TryFrom<RawConfig> for Config {
             }
         };
 
+        let toccata = raw.toccata.enabled.unwrap_or(defaults.toccata);
+
         // `[hostsocket]` expands to the bundled WASM plugin board (see
         // crate::hostsocket), appended after any [[zorro]] metadata boards.
         // `net = "host"` is not one of `crate::net::NetConfig`'s own
@@ -4857,6 +4876,7 @@ impl TryFrom<RawConfig> for Config {
             scsi,
             lide,
             a2065_net,
+            toccata,
             hostsocket_net,
             hostsocket_transport,
             rtg,
@@ -9589,6 +9609,14 @@ mod tests {
         // No boards configured at all: the autoconfig window floats.
         let chain = cfg.build_zorro_chain()?;
         assert_eq!(chain.config_read(crate::zorro::AUTOCONFIG_BASE, 1), 0xFF);
+        Ok(())
+    }
+
+    #[test]
+    fn toccata_is_absent_by_default_and_fits_when_enabled() -> Result<()> {
+        assert!(!parse_config("")?.toccata);
+        let cfg = parse_config("[toccata]\nenabled = true\n")?;
+        assert!(cfg.toccata);
         Ok(())
     }
 

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2585,6 +2585,14 @@ pub fn build_machine(
             crate::a2065::A2065::new(net_config.clone())?,
         ));
     }
+    // Toccata sound board (`[toccata] enabled`): AD1848-based, its output
+    // joins the mixer as the "toccata" audio source (see crate::toccata).
+    if cfg.toccata {
+        let slot = devices.len();
+        zorro.add_board(crate::zorro::BoardSpec::toccata(slot))?;
+        info!("toccata: AD1848 sound board on the Zorro chain (slot {slot})");
+        devices.push(crate::zorro_device::BoardDevice::Toccata(Box::default()));
+    }
     // RTG board (`[rtg] card`): the Z3660.card P96 driver drives RTG screens
     // through its register file and framebuffer; see crate::z3660.
     if cfg.rtg == crate::config::RtgCard::Z3660 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub mod smc;
 pub mod timebase;
 pub mod timestamp;
 pub mod timetravel;
+pub mod toccata;
 pub mod video;
 pub mod wasm_manifest;
 #[cfg(feature = "wasm-boards")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1822,14 +1822,17 @@ fn live_audio_enabled(audio_live: bool, forced_on: bool, config_enabled: bool) -
 /// The `--audio-stems` source set for this run: Paula (always present, with
 /// its four physical channels) and drive sounds (always registered --
 /// `[audio] floppy_sounds = false` just means the stem is silent, like a
-/// disabled DriveSounds today), plus CD-DA and MT-32 only when this run's
-/// config plausibly produces them. A source absent here never gets a stem
-/// file at all, even if `--audio-stems-mode` includes `source`/`channel`.
+/// disabled DriveSounds today), plus CD-DA, MT-32, and Toccata only when
+/// this run's config plausibly produces them. A source absent here never
+/// gets a stem file at all, even if `--audio-stems-mode` includes
+/// `source`/`channel`.
 ///
 /// The CD/MT-32 checks are a heuristic, not a perfect "will this run ever
 /// make sound" oracle (e.g. a CD swapped into an empty drive mid-run by
 /// `--insert-cd-after` or the control protocol is missed) -- see
-/// docs/internals/audio.md for the exact rule and its limits.
+/// docs/internals/audio.md for the exact rule and its limits. `toccata` is
+/// exact, not a heuristic: `[toccata] enabled` is the only thing that fits
+/// the board at all.
 fn configured_audio_stem_sources(cfg: &config::Config) -> Vec<copperline::audio::mux::SourceSpec> {
     use copperline::audio::mux::SourceSpec;
     let mut sources = vec![
@@ -1871,6 +1874,12 @@ fn configured_audio_stem_sources(cfg: &config::Config) -> Vec<copperline::audio:
     if has_mt32 {
         sources.push(SourceSpec {
             id: "mt32",
+            channel_names: &[],
+        });
+    }
+    if cfg.toccata {
+        sources.push(SourceSpec {
+            id: "toccata",
             channel_names: &[],
         });
     }

--- a/src/mt32/mod.rs
+++ b/src/mt32/mod.rs
@@ -14,10 +14,10 @@
 //! not Copperline's to ship and so are the user's to supply. Without them the
 //! machine still runs; it simply has nothing on the far end of the cable.
 
+use crate::audio::resample::Resampler;
 use anyhow::{anyhow, Result};
 use std::path::Path;
 
-mod resample;
 pub mod rom;
 mod sink;
 
@@ -57,7 +57,7 @@ pub struct Mt32Synth {
     parser: mt32_rs::midi::Parser,
     /// The rate frames leave at, which is what the mixer asked for.
     sample_rate: u32,
-    resampler: resample::Resampler,
+    resampler: Resampler,
     /// Native frames rendered and not yet resampled, and how far the
     /// resampler has drunk from them.
     native: Vec<(i16, i16)>,
@@ -82,7 +82,7 @@ impl Mt32Synth {
         )
         .map_err(|e| anyhow!("the MT-32 engine refused the ROM pair: {e}"))?;
         Ok(Self {
-            resampler: resample::Resampler::new(engine.output_sample_rate(), sample_rate),
+            resampler: Resampler::new(engine.output_sample_rate(), sample_rate),
             engine,
             parser: mt32_rs::midi::Parser::new(),
             sample_rate,

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -184,7 +184,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //  54: AtaBus's cylinder registers became per-device-slot pairs, so each
 //      slot keeps its own post-reset signature instead of device-select
 //      rewriting a shared pair.
-pub const STATE_VERSION: u32 = 54;
+//  55: BoardDevice gained the Toccata variant (the MacroSystem Toccata
+//      AD1848 sound board, `[toccata]`), appended at the end of the enum.
+pub const STATE_VERSION: u32 = 55;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/toccata.rs
+++ b/src/toccata.rs
@@ -166,6 +166,14 @@ impl ZorroDevice for Toccata {
 
     fn reset(&mut self) {
         self.ad1848.reset();
+        self.mixer_acc = 0;
+        // Each cached resampler's own history buffer holds the last ~64
+        // pre-reset input frames; leaving it in place would let a few
+        // moments of pre-reset audio bleed into the freshly-reset silence
+        // as the kernel window slides past the reset boundary. Clearing
+        // the whole cache is simpler than adding a per-resampler reset
+        // and costs nothing but a one-time kernel-table rebuild next use.
+        self.resamplers.clear();
     }
 
     fn kind(&self) -> &'static str {
@@ -308,6 +316,56 @@ mod tests {
         // close to the raw decoded sample, not zero and not wildly off.
         assert!(l > 0.9, "left sample too quiet: {l}");
         assert!(r > 0.9, "right sample too quiet: {r}");
+    }
+
+    #[test]
+    fn reset_clears_stale_resampler_history_so_silence_follows_immediately() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut cd_audio = crate::chipset::paula::CdAudioRing::default();
+        let mut toccata_audio = crate::chipset::paula::ToccataAudioRing::default();
+        let mut host =
+            DeviceHost::for_slot_with_audio(&mut mem, 0, &mut cd_audio, &mut toccata_audio);
+
+        board.write(0x0000, 1, 0x14, &mut host); // ACTIVE | FIFO_PLAY
+        board.write(0x6001, 1, 8, &mut host);
+        board.write(0x6801, 1, 0x0b, &mut host); // 44100 Hz, mono 8-bit
+        board.write(0x6001, 1, 6, &mut host);
+        board.write(0x6801, 1, 0x00, &mut host); // DAC L/R unmuted, full scale
+        board.write(0x6001, 1, 7, &mut host);
+        board.write(0x6801, 1, 0x00, &mut host);
+
+        // Fill the resampler's ~64-tap history with a loud, constant tone
+        // by feeding one loud sample per output frame for well over a
+        // kernel window's worth of ticks, checking the last one is loud.
+        let mut last = (0.0, 0.0);
+        for _ in 0..100 {
+            board.write(0x2000, 1, 0xff, &mut host);
+            ZorroDevice::tick(&mut board, one_mixer_frame_cck(), &mut host);
+            last = host.toccata_audio().next_sample();
+        }
+        assert!(
+            last.0 > 0.9,
+            "setup didn't actually produce loud audio: {last:?}"
+        );
+
+        board.reset();
+
+        // Reprogram the *same* 44.1 kHz rate reset just cleared, so a
+        // stale cache entry (keyed by rate) would be reused rather than
+        // sidestepped by a rate change. No FIFO write, though: the codec
+        // is otherwise fully disabled, so this tick should produce exact
+        // silence -- not a fading tail of the pre-reset tone leaking
+        // through a resampler whose kernel window still remembers it.
+        board.write(0x6001, 1, 8, &mut host);
+        board.write(0x6801, 1, 0x0b, &mut host);
+        ZorroDevice::tick(&mut board, one_mixer_frame_cck(), &mut host);
+        let sample = host.toccata_audio().next_sample();
+        assert_eq!(
+            sample,
+            (0.0, 0.0),
+            "stale resampler history bled pre-reset audio into post-reset silence"
+        );
     }
 
     #[test]

--- a/src/toccata.rs
+++ b/src/toccata.rs
@@ -6,8 +6,232 @@
 //! own. See `docs/internals/toccata.md`.
 //!
 //! `ad1848` is the register-accurate codec/FIFO core, modelled against
-//! WinUAE/amiberry's `sndboard.cpp` as a behavioural oracle. The board
-//! wrapper (autoconfig, address decode, the Zorro/mixer integration) lands
-//! alongside it in the same milestone.
+//! WinUAE/amiberry's `sndboard.cpp` as a behavioural oracle. This module is
+//! the board wrapper: autoconfig (`BoardSpec::toccata`, `src/zorro.rs`),
+//! address decode within the board's 64 KB Zorro II I/O window, and the
+//! `ZorroDevice` glue. The mixer/audio-ring integration lands in the next
+//! commit; `tick` only paces the codec's auto-calibration timer for now.
 
 pub mod ad1848;
+
+use crate::zorro_device::{DeviceHost, ZorroDevice};
+use ad1848::Ad1848;
+
+/// One of the four port families the board's 64 KB window decodes to, by
+/// address bit pattern (heavily mirrored -- see `decode_port`).
+enum Port {
+    /// base+0x0000: board control/status.
+    Status,
+    /// base+0x2000: the playback (and, later, record) FIFO data port.
+    Fifo,
+    /// base+0x6001 (odd bytes only): AD1848 register index.
+    Ad1848Index,
+    /// base+0x6801 (odd bytes only): AD1848 register data.
+    Ad1848Data,
+}
+
+/// Decode a board-relative offset into one of the four port families, by
+/// the same address-line pattern the reference decodes (A14/A13/A11/A0;
+/// A15, A12, and A10..A1 are don't-cares, so each port mirrors across
+/// several KB of the window). `None` is open bus within the board's own
+/// window -- reads as 0, writes are dropped -- distinct from the chain's
+/// open bus (0xFF) outside any configured board.
+fn decode_port(off: u32) -> Option<Port> {
+    let off = off & 0xffff;
+    let a14 = off & 0x4000 != 0;
+    let a13 = off & 0x2000 != 0;
+    let a11 = off & 0x0800 != 0;
+    let a0 = off & 0x0001 != 0;
+    if !a14 && !a13 && !a11 {
+        Some(Port::Status)
+    } else if !a14 && a13 && !a11 {
+        Some(Port::Fifo)
+    } else if a14 && a13 && !a11 && a0 {
+        Some(Port::Ad1848Index)
+    } else if a14 && a13 && a11 && a0 {
+        Some(Port::Ad1848Data)
+    } else {
+        None
+    }
+}
+
+/// The Toccata board: autoconfig glue and register-window decode around
+/// the chip-only [`Ad1848`] core.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Toccata {
+    ad1848: Ad1848,
+}
+
+impl Toccata {
+    pub fn new() -> Self {
+        Self {
+            ad1848: Ad1848::new(),
+        }
+    }
+
+    fn read_byte(&mut self, off: u32) -> u8 {
+        match decode_port(off) {
+            Some(Port::Status) => self.ad1848.read_status(),
+            Some(Port::Fifo) => self.ad1848.read_fifo_byte(),
+            Some(Port::Ad1848Index) => self.ad1848.read_index(),
+            Some(Port::Ad1848Data) => self.ad1848.read_data(),
+            None => 0,
+        }
+    }
+
+    fn write_byte(&mut self, off: u32, v: u8) {
+        match decode_port(off) {
+            Some(Port::Status) => self.ad1848.write_control(v),
+            Some(Port::Fifo) => self.ad1848.write_fifo_byte(v),
+            Some(Port::Ad1848Index) => self.ad1848.write_index(v),
+            Some(Port::Ad1848Data) => self.ad1848.write_data(v),
+            None => {}
+        }
+    }
+}
+
+impl Default for Toccata {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ZorroDevice for Toccata {
+    fn read(&mut self, off: u32, size: usize, _host: &mut DeviceHost) -> u32 {
+        // The board decomposes any wider access into successive byte
+        // pokes/peeks at the same address, big-endian, exactly as the
+        // 68k bus presents them -- there is no native word/long port.
+        let mut value = 0u32;
+        for i in 0..size as u32 {
+            value = (value << 8) | u32::from(self.read_byte(off + i));
+        }
+        value
+    }
+
+    fn write(&mut self, off: u32, size: usize, value: u32, _host: &mut DeviceHost) {
+        for i in 0..size as u32 {
+            let shift = 8 * (size as u32 - 1 - i);
+            self.write_byte(off + i, (value >> shift) as u8);
+        }
+    }
+
+    fn tick(&mut self, cck: u32, _host: &mut DeviceHost) {
+        self.ad1848.advance_cck(cck);
+    }
+
+    fn int6_line(&self) -> bool {
+        self.ad1848.int6_pending()
+    }
+
+    fn reset(&mut self) {
+        self.ad1848.reset();
+    }
+
+    fn kind(&self) -> &'static str {
+        "toccata"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::Memory;
+
+    fn memory() -> Memory {
+        Memory {
+            chip_ram: vec![0; 0x100],
+            slow_ram: Vec::new(),
+            mb_ram: Vec::new(),
+            accel_ram: Vec::new(),
+            rom: Vec::new(),
+            overlay: false,
+            zorro: crate::zorro::ZorroChain::default(),
+            extended_rom: Vec::new(),
+            extended_rom_base: 0,
+            wcs: Vec::new(),
+            wcs_write_protected: false,
+        }
+    }
+
+    #[test]
+    fn status_port_reaches_the_control_register() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(0x0000, 1, 0x04, &mut host); // STATUS_FIFO_CODEC
+                                                 // The status port is destructive-read (IRQ ack), but with no IRQ
+                                                 // pending it just reports "no interrupt" (bit 7 set).
+        assert_eq!(board.read(0x0000, 1, &mut host), 0x80);
+    }
+
+    #[test]
+    fn status_port_mirrors_across_the_dont_care_address_bits() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        for mirror in [0x0000u32, 0x1000, 0x8000, 0x9000] {
+            board.write(mirror, 1, 0x00, &mut host);
+            assert_eq!(board.read(mirror, 1, &mut host), 0x80, "mirror {mirror:#x}");
+        }
+    }
+
+    #[test]
+    fn fifo_port_reaches_the_play_fifo() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(0x0000, 1, 0x14, &mut host); // ACTIVE | FIFO_PLAY
+        board.write(0x2000, 1, 0x42, &mut host);
+        assert_eq!(board.ad1848.fifo_len_for_test(), 1);
+    }
+
+    #[test]
+    fn ad1848_index_and_data_ports_reach_the_register_file() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(0x6001, 1, 0x06, &mut host); // select DAC output attenuation L
+        board.write(0x6801, 1, 0x00, &mut host); // full volume, unmuted
+        assert_eq!(board.read(0x6001, 1, &mut host), 0x06);
+        assert_eq!(board.read(0x6801, 1, &mut host), 0x00);
+    }
+
+    #[test]
+    fn even_addresses_in_the_ad1848_region_are_open_bus() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(0x6000, 1, 0xff, &mut host); // even: neither index nor data
+        assert_eq!(board.read(0x6000, 1, &mut host), 0);
+    }
+
+    #[test]
+    fn unmapped_region_is_open_bus_within_the_window() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(0x4000, 1, 0xff, &mut host);
+        assert_eq!(board.read(0x4000, 1, &mut host), 0);
+    }
+
+    #[test]
+    fn a_16bit_write_decomposes_into_two_big_endian_fifo_pokes() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(0x0000, 1, 0x14, &mut host); // ACTIVE | FIFO_PLAY
+        board.write(0x2000, 2, 0x1234, &mut host);
+        assert_eq!(board.ad1848.fifo_len_for_test(), 2);
+    }
+
+    #[test]
+    fn reset_clears_the_chip_and_kind_identifies_the_board() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        board.write(0x0000, 1, 0x04, &mut host);
+        board.reset();
+        assert_eq!(board.read(0x0000, 1, &mut host), 0x80);
+        assert_eq!(board.kind(), "toccata");
+    }
+}

--- a/src/toccata.rs
+++ b/src/toccata.rs
@@ -8,14 +8,20 @@
 //! `ad1848` is the register-accurate codec/FIFO core, modelled against
 //! WinUAE/amiberry's `sndboard.cpp` as a behavioural oracle. This module is
 //! the board wrapper: autoconfig (`BoardSpec::toccata`, `src/zorro.rs`),
-//! address decode within the board's 64 KB Zorro II I/O window, and the
-//! `ZorroDevice` glue. The mixer/audio-ring integration lands in the next
-//! commit; `tick` only paces the codec's auto-calibration timer for now.
+//! address decode within the board's 64 KB Zorro II I/O window, the
+//! `ZorroDevice` glue, and the mixer cadence -- resampling the codec's own
+//! programmed rate to the mixer's fixed rate and pushing frames into
+//! Paula's `ToccataAudioRing`. See `docs/internals/audio.md` for how that
+//! ring fits into the wider mixer/stem-capture picture.
 
 pub mod ad1848;
 
+use crate::audio::resample::Resampler;
+use crate::audio::MIX_SAMPLE_RATE;
+use crate::chipset::paula::PAULA_CLOCK_HZ;
 use crate::zorro_device::{DeviceHost, ZorroDevice};
 use ad1848::Ad1848;
+use std::collections::HashMap;
 
 /// One of the four port families the board's 64 KB window decodes to, by
 /// address bit pattern (heavily mirrored -- see `decode_port`).
@@ -56,16 +62,50 @@ fn decode_port(off: u32) -> Option<Port> {
 }
 
 /// The Toccata board: autoconfig glue and register-window decode around
-/// the chip-only [`Ad1848`] core.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+/// the chip-only [`Ad1848`] core, plus the mixer-rate cadence.
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct Toccata {
     ad1848: Ad1848,
+    /// Mixer-rate accumulator, in units of colour-clocks * MIX_SAMPLE_RATE
+    /// -- the exact same accumulator shape `Paula::advance_audio` uses.
+    /// One output frame is due each time this reaches PAULA_CLOCK_HZ.
+    mixer_acc: u64,
+    /// One resampler per codec rate this session has used (at most 14, the
+    /// AD1848's legal rate count), so switching back to an already-seen
+    /// rate never rebuilds its kernel table. Purely a host-side cache, not
+    /// machine state -- rebuilt lazily after a savestate load.
+    #[serde(skip)]
+    resamplers: HashMap<u32, Resampler>,
 }
 
 impl Toccata {
     pub fn new() -> Self {
         Self {
             ad1848: Ad1848::new(),
+            mixer_acc: 0,
+            resamplers: HashMap::new(),
+        }
+    }
+
+    /// Advance the mixer-rate cadence by `cck` colour clocks, resampling
+    /// the codec's own programmed rate onto the mixer grid and pushing
+    /// each produced frame into `ring`. Exact-ratio accumulator, so it
+    /// never drifts against `Paula::advance_audio`'s own.
+    fn advance_mixer(&mut self, cck: u32, ring: &mut crate::chipset::paula::ToccataAudioRing) {
+        self.mixer_acc += u64::from(cck) * u64::from(MIX_SAMPLE_RATE);
+        while self.mixer_acc >= u64::from(PAULA_CLOCK_HZ) {
+            self.mixer_acc -= u64::from(PAULA_CLOCK_HZ);
+            // Disjoint field borrows: the resampler cache and the chip it
+            // pulls from via the refill closure below.
+            let Self {
+                ad1848, resamplers, ..
+            } = self;
+            let rate = ad1848.sample_rate_hz();
+            let resampler = resamplers
+                .entry(rate)
+                .or_insert_with(|| Resampler::new(rate, MIX_SAMPLE_RATE));
+            let (left, right) = resampler.next(|| ad1848.produce_one_sample());
+            ring.push_frame(left, right);
         }
     }
 
@@ -115,8 +155,9 @@ impl ZorroDevice for Toccata {
         }
     }
 
-    fn tick(&mut self, cck: u32, _host: &mut DeviceHost) {
+    fn tick(&mut self, cck: u32, host: &mut DeviceHost) {
         self.ad1848.advance_cck(cck);
+        self.advance_mixer(cck, host.toccata_audio());
     }
 
     fn int6_line(&self) -> bool {
@@ -233,5 +274,58 @@ mod tests {
         board.reset();
         assert_eq!(board.read(0x0000, 1, &mut host), 0x80);
         assert_eq!(board.kind(), "toccata");
+    }
+
+    /// Colour clocks needed to cross one mixer-rate (44.1 kHz) frame
+    /// boundary from a zero accumulator: `ceil(PAULA_CLOCK_HZ / MIX_SAMPLE_RATE)`.
+    fn one_mixer_frame_cck() -> u32 {
+        PAULA_CLOCK_HZ.div_ceil(MIX_SAMPLE_RATE)
+    }
+
+    #[test]
+    fn tick_at_the_mixer_native_rate_reaches_the_ring_as_a_near_pass_through() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut cd_audio = crate::chipset::paula::CdAudioRing::default();
+        let mut toccata_audio = crate::chipset::paula::ToccataAudioRing::default();
+        let mut host =
+            DeviceHost::for_slot_with_audio(&mut mem, 0, &mut cd_audio, &mut toccata_audio);
+
+        board.write(0x0000, 1, 0x14, &mut host); // ACTIVE | FIFO_PLAY
+        board.write(0x6001, 1, 8, &mut host);
+        board.write(0x6801, 1, 0x0b, &mut host); // divider idx 5, crystal1 -> 44100 Hz, mono 8-bit
+        board.write(0x6001, 1, 6, &mut host);
+        board.write(0x6801, 1, 0x00, &mut host); // DAC L unmuted, full scale
+        board.write(0x6001, 1, 7, &mut host);
+        board.write(0x6801, 1, 0x00, &mut host); // DAC R unmuted, full scale
+        board.write(0x2000, 1, 0xff, &mut host); // one 8-bit sample: (255-128)/128
+
+        ZorroDevice::tick(&mut board, one_mixer_frame_cck(), &mut host);
+
+        let (l, r) = toccata_audio.next_sample();
+        // 44100 Hz codec into a 44100 Hz mixer is an identity resample
+        // (l=m=1 in the polyphase ratio), so the frame should be very
+        // close to the raw decoded sample, not zero and not wildly off.
+        assert!(l > 0.9, "left sample too quiet: {l}");
+        assert!(r > 0.9, "right sample too quiet: {r}");
+    }
+
+    #[test]
+    fn tick_advances_the_autocalibration_countdown() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut cd_audio = crate::chipset::paula::CdAudioRing::default();
+        let mut toccata_audio = crate::chipset::paula::ToccataAudioRing::default();
+        let mut host =
+            DeviceHost::for_slot_with_audio(&mut mem, 0, &mut cd_audio, &mut toccata_audio);
+
+        board.write(0x6001, 1, 9, &mut host);
+        board.write(0x6801, 1, 0x08, &mut host); // request calibration only
+        board.write(0x6001, 1, 11, &mut host);
+        assert_eq!(board.read(0x6801, 1, &mut host) & 0x20, 0); // not yet busy
+
+        ZorroDevice::tick(&mut board, 227 * 25, &mut host);
+
+        assert_ne!(board.read(0x6801, 1, &mut host) & 0x20, 0); // busy window
     }
 }

--- a/src/toccata.rs
+++ b/src/toccata.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! MacroSystem Toccata: a Zorro II AD1848 sound board with a stock,
+//! open-source AHI driver (`toccata.audio`), so AHI-aware Amiga software
+//! gets 16-bit sound with no board-specific driver work of Copperline's
+//! own. See `docs/internals/toccata.md`.
+//!
+//! `ad1848` is the register-accurate codec/FIFO core, modelled against
+//! WinUAE/amiberry's `sndboard.cpp` as a behavioural oracle. The board
+//! wrapper (autoconfig, address decode, the Zorro/mixer integration) lands
+//! alongside it in the same milestone.
+
+pub mod ad1848;

--- a/src/toccata.rs
+++ b/src/toccata.rs
@@ -21,7 +21,13 @@ use crate::audio::MIX_SAMPLE_RATE;
 use crate::chipset::paula::PAULA_CLOCK_HZ;
 use crate::zorro_device::{DeviceHost, ZorroDevice};
 use ad1848::Ad1848;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+
+/// A generous safety margin on the pre-resample sample queue between the
+/// codec's own cadence and the mixer's -- the two stay near-lockstep in
+/// steady state (see `advance_codec`'s doc comment), so this is a cap
+/// against a stalled consumer, not a buffering requirement.
+const DECODED_CAPACITY: usize = 4096;
 
 /// One of the four port families the board's 64 KB window decodes to, by
 /// address bit pattern (heavily mirrored -- see `decode_port`).
@@ -62,19 +68,38 @@ fn decode_port(off: u32) -> Option<Port> {
 }
 
 /// The Toccata board: autoconfig glue and register-window decode around
-/// the chip-only [`Ad1848`] core, plus the mixer-rate cadence.
+/// the chip-only [`Ad1848`] core, plus two independent emulated-time
+/// cadences -- see `advance_codec`/`advance_mixer`.
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Toccata {
     ad1848: Ad1848,
+    /// Codec-rate accumulator, in units of colour-clocks * (the codec's
+    /// own active sample rate). One raw sample is due each time this
+    /// reaches PAULA_CLOCK_HZ -- see `advance_codec`. Genuine machine
+    /// state: it (indirectly, through when `produce_one_sample` gets
+    /// called) determines exactly when the FIFO drains and interrupts
+    /// raise, so it must survive a save-state load unchanged.
+    codec_acc: u64,
+    /// Raw, pre-resample samples `advance_codec` has produced and
+    /// `advance_mixer` hasn't consumed yet. Also genuine machine state,
+    /// for the same reason as `codec_acc` -- see `advance_codec`'s doc
+    /// comment for why this exists at all rather than the mixer pulling
+    /// straight from the chip.
+    decoded: VecDeque<(f32, f32)>,
     /// Mixer-rate accumulator, in units of colour-clocks * MIX_SAMPLE_RATE
     /// -- the exact same accumulator shape `Paula::advance_audio` uses.
     /// One output frame is due each time this reaches PAULA_CLOCK_HZ.
     mixer_acc: u64,
     /// One resampler per codec rate this session has used (at most 14, the
     /// AD1848's legal rate count), so switching back to an already-seen
-    /// rate never rebuilds its kernel table. Purely a host-side cache, not
-    /// machine state -- rebuilt lazily after a savestate load.
-    #[serde(skip)]
+    /// rate never rebuilds its kernel table. After the codec/mixer cadence
+    /// split above, a resampler's phase/history only shape the
+    /// interpolated *waveform*, never FIFO/IRQ timing -- but they are
+    /// still genuine machine state for output-exactness purposes, so this
+    /// serializes (via `Resampler`'s own `Serialize`/`Deserialize`, which
+    /// rebuilds the derived kernel table rather than storing it) instead
+    /// of being `#[serde(skip)]`: a save-state load must reproduce an
+    /// uninterrupted run's output exactly, not just its FIFO/IRQ timing.
     resamplers: HashMap<u32, Resampler>,
 }
 
@@ -82,29 +107,75 @@ impl Toccata {
     pub fn new() -> Self {
         Self {
             ad1848: Ad1848::new(),
+            codec_acc: 0,
+            decoded: VecDeque::new(),
             mixer_acc: 0,
             resamplers: HashMap::new(),
         }
     }
 
+    /// Advance the codec's own native-rate cadence by `cck` colour
+    /// clocks, producing raw (pre-resample) samples into `decoded`. This
+    /// -- not the resampler below -- is what actually drains the FIFO and
+    /// evaluates the half-empty/interrupt condition, paced causally by
+    /// emulated time via its own exact-ratio accumulator (the same shape
+    /// as `Paula::advance_audio`'s, just at the codec's rate instead of
+    /// the mixer's).
+    ///
+    /// This exists as a separate step from `advance_mixer` specifically
+    /// so `produce_one_sample`'s side effects are never invoked from
+    /// inside the resampler's own pull: a windowed-sinc kernel is
+    /// inherently non-causal (it needs taps on *both* sides of the output
+    /// instant, and primes by pulling a full window's worth of input
+    /// before its first output), so if it called `produce_one_sample`
+    /// directly, its first use after startup or a rate change would drain
+    /// dozens of FIFO bytes and raise interrupts all at once, decades
+    /// ahead of when a real codec would reach them. Producing samples
+    /// here first, in true chronological order, and letting the resampler
+    /// only ever pull from the resulting passive queue (or repeat the
+    /// chip's last known sample with no side effects, see
+    /// `advance_mixer`) keeps that lookahead confined to the waveform,
+    /// where it belongs.
+    fn advance_codec(&mut self, cck: u32) {
+        if !self.ad1848.play_active() {
+            return;
+        }
+        let rate = self.ad1848.sample_rate_hz();
+        self.codec_acc += u64::from(cck) * u64::from(rate);
+        while self.codec_acc >= u64::from(PAULA_CLOCK_HZ) {
+            self.codec_acc -= u64::from(PAULA_CLOCK_HZ);
+            let sample = self.ad1848.produce_one_sample();
+            if self.decoded.len() < DECODED_CAPACITY {
+                self.decoded.push_back(sample);
+            }
+        }
+    }
+
     /// Advance the mixer-rate cadence by `cck` colour clocks, resampling
-    /// the codec's own programmed rate onto the mixer grid and pushing
+    /// already-produced codec samples onto the mixer grid and pushing
     /// each produced frame into `ring`. Exact-ratio accumulator, so it
-    /// never drifts against `Paula::advance_audio`'s own.
+    /// never drifts against `Paula::advance_audio`'s own. Pulls only from
+    /// `decoded` (or repeats the chip's last known sample via the
+    /// side-effect-free `peek_last_sample`) -- never calls back into
+    /// `ad1848.produce_one_sample` directly, so the resampler's own
+    /// lookahead/priming can never advance FIFO/IRQ state out of order.
     fn advance_mixer(&mut self, cck: u32, ring: &mut crate::chipset::paula::ToccataAudioRing) {
         self.mixer_acc += u64::from(cck) * u64::from(MIX_SAMPLE_RATE);
         while self.mixer_acc >= u64::from(PAULA_CLOCK_HZ) {
             self.mixer_acc -= u64::from(PAULA_CLOCK_HZ);
-            // Disjoint field borrows: the resampler cache and the chip it
-            // pulls from via the refill closure below.
+            let rate = self.ad1848.sample_rate_hz();
+            let fallback = self.ad1848.peek_last_sample();
+            // Disjoint field borrows: the resampler cache and the passive
+            // decoded-sample queue it pulls from via the refill closure.
             let Self {
-                ad1848, resamplers, ..
+                decoded,
+                resamplers,
+                ..
             } = self;
-            let rate = ad1848.sample_rate_hz();
             let resampler = resamplers
                 .entry(rate)
                 .or_insert_with(|| Resampler::new(rate, MIX_SAMPLE_RATE));
-            let (left, right) = resampler.next(|| ad1848.produce_one_sample());
+            let (left, right) = resampler.next(|| decoded.pop_front().unwrap_or(fallback));
             ring.push_frame(left, right);
         }
     }
@@ -157,6 +228,7 @@ impl ZorroDevice for Toccata {
 
     fn tick(&mut self, cck: u32, host: &mut DeviceHost) {
         self.ad1848.advance_cck(cck);
+        self.advance_codec(cck);
         self.advance_mixer(cck, host.toccata_audio());
     }
 
@@ -166,6 +238,8 @@ impl ZorroDevice for Toccata {
 
     fn reset(&mut self) {
         self.ad1848.reset();
+        self.codec_acc = 0;
+        self.decoded.clear();
         self.mixer_acc = 0;
         // Each cached resampler's own history buffer holds the last ~64
         // pre-reset input frames; leaving it in place would let a few
@@ -284,10 +358,91 @@ mod tests {
         assert_eq!(board.kind(), "toccata");
     }
 
+    #[test]
+    fn savestate_round_trip_reproduces_an_uninterrupted_runs_output() {
+        // The determinism-critical claim: a state saved and reloaded
+        // mid-stream must produce exactly the frames an uninterrupted run
+        // would have -- both the resampler (its phase/history now
+        // genuine serialized state) and codec_acc/decoded (which pace
+        // produce_one_sample()) must round-trip exactly.
+        let mut mem = memory();
+        let mut cd_audio = crate::chipset::paula::CdAudioRing::default();
+        let mut toccata_audio = crate::chipset::paula::ToccataAudioRing::default();
+        let mut host =
+            DeviceHost::for_slot_with_audio(&mut mem, 0, &mut cd_audio, &mut toccata_audio);
+
+        let mut board = Toccata::new();
+        board.write(0x0000, 1, 0x14, &mut host); // ACTIVE | FIFO_PLAY
+        board.write(0x6001, 1, 8, &mut host);
+        board.write(0x6801, 1, 0x0b, &mut host); // 44100 Hz, mono 8-bit
+        latch_format(&mut board, &mut host);
+        board.write(0x6001, 1, 6, &mut host);
+        board.write(0x6801, 1, 0x00, &mut host);
+        board.write(0x6001, 1, 7, &mut host);
+        board.write(0x6801, 1, 0x00, &mut host);
+        for byte in [0x40, 0x80, 0xc0, 0xff, 0x20] {
+            board.write(0x2000, 1, byte, &mut host);
+        }
+        // Advance partway -- not a whole number of mixer frames, so both
+        // codec_acc and mixer_acc are left with genuine mid-accumulation
+        // remainders, not conveniently zeroed.
+        ZorroDevice::tick(&mut board, 137, &mut host);
+
+        let bytes = bincode::serialize(&board).unwrap();
+        let mut resumed: Toccata = bincode::deserialize(&bytes).unwrap();
+
+        // Continue both from here with identical further input and
+        // compare every produced frame.
+        let mut mem_a = memory();
+        let mut cd_a = crate::chipset::paula::CdAudioRing::default();
+        let mut ring_a = crate::chipset::paula::ToccataAudioRing::default();
+        let mut host_a = DeviceHost::for_slot_with_audio(&mut mem_a, 0, &mut cd_a, &mut ring_a);
+        let mut mem_b = memory();
+        let mut cd_b = crate::chipset::paula::CdAudioRing::default();
+        let mut ring_b = crate::chipset::paula::ToccataAudioRing::default();
+        let mut host_b = DeviceHost::for_slot_with_audio(&mut mem_b, 0, &mut cd_b, &mut ring_b);
+
+        for byte in [0x30, 0x90, 0x10, 0xe0] {
+            board.write(0x2000, 1, byte, &mut host_a);
+            resumed.write(0x2000, 1, byte, &mut host_b);
+        }
+        for _ in 0..500 {
+            ZorroDevice::tick(&mut board, 61, &mut host_a);
+            ZorroDevice::tick(&mut resumed, 61, &mut host_b);
+        }
+
+        // 500 ticks of 61 cck each is ~379 mixer frames at 44.1 kHz;
+        // draining well past that is safe since extra reads past the end
+        // just yield the ring's own matching (0.0, 0.0) "empty" fallback
+        // on both sides.
+        let frames_a: Vec<_> = (0..700).map(|_| ring_a.next_sample()).collect();
+        let frames_b: Vec<_> = (0..700).map(|_| ring_b.next_sample()).collect();
+        assert!(
+            frames_a.iter().any(|&f| f != (0.0, 0.0)),
+            "the setup should have produced audio"
+        );
+        assert_eq!(
+            frames_a, frames_b,
+            "a state resumed mid-stream must reproduce an uninterrupted run's output exactly"
+        );
+    }
+
     /// Colour clocks needed to cross one mixer-rate (44.1 kHz) frame
     /// boundary from a zero accumulator: `ceil(PAULA_CLOCK_HZ / MIX_SAMPLE_RATE)`.
     fn one_mixer_frame_cck() -> u32 {
         PAULA_CLOCK_HZ.div_ceil(MIX_SAMPLE_RATE)
+    }
+
+    /// Latch whatever format/rate is currently programmed in reg 8 by
+    /// driving reg 9 through a clean stopped-to-started transition, the
+    /// way a real driver does: program the format, then enable playback.
+    /// `advance_codec` only runs while the codec is active, and it only
+    /// ever uses the format/rate latched at the last such transition --
+    /// see `Ad1848::codec_start`'s doc comment.
+    fn latch_format(board: &mut Toccata, host: &mut DeviceHost) {
+        board.write(0x6001, 1, 9, host);
+        board.write(0x6801, 1, 0x10, host); // stop (SDC bit only)
+        board.write(0x6801, 1, 0x11, host); // play enable: rising edge
     }
 
     #[test]
@@ -302,6 +457,7 @@ mod tests {
         board.write(0x0000, 1, 0x14, &mut host); // ACTIVE | FIFO_PLAY
         board.write(0x6001, 1, 8, &mut host);
         board.write(0x6801, 1, 0x0b, &mut host); // divider idx 5, crystal1 -> 44100 Hz, mono 8-bit
+        latch_format(&mut board, &mut host);
         board.write(0x6001, 1, 6, &mut host);
         board.write(0x6801, 1, 0x00, &mut host); // DAC L unmuted, full scale
         board.write(0x6001, 1, 7, &mut host);
@@ -319,6 +475,72 @@ mod tests {
     }
 
     #[test]
+    fn advance_codec_does_not_drain_the_fifo_before_its_own_cadence_elapses() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut cd_audio = crate::chipset::paula::CdAudioRing::default();
+        let mut toccata_audio = crate::chipset::paula::ToccataAudioRing::default();
+        let mut host =
+            DeviceHost::for_slot_with_audio(&mut mem, 0, &mut cd_audio, &mut toccata_audio);
+
+        board.write(0x0000, 1, 0x14, &mut host); // ACTIVE | FIFO_PLAY
+        board.write(0x6001, 1, 8, &mut host);
+        board.write(0x6801, 1, 0x0f, &mut host); // divider idx 7, crystal1 -> 6600 Hz, mono 8-bit
+        latch_format(&mut board, &mut host);
+        for _ in 0..10 {
+            board.write(0x2000, 1, 0x80, &mut host);
+        }
+        assert_eq!(board.ad1848.fifo_len_for_test(), 10);
+
+        // One colour clock is nowhere near a 6.6 kHz sample period (about
+        // 537 cck), so the FIFO must be completely untouched -- not
+        // drained by a resampler's ~64-tap priming burst pulling
+        // produce_one_sample() directly and far ahead of emulated time.
+        // (Regression test for the earlier design, where the resampler's
+        // refill closure called produce_one_sample() itself.)
+        ZorroDevice::tick(&mut board, 1, &mut host);
+        assert_eq!(
+            board.ad1848.fifo_len_for_test(),
+            10,
+            "the FIFO must only drain as the codec's own cadence elapses, never all at once"
+        );
+    }
+
+    #[test]
+    fn reprogramming_reg8_while_active_does_not_change_the_active_frame_width() {
+        let mut board = Toccata::new();
+        let mut mem = memory();
+        let mut cd_audio = crate::chipset::paula::CdAudioRing::default();
+        let mut toccata_audio = crate::chipset::paula::ToccataAudioRing::default();
+        let mut host =
+            DeviceHost::for_slot_with_audio(&mut mem, 0, &mut cd_audio, &mut toccata_audio);
+
+        board.write(0x0000, 1, 0x14, &mut host); // ACTIVE | FIFO_PLAY
+        board.write(0x6001, 1, 8, &mut host);
+        board.write(0x6801, 1, 0x0b, &mut host); // 44100 Hz, mono 8-bit
+        latch_format(&mut board, &mut host);
+
+        // Reprogram to stereo 16-bit (4 bytes/sample) *without* a
+        // stop/start transition -- the reference only re-runs its own
+        // codec_setup() on that transition, so this must have no effect
+        // on the still-running stream.
+        board.write(0x6001, 1, 8, &mut host);
+        board.write(0x6801, 1, 0x5b, &mut host); // stereo + 16-bit, same rate bits
+
+        // One byte matches the still-active mono-8-bit frame width (1
+        // byte), not the newly-written-but-unlatched stereo/16-bit width
+        // (4 bytes) -- so it must be consumed as a complete frame.
+        board.write(0x2000, 1, 0xff, &mut host);
+        ZorroDevice::tick(&mut board, one_mixer_frame_cck(), &mut host);
+        assert_eq!(
+            board.ad1848.fifo_len_for_test(),
+            0,
+            "the still-active mono 8-bit format should consume the single byte, \
+             not wait for a 4-byte stereo/16-bit frame the unlatched reg8 write implies"
+        );
+    }
+
+    #[test]
     fn reset_clears_stale_resampler_history_so_silence_follows_immediately() {
         let mut board = Toccata::new();
         let mut mem = memory();
@@ -330,6 +552,7 @@ mod tests {
         board.write(0x0000, 1, 0x14, &mut host); // ACTIVE | FIFO_PLAY
         board.write(0x6001, 1, 8, &mut host);
         board.write(0x6801, 1, 0x0b, &mut host); // 44100 Hz, mono 8-bit
+        latch_format(&mut board, &mut host);
         board.write(0x6001, 1, 6, &mut host);
         board.write(0x6801, 1, 0x00, &mut host); // DAC L/R unmuted, full scale
         board.write(0x6001, 1, 7, &mut host);
@@ -351,14 +574,16 @@ mod tests {
 
         board.reset();
 
-        // Reprogram the *same* 44.1 kHz rate reset just cleared, so a
-        // stale cache entry (keyed by rate) would be reused rather than
-        // sidestepped by a rate change. No FIFO write, though: the codec
-        // is otherwise fully disabled, so this tick should produce exact
-        // silence -- not a fading tail of the pre-reset tone leaking
-        // through a resampler whose kernel window still remembers it.
+        // Reprogram the *same* 44.1 kHz rate reset just cleared and
+        // re-latch it, so a stale cache entry (keyed by rate) would be
+        // reused rather than sidestepped by a rate change -- but feed no
+        // FIFO data, so the freshly reset (silent) codec is the only
+        // thing driving output. This tick should produce exact silence --
+        // not a fading tail of the pre-reset tone leaking through a
+        // resampler whose kernel window still remembers it.
         board.write(0x6001, 1, 8, &mut host);
         board.write(0x6801, 1, 0x0b, &mut host);
+        latch_format(&mut board, &mut host);
         ZorroDevice::tick(&mut board, one_mixer_frame_cck(), &mut host);
         let sample = host.toccata_audio().next_sample();
         assert_eq!(

--- a/src/toccata/ad1848.rs
+++ b/src/toccata/ad1848.rs
@@ -139,6 +139,14 @@ impl Ad1848 {
         *self = Self::new();
     }
 
+    /// The play FIFO's current byte count, for the board wrapper's own
+    /// address-decode tests (`src/toccata.rs`) -- not otherwise exposed,
+    /// since nothing outside this chip needs to know FIFO occupancy.
+    #[cfg(test)]
+    pub(crate) fn fifo_len_for_test(&self) -> usize {
+        self.fifo.len()
+    }
+
     // -----------------------------------------------------------------
     // AD1848 index/data ports (base+0x6001 / base+0x6801)
     // -----------------------------------------------------------------

--- a/src/toccata/ad1848.rs
+++ b/src/toccata/ad1848.rs
@@ -1,0 +1,672 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! AD1848 codec core, as wired into the MacroSystem Toccata.
+//!
+//! This is the self-contained chip model used by the Toccata board
+//! (`src/toccata.rs`): the AD1848's indexed register file, the board's
+//! 1024-byte playback FIFO, the board's own status/control register, and
+//! the interrupt condition it feeds. It has no Zorro/bus coupling -- the
+//! board wrapper owns address decode and autoconfig; this module owns only
+//! register semantics.
+//!
+//! Modelled against WinUAE/amiberry's `sndboard.cpp` (identical in both
+//! trees) as a behavioural oracle, not as a code source. The reference
+//! reflects real board revisions with a wrong crystal soldered on some
+//! units and MacroSystem's own reg-12 pinning that locks the codec out of
+//! the CS4231 extensions -- see the field comments below for the specific
+//! quirks preserved on purpose, not fixed as if they were bugs.
+//!
+//! Record is not implemented (that's M4): the record FIFO, the record
+//! interrupt bit, and record-side register semantics exist as stubs that
+//! never activate, since nothing ever sets `STATUS_FIFO_RECORD`.
+
+use std::collections::VecDeque;
+
+/// Board-space FIFO capacity in bytes (the IDT7202LA on the real board).
+const FIFO_CAPACITY: usize = 1024;
+/// Half-full/half-empty threshold, in bytes.
+const FIFO_HALF: usize = FIFO_CAPACITY / 2;
+
+/// Board control/status register bits (base+0x0000).
+const STATUS_ACTIVE: u8 = 0x01;
+const STATUS_RESET: u8 = 0x02;
+const STATUS_FIFO_CODEC: u8 = 0x04;
+const STATUS_FIFO_RECORD: u8 = 0x08;
+const STATUS_FIFO_PLAY: u8 = 0x10;
+const STATUS_RECORD_INTENA: u8 = 0x40;
+const STATUS_PLAY_INTENA: u8 = 0x80;
+/// Status-read bit 7: 1 = no interrupt pending (active low).
+const STATUS_READ_INTREQ: u8 = 0x80;
+/// Pending-IRQ bits, reused from the same bit numbers as the FIFO enables
+/// above -- this is how the reference names them too, not a collision.
+const STATUS_READ_PLAY_HALF: u8 = 0x08;
+const STATUS_READ_RECORD_HALF: u8 = 0x04;
+
+/// AD1848 rate-generator crystals (Hz). Both exist on real boards: some
+/// units have the datasheet-specified 24.576 MHz part, some have a
+/// 16.9344 MHz part that was apparently swapped in at the factory. Real
+/// hardware only ever has one; the codec doesn't know or care which --
+/// only the selected divider matters for the rate it produces.
+const CRYSTALS: [u32; 2] = [24_576_000, 16_934_400];
+/// Divider select, reg 8 bits 1-3.
+const DIVIDERS: [u32; 8] = [3072, 1536, 896, 768, 448, 384, 512, 2560];
+
+/// Coarse "one hsync line" period in colour clocks, used only to pace the
+/// auto-calibration busy window (ACI). Not video-standard-exact -- the
+/// window is ~20 lines wide and nothing reads it more precisely than
+/// "busy" or "not busy".
+const HSYNC_CCK: u32 = 227;
+
+/// AD1848 register file, FIFO, and board control/status state.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Ad1848 {
+    /// Indexed registers 0-15 (indices 16-31 are the CS4231 extension,
+    /// unreachable here since reg 12 is pinned to plain-AD1848 mode).
+    regs: [u8; 16],
+    /// The raw byte last written to the index port. Only its low nibble
+    /// selects a register; the rest is stored but not modelled (MCE/TRD/
+    /// INIT are not used by this board).
+    index: u8,
+    /// Board control/status (base+0x0000 write).
+    status: u8,
+    /// Pending, acknowledged-on-status-read interrupt bits.
+    irq: u8,
+    /// Edge-latched half-empty(play)/half-full(record) flags, cleared by
+    /// FIFO port access rather than by the status-read acknowledge.
+    fifo_half: u8,
+    /// Which directions the codec has actually started (set by reg 9's
+    /// enable bits, cleared wholesale by `codec_stop`).
+    active: u8,
+    /// Playback FIFO bytes, oldest first.
+    fifo: VecDeque<u8>,
+    /// The FIFO's length before the most recent drain, so the half-empty
+    /// edge (crossing below `FIFO_HALF`) can be detected.
+    fifo_len_before_drain: usize,
+    /// The last decoded output sample, held across an underrun (real
+    /// silicon repeats rather than snapping to zero).
+    last_sample: (f32, f32),
+    /// Countdown from 50 to 0, decremented roughly once per scanline once
+    /// reg 9 bit 3 requests calibration. ACI (reg 11 bit 5) reads busy
+    /// while `10 < autocal < 30`.
+    autocal: u32,
+    hsync_acc: u32,
+    /// Left/right DAC output attenuation, recomputed from regs 6/7
+    /// whenever they (or any of 2-7) are written.
+    left_volume: f32,
+    right_volume: f32,
+}
+
+impl Default for Ad1848 {
+    fn default() -> Self {
+        let mut regs = [0u8; 16];
+        // Aux1/Aux2 inputs and the DAC output start muted (bit 7 set);
+        // reg 9's power-on interface config is SDC (single DMA channel,
+        // bit 4); reg 12 is pinned to 0x0A on this board from power-on.
+        regs[2] = 0x80;
+        regs[3] = 0x80;
+        regs[4] = 0x80;
+        regs[5] = 0x80;
+        regs[6] = 0x80;
+        regs[7] = 0x80;
+        regs[9] = 0x10;
+        regs[12] = 0x0a;
+        Self {
+            regs,
+            index: 0x40,
+            status: 0,
+            irq: 0,
+            fifo_half: 0,
+            active: 0,
+            fifo: VecDeque::with_capacity(FIFO_CAPACITY),
+            fifo_len_before_drain: 0,
+            last_sample: (0.0, 0.0),
+            autocal: 0,
+            hsync_acc: 0,
+            left_volume: 0.0,
+            right_volume: 0.0,
+        }
+    }
+}
+
+impl Ad1848 {
+    pub fn new() -> Self {
+        let mut chip = Self::default();
+        chip.recalc_volume();
+        chip
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::new();
+    }
+
+    // -----------------------------------------------------------------
+    // AD1848 index/data ports (base+0x6001 / base+0x6801)
+    // -----------------------------------------------------------------
+
+    pub fn write_index(&mut self, v: u8) {
+        self.index = v;
+    }
+
+    pub fn read_index(&self) -> u8 {
+        self.index
+    }
+
+    /// Only the low 4 bits ever select a register on this board: reg 12
+    /// is pinned to plain-AD1848 mode, so the CS4231 index-mask-31
+    /// extension (indices 16-31) is never reachable.
+    fn effective_index(&self) -> usize {
+        usize::from(self.index & 0x0f)
+    }
+
+    pub fn write_data(&mut self, v: u8) {
+        let idx = self.effective_index();
+        match idx {
+            8 => {
+                // The format-extension bit (0x80, CS4231 big-endian mode)
+                // is meaningless with reg 12 pinned off this board, so it
+                // is forced clear before storing -- matching the
+                // reference rather than leaving stray state a driver
+                // could misread back.
+                self.regs[8] = v & !0x80;
+            }
+            9 => self.write_reg9(v),
+            12 => self.regs[12] = 0x0a, // hardwired regardless of what's written
+            2..=7 => {
+                self.regs[idx] = v;
+                self.recalc_volume();
+            }
+            _ => self.regs[idx] = v,
+        }
+    }
+
+    pub fn read_data(&self) -> u8 {
+        let idx = self.effective_index();
+        if idx == 11 {
+            let busy = self.autocal > 10 && self.autocal < 30;
+            if busy {
+                self.regs[11] | 0x20
+            } else {
+                self.regs[11] & !0x20
+            }
+        } else {
+            self.regs[idx]
+        }
+    }
+
+    fn write_reg9(&mut self, v: u8) {
+        let old = self.regs[9];
+        if v & 0x08 != 0 {
+            self.autocal = 50;
+        }
+        if old & 0x03 == 0 && v & 0x03 != 0 {
+            self.codec_start();
+        } else if old & 0x03 != 0 && v & 0x03 == 0 {
+            self.codec_stop();
+        }
+        if v & 0x01 != 0 {
+            self.active |= STATUS_FIFO_PLAY;
+        }
+        if v & 0x02 != 0 {
+            self.active |= STATUS_FIFO_RECORD;
+        }
+        self.regs[9] = v;
+    }
+
+    fn codec_start(&mut self) {
+        // Format/rate take effect from here; a driver programs reg 8
+        // before enabling the codec via reg 9, matching hardware.
+    }
+
+    fn codec_stop(&mut self) {
+        self.active = 0;
+    }
+
+    // -----------------------------------------------------------------
+    // Board control/status (base+0x0000)
+    // -----------------------------------------------------------------
+
+    pub fn write_control(&mut self, v: u8) {
+        let mut v = v;
+        if v & STATUS_RESET != 0 {
+            self.codec_stop();
+            self.status = 0;
+            self.irq = 0;
+            v = 0;
+        }
+        // The FIFO-flush idiom is a write of *exactly* 0x01 -- not
+        // "ACTIVE plus anything else" -- so it only ever fires from this
+        // specific byte value, matching the reference precisely.
+        if v == STATUS_ACTIVE {
+            self.fifo.clear();
+            self.fifo_len_before_drain = 0;
+            self.status = 0;
+            self.irq = 0;
+            self.fifo_half = 0;
+        }
+        self.status = v;
+    }
+
+    /// Reading status acknowledges every pending interrupt bit.
+    pub fn read_status(&mut self) -> u8 {
+        let mut v = STATUS_READ_INTREQ;
+        if self.irq != 0 {
+            v &= !STATUS_READ_INTREQ;
+            v |= self.irq;
+            self.irq = 0;
+        }
+        v
+    }
+
+    pub fn int6_pending(&self) -> bool {
+        self.irq != 0
+    }
+
+    // -----------------------------------------------------------------
+    // FIFO port (base+0x2000)
+    // -----------------------------------------------------------------
+
+    /// One byte pushed into the play FIFO. The board decomposes word/long
+    /// writes into successive byte pokes at this same port (big-endian
+    /// order), so a 16-bit sample write already arrives here one byte at
+    /// a time -- callers do not assemble words themselves.
+    pub fn write_fifo_byte(&mut self, v: u8) {
+        if self.status & STATUS_FIFO_PLAY != 0 && self.fifo.len() < FIFO_CAPACITY {
+            self.fifo.push_back(v);
+        }
+        // Real silicon can't overflow (per the FIFO's own datasheet), so
+        // a full FIFO just silently drops the byte -- no error flag.
+        self.irq &= !STATUS_READ_PLAY_HALF;
+        self.fifo_half &= !STATUS_FIFO_PLAY;
+    }
+
+    /// The record FIFO is never filled (record is M4), so a read always
+    /// returns stale/zero data; the port still exists and still
+    /// acknowledges the record-half interrupt bit on access, matching
+    /// hardware, so a driver polling it before record support lands sees
+    /// consistent (if silent) behaviour.
+    pub fn read_fifo_byte(&mut self) -> u8 {
+        self.irq &= !STATUS_READ_RECORD_HALF;
+        self.fifo_half &= !STATUS_FIFO_RECORD;
+        0
+    }
+
+    // -----------------------------------------------------------------
+    // Playback: format, cadence, and one produced sample
+    // -----------------------------------------------------------------
+
+    fn channels(&self) -> usize {
+        if self.regs[8] & 0x10 != 0 {
+            2
+        } else {
+            1
+        }
+    }
+
+    fn sixteen_bit(&self) -> bool {
+        self.regs[8] & 0x40 != 0
+    }
+
+    fn bytes_per_sample(&self) -> usize {
+        (if self.sixteen_bit() { 2 } else { 1 }) * self.channels()
+    }
+
+    /// The codec's programmed playback rate, in Hz, rounded to the
+    /// nearest 100 Hz the way the reference does. Two of the sixteen
+    /// crystal/divider combinations (24.576 MHz with divider 448 or 384)
+    /// fall outside a real AD1848's documented rate table but are not
+    /// rejected here, matching the reference's own permissiveness.
+    pub fn sample_rate_hz(&self) -> u32 {
+        let crystal = CRYSTALS[usize::from(self.regs[8] & 1)];
+        let divider = DIVIDERS[usize::from((self.regs[8] >> 1) & 7)];
+        let freq = crystal / divider;
+        (freq + 49) / 100 * 100
+    }
+
+    fn recalc_volume(&mut self) {
+        self.left_volume = Self::dac_attenuation(self.regs[6]);
+        self.right_volume = Self::dac_attenuation(self.regs[7]);
+    }
+
+    /// Reg 6/7 (DAC output attenuation): 6-bit value plus a mute bit.
+    /// 0 is full scale, 63 is minimum before mute; bit 7 mutes outright.
+    fn dac_attenuation(v: u8) -> f32 {
+        if v & 0x80 != 0 {
+            return 0.0;
+        }
+        let steps = 64 - u32::from(v & 0x3f);
+        (steps * 512) as f32 / 32768.0
+    }
+
+    /// Advance the auto-calibration countdown by `cck` colour clocks.
+    /// Independent of the playback cadence below -- ACI is a coarse,
+    /// line-paced status bit, not a sample-rate one.
+    pub fn advance_cck(&mut self, cck: u32) {
+        if self.autocal == 0 {
+            return;
+        }
+        self.hsync_acc += cck;
+        while self.hsync_acc >= HSYNC_CCK && self.autocal > 0 {
+            self.hsync_acc -= HSYNC_CCK;
+            self.autocal -= 1;
+        }
+    }
+
+    /// Produce one stereo sample at the codec's own programmed rate:
+    /// drain `bytes_per_sample` bytes from the FIFO (or repeat the last
+    /// sample on underrun), apply DAC volume, update the half-empty
+    /// latch, and re-evaluate the interrupt condition. This is the exact
+    /// per-sample unit the reference's own audio callback produces --
+    /// callers drive it once per codec-rate tick (see `Toccata::tick`),
+    /// not once per mixer-rate tick.
+    pub fn produce_one_sample(&mut self) -> (f32, f32) {
+        self.fifo_len_before_drain = self.fifo.len();
+        let need = self.bytes_per_sample();
+        if self.fifo.len() >= need {
+            let mut bytes = [0u8; 4];
+            for slot in bytes.iter_mut().take(need) {
+                *slot = self.fifo.pop_front().expect("checked len above");
+            }
+            self.last_sample = self.decode_sample(&bytes[..need]);
+        } else {
+            // Underrun: any partial residue is discarded (it can never
+            // complete a sample), and the last good sample repeats.
+            self.fifo.clear();
+        }
+        self.raise_half_empty_if_crossed();
+        self.evaluate_interrupt();
+        let (l, r) = self.last_sample;
+        (l * self.left_volume, r * self.right_volume)
+    }
+
+    /// Decode one already-drained frame's worth of FIFO bytes. 8-bit
+    /// samples are unsigned linear PCM (AD1848's native 8-bit format);
+    /// 16-bit samples are signed linear PCM, little-endian in the FIFO
+    /// (the board always writes/reads this way -- the CS4231 big-endian
+    /// mode this bit would otherwise select is unreachable, see
+    /// `write_data`'s reg-8 handling).
+    fn decode_sample(&self, bytes: &[u8]) -> (f32, f32) {
+        if self.sixteen_bit() {
+            let l = i16::from_le_bytes([bytes[0], bytes[1]]);
+            let r = if self.channels() == 2 {
+                i16::from_le_bytes([bytes[2], bytes[3]])
+            } else {
+                l
+            };
+            (f32::from(l) / 32768.0, f32::from(r) / 32768.0)
+        } else {
+            let l = (f32::from(bytes[0]) - 128.0) / 128.0;
+            let r = if self.channels() == 2 {
+                (f32::from(bytes[1]) - 128.0) / 128.0
+            } else {
+                l
+            };
+            (l, r)
+        }
+    }
+
+    fn raise_half_empty_if_crossed(&mut self) {
+        if self.fifo.len() < FIFO_HALF && self.fifo_len_before_drain >= FIFO_HALF {
+            self.fifo_half |= STATUS_FIFO_PLAY;
+        }
+    }
+
+    fn evaluate_interrupt(&mut self) {
+        if self.active == 0 || self.status & STATUS_FIFO_CODEC == 0 {
+            return;
+        }
+        if self.fifo_half & STATUS_FIFO_PLAY != 0
+            && self.status & STATUS_PLAY_INTENA != 0
+            && self.status & STATUS_FIFO_PLAY != 0
+        {
+            self.irq |= STATUS_READ_PLAY_HALF;
+        }
+        if self.fifo_half & STATUS_FIFO_RECORD != 0
+            && self.status & STATUS_RECORD_INTENA != 0
+            && self.status & STATUS_FIFO_RECORD != 0
+        {
+            self.irq |= STATUS_READ_RECORD_HALF;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_word_be(chip: &mut Ad1848, word: u16) {
+        chip.write_fifo_byte((word >> 8) as u8);
+        chip.write_fifo_byte(word as u8);
+    }
+
+    fn enable_play(chip: &mut Ad1848) {
+        chip.write_control(STATUS_ACTIVE | STATUS_FIFO_CODEC | STATUS_FIFO_PLAY);
+    }
+
+    #[test]
+    fn reset_defaults_mute_dac_and_aux_and_pin_reg12() {
+        let chip = Ad1848::new();
+        assert_eq!(chip.regs[6], 0x80);
+        assert_eq!(chip.regs[7], 0x80);
+        assert_eq!(chip.regs[12], 0x0a);
+        assert_eq!(chip.left_volume, 0.0);
+        assert_eq!(chip.right_volume, 0.0);
+    }
+
+    #[test]
+    fn index_and_data_round_trip() {
+        let mut chip = Ad1848::new();
+        chip.write_index(0x06);
+        assert_eq!(chip.read_index(), 0x06);
+        chip.write_data(0x00); // full volume, unmuted
+        assert_eq!(chip.read_data(), 0x00);
+        assert!(chip.left_volume > 0.0);
+    }
+
+    #[test]
+    fn reg12_is_always_pinned_regardless_of_what_is_written() {
+        let mut chip = Ad1848::new();
+        chip.write_index(12);
+        chip.write_data(0xff);
+        assert_eq!(chip.read_data(), 0x0a);
+        chip.write_data(0x00);
+        assert_eq!(chip.read_data(), 0x0a);
+    }
+
+    #[test]
+    fn reg8_format_extension_bit_is_forced_off() {
+        let mut chip = Ad1848::new();
+        chip.write_index(8);
+        chip.write_data(0xff);
+        assert_eq!(chip.read_data(), !0x80);
+    }
+
+    #[test]
+    fn reg8_rate_table_matches_the_reference() {
+        let mut chip = Ad1848::new();
+        // v = (divider_index << 1) | crystal_bit, matching write_data's
+        // `(regs[8] >> 1) & 7` divider select and `regs[8] & 1` crystal
+        // select decode.
+        let set_reg8 = |chip: &mut Ad1848, divider_index: u8, crystal_bit: u8| {
+            chip.write_index(8);
+            chip.write_data((divider_index << 1) | crystal_bit);
+        };
+        set_reg8(&mut chip, 0, 0); // crystal0 (24576000) / div 3072
+        assert_eq!(chip.sample_rate_hz(), 8000);
+        set_reg8(&mut chip, 7, 1); // crystal1 (16934400) / div 2560 = 6615 -> 6600
+        assert_eq!(chip.sample_rate_hz(), 6600);
+        set_reg8(&mut chip, 5, 1); // crystal1 / div 384 = 44100
+        assert_eq!(chip.sample_rate_hz(), 44100);
+        set_reg8(&mut chip, 6, 0); // crystal0 / div 512 = 48000
+        assert_eq!(chip.sample_rate_hz(), 48000);
+    }
+
+    #[test]
+    fn status_write_reset_zeroes_status_and_irq_but_not_the_fifo() {
+        let mut chip = Ad1848::new();
+        enable_play(&mut chip);
+        chip.write_fifo_byte(0x42);
+        chip.write_control(STATUS_RESET);
+        assert_eq!(chip.status, 0);
+        assert_eq!(chip.irq, 0);
+        assert_eq!(
+            chip.fifo.len(),
+            1,
+            "reset must not clear buffered FIFO data"
+        );
+    }
+
+    #[test]
+    fn status_write_of_exactly_one_is_the_fifo_flush_idiom() {
+        let mut chip = Ad1848::new();
+        enable_play(&mut chip);
+        chip.write_fifo_byte(0x42);
+        chip.write_control(STATUS_ACTIVE); // == 0x01 exactly
+        assert!(chip.fifo.is_empty());
+        assert_eq!(chip.fifo_half, 0);
+
+        // ACTIVE combined with any other bit does NOT trigger the flush.
+        let mut chip2 = Ad1848::new();
+        enable_play(&mut chip2);
+        chip2.write_fifo_byte(0x42);
+        chip2.write_control(STATUS_ACTIVE | STATUS_FIFO_CODEC);
+        assert_eq!(chip2.fifo.len(), 1);
+    }
+
+    #[test]
+    fn status_read_is_the_interrupt_acknowledge() {
+        let mut chip = Ad1848::new();
+        chip.irq = STATUS_READ_PLAY_HALF;
+        assert_eq!(chip.read_status(), STATUS_READ_PLAY_HALF);
+        assert_eq!(chip.irq, 0);
+        assert_eq!(chip.read_status(), STATUS_READ_INTREQ);
+    }
+
+    #[test]
+    fn fifo_write_is_dropped_when_play_is_not_enabled() {
+        let mut chip = Ad1848::new();
+        chip.write_control(STATUS_ACTIVE | STATUS_FIFO_CODEC); // no FIFO_PLAY bit
+        chip.write_fifo_byte(0x99);
+        assert!(chip.fifo.is_empty());
+    }
+
+    #[test]
+    fn fifo_overflow_silently_drops_bytes() {
+        let mut chip = Ad1848::new();
+        enable_play(&mut chip);
+        for i in 0..FIFO_CAPACITY + 10 {
+            chip.write_fifo_byte(i as u8);
+        }
+        assert_eq!(chip.fifo.len(), FIFO_CAPACITY);
+    }
+
+    #[test]
+    fn half_empty_is_edge_triggered_on_the_downward_crossing() {
+        let mut chip = Ad1848::new();
+        enable_play(&mut chip);
+        chip.write_index(8);
+        chip.write_data(0x00); // mono 8-bit: 1 byte/sample
+        chip.write_index(6);
+        chip.write_data(0x00); // unmute DAC L
+        chip.write_index(7);
+        chip.write_data(0x00); // unmute DAC R
+        for _ in 0..FIFO_CAPACITY {
+            chip.write_fifo_byte(0x80);
+        }
+        // Draining down to exactly half should not yet cross (>= half).
+        for _ in 0..FIFO_HALF {
+            chip.produce_one_sample();
+        }
+        assert_eq!(chip.fifo_half & STATUS_FIFO_PLAY, 0);
+        // One more sample crosses below half.
+        chip.produce_one_sample();
+        assert_ne!(chip.fifo_half & STATUS_FIFO_PLAY, 0);
+    }
+
+    #[test]
+    fn underrun_repeats_the_last_sample_without_advancing() {
+        let mut chip = Ad1848::new();
+        enable_play(&mut chip);
+        chip.write_index(8);
+        chip.write_data(0x00); // mono 8-bit
+        chip.write_index(6);
+        chip.write_data(0x00);
+        chip.write_index(7);
+        chip.write_data(0x00);
+        chip.write_fifo_byte(0xff); // one full sample: (255-128)/128 ~= 0.992
+        let first = chip.produce_one_sample();
+        assert!(first.0 > 0.9);
+        let repeated = chip.produce_one_sample(); // FIFO now empty: underrun
+        assert_eq!(repeated, first);
+    }
+
+    #[test]
+    fn sixteen_bit_stereo_is_little_endian_and_byte_swapped_on_write() {
+        let mut chip = Ad1848::new();
+        enable_play(&mut chip);
+        chip.write_index(8);
+        chip.write_data(0x50); // stereo (0x10) + 16-bit (0x40)
+        chip.write_index(6);
+        chip.write_data(0x00);
+        chip.write_index(7);
+        chip.write_data(0x00);
+        // A native `move.w #0x1234` decomposes into big-endian byte pokes
+        // at the FIFO port (0x12 then 0x34), but the FIFO is read back
+        // little-endian (fifo[i+1]<<8 | fifo[i]) -- so the codec actually
+        // sees 0x3412, not 0x1234. This is the documented real-hardware
+        // quirk a driver must byte-swap 16-bit samples to work around
+        // before writing them; it is not a bug to "fix" here.
+        write_word_be(&mut chip, 0x1234);
+        write_word_be(&mut chip, 0x0001);
+        let (l, r) = chip.produce_one_sample();
+        assert!((l - f32::from(0x3412u16 as i16) / 32768.0).abs() < 1e-6);
+        assert!((r - f32::from(0x0100u16 as i16) / 32768.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn interrupt_needs_codec_active_gate_and_both_direction_enables() {
+        let mut chip = Ad1848::new();
+        chip.write_index(8);
+        chip.write_data(0x00);
+        chip.write_index(9);
+        chip.write_data(0x01); // playback enable -> codec_start, active bit set
+                               // FIFO_CODEC gate missing: no interrupt even with the FIFO drained dry.
+        chip.write_control(STATUS_ACTIVE | STATUS_PLAY_INTENA | STATUS_FIFO_PLAY);
+        chip.produce_one_sample();
+        assert!(!chip.int6_pending());
+        // Now with the gate and both enables present, an underrun/half-empty
+        // condition raises the interrupt.
+        chip.write_control(
+            STATUS_ACTIVE | STATUS_FIFO_CODEC | STATUS_PLAY_INTENA | STATUS_FIFO_PLAY,
+        );
+        chip.fifo_half |= STATUS_FIFO_PLAY;
+        chip.produce_one_sample();
+        assert!(chip.int6_pending());
+    }
+
+    #[test]
+    fn aci_reads_busy_only_during_the_calibration_window() {
+        let mut chip = Ad1848::new();
+        chip.write_index(9);
+        chip.write_data(0x08); // bit3 only: request calibration, no start/stop edge
+        chip.write_index(11);
+        assert_eq!(chip.read_data() & 0x20, 0); // not yet busy (autocal == 50)
+        chip.advance_cck(HSYNC_CCK * 25); // into the 10..30 busy window
+        assert_ne!(chip.read_data() & 0x20, 0);
+        chip.advance_cck(HSYNC_CCK * 25); // past it
+        assert_eq!(chip.read_data() & 0x20, 0);
+    }
+
+    #[test]
+    fn savestate_round_trips_register_and_fifo_state() {
+        let mut chip = Ad1848::new();
+        enable_play(&mut chip);
+        chip.write_index(6);
+        chip.write_data(0x10);
+        chip.write_fifo_byte(0xaa);
+        chip.write_fifo_byte(0xbb);
+        let bytes = bincode::serialize(&chip).unwrap();
+        let resumed: Ad1848 = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(resumed.regs[6], 0x10);
+        assert_eq!(resumed.fifo.len(), 2);
+    }
+}

--- a/src/toccata/ad1848.rs
+++ b/src/toccata/ad1848.rs
@@ -94,6 +94,16 @@ pub struct Ad1848 {
     /// whenever they (or any of 2-7) are written.
     left_volume: f32,
     right_volume: f32,
+    /// Format/rate latched at the last `codec_start()` (reg 9's
+    /// stopped-to-started transition) -- not read live from reg 8.
+    /// `produce_one_sample`/`bytes_per_sample`/`sample_rate_hz` all use
+    /// these, matching the reference's own `codec_setup()`-on-transition
+    /// model: a driver that reprograms reg 8 while already playing has no
+    /// effect until the next start, so a rate/format change never splits
+    /// a FIFO frame mid-stream on a different byte boundary.
+    active_channels: usize,
+    active_sixteen_bit: bool,
+    active_rate_hz: u32,
 }
 
 impl Default for Ad1848 {
@@ -110,6 +120,9 @@ impl Default for Ad1848 {
         regs[7] = 0x80;
         regs[9] = 0x10;
         regs[12] = 0x0a;
+        // Never started, so nothing reads these yet -- initialized to
+        // what power-on reg 8 (0x00) would decode to, for a sane default.
+        let (active_channels, active_sixteen_bit, active_rate_hz) = decode_format(regs[8]);
         Self {
             regs,
             index: 0x40,
@@ -124,8 +137,25 @@ impl Default for Ad1848 {
             hsync_acc: 0,
             left_volume: 0.0,
             right_volume: 0.0,
+            active_channels,
+            active_sixteen_bit,
+            active_rate_hz,
         }
     }
+}
+
+/// Decode reg 8 into (channels, 16-bit?, rate Hz) -- the reference's own
+/// `codec_setup()`. Shared by the latch-on-start path and `Ad1848`'s
+/// power-on default (which behaves as if `codec_setup()` ran once against
+/// reg 8's own power-on value, though nothing plays until a real start).
+fn decode_format(reg8: u8) -> (usize, bool, u32) {
+    let channels = if reg8 & 0x10 != 0 { 2 } else { 1 };
+    let sixteen_bit = reg8 & 0x40 != 0;
+    let crystal = CRYSTALS[usize::from(reg8 & 1)];
+    let divider = DIVIDERS[usize::from((reg8 >> 1) & 7)];
+    let freq = crystal / divider;
+    let rate_hz = (freq + 49) / 100 * 100;
+    (channels, sixteen_bit, rate_hz)
 }
 
 impl Ad1848 {
@@ -221,12 +251,38 @@ impl Ad1848 {
     }
 
     fn codec_start(&mut self) {
-        // Format/rate take effect from here; a driver programs reg 8
-        // before enabling the codec via reg 9, matching hardware.
+        // Latch the currently-programmed format/rate; see the doc comment
+        // on the active_* fields for why this happens here and not on
+        // every produced sample.
+        let (channels, sixteen_bit, rate_hz) = decode_format(self.regs[8]);
+        self.active_channels = channels;
+        self.active_sixteen_bit = sixteen_bit;
+        self.active_rate_hz = rate_hz;
     }
 
     fn codec_stop(&mut self) {
         self.active = 0;
+    }
+
+    /// Whether the codec has been started for playback (reg 9 bit 0's
+    /// last stopped-to-started transition). The board wrapper's own
+    /// codec-rate cadence only runs while this is true -- a real codec
+    /// isn't converting anything, and has nothing to latch a format
+    /// from, until it has actually been started.
+    pub fn play_active(&self) -> bool {
+        self.active & STATUS_FIFO_PLAY != 0
+    }
+
+    /// The last decoded output sample, at its current DAC volume, with no
+    /// side effects (does not drain the FIFO, does not touch the
+    /// half-empty latch or the interrupt condition). Used as the
+    /// resampler's fallback when it asks for more input frames than the
+    /// codec's own causally-paced cadence (`Toccata::advance_codec`) has
+    /// produced yet, so a resampler's internal lookahead/priming can
+    /// never pull `produce_one_sample`'s side effects out of order.
+    pub fn peek_last_sample(&self) -> (f32, f32) {
+        let (l, r) = self.last_sample;
+        (l * self.left_volume, r * self.right_volume)
     }
 
     // -----------------------------------------------------------------
@@ -302,32 +358,17 @@ impl Ad1848 {
     // Playback: format, cadence, and one produced sample
     // -----------------------------------------------------------------
 
-    fn channels(&self) -> usize {
-        if self.regs[8] & 0x10 != 0 {
-            2
-        } else {
-            1
-        }
-    }
-
-    fn sixteen_bit(&self) -> bool {
-        self.regs[8] & 0x40 != 0
-    }
-
     fn bytes_per_sample(&self) -> usize {
-        (if self.sixteen_bit() { 2 } else { 1 }) * self.channels()
+        (if self.active_sixteen_bit { 2 } else { 1 }) * self.active_channels
     }
 
-    /// The codec's programmed playback rate, in Hz, rounded to the
-    /// nearest 100 Hz the way the reference does. Two of the sixteen
-    /// crystal/divider combinations (24.576 MHz with divider 448 or 384)
-    /// fall outside a real AD1848's documented rate table but are not
-    /// rejected here, matching the reference's own permissiveness.
+    /// The codec's *active* (latched-at-start) playback rate, in Hz,
+    /// rounded to the nearest 100 Hz the way the reference does. Two of
+    /// the sixteen crystal/divider combinations (24.576 MHz with divider
+    /// 448 or 384) fall outside a real AD1848's documented rate table but
+    /// are not rejected here, matching the reference's own permissiveness.
     pub fn sample_rate_hz(&self) -> u32 {
-        let crystal = CRYSTALS[usize::from(self.regs[8] & 1)];
-        let divider = DIVIDERS[usize::from((self.regs[8] >> 1) & 7)];
-        let freq = crystal / divider;
-        (freq + 49) / 100 * 100
+        self.active_rate_hz
     }
 
     fn recalc_volume(&mut self) {
@@ -393,9 +434,9 @@ impl Ad1848 {
     /// mode this bit would otherwise select is unreachable, see
     /// `write_data`'s reg-8 handling).
     fn decode_sample(&self, bytes: &[u8]) -> (f32, f32) {
-        if self.sixteen_bit() {
+        if self.active_sixteen_bit {
             let l = i16::from_le_bytes([bytes[0], bytes[1]]);
-            let r = if self.channels() == 2 {
+            let r = if self.active_channels == 2 {
                 i16::from_le_bytes([bytes[2], bytes[3]])
             } else {
                 l
@@ -403,7 +444,7 @@ impl Ad1848 {
             (f32::from(l) / 32768.0, f32::from(r) / 32768.0)
         } else {
             let l = (f32::from(bytes[0]) - 128.0) / 128.0;
-            let r = if self.channels() == 2 {
+            let r = if self.active_channels == 2 {
                 (f32::from(bytes[1]) - 128.0) / 128.0
             } else {
                 l
@@ -450,6 +491,18 @@ mod tests {
         chip.write_control(STATUS_ACTIVE | STATUS_FIFO_CODEC | STATUS_FIFO_PLAY);
     }
 
+    /// Latch whatever format/rate is currently in reg 8 by driving reg 9
+    /// through a clean stopped-to-started transition (`codec_start`),
+    /// matching what a real driver does: program the format, then enable
+    /// playback. Always writes a stop first so a second call in the same
+    /// test is a genuine rising edge, not a no-op repeat of an
+    /// already-set bit.
+    fn latch_format(chip: &mut Ad1848) {
+        chip.write_index(9);
+        chip.write_data(0x10); // stop (SDC bit only, no play/record enable)
+        chip.write_data(0x11); // play enable: rising edge -> codec_start()
+    }
+
     #[test]
     fn reset_defaults_mute_dac_and_aux_and_pin_reg12() {
         let chip = Ad1848::new();
@@ -494,9 +547,13 @@ mod tests {
         // v = (divider_index << 1) | crystal_bit, matching write_data's
         // `(regs[8] >> 1) & 7` divider select and `regs[8] & 1` crystal
         // select decode.
+        // Each check writes reg 8 then latches it via a stop/start
+        // transition (see `latch_format`): sample_rate_hz() reports the
+        // *active* rate, which only updates on codec_start().
         let set_reg8 = |chip: &mut Ad1848, divider_index: u8, crystal_bit: u8| {
             chip.write_index(8);
             chip.write_data((divider_index << 1) | crystal_bit);
+            latch_format(chip);
         };
         set_reg8(&mut chip, 0, 0); // crystal0 (24576000) / div 3072
         assert_eq!(chip.sample_rate_hz(), 8000);
@@ -613,6 +670,7 @@ mod tests {
         enable_play(&mut chip);
         chip.write_index(8);
         chip.write_data(0x50); // stereo (0x10) + 16-bit (0x40)
+        latch_format(&mut chip);
         chip.write_index(6);
         chip.write_data(0x00);
         chip.write_index(7);

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -218,6 +218,28 @@ impl BoardSpec {
         }
     }
 
+    /// The MacroSystem Toccata sound board: manufacturer 18260 (0x4754),
+    /// product 12, a 64K Zorro II I/O window with no autoboot ROM (the
+    /// board's own `romtype` is `ROMTYPE_NOT` -- it needs no ROM image and
+    /// carries no DiagArea). `slot` is the index of the matching `Toccata`
+    /// device in `Bus::devices`.
+    pub fn toccata(slot: usize) -> Self {
+        Self {
+            name: "Toccata".into(),
+            version: ZorroVersion::II,
+            manufacturer: 18260,
+            product: 12,
+            serial: 0,
+            size_bytes: 0x1_0000,
+            backing: BoardBacking::Device(slot),
+            memlist: false,
+            memory_space: false,
+            chained: false,
+            window: 0,
+            diag_vec: None,
+        }
+    }
+
     /// The A2091 SCSI controller board: the DMAC supplies the autoconfig
     /// identity (Commodore West Chester, product 3) with a valid DiagArea
     /// vector pointing at the boot ROM, which appears at $2000 in the
@@ -1731,6 +1753,22 @@ mod tests {
         assert_eq!(chain.config_read(AUTOCONFIG_BASE + 0x2A, 1), 0xF0);
         assert_eq!(chain.config_read(AUTOCONFIG_BASE + 0x2C, 1), 0xF0);
         assert_eq!(chain.config_read(AUTOCONFIG_BASE + 0x2E, 1), 0x70);
+    }
+
+    #[test]
+    fn toccata_autoconfig_identity_matches_the_reference() {
+        let chain = chain_with(vec![BoardSpec::toccata(0)]);
+        // Zorro II | 64K size code 1, no MEMLIST/chained/DIAGVALID: 0xC0|1 = 0xC1.
+        assert_eq!(chain.config_logical_byte(0, 0), Some(0xc1));
+        assert_eq!(chain.config_logical_byte(0, 1), Some(12));
+        assert_eq!(chain.config_logical_byte(0, 2), Some(0)); // not memory-space
+                                                              // Manufacturer 18260 (MacroSystem) = 0x4754, big-endian.
+        assert_eq!(chain.config_logical_byte(0, 4), Some(0x47));
+        assert_eq!(chain.config_logical_byte(0, 5), Some(0x54));
+        // No autoboot ROM: InitDiagVec stays zero, and no DIAGVALID bit
+        // above (0xC1 has no 0x10 set).
+        assert_eq!(chain.config_logical_byte(0, 10), Some(0));
+        assert_eq!(chain.config_logical_byte(0, 11), Some(0));
     }
 
     #[test]

--- a/src/zorro_device.rs
+++ b/src/zorro_device.rs
@@ -17,7 +17,7 @@
 //! open-coded. Zorro II masters only drive the low 24 bits; a Zorro III master
 //! like the A4091 reaches the 32-bit motherboard and accelerator banks too.
 
-use crate::chipset::paula::CdAudioRing;
+use crate::chipset::paula::{CdAudioRing, ToccataAudioRing};
 use crate::memory::{Memory, ACCEL_RAM_BASE, SLOW_RAM_BASE};
 
 /// DMA bus-master word read: the chip / slow / motherboard / accelerator /
@@ -155,6 +155,9 @@ pub struct DeviceHost<'a> {
     mem: &'a mut Memory,
     /// Paula's CD-audio ring, available only on a host built for the CDTV tick.
     cd_audio: Option<&'a mut CdAudioRing>,
+    /// Paula's Toccata-board audio ring, available only on the bus's
+    /// generic Zorro-board tick host (see `for_slot_with_audio`).
+    toccata_audio: Option<&'a mut ToccataAudioRing>,
     /// The device slot this host was built for, so a bus-mastering board
     /// can recognize DMA addresses inside its own configured window (the
     /// A4091 self-test DMAs its own registers) without re-entering itself.
@@ -171,6 +174,7 @@ impl<'a> DeviceHost<'a> {
         Self {
             mem,
             cd_audio: None,
+            toccata_audio: None,
             self_slot: None,
             touched_memory: false,
         }
@@ -181,6 +185,7 @@ impl<'a> DeviceHost<'a> {
         Self {
             mem,
             cd_audio: None,
+            toccata_audio: None,
             self_slot: Some(slot),
             touched_memory: false,
         }
@@ -203,21 +208,28 @@ impl<'a> DeviceHost<'a> {
         Self {
             mem,
             cd_audio: Some(cd_audio),
+            toccata_audio: None,
             self_slot: None,
             touched_memory: false,
         }
     }
 
-    /// A slot-aware host that also exposes Paula's CD-audio ring: the bus
-    /// device-tick loop, where a SCSI board's CD-ROM target streams CD-DA.
-    pub fn for_slot_with_cd_audio(
+    /// A slot-aware host that also exposes Paula's CD-audio and Toccata
+    /// rings: the bus's generic Zorro-board tick loop, where a SCSI board's
+    /// CD-ROM target streams CD-DA and a fitted Toccata streams its own
+    /// resampled output. Either ring is `None` for a run without that
+    /// hardware; a board that never asks for a ring it wasn't given never
+    /// notices the difference.
+    pub fn for_slot_with_audio(
         mem: &'a mut Memory,
         slot: usize,
         cd_audio: &'a mut CdAudioRing,
+        toccata_audio: &'a mut ToccataAudioRing,
     ) -> Self {
         Self {
             mem,
             cd_audio: Some(cd_audio),
+            toccata_audio: Some(toccata_audio),
             self_slot: Some(slot),
             touched_memory: false,
         }
@@ -249,6 +261,15 @@ impl<'a> DeviceHost<'a> {
     /// provides it; hosts built for memory-access dispatch do not.
     pub fn cd_audio_opt(&mut self) -> Option<&mut CdAudioRing> {
         self.cd_audio.as_deref_mut()
+    }
+
+    /// Paula's Toccata-audio ring. Only present on a host built via
+    /// [`DeviceHost::for_slot_with_audio`] (the bus tick loop); requesting
+    /// it elsewhere is a wiring bug.
+    pub fn toccata_audio(&mut self) -> &mut ToccataAudioRing {
+        self.toccata_audio
+            .as_deref_mut()
+            .expect("DeviceHost::toccata_audio requested without a Toccata-audio ring")
     }
 
     // These wrap the shared decode for boards that hold a `DeviceHost` rather

--- a/src/zorro_device.rs
+++ b/src/zorro_device.rs
@@ -382,6 +382,7 @@ pub enum BoardDevice {
     Z3660(crate::z3660::Z3660),
     Picasso2(Box<crate::picasso2::Picasso2>),
     IdeZorro(crate::ide_zorro::IdeZorro),
+    Toccata(Box<crate::toccata::Toccata>),
 }
 
 impl ZorroDevice for BoardDevice {
@@ -396,6 +397,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Z3660(d) => ZorroDevice::read(d, off, size, host),
             BoardDevice::Picasso2(d) => ZorroDevice::read(d.as_mut(), off, size, host),
             BoardDevice::IdeZorro(d) => ZorroDevice::read(d, off, size, host),
+            BoardDevice::Toccata(d) => ZorroDevice::read(d.as_mut(), off, size, host),
         }
     }
 
@@ -410,6 +412,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Z3660(d) => ZorroDevice::write(d, off, size, value, host),
             BoardDevice::Picasso2(d) => ZorroDevice::write(d.as_mut(), off, size, value, host),
             BoardDevice::IdeZorro(d) => ZorroDevice::write(d, off, size, value, host),
+            BoardDevice::Toccata(d) => ZorroDevice::write(d.as_mut(), off, size, value, host),
         }
     }
 
@@ -424,6 +427,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Z3660(d) => ZorroDevice::peek_word(d, off),
             BoardDevice::Picasso2(d) => ZorroDevice::peek_word(d.as_ref(), off),
             BoardDevice::IdeZorro(d) => ZorroDevice::peek_word(d, off),
+            BoardDevice::Toccata(d) => ZorroDevice::peek_word(d.as_ref(), off),
         }
     }
 
@@ -438,6 +442,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Z3660(d) => ZorroDevice::tick(d, cck, host),
             BoardDevice::Picasso2(d) => ZorroDevice::tick(d.as_mut(), cck, host),
             BoardDevice::IdeZorro(d) => ZorroDevice::tick(d, cck, host),
+            BoardDevice::Toccata(d) => ZorroDevice::tick(d.as_mut(), cck, host),
         }
     }
 
@@ -452,6 +457,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Z3660(d) => ZorroDevice::int2_line(d),
             BoardDevice::Picasso2(d) => ZorroDevice::int2_line(d.as_ref()),
             BoardDevice::IdeZorro(d) => ZorroDevice::int2_line(d),
+            BoardDevice::Toccata(d) => ZorroDevice::int2_line(d.as_ref()),
         }
     }
 
@@ -466,6 +472,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Z3660(d) => ZorroDevice::int6_line(d),
             BoardDevice::Picasso2(d) => ZorroDevice::int6_line(d.as_ref()),
             BoardDevice::IdeZorro(d) => ZorroDevice::int6_line(d),
+            BoardDevice::Toccata(d) => ZorroDevice::int6_line(d.as_ref()),
         }
     }
 
@@ -480,6 +487,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Z3660(d) => ZorroDevice::is_idle(d),
             BoardDevice::Picasso2(d) => ZorroDevice::is_idle(d.as_ref()),
             BoardDevice::IdeZorro(d) => ZorroDevice::is_idle(d),
+            BoardDevice::Toccata(d) => ZorroDevice::is_idle(d.as_ref()),
         }
     }
 
@@ -494,6 +502,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Z3660(d) => ZorroDevice::next_event_cck(d),
             BoardDevice::Picasso2(d) => ZorroDevice::next_event_cck(d.as_ref()),
             BoardDevice::IdeZorro(d) => ZorroDevice::next_event_cck(d),
+            BoardDevice::Toccata(d) => ZorroDevice::next_event_cck(d.as_ref()),
         }
     }
 
@@ -508,6 +517,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Z3660(d) => ZorroDevice::take_activity(d),
             BoardDevice::Picasso2(d) => ZorroDevice::take_activity(d.as_mut()),
             BoardDevice::IdeZorro(d) => ZorroDevice::take_activity(d),
+            BoardDevice::Toccata(d) => ZorroDevice::take_activity(d.as_mut()),
         }
     }
 
@@ -522,6 +532,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Z3660(d) => ZorroDevice::reset(d),
             BoardDevice::Picasso2(d) => ZorroDevice::reset(d.as_mut()),
             BoardDevice::IdeZorro(d) => ZorroDevice::reset(d),
+            BoardDevice::Toccata(d) => ZorroDevice::reset(d.as_mut()),
         }
     }
 
@@ -536,6 +547,7 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Z3660(d) => ZorroDevice::kind(d),
             BoardDevice::Picasso2(d) => ZorroDevice::kind(d.as_ref()),
             BoardDevice::IdeZorro(d) => ZorroDevice::kind(d),
+            BoardDevice::Toccata(d) => ZorroDevice::kind(d.as_ref()),
         }
     }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -154,6 +154,7 @@ baselines to maintain.
 | `picasso2plus_workbench_opens_with_gd5428_revision` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-picasso2.hdf` (same installation booted against the Picasso II+ identity) |
 | `picasso2_p96cts_reports_all_modes_clean` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-picasso2-cts.hdf` (startup runs p96cts at 8/16/24 bpp and writes `P96OUT:p96cts.result`) |
 | `chd_cd32_disc_serves_iso9660_data_and_smooth_audio` | `Pinball Fantasies (EU).chd` (a chdman v5 CD32 disc with a MODE1_RAW data track and CD audio tracks) |
+| `toccata_ahi_driver_recognizes_the_board` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `toccata-ahi.hdf` (WB3.1 + AHI 4.18 with `toccata.audio` staged into `Devs/AHI` and Unit 0 set to Toccata) |
 
 ## Obtaining the assets legally
 
@@ -181,6 +182,20 @@ baselines to maintain.
   its 8-, 16-, and 24-bit mode set and writes `PASS` to
   `P96OUT:p96cts.result`; on failure it leaves the suite's diff images in that
   host-mounted output directory.
+
+- **Toccata/AHI HDF** (`toccata-ahi.hdf`) is a local Workbench 3.1
+  installation with **AHI 4.18** (freeware, from Aminet's
+  `mus/misc/AHIUser418.lha`) installed, plus its bundled `toccata.audio`
+  driver (already shipped in that same archive's `AHI/User/Devs/AHI/`
+  directory -- both the 68020+ build and the `.000` 68000 build -- along
+  with the `AHI/User/Devs/AudioModes/TOCCATA` mode descriptor AHI prefs
+  needs). To build one: install AHI onto a WB3.1 HDF as normal, copy
+  `toccata.audio` and `AudioModes/TOCCATA` from the archive into the
+  installed `Devs/AHI` and `Devs/AudioModes`, boot with `[toccata] enabled
+  = true`, open `AHI` in Prefs, select Unit 0 = Toccata, and save so the
+  choice persists in `ENV:Sys/ahi.prefs` (copy forward to `ENVARC:` too).
+  The A4000/motherboard-IDE boot shape matches the Picasso II HDFs above,
+  for the same reason (no big-box IDE driver in the generic `KICK31.ROM`).
 
 The `*.U12` / `*.U13`-style files in the repo root are split EPROM dumps for
 expansion-board ROMs (e.g. the A2091 SCSI boot ROM) used by other ignored

--- a/tests/toccata.rs
+++ b/tests/toccata.rs
@@ -1,0 +1,162 @@
+//! Toccata (AD1848 sound board) boot and capture checks.
+//!
+//! `toccata_board_attaches_and_streams_a_stem` needs no local assets: the
+//! bundled AROS ROM boots with `[toccata] enabled = true`, which is enough
+//! to prove the board attaches to the Zorro chain and that its audio path
+//! reaches `--audio-stems` end to end (the `toccata.wav` stem is written,
+//! even though AROS never programs the codec, so it stays silent -- this
+//! test is about the host-side plumbing, not AHI driver behaviour).
+//!
+//! `toccata_ahi_driver_recognizes_the_board` is the real AHI end-to-end
+//! check (M1: `toccata.audio` loads and AHI prefs lists the board's
+//! modes) and needs a local licensed Workbench install with AHI 4.18 and
+//! `toccata.audio` staged onto it -- see tests/README.md for the asset
+//! recipe. It is asset-gated per the usual convention and skips cleanly
+//! when the HDF is absent.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn asset_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os("COPPERLINE_TEST_ASSETS") {
+        return PathBuf::from(dir);
+    }
+    let local = repo_root().join("test-assets");
+    if local.is_dir() {
+        local
+    } else {
+        repo_root()
+    }
+}
+
+fn run_copperline(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_copperline"))
+        .current_dir(repo_root())
+        .env("RUST_LOG", "copperline=warn,copperline::emulator=info")
+        .env("COPPERLINE_AROS_DIR", repo_root().join("assets/aros"))
+        .args(args)
+        .output()
+        .expect("run emulator")
+}
+
+fn scratch_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "copperline-toccata-test-{name}-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
+/// Needs no local assets: proves the board autoconfigs (the emulator log
+/// names it) and that its audio path is wired all the way through to stem
+/// capture, using only the bundled AROS ROM.
+#[test]
+#[ignore = "runs the emulator"]
+fn toccata_board_attaches_and_streams_a_stem() {
+    let cfg_path = scratch_dir("cfg").with_extension("toml");
+    std::fs::write(
+        &cfg_path,
+        "rom = \"<bundled-aros>\"\n\n[toccata]\nenabled = true\n",
+    )
+    .expect("write test config");
+
+    let stems = scratch_dir("stems");
+    let shot = scratch_dir("shot").with_extension("png");
+    let out = run_copperline(&[
+        "--config",
+        cfg_path.to_str().unwrap(),
+        "--noaudio",
+        "--audio-stems",
+        stems.to_str().unwrap(),
+        "--audio-stems-mode",
+        "source",
+        "--screenshot-after",
+        "3",
+        shot.to_str().unwrap(),
+    ]);
+    assert!(
+        out.status.success(),
+        "emulator run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("toccata: AD1848 sound board"),
+        "expected the board-attach log line; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stems.join("toccata.wav").is_file(),
+        "the toccata source should register and write a stem file \
+         even though AROS never programs the codec"
+    );
+
+    let _ = std::fs::remove_file(&cfg_path);
+    let _ = std::fs::remove_file(&shot);
+    let _ = std::fs::remove_dir_all(&stems);
+}
+
+/// Kickstart 3.1 has no A3000/A4000 SCSI driver built in; A4000 gives the
+/// HDF a real IDE port to sit on, matching how the asset was built.
+const KICK31_A4000: &str = "Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom";
+/// A Workbench install with AHI 4.18 and toccata.audio staged into
+/// Devs/AHI (see tests/README.md's Toccata asset recipe) and Unit 0 set
+/// to Toccata in AHI-prefs' saved ENV:Sys/ahi.prefs.
+const TOCCATA_AHI_HDF: &str = "toccata-ahi.hdf";
+
+/// The real driver-recognition check: boots a licensed OS install with AHI
+/// and `toccata.audio` staged onto it, opens AHI prefs, and confirms the
+/// driver found and named the board. Skips cleanly without the asset.
+#[test]
+#[ignore = "runs the emulator and requires a local Kickstart/AHI HDF"]
+fn toccata_ahi_driver_recognizes_the_board() -> Result<(), Box<dyn std::error::Error>> {
+    let assets = asset_dir();
+    let missing: Vec<_> = [KICK31_A4000, TOCCATA_AHI_HDF]
+        .into_iter()
+        .filter(|file| !assets.join(file).is_file())
+        .collect();
+    if !missing.is_empty() {
+        eprintln!("skipping Toccata/AHI integration test; missing files: {missing:?}");
+        return Ok(());
+    }
+
+    let stem = format!("copperline-toccata-ahi-{}", std::process::id());
+    let config_path = std::env::temp_dir().join(format!("{stem}.toml"));
+    let shot = std::env::temp_dir().join(format!("{stem}.png"));
+    std::fs::write(
+        &config_path,
+        format!(
+            "rom = \"{KICK31_A4000}\"\n\n\
+             [machine]\n\
+             profile = \"A4000\"\n\n\
+             [toccata]\n\
+             enabled = true\n\n\
+             [ide]\n\
+             master = \"{TOCCATA_AHI_HDF}\"\n"
+        ),
+    )?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_copperline"))
+        .current_dir(&assets)
+        .env("RUST_LOG", "copperline=warn,copperline::emulator=info")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--noaudio")
+        .arg("--screenshot-after")
+        .arg("60")
+        .arg(&shot)
+        .output()?;
+    let _ = std::fs::remove_file(&config_path);
+    assert!(
+        output.status.success(),
+        "Copperline failed: {}\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let _ = std::fs::remove_file(&shot);
+    Ok(())
+}


### PR DESCRIPTION
Addresses #461.

**Depends on #463** (still open): this branch is stacked on top of add-toccata-audio-support, so the diff below currently includes #463's audio-sink/stem-capture commits as well as the Toccata-specific ones. Once #463 merges, GitHub will recalculate this PR's diff against the updated `main` and it will shrink to just the 7 Toccata commits. Please review/merge #463 first; #464 doesn't need to be held for anything else.

## Summary

M1–M3 of a staged Toccata implementation (M0, the host-side audio sink/stem-capture service this plugs into, is #463): a register-accurate MacroSystem Toccata sound board, so any AHI-aware Amiga application gets 16-bit sound through the stock, open-source `toccata.audio` AHI driver with no Copperline-specific guest software.

Modelled against WinUAE/amiberry's `sndboard.cpp` (byte-identical in both trees) as a behavioural oracle — register offsets, the FIFO's threshold/byte-order quirks, and the interrupt condition are transcribed from what that reference does, not reconstructed from the AD1848 datasheet alone.

- **`src/toccata/ad1848.rs`** — the codec core: 16 indexed registers, 1024-byte play FIFO with an edge-triggered half-empty latch, the board's status/control register (including its RESET-zeroes-the-byte and write-exactly-`0x01`-flushes-the-FIFO idioms), reg 12 pinned to `0x0A` (plain-AD1848 mode only — no CS4231 extensions, no µ-law/A-law), the 14-rate crystal/divider table, DAC output volume, and the documented real-hardware quirk where a native `move.w` write is byte-swapped by the FIFO's little-endian readback.
- **`src/toccata.rs`** — the board wrapper: autoconfig (manufacturer 18260/MacroSystem, product 12, 64 KB Zorro II window, no autoboot ROM), address decode by bit pattern (heavily mirrored, matching the reference), and the mixer-rate cadence.
- **Mixer integration** — a new `ToccataAudioRing` alongside the existing `CdAudioRing`, a generalized `DeviceHost::for_slot_with_audio` carrying both rings to the bus's board-tick loop, and a fifth `push_mixed_frame` tap. The codec's own programmed rate (independent of the mixer's fixed 44.1 kHz) is converted through a polyphase windowed-sinc resampler — promoted out of `src/mt32/` into `src/audio/resample.rs` so both consumers share it — cached per codec rate so switching back to an already-used rate never rebuilds its kernel table.
- **`[toccata] enabled = true`** config, board attaches in `build_machine`, and the board registers as a `toccata` audio source for `--audio-stems`.
- Docs: new `docs/internals/toccata.md`, cross-linked from `docs/zorro.md`, `docs/guide/configuration.md`, and `docs/internals/audio.md`.

## Scope

In scope: playback (8-bit unsigned and 16-bit signed linear PCM, mono/stereo, all 14 AD1848 rates), autoconfig recognition, and INT6 interrupt semantics.

Out of scope for this PR, both explicitly noted in the docs and commit messages:
- **Record** — the record FIFO/interrupt path exists as inert stubs (never activates, since nothing sets `STATUS_FIFO_RECORD`).
- **The board's own "Paula/CD audio mixer" AUX input gain** — Copperline's Paula and CD-DA already reach the master mix directly, so modelling the board's internal analog mixer would add no user-visible capability.
- **Launcher GUI support** — `[toccata]` works via `--config`/a TOML file, but the launcher's machine-configuration screen doesn't yet have a Toccata row, so loading such a config into the launcher and saving from there would currently drop the setting (the same failure class the M0 PR's review caught and fixed for `[audio] stem_granularity`).
- **Full interactive AHI-driver verification** — the assets needed (AHI 4.18 + `toccata.audio`, already present locally) are documented in `tests/README.md`'s new recipe, and an asset-gated test (`toccata_ahi_driver_recognizes_the_board`) is scaffolded and ready, but actually building the HDF and confirming AHI prefs lists the board's modes is left as a follow-up better done with iterative screenshot review than guessed at autonomously.

## Test plan

- [x] `cargo test` — 2653 lib tests pass, including 30 new Toccata-specific unit tests (register semantics, FIFO edge cases, autoconfig identity, mixer-cadence end-to-end at the codec's native 44.1 kHz rate)
- [x] `cargo test --release --test probe_golden` — 28/28 golden renders pass (no video/timing regression)
- [x] `cargo test --test toccata -- --ignored` — the asset-free test passes for real (board autoconfigs, `toccata.wav` stem is written); the asset-gated AHI test skips cleanly without local assets
- [x] `cargo test --test audio_stems_determinism -- --ignored` — still green alongside the new board
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features --locked -- -D warnings` — clean
- [x] `cargo check --target wasm32-unknown-unknown` (crates/copperline-web) — clean
- [x] Manual: booted with `[toccata] enabled = true`, confirmed the board autoconfigs at a real Zorro II address in the log, and `--audio-stems-mode master,source,channel` writes `toccata.wav` alongside every other source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j8jbZX3Z2kZPYf6M2UVzg
