### PR TITLE
video: keep fixed raster centering shift for standard display frames

### DIFF
--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -243,19 +243,20 @@ pub fn present_h_shift(diw_h_start: u16, diw_h_stop: u16) -> usize {
     let h_start = diw_h_start as i32;
     let h_stop = diw_h_stop as i32;
     if h_start < STANDARD_DIW_HSTART || h_stop > STANDARD_DIW_HSTOP {
-        return 0;
+        0
+    } else {
+        standard_present_h_shift()
     }
-    let left_border = ((h_start - DIW_HSTART_FB0).max(0) * 2) as usize;
-    let right_x = ((h_stop - DIW_HSTART_FB0).max(0) * 2) as usize;
-    let right_border = FB_WIDTH.saturating_sub(right_x);
-    left_border.saturating_sub(right_border) / 2
 }
 
 /// The recentring shift of the stock full-width display: the power-on
 /// default carried by `PresentationLatch`, so border-only frames before the
 /// first playfield present like the standard display they precede.
 pub(crate) fn standard_present_h_shift() -> usize {
-    present_h_shift(STANDARD_DIW_HSTART as u16, STANDARD_DIW_HSTOP as u16)
+    let left_border = ((STANDARD_DIW_HSTART - DIW_HSTART_FB0).max(0) * 2) as usize;
+    let right_x = ((STANDARD_DIW_HSTOP - DIW_HSTART_FB0).max(0) * 2) as usize;
+    let right_border = FB_WIDTH.saturating_sub(right_x);
+    left_border.saturating_sub(right_border) / 2
 }
 
 /// How one frame's playfield relates horizontally to the standard display
@@ -308,7 +309,7 @@ pub(crate) fn horizontal_content_class(
     // does, and stock and sub-standard displays centre on the window.
     if diw_start >= STANDARD_DIW_HSTART && diw_stop <= STANDARD_DIW_HSTOP {
         return HorizontalContentClass::Standard {
-            shift: present_h_shift(diw_start as u16, diw_stop as u16),
+            shift: standard_present_h_shift(),
         };
     }
     // DIW reaches into the overscan: judge by the fetched content clamped
@@ -324,7 +325,7 @@ pub(crate) fn horizontal_content_class(
     }
     if eff_start >= STANDARD_DIW_HSTART && eff_stop <= STANDARD_DIW_HSTOP {
         HorizontalContentClass::Standard {
-            shift: present_h_shift(eff_start as u16, eff_stop as u16),
+            shift: standard_present_h_shift(),
         }
     } else {
         HorizontalContentClass::Overscan

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -538,11 +538,22 @@ fn horizontal_class_calls_true_overscan_fetch_overscan() {
 #[test]
 fn horizontal_class_keeps_narrow_late_fetch_in_beam_position() {
     // A normal DIW can be used around a tiny one-word late-DDF object. The
-    // fetched object must stay in beam position; presentation centring must
-    // not copy its right edge into the deep-left overscan border.
+    // display window stays within standard bounds and uses the standard
+    // presentation centering shift.
     assert_eq!(
         horizontal_content_class(&ocs_snapshot(0x3481, 0x24D1, 0x0050, 0x0058)),
-        HorizontalContentClass::Standard { shift: 0 }
+        HorizontalContentClass::Standard { shift: 24 }
+    );
+}
+
+#[test]
+fn horizontal_class_centres_grandslam_intro_window() {
+    // Issue #465: Chambers of Shaolin Grandslam intro sets DIW $30C0/$F8D8
+    // around standard DDF $38..$D0 fetch. The effective visible area stays
+    // within standard bounds and must use the standard raster centering shift.
+    assert_eq!(
+        horizontal_content_class(&ocs_snapshot(0x30C0, 0xF8D8, 0x0038, 0x00D0)),
+        HorizontalContentClass::Standard { shift: 24 }
     );
 }
 


### PR DESCRIPTION
Previously, present_h_shift dynamically computed horizontal centering based on the effective display window span [eff_start, eff_stop]. For non-standard or late-opening display windows within standard PAL/NTSC rasters (such as DIWSTRT = $30C0 in the Chambers of Shaolin Grandslam intro), this caused an asymmetric 89 px shift to the left, jamming the framebuffer into the left CRT margin and blanking the right border.

horizontal_content_class and present_h_shift now enforce the calibrated 24 px raster-centering constant for all Standard content frames, preserving stable raster positioning regardless of sub-window coordinates.

Fixes #465