### PR TITLE
HDD LED: Enable for Zorro IDE

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3891,7 +3891,7 @@ impl Bus {
             fdd_track: self.floppy.selected_track(),
             hdd_led: (self.gayle.is_some()
                 || self.ide_a4000.is_some()
-                || self.has_scsi_device()
+                || self.has_hard_disk_controller()
                 || self.has_filesys_mount())
             .then_some(self.emulated_cck < self.hdd_led_until_cck),
             cd_led: self
@@ -4179,13 +4179,14 @@ impl Bus {
 
     /// Whether the machine has a hard-disk controller, which is what gives it
     /// an HDD LED: a Zorro board, or the A3000's motherboard SCSI.
-    fn has_scsi_device(&self) -> bool {
+    fn has_hard_disk_controller(&self) -> bool {
         self.sdmac.is_some()
             || self.devices.iter().any(|d| {
                 matches!(
                     d,
                     crate::zorro_device::BoardDevice::A2091(_)
                         | crate::zorro_device::BoardDevice::A4091(_)
+                        | crate::zorro_device::BoardDevice::IdeZorro(_)
                 )
             })
     }

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -10299,6 +10299,29 @@ fn front_panel_hdd_led_present_for_filesys_mount() {
 }
 
 #[test]
+fn front_panel_hdd_led_present_for_zorro_ide() {
+    let mut bus = empty_bus();
+    // No storage controller: no HDD LED at all.
+    assert_eq!(bus.front_panel_status().hdd_led, None);
+
+    // A lide-compatible Zorro IDE board is a hard-disk controller, so its
+    // presence alone gives the machine an HDD LED -- even hardware-only
+    // (no boot ROM) with no drives attached.
+    let board =
+        crate::ide_zorro::IdeZorro::new(crate::ide_zorro::LidePersonality::Ripple, Vec::new())
+            .unwrap();
+    bus.attach_devices(vec![crate::zorro_device::BoardDevice::IdeZorro(board)]);
+    assert_eq!(bus.front_panel_status().hdd_led, Some(false));
+
+    bus.note_hdd_activity();
+    assert_eq!(bus.front_panel_status().hdd_led, Some(true));
+
+    // The hold expires once emulated time passes the deadline.
+    bus.emulated_cck += u64::from(PAULA_CLOCK_HZ);
+    assert_eq!(bus.front_panel_status().hdd_led, Some(false));
+}
+
+#[test]
 fn front_panel_reports_host_output_volume() {
     let mut bus = empty_bus();
 


### PR DESCRIPTION
Thanks @sidick and @LinuxJedi for adding RIPPLE/RIDE/AT-Bus!

The HDD LED was not enabled for Zorro IDE boards, this PR fixes that