### PR TITLE
launcher: the I/O Ports tab splits into pages, and panels stop clipping

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1217,7 +1217,7 @@ With an `AUX:` shell on the Amiga side, `tcp`/`pty` give a remote AmigaDOS
 console. `--serial MODE` overrides the mode per run,
 `--serial-connect HOST:PORT` sets the dial-out target (and implies
 `mode = "tcp-connect"`), and `--midi-out NAME`/`--midi-in NAME` imply
-`mode = "midi"`. The launcher's **I/O Ports** tab (Serial section) sets all
+`mode = "midi"`. The launcher's **I/O Ports** tab (Serial Port page) sets all
 of this interactively: **Device / Mode** picks the mode, and the mode brings
 its own address box with it -- **Connect** under `tcp-connect` for the
 remote to dial, **Listen** under `tcp` for the local bind address (it shows
@@ -1777,7 +1777,7 @@ net = "nat"   # or "bridge", "loopback"; "none" for an isolated NIC
 
 Fits a Commodore A2065 Ethernet board (Am7990 LANCE) on the Zorro chain;
 `--a2065-net BACKEND` is the matching per-run flag, and the launcher's
-**I/O Ports** tab (Ethernet section) has the same picker. `net` selects the
+**I/O Ports** tab (Networking page) has the same picker. `net` selects the
 host network backend:
 
 - `"nat"` -- userspace NAT: the guest gets outbound IPv4 internet through a
@@ -1819,7 +1819,7 @@ chain. Its stock, open-source AHI driver (`toccata.audio`) works unmodified,
 so any AHI-aware guest application gets 16-bit sound with no
 Copperline-specific setup. No other options exist yet. Omit the section
 (or `enabled = false`) for no board. The launcher's **I/O Ports** tab
-(Sound section) has the matching fit/don't-fit toggle; host-side audio
+(Audio page) has the matching fit/don't-fit toggle; host-side audio
 capture and backend settings (`--audio-wav`, `--audio-stems`, device
 selection) stay command-line/config-file only and have no launcher row.
 The board's output joins the mixer as the `toccata` source for
@@ -1839,7 +1839,7 @@ chain, serving the Amiga MHI API through the ported
 hardware-accelerated MP3 decoding. No other options exist yet. Omit the
 section (or `enabled = false`) for no board. Needs a build with the `mhi`
 feature (on by default; off only for the wasm32 build). The launcher's
-**I/O Ports** tab (Sound section) has the matching fit/don't-fit toggle;
+**I/O Ports** tab (Audio page) has the matching fit/don't-fit toggle;
 host-side audio capture and backend settings (`--audio-wav`,
 `--audio-stems`, device selection) stay command-line/config-file only and
 have no launcher row.
@@ -1880,7 +1880,7 @@ with an online mode) opens `bsdsocket.library` and calls
 Roadshow -- but there is no guest-side stack to install, configure, or boot:
 the library autoboots from the board's ROM on Kickstart 1.3 through 3.x and
 on the bundled AROS ROM. `--hostsocket-net BACKEND` is the matching per-run
-flag, and the launcher's **I/O Ports** tab (Ethernet section) has the same
+flag, and the launcher's **I/O Ports** tab (Networking page) has the same
 picker.
 
 `net` selects the same host network backends as the A2065 (see above for

--- a/docs/guide/mt32.md
+++ b/docs/guide/mt32.md
@@ -35,7 +35,7 @@ that sounds subtly wrong.
 ## Turning it on
 
 The serial port has to be in MIDI mode with the MT-32 as its output. In the
-launcher, that is the **I/O Ports** tab, Serial section: set **Device / Mode**
+launcher, that is the **I/O Ports** tab (its Serial Port page): set **Device / Mode**
 to `MIDI`, then **MIDI output** to `MT-32`. Choosing it reveals the rest
 of the rows:
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -540,10 +540,12 @@ The layout is:
   that returns to Storage),
   *Input* (the controller device in each game port and the joystick input
   source),
