### PR TITLE
tests: track the 4:3 glass height in the vAmigaTS screenshot assert

### DIFF
--- a/tests/vamiga_ts.rs
+++ b/tests/vamiga_ts.rs
@@ -182,14 +182,15 @@ fn run_case(
     }
 
     // A screenshot of any other size means the presentation path changed
-    // shape: 716x540 is the TV-glass picture (the captured aperture
-    // resampled onto the 4:3 glass), and COPPERLINE_SHOT_RAW saves the
-    // woven native framebuffer instead (716x570 = the vAmiga regression
-    // cutout with line doubling).
+    // shape: 716x537 is the 4:3 glass (PRESENT_HEIGHT_TV = FB_WIDTH * 3/4,
+    // the woven scanlines resampled onto the TV-aspect canvas), and
+    // COPPERLINE_SHOT_RAW saves the woven native framebuffer instead
+    // (716x570 = the vAmiga regression cutout with line doubling, the
+    // format tools/vamigats-compare.py consumes -- sweeps set it).
     if envcfg::flag("COPPERLINE_SHOT_RAW") {
         assert_png_dimensions(&png_path, 716, 570)?;
     } else {
-        assert_png_dimensions(&png_path, 716, 540)?;
+        assert_png_dimensions(&png_path, 716, 537)?;
     }
     if let Some(baseline_root) = baseline_root {
         let mut expected = baseline_root.join(&case.rel_path);


### PR DESCRIPTION
## Summary

The vamiga_ts harness's default-path screenshot assert still expected the 716x540 glass, but the square-pixel-aspect work made the TV-aspect presentation `PRESENT_HEIGHT_TV = FB_WIDTH * 3/4 = 537` rows, so any `vamiga_ts` run without `COPPERLINE_SHOT_RAW` failed on its first case. This updates the assert to 716x537 and clarifies in the comment that sweeps set `COPPERLINE_SHOT_RAW=1` for the 716x570 woven-framebuffer dumps `tools/vamigats-compare.py` consumes -- that path was never affected.

## Validation

- Both paths verified green on the `Agnus/DIW/OLDDIW` subtree (12 cases each way).
- Full 9-family sweep with fresh VAHeadless references runs clean end to end: 2998 cases in 81 min, case set matching the 2026-07-27 baseline 1:1.

## Sweep status (for the record, local `vamigats-reports/2026-08-16/`)

Against the 2026-07-27 baseline the suite is essentially flat: Paula/Memory/Mainboard/FPU/Misc identical to the decimal, Agnus -1.8, Denise -0.3, CIA +0.95 (single case). The only real movement is CPU `_68010` IPL cases: +40.9 net over 246 rows in a bidirectional +-2..6 scatter -- a small systematic 68010 interrupt-recognition phase shift relative to vAmiga, plausibly from the m68k 0.10.13 bump (#450); 68000 cases improved slightly. Worth a targeted follow-up on the 68010 IPL pipeline; filed here as context, not addressed by this PR.