-  *I/O Ports* (the serial, parallel, Ethernet, and sound boards under
-  **Serial:** / **Parallel:** / **Ethernet:** / **Sound:** headings, with
+  *I/O Ports* (the serial, parallel, networking, and audio boards, each
+  on its own page -- **Serial Port**, **Parallel Port**, **Networking**,
+  **Audio** -- switched between on the top nav row, with
   each port's options indented
-  beneath it: serial mode and MIDI endpoints, with the emulated MT-32's ROM
+  beneath its heading: serial mode and MIDI endpoints, with the emulated
+  MT-32's ROM
   images, front panel and display style when it is the chosen output (see
   [The MT-32](mt32.md)), and, for the two TCP modes, the address box that
   mode needs -- **Connect** (`tcp-connect`) for the `host:port` to dial, or

--- a/docs/internals/mhi.md
+++ b/docs/internals/mhi.md
@@ -553,7 +553,7 @@ content above.
 - **Savestate layout**: adding the `mhi_audio` ring to `Paula` and the
   `BoardDevice::Mhi` variant bumped `savestate::STATE_VERSION` to **57**.
 - **Launcher**: the machine-configuration launcher's **I/O Ports** tab
-  (Sound section) has a plain fit/don't-fit toggle for the board (same as
+  (Audio page) has a plain fit/don't-fit toggle for the board (same as
   Toccata, see [](toccata)'s "What's out of scope" section); host-side
   audio capture/backend options stay command-line/config-file only.
 - **Large-descriptor DMA copy**: `DESC_LEN` genuinely does not truncate --

--- a/docs/internals/toccata.md
+++ b/docs/internals/toccata.md
@@ -158,7 +158,7 @@ same point, covered by
   gain feeding the board's own analog mixer) is not modelled: Copperline's
   Paula and CD-DA already reach the master mix directly, so replicating
   the board's own internal mixing would add no user-visible capability.
-- The launcher's **I/O Ports** tab (Sound section) has a plain fit/don't-fit
+- The launcher's **I/O Ports** tab (Audio page) has a plain fit/don't-fit
   toggle for the board; host-side audio capture/backend options
   (`--audio-wav`, `--audio-stems`, device selection) are not exposed there
   and stay command-line/config-file only.

--- a/docs/zorro.md
+++ b/docs/zorro.md
@@ -244,7 +244,8 @@ net = "nat"   # "bridge", "loopback", or "none" for isolation
 ```
 
 (`--a2065-net BACKEND` is the matching per-run flag, and the launcher's
-**I/O Ports** tab has the same picker under its **Ethernet:** heading. Bridged
+**I/O Ports** tab's **Networking** page has the same picker under its
+**Ethernet:** heading. Bridged
 mode adds a live host-adapter picker. `--list-net-interfaces` prints the stable
 names accepted by `[a2065] interface` and `--a2065-interface`.)
 

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -2126,8 +2126,8 @@ pub struct MachineSetup {
     /// The MacroSystem Toccata sound board, edited in the I/O Ports tab's
     /// Audio page (`[toccata] enabled`). No other options exist yet.
     toccata: bool,
-    /// The MHI virtual MPEG audio decoder board, edited in the same Sound
-    /// section (`[mhi] enabled`) in an `mhi` build, the only build that can
+    /// The MHI virtual MPEG audio decoder board, edited on the same Audio
+    /// page (`[mhi] enabled`) in an `mhi` build, the only build that can
     /// fit the board. Kept as an unconditional passthrough field even in a
     /// non-`mhi` build so loading and re-saving a config does not silently
     /// drop a `[mhi] enabled` set by some other build -- only the launcher

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -194,9 +194,15 @@ pub enum LauncherTab {
     /// The `[lide]` built-in Zorro II IDE board: personality, boot ROM(s),
     /// and its drives, reached from the Storage tab.
     Lide,
-    /// Serial and parallel ports on one tab, under `Serial:` / `Parallel:`
-    /// section headings.
+    /// The "I/O Ports" strip tab, whose default category is the serial
+    /// port. Parallel, networking and audio are its sibling categories,
+    /// switched between via the top nav row, with no Back button --
+    /// `IoPorts.label()` is therefore the strip's "I/O Ports", not
+    /// "Serial Port".
     IoPorts,
+    IoParallel,
+    IoNetworking,
+    IoAudio,
     Input,
     Zorro,
     /// The "A/V & Emu" strip tab, whose default category is Audio (its rows are
@@ -289,6 +295,9 @@ impl LauncherTab {
             LauncherTab::Cd => "CD",
             LauncherTab::Lide => "Lide",
             LauncherTab::IoPorts => "I/O Ports",
+            LauncherTab::IoParallel => "Parallel Port",
+            LauncherTab::IoNetworking => "Networking",
+            LauncherTab::IoAudio => "Audio",
             LauncherTab::Input => "Input",
             LauncherTab::Zorro => "Zorro",
             LauncherTab::AvAudio => "A/V & Emu",
@@ -323,6 +332,9 @@ impl LauncherTab {
             LauncherTab::FluxBridge => LauncherTab::Floppy,
             LauncherTab::AvVideo | LauncherTab::AvEmulation | LauncherTab::AvPaths => {
                 LauncherTab::AvAudio
+            }
+            LauncherTab::IoParallel | LauncherTab::IoNetworking | LauncherTab::IoAudio => {
+                LauncherTab::IoPorts
             }
             other => other,
         }
@@ -363,6 +375,10 @@ impl LauncherTab {
             | LauncherTab::AvVideo
             | LauncherTab::AvEmulation
             | LauncherTab::AvPaths => AV_NAV,
+            LauncherTab::IoPorts
+            | LauncherTab::IoParallel
+            | LauncherTab::IoNetworking
+            | LauncherTab::IoAudio => IO_NAV,
             LauncherTab::CreateFloppy | LauncherTab::CreateHard => CREATE_NAV,
             #[cfg(feature = "game-library")]
             LauncherTab::Whdload | LauncherTab::WhdloadLibrary => WHDLOAD_NAV,
@@ -407,6 +423,15 @@ const WHDLOAD_NAV: &[(&str, LauncherTab)] = &[
 const CREATE_NAV: &[(&str, LauncherTab)] = &[
     ("Floppy Disk", LauncherTab::CreateFloppy),
     ("Hard Disk", LauncherTab::CreateHard),
+];
+
+/// The I/O Ports categories, left to right. `IoPorts` is the default,
+/// so its button reads "Serial Port".
+const IO_NAV: &[(&str, LauncherTab)] = &[
+    ("Serial Port", LauncherTab::IoPorts),
+    ("Parallel Port", LauncherTab::IoParallel),
+    ("Networking", LauncherTab::IoNetworking),
+    ("Audio", LauncherTab::IoAudio),
 ];
 
 /// The A/V & Emu categories, left to right (matching "A/V"). `AvAudio` is the
@@ -1300,11 +1325,10 @@ pub fn rows(
         LauncherTab::HostDisk => Cow::Borrowed(&[]),
         LauncherTab::Cd => Cow::Borrowed(&CD_ROWS),
         LauncherTab::Lide => Cow::Borrowed(&LIDE_ROWS),
-        LauncherTab::IoPorts => Cow::Owned(io_ports_rows(
-            serial_mode,
-            midi_out_is_mt32,
-            parallel_device,
-        )),
+        LauncherTab::IoPorts => Cow::Owned(io_serial_rows(serial_mode, midi_out_is_mt32)),
+        LauncherTab::IoParallel => Cow::Owned(io_parallel_rows(parallel_device)),
+        LauncherTab::IoNetworking => Cow::Owned(io_networking_rows()),
+        LauncherTab::IoAudio => Cow::Owned(io_audio_rows()),
         LauncherTab::Input => Cow::Borrowed(&INPUT_ROWS),
         LauncherTab::Zorro => Cow::Borrowed(&[]),
         // A/V & Emu defaults to the Audio category; Video and Emulation are its
@@ -1316,26 +1340,34 @@ pub fn rows(
     }
 }
 
-/// The I/O Ports tab: a `Serial:` section (only in a `midi` build, which is the
-/// only build with serial rows), a `Parallel:` section, an `Ethernet:`
-/// section, and a `Sound:` section, each under a greyed heading and each
+/// The I/O Ports pages, one section each: `Serial:` (only in a `midi`
+/// build, which is the only build with serial rows), `Parallel:`,
+/// `Ethernet:` and `Audio:`, each under its greyed heading and each
 /// showing only the rows relevant to its selected device/mode.
-fn io_ports_rows(
-    serial_mode: SerialMode,
-    midi_out_is_mt32: bool,
-    parallel_device: ParallelDevice,
-) -> Vec<Row> {
+fn io_serial_rows(serial_mode: SerialMode, midi_out_is_mt32: bool) -> Vec<Row> {
     let mut rows = Vec::new();
     let serial = serial_rows(serial_mode, midi_out_is_mt32);
     if !serial.is_empty() {
         rows.push(section_header("Serial:"));
         rows.extend_from_slice(serial);
     }
-    rows.push(section_header("Parallel:"));
+    rows
+}
+
+fn io_parallel_rows(parallel_device: ParallelDevice) -> Vec<Row> {
+    let mut rows = vec![section_header("Parallel:")];
     rows.extend_from_slice(parallel_rows(parallel_device));
-    rows.push(section_header("Ethernet:"));
+    rows
+}
+
+fn io_networking_rows() -> Vec<Row> {
+    let mut rows = vec![section_header("Ethernet:")];
     rows.extend_from_slice(&ETHERNET_ROWS);
-    rows.push(section_header("Sound:"));
+    rows
+}
+
+fn io_audio_rows() -> Vec<Row> {
+    let mut rows = vec![section_header("Audio:")];
     rows.extend_from_slice(&SOUND_ROWS);
     rows
 }
@@ -2092,7 +2124,7 @@ pub struct MachineSetup {
     hostsocket_gateway: Option<String>,
     hostsocket_resolver: Option<String>,
     /// The MacroSystem Toccata sound board, edited in the I/O Ports tab's
-    /// Sound section (`[toccata] enabled`). No other options exist yet.
+    /// Audio page (`[toccata] enabled`). No other options exist yet.
     toccata: bool,
     /// The MHI virtual MPEG audio decoder board, edited in the same Sound
     /// section (`[mhi] enabled`) in an `mhi` build, the only build that can
@@ -12161,31 +12193,83 @@ mod tests {
 
     #[cfg(feature = "midi")]
     #[test]
-    fn io_ports_tab_groups_serial_parallel_and_ethernet_under_headers() {
+    fn io_ports_pages_carry_one_section_each() {
+        let header = |tab| {
+            let r = rows(tab, ParallelDevice::None, SerialMode::Midi, false);
+            r.iter()
+                .filter(|x| x.kind == RowKind::SectionHeader)
+                .map(|x| x.label)
+                .collect::<Vec<_>>()
+        };
+        // Serial Port page: the Device / Mode selector and (in MIDI) the
+        // endpoints, under the one heading.
+        assert_eq!(
+            header(LauncherTab::IoPorts),
+            ["Serial:"],
+            "the strip tab is the serial page"
+        );
         let r = rows(
             LauncherTab::IoPorts,
             ParallelDevice::None,
             SerialMode::Midi,
             false,
         );
-        let headers: Vec<_> = r
-            .iter()
-            .filter(|x| x.kind == RowKind::SectionHeader)
-            .map(|x| x.label)
-            .collect();
-        assert_eq!(headers, ["Serial:", "Parallel:", "Ethernet:", "Sound:"]);
-        // Serial section: the Device / Mode selector, and (in MIDI) the endpoints.
         assert!(r.iter().any(|x| x.field == LauncherField::SerialMode));
         assert!(r.iter().any(|x| x.field == LauncherField::MidiOut));
-        // Parallel section: the device selector.
+        assert!(
+            !r.iter().any(|x| x.field == LauncherField::ParallelDevice),
+            "parallel lives on its own page now"
+        );
+        // Parallel Port page: the device selector.
+        assert_eq!(header(LauncherTab::IoParallel), ["Parallel:"]);
+        let r = rows(
+            LauncherTab::IoParallel,
+            ParallelDevice::None,
+            SerialMode::Midi,
+            false,
+        );
         assert!(r.iter().any(|x| x.field == LauncherField::ParallelDevice));
-        // Ethernet section: the A2065 board selector.
+        // Networking page: the A2065 board selector.
+        assert_eq!(header(LauncherTab::IoNetworking), ["Ethernet:"]);
+        let r = rows(
+            LauncherTab::IoNetworking,
+            ParallelDevice::None,
+            SerialMode::Midi,
+            false,
+        );
         assert!(r.iter().any(|x| x.field == LauncherField::Ethernet));
-        // Sound section: the Toccata board toggle, and (in an `mhi` build)
+        // Audio page: the Toccata board toggle, and (in an `mhi` build)
         // the MHI board toggle alongside it.
+        assert_eq!(header(LauncherTab::IoAudio), ["Audio:"]);
+        let r = rows(
+            LauncherTab::IoAudio,
+            ParallelDevice::None,
+            SerialMode::Midi,
+            false,
+        );
         assert!(r.iter().any(|x| x.field == LauncherField::Toccata));
         #[cfg(feature = "mhi")]
         assert!(r.iter().any(|x| x.field == LauncherField::Mhi));
+        // The four pages switch between each other on the nav row, under
+        // the one strip entry, with no Back button -- the A/V pattern.
+        for tab in [
+            LauncherTab::IoParallel,
+            LauncherTab::IoNetworking,
+            LauncherTab::IoAudio,
+        ] {
+            assert_eq!(tab.strip_tab(), LauncherTab::IoPorts);
+            assert_eq!(tab.parent_tab(), None);
+            assert!(tab.has_top_nav());
+        }
+        assert_eq!(
+            LauncherTab::IoPorts.nav_options(),
+            [
+                ("Serial Port", LauncherTab::IoPorts),
+                ("Parallel Port", LauncherTab::IoParallel),
+                ("Networking", LauncherTab::IoNetworking),
+                ("Audio", LauncherTab::IoAudio),
+            ]
+        );
     }
 
     #[test]
@@ -12399,9 +12483,14 @@ mod tests {
     #[test]
     fn parallel_sampler_rows_appear_only_when_selected() {
         let has = |device| {
-            rows(LauncherTab::IoPorts, device, SerialMode::default(), false)
-                .iter()
-                .any(|r| r.field == LauncherField::SamplerInput)
+            rows(
+                LauncherTab::IoParallel,
+                device,
+                SerialMode::default(),
+                false,
+            )
+            .iter()
+            .any(|r| r.field == LauncherField::SamplerInput)
         };
         // The sampler rows are hidden (not greyed) unless the sampler is chosen.
         assert!(!has(ParallelDevice::None));
@@ -12437,9 +12526,14 @@ mod tests {
         let mut s = MachineSetup::default();
         // The Output file row shows only when the printer is selected.
         let has_output = |device| {
-            rows(LauncherTab::IoPorts, device, SerialMode::default(), false)
-                .iter()
-                .any(|r| r.field == LauncherField::ParallelOutput)
+            rows(
+                LauncherTab::IoParallel,
+                device,
+                SerialMode::default(),
+                false,
+            )
+            .iter()
+            .any(|r| r.field == LauncherField::ParallelOutput)
         };
         assert!(!has_output(ParallelDevice::None));
         assert!(has_output(ParallelDevice::Printer));

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -8898,11 +8898,11 @@ fn draw_launcher(
     // NAT and bridged backends deliver inbound traffic on the host's schedule,
     // so warn that runs stop being reproducible the moment packets flow
     // (loopback and an isolated NIC stay deterministic).
-    if state.tab == LauncherTab::IoPorts && setup.ethernet_breaks_determinism() {
+    if state.tab == LauncherTab::IoNetworking && setup.ethernet_breaks_determinism() {
         let note_top = launcher_row_y(
             rect,
             launcher::rows(
-                LauncherTab::IoPorts,
+                LauncherTab::IoNetworking,
                 state.setup.parallel_device(),
                 state.setup.serial_mode(),
                 state.setup.midi_out_is_mt32(),

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -963,7 +963,12 @@ fn panel_dims(panel: &Panel) -> (usize, usize) {
         Panel::Debugger(_) => (684, 520),
         Panel::FrameAnalyzer(_) => (700, 526),
         Panel::Console(_) => (700, 460),
-        Panel::Launcher(_) => (LAUNCHER_W, LAUNCHER_H),
+        // Clamped to the display area so the status bar below stays a
+        // status bar whatever the height grows to: a taller launcher
+        // gives up height rather than pixels, because its bottom row is
+        // its buttons, and buttons drawn off the canvas cannot be
+        // clicked.
+        Panel::Launcher(_) => (LAUNCHER_W, LAUNCHER_H.min(present_height())),
         Panel::DropChooser(state) => (
             460,
             TITLE_H
@@ -4299,11 +4304,10 @@ fn draw_heat_census(
 // Machine-configuration (launcher) panel
 // ---------------------------------------------------------------------------
 
-const LAUNCHER_W: usize = 700;
-// Tall enough for the I/O Ports tab's worst case: Serial (MT-32, 7 rows),
-// Parallel (Sampler, 3 rows), Ethernet (4 rows), and Sound (2 rows), each
-// under its own heading -- see `every_launcher_tab_row_fits_inside_the_panel`.
-const LAUNCHER_H: usize = 600;
+// Full canvas width: the panel's edges line up with the status bar
+// below it rather than leaving gutters of display either side.
+const LAUNCHER_W: usize = FB_WIDTH;
+const LAUNCHER_H: usize = 520;
 const LAUNCH_MARGIN: usize = 8;
 const LAUNCH_MODEL_H: usize = 22;
 const LAUNCH_MODEL_GAP: usize = 4;
@@ -10001,6 +10005,9 @@ mod tests {
         // The strip tabs, plus the sub-pages and A/V categories reached from a
         // nav row rather than the strip.
         let off_strip = [
+            LauncherTab::IoParallel,
+            LauncherTab::IoNetworking,
+            LauncherTab::IoAudio,
             LauncherTab::Cd,
             LauncherTab::HostFs,
             LauncherTab::Whdload,
@@ -10666,7 +10673,9 @@ mod tests {
         .filter(|r| !state.setup.row_hidden(r.field))
         .position(|r| r.field == LauncherField::SerialConnect)
         .expect("no Connect row in tcp-connect mode");
-        let row_y = launcher_row_y(rect, index);
+        // The serial page sits under the I/O Ports nav row, so its rows
+        // start a nav block lower.
+        let row_y = launcher_row_y(rect, index) + LAUNCH_NAV_BLOCK_H;
         let box_rect = launcher_text_rect(rect, row_y, LauncherField::SerialConnect);
         assert_eq!(
             ui.control_at((box_rect.x as i32 + 4, box_rect.y as i32 + 4)),


### PR DESCRIPTION
be01d0de raised the launcher panel to 600 rows for the fuller I/O Ports tab, but the panel centres inside the 4:3 presentation's 537 rows: the bottom row of buttons clipped off the canvas and the status bar vanished behind the panel — and no amount of compression holds once serial MIDI + MT-32, a sampler, a network board and both sound boards are all showing.

The tab grows sideways instead, the way A/V & Emu already does: one strip entry with four pages on its top nav row — **Serial Port**, **Parallel Port**, **Networking**, **Audio** — each carrying the section that used to stack (`Sound:` renamed `Audio:` to match). The panel height returns to 520, clamps to the display area so the status bar always survives, and takes the full canvas width so its edges line up with the bar. Docs follow the sections to their pages; `every_launcher_tab_row_fits_inside_the_panel` sweeps the new pages.

Previously:
<img width="722" height="635" alt="Screenshot 2026-08-17 at 00 47 26" src="https://github.com/user-attachments/assets/afc56409-41e5-4e42-acc7-6ec40b7cebfd" />
<img width="732" height="613" alt="Screenshot 2026-08-17 at 01 56 13" src="https://github.com/user-attachments/assets/6e09017c-0240-4020-85ae-0dccebfec481" />

Now: 
<img width="725" height="616" alt="image" src="https://github.com/user-attachments/assets/c6b40284-b01d-48ab-9bca-ee897b30f74a" />
