### PR TITLE
MHI: pure-Rust Symphonia decoder (fixes Windows ARM64 build) + win-arm64 CI and release zips

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,9 @@
-# Static-link the MSVC C runtime on Windows so the release binary and the
-# packaged zip (packaging/windows/build-zip.ps1) run without the Visual C++
-# Redistributable installed. Scoped to the MSVC target, so the macOS and Linux
-# builds are unaffected.
+# Static-link the MSVC C runtime on Windows so the release binaries and the
+# packaged zips (packaging/windows/build-zip.ps1) run without the Visual C++
+# Redistributable installed. Scoped to the MSVC targets (x86-64 and ARM64),
+# so the macOS and Linux builds are unaffected.
 [target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,16 +1,20 @@
 name: Windows
 
-# Two parallel builder jobs produce the portable Windows zip and the prebuilt
-# test executables (both are full release compiles and roughly equally
-# expensive, so splitting them halves the critical path), then the checks fan
-# out in parallel against those artifacts, mirroring ci.yml: the packaged zip
-# is booted from a clean directory, and the unit suites plus the probe golden
+# Everything here runs as a two-leg matrix: x86-64 on windows-latest and
+# ARM64 on the windows-11-arm runner, each leg building natively for its own
+# architecture (no cross-compiling). Per architecture, two parallel builder
+# jobs produce the portable Windows zip and the prebuilt test executables
+# (both are full release compiles and roughly equally expensive, so
+# splitting them halves the critical path), then the checks fan out in
+# parallel against those artifacts, mirroring ci.yml: the packaged zip is
+# booted from a clean directory, and the unit suites plus the probe golden
 # renders (pixel-exact deterministic boots on the bundled AROS ROM) run
 # against the same release binaries. This is also the only Windows coverage
 # (the main CI runs on macOS and Linux), so the code-path triggers below run
 # the full release build on pull requests too. On a v* tag push (or a manual
-# run with release_tag) the zip is attached to the GitHub Release by the
-# release job, which runs only after every check passes.
+# run with release_tag) both zips are attached to the GitHub Release by the
+# release job, which runs only after every check on both architectures has
+# passed.
 on:
   push:
     branches: [main]
@@ -34,15 +38,15 @@ on:
       - ".cargo/**"
       - "packaging/windows/**"
       - ".github/workflows/windows.yml"
-  # Manual rebuild. Use this to attach a zip to a release whose tag predates
+  # Manual rebuild. Use this to attach zips to a release whose tag predates
   # this workflow (the v* tag tree has no windows.yml, so a tag push cannot
   # trigger it): run it against a branch that has the source parity you want
   # (for v0.2.0, main is identical to the tag bar the Homebrew bump) and set
-  # release_tag to push the built zip onto that existing release.
+  # release_tag to push the built zips onto that existing release.
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Existing release tag to attach the zip to (e.g. v0.2.0). Leave blank to only upload a workflow artifact."
+        description: "Existing release tag to attach the zips to (e.g. v0.2.0). Leave blank to only upload workflow artifacts."
         required: false
         default: ""
 
@@ -52,11 +56,21 @@ concurrency:
 
 jobs:
   build:
-    name: Build Windows zip
+    name: Build Windows zip (${{ matrix.arch }})
     # Compiles the release binary and packages the portable zip; the sibling
     # test-bins job compiles the test executables in parallel on its own
     # runner.
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+          - arch: arm64
+            runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
     steps:
       - name: Force LF checkout
         # The runner's git converts detected-text files to CRLF on checkout
@@ -65,18 +79,30 @@ jobs:
         # keep the working tree identical to the macOS/Linux jobs.
         run: git config --global core.autocrlf false
       - uses: actions/checkout@v7
+      - name: Ensure rustup
+        # windows-latest ships rustup preinstalled; the windows-11-arm image
+        # may not. Install the native rustup when it is absent so the
+        # toolchain action below works identically on both runners.
+        shell: pwsh
+        run: |
+          if (-not (Get-Command rustup -ErrorAction SilentlyContinue)) {
+            Invoke-WebRequest "https://static.rust-lang.org/rustup/dist/${{ matrix.target }}/rustup-init.exe" -OutFile rustup-init.exe
+            ./rustup-init.exe -y --default-toolchain none --profile minimal
+            Remove-Item rustup-init.exe
+            "$env:USERPROFILE\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          }
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-pc-windows-msvc
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
       - name: Build release zip
         shell: pwsh
-        run: packaging/windows/build-zip.ps1
+        run: packaging/windows/build-zip.ps1 -Target ${{ matrix.target }}
       - name: Locate artifact
         id: artifact
         shell: pwsh
         run: |
-          $zip = Get-ChildItem Copperline-*-win-x64.zip | Select-Object -First 1
+          $zip = Get-ChildItem Copperline-*-win-${{ matrix.arch }}.zip | Select-Object -First 1
           "path=$($zip.Name)" >> $env:GITHUB_OUTPUT
       - name: Upload zip
         # Consumed by the zip-smoke and release jobs, and kept as the
@@ -85,12 +111,12 @@ jobs:
         # debugging.
         uses: actions/upload-artifact@v7
         with:
-          name: copperline-windows
+          name: copperline-windows-${{ matrix.arch }}
           path: ${{ steps.artifact.outputs.path }}
           if-no-files-found: error
 
   test-bins:
-    name: Build test binaries
+    name: Build test binaries (${{ matrix.arch }})
     # Compiles the #[test] targets once and hands the finished executables
     # to the test jobs below (needs: test-bins) as a workflow artifact.
     # Binaries, not a shared cargo cache: the test executables are plain
@@ -99,17 +125,38 @@ jobs:
     # compile-time CARGO_BIN_EXE_copperline path), so the staged
     # copperline.exe pairs with the probe_golden harness compiled alongside
     # it and this job needs nothing from the zip build. Swatinem/rust-cache
-    # keys per job, so each builder keeps its own warm cache.
-    runs-on: windows-latest
+    # keys per job and per toolchain, so each builder keeps its own warm
+    # cache.
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+          - arch: arm64
+            runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
     steps:
       - name: Force LF checkout
         # Keep committed fixture bytes identical to the build job (see the
         # comment there).
         run: git config --global core.autocrlf false
       - uses: actions/checkout@v7
+      - name: Ensure rustup
+        # See the build job's identical step.
+        shell: pwsh
+        run: |
+          if (-not (Get-Command rustup -ErrorAction SilentlyContinue)) {
+            Invoke-WebRequest "https://static.rust-lang.org/rustup/dist/${{ matrix.target }}/rustup-init.exe" -OutFile rustup-init.exe
+            ./rustup-init.exe -y --default-toolchain none --profile minimal
+            Remove-Item rustup-init.exe
+            "$env:USERPROFILE\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          }
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-pc-windows-msvc
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
       - name: Compile test binaries
         shell: pwsh
@@ -120,10 +167,10 @@ jobs:
         # excluded from the build).
         run: |
           $ErrorActionPreference = "Stop"
-          cargo test --release --locked --target x86_64-pc-windows-msvc --no-run --message-format=json > cargo-test-build.json
+          cargo test --release --locked --target ${{ matrix.target }} --no-run --message-format=json > cargo-test-build.json
           if ($LASTEXITCODE -ne 0) { throw "cargo test --no-run exited with $LASTEXITCODE" }
           New-Item -ItemType Directory -Force -Path ci-bins | Out-Null
-          Copy-Item target\x86_64-pc-windows-msvc\release\copperline.exe ci-bins\
+          Copy-Item target\${{ matrix.target }}\release\copperline.exe ci-bins\
           Get-Content cargo-test-build.json | ForEach-Object {
             $msg = $_ | ConvertFrom-Json
             if ($msg.reason -eq "compiler-artifact" -and $msg.profile.test -and $msg.executable) {
@@ -139,19 +186,27 @@ jobs:
       - name: Upload binaries for the test jobs
         uses: actions/upload-artifact@v7
         with:
-          name: windows-test-bins
+          name: windows-test-bins-${{ matrix.arch }}
           path: ci-bins/
 
   zip-smoke:
-    name: Packaged zip boot smoke
+    name: Packaged zip boot smoke (${{ matrix.arch }})
     needs: build
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+          - arch: arm64
+            runner: windows-11-arm
     # No checkout: the zip must stand on its own, which is the point of the
     # test.
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: copperline-windows
+          name: copperline-windows-${{ matrix.arch }}
       - name: Smoke test the packaged zip
         shell: pwsh
         # Expand the freshly built zip outside the workspace and boot it from
@@ -164,7 +219,7 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           Set-StrictMode -Version Latest
-          $zip = Get-ChildItem Copperline-*-win-x64.zip | Select-Object -First 1
+          $zip = Get-ChildItem Copperline-*-win-${{ matrix.arch }}.zip | Select-Object -First 1
           $stage = Join-Path $env:RUNNER_TEMP "zip-smoke"
           Expand-Archive -Path $zip.FullName -DestinationPath $stage
           $exe = Get-ChildItem -Path $stage -Recurse -Filter copperline.exe | Select-Object -First 1
@@ -174,9 +229,17 @@ jobs:
           if ((Get-Item smoke.png).Length -eq 0) { throw "screenshot is empty" }
 
   unit-tests:
-    name: Unit tests
+    name: Unit tests (${{ matrix.arch }})
     needs: test-bins
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+          - arch: arm64
+            runner: windows-11-arm
     steps:
       - name: Force LF checkout
         # Keep committed fixture bytes identical to the build job (see the
@@ -185,7 +248,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
-          name: windows-test-bins
+          name: windows-test-bins-${{ matrix.arch }}
           path: ci-bins
       - name: Unit tests
         shell: pwsh
@@ -203,9 +266,19 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "unit-bin-copperline-ctl exited with $LASTEXITCODE" }
 
   probe-golden:
-    name: Probe golden renders
+    name: Probe golden renders (${{ matrix.arch }})
     needs: test-bins
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+          - arch: arm64
+            runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
     steps:
       - name: Force LF checkout
         # Keep committed fixture bytes identical to the build job (see the
@@ -214,7 +287,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
-          name: windows-test-bins
+          name: windows-test-bins-${{ matrix.arch }}
           path: ci-bins
       - name: Probe golden renders
         shell: pwsh
@@ -233,8 +306,8 @@ jobs:
         # --target build directory before running.
         run: |
           $ErrorActionPreference = "Stop"
-          New-Item -ItemType Directory -Force -Path target\x86_64-pc-windows-msvc\release | Out-Null
-          Copy-Item ci-bins\copperline.exe target\x86_64-pc-windows-msvc\release\copperline.exe
+          New-Item -ItemType Directory -Force -Path target\${{ matrix.target }}\release | Out-Null
+          Copy-Item ci-bins\copperline.exe target\${{ matrix.target }}\release\copperline.exe
           ./ci-bins/probe_golden.exe
           if ($LASTEXITCODE -ne 0) { throw "probe_golden exited with $LASTEXITCODE" }
       - name: Upload probe render diffs
@@ -243,15 +316,16 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: probe-golden-diffs-windows
+          name: probe-golden-diffs-windows-${{ matrix.arch }}
           path: target/probe-golden/
           if-no-files-found: ignore
 
   release:
-    name: Attach zip to release
-    # Runs only once every Windows check has passed, preserving the old
-    # single-job ordering where the tests gated the release attach. Plain
-    # ubuntu: this job only moves the already-built artifact.
+    name: Attach zips to release
+    # Runs only once every Windows check on both architectures has passed,
+    # preserving the old single-job ordering where the tests gated the
+    # release attach. Plain ubuntu: this job only moves the already-built
+    # artifacts.
     needs: [zip-smoke, unit-tests, probe-golden]
     if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     runs-on: ubuntu-latest
@@ -260,28 +334,35 @@ jobs:
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: copperline-windows
-      - name: Locate artifact
-        id: artifact
-        # Fail fast if the downloaded zip is not where this job expects it;
-        # an unmatched glob would otherwise pass the literal pattern to the
-        # upload steps below.
+          pattern: copperline-windows-*
+          merge-multiple: true
+      - name: Locate artifacts
+        id: artifacts
+        # Fail fast if the downloaded zips are not where this job expects
+        # them; an unmatched glob would otherwise pass the literal pattern
+        # to the upload steps below. Both architectures must be present --
+        # a release with only one of the two zips is a packaging bug.
         run: |
-          zip=(Copperline-*-win-x64.zip)
-          if [ ! -f "${zip[0]}" ]; then
-            echo "no Copperline-*-win-x64.zip in $PWD" >&2
-            exit 1
-          fi
-          echo "path=${zip[0]}" >> "$GITHUB_OUTPUT"
+          for arch in x64 arm64; do
+            zip=(Copperline-*-win-"$arch".zip)
+            if [ ! -f "${zip[0]}" ]; then
+              echo "no Copperline-*-win-$arch.zip in $PWD" >&2
+              exit 1
+            fi
+          done
+          echo "paths=$(ls Copperline-*-win-*.zip | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ steps.artifact.outputs.path }}
+          files: Copperline-*-win-*.zip
       - name: Attach to existing release (manual run)
         if: github.event_name == 'workflow_dispatch' && inputs.release_tag != ''
         env:
           GH_TOKEN: ${{ github.token }}
-        # --clobber so a re-run replaces the asset instead of failing on a
+        # --clobber so a re-run replaces the assets instead of failing on a
         # name clash; --repo because this job runs without a checkout.
-        run: gh release upload "${{ inputs.release_tag }}" "${{ steps.artifact.outputs.path }}" --clobber --repo "${{ github.repository }}"
+        run: |
+          for zip in ${{ steps.artifacts.outputs.paths }}; do
+            gh release upload "${{ inputs.release_tag }}" "$zip" --clobber --repo "${{ github.repository }}"
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,6 @@ dependencies = [
  "libloading 0.9.0",
  "log",
  "m68k",
- "minimp3-sys",
  "mt32-rs",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
@@ -585,6 +584,8 @@ dependencies = [
  "serde_json",
  "smoltcp",
  "socket2",
+ "symphonia-bundle-mp3",
+ "symphonia-core",
  "thread-priority",
  "toml",
  "ureq",
@@ -1971,6 +1972,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,15 +2163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimp3-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21c73734c69dc95696c9ed8926a2b393171d98b3f5f5935686a26a487ab9b90"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2280,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3680,6 +3687,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symphonia-bundle-mp3"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ea5ffc8716bff677dfb3b01b420c7b758de901a72b8c330bf2040ab74b4add"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c412864d599d4750d0c3d684d7e093ec05e5309681ef5252cc1096a437f6e0"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "lazy_static",
+ "log",
+ "num-complex",
+ "smallvec",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3714,7 +3746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ coppersynth = ["dep:coppersynth"]
 # loads. See src/gamelib/.
 game-library = ["dep:ureq", "dep:serde_json", "dep:zeroize"]
 # The MHI virtual MPEG audio decoder board (src/mhi.rs, `[mhi]`): pulls in
-# minimp3-sys, whose build.rs compiles the vendored (CC0) minimp3.c through
-# the `cc` crate. That needs a native C toolchain, which the wasm32 browser
-# build (crates/copperline-web, `default-features = false`) does not carry,
-# so this stays a default-on native feature rather than an unconditional
-# dependency -- the same shape as `mt32`/`wasm-boards` above.
-mhi = ["dep:minimp3-sys"]
+# Symphonia's pure-Rust MPEG audio decoder. Kept a default-on feature (not an
+# unconditional dependency) so builds that do not want the board -- the
+# wasm32 browser build (crates/copperline-web, `default-features = false`)
+# does not wire it up -- carry none of it, the same shape as `mt32`/
+# `wasm-boards` above.
+mhi = ["dep:symphonia-bundle-mp3", "dep:symphonia-core"]
 display-plan-trace = []
 # Detailed host-cost counters used by native diagnostics. The browser crate
 # builds the core with `default-features = false`, so its release hot paths do
@@ -146,15 +146,20 @@ serde_json = { version = "1", optional = true }
 # away into nothing at all.
 zeroize = { version = "1", optional = true }
 serde-big-array = "0.5"
-# MP3 (MPEG-1/2/2.5 Layer III) decoding for the MHI board (src/mhi.rs). CC0
-# C library (github.com/lieff/minimp3) wrapped by MIT-licensed bindgen
-# bindings, compiled by `build.rs` via the `cc` crate -- no vendored/system
-# dependency beyond a C toolchain, clean on macOS/Linux/Windows. Left at the
-# default (non-`MINIMP3_FLOAT_OUTPUT`) build: `mp3d_sample_t` is `int16_t`,
-# so the only floating point is the internal synthesis filterbank's, exactly
-# the same "C float path" every other minimp3 consumer relies on for
-# bit-exact, platform-independent output -- see src/mhi.rs's doc comment.
-minimp3-sys = { version = "0.3", optional = true }
+# MP3 (MPEG-1/2/2.5 Layer III) decoding for the MHI board (src/mhi.rs).
+# Symphonia's MPEG audio decoder: pure Rust (MPL-2.0, GPL-compatible), so it
+# builds on every target Rust itself does -- in particular on
+# aarch64-pc-windows-msvc, where the previous decoder's C build broke (its
+# vendored minimp3.c promised NEON for MSVC ARM64 but only detected it via
+# GCC/Clang macros; issue #474). Removing it also removed the last C compile
+# from the default build. Only the Layer III feature is enabled, matching
+# the board's CAPS register (Layer I/II are not part of protocol VERSION 1;
+# see docs/internals/mhi.md). symphonia-core is the same project's type
+# crate (Packet/CodecParameters/AudioBuffer), needed to drive the decoder
+# directly -- src/mhi.rs feeds it hand-packetized frames from the board's
+# byte-queue bitstream rather than going through a format reader.
+symphonia-bundle-mp3 = { version = "0.6.1", default-features = false, features = ["mp3"], optional = true }
+symphonia-core = { version = "0.6.1", default-features = false, optional = true }
 # Save-state and snapshot serialization (src/savestate.rs and friends).
 # Held on the 1.x serde API on purpose: bincode 2+/3 replaces the API and
 # defaults to a different wire format, so moving would invalidate every

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -167,16 +167,20 @@ build one by hand on a Linux host:
 
 ## Windows
 
-Windows distribution is a portable zip (`packaging/windows/`). The `Windows`
-workflow builds it on `windows-latest` and, on a `v*` tag, attaches
-`Copperline-X.Y.Z-win-x64.zip` to the GitHub Release automatically. The same
-workflow runs the full release build on pull requests that touch the code, so
-it doubles as the Windows build check (the main CI runs on macOS only).
+Windows distribution is a portable zip per architecture
+(`packaging/windows/`). The `Windows` workflow builds them natively on
+`windows-latest` (x86-64) and `windows-11-arm` (ARM64) and, on a `v*` tag,
+attaches `Copperline-X.Y.Z-win-x64.zip` and
+`Copperline-X.Y.Z-win-arm64.zip` to the GitHub Release automatically. The
+same workflow runs the full release build on pull requests that touch the
+code, so it doubles as the Windows build check for both architectures (the
+main CI runs on macOS only).
 
-The zip is self-contained: the MSVC C runtime is linked statically (see
-`.cargo/config.toml`) so it needs no Visual C++ Redistributable, and the
+The zips are self-contained: the MSVC C runtime is linked statically (see
+`.cargo/config.toml`) so they need no Visual C++ Redistributable, and the
 bundled AROS ROM sits in a sibling `aros\` folder that `romsearch.rs` probes
-first. To build one by hand on a Windows host:
+first. To build one by hand on a Windows host (add
+`-Target aarch64-pc-windows-msvc` for the ARM64 zip):
 
 ```pwsh
 packaging/windows/build-zip.ps1

--- a/docs/internals/mhi.md
+++ b/docs/internals/mhi.md
@@ -501,7 +501,7 @@ to:
    scenarios and captures built against one implementation reproduce on
    the other.
 
-Copperline's own implementation notes -- the `minimp3`-based decoder
+Copperline's own implementation notes -- the Symphonia-based decoder
 choice, how `push_source("mhi", ...)` joins the mixer, `BoardDevice`
 wiring, and savestate serialization of in-flight decoder/queue state --
 are Copperline-internal and out of scope for this document; they belong
@@ -514,14 +514,26 @@ This section summarizes `src/mhi.rs` (`[mhi]`, feature-gated behind the
 default-on `mhi` build feature); it does not change any of the protocol
 content above.
 
-- **Decoder**: [`minimp3-sys`](https://crates.io/crates/minimp3-sys), MIT-
-  licensed bindgen bindings (compiled from source via the `cc` crate, no
-  system minimp3 dependency) around lieff/minimp3.c (CC0), built without
-  `MINIMP3_FLOAT_OUTPUT` so the C library's own synthesis filterbank
-  quantizes to `int16_t` before Rust ever sees a sample -- the same
-  bit-exact, platform-independent "C float path" every other minimp3
-  consumer relies on. Samples convert to `f32` the same way
-  `Ad1848::produce_one_sample` does.
+- **Decoder**:
+  [Symphonia](https://crates.io/crates/symphonia-bundle-mp3)'s pure-Rust
+  MPEG audio decoder (`MpaDecoder`, MPL-2.0), with only its Layer III
+  feature enabled to match `CAPS`. Pure Rust is the point: the previous
+  decoder (`minimp3-sys`) compiled a vendored C minimp3 whose SIMD
+  detection broke the default build on MSVC ARM64 hosts (issue #474), and
+  it was the last C compile in the default feature set. `MpaDecoder` is
+  packet-based, so `src/mhi.rs` carries its own packetizer that cuts the
+  doorbell-fed byte queue into whole frames using the same ISO 11172-3
+  header/length arithmetic Symphonia's parser applies; junk bytes, fake
+  syncs, free-format frames (bitrate index 0, outside `CAPS`), and
+  non-Layer-III frames are consumed as resync junk. Everything
+  register-visible (pacing, completion counts, interrupts) derives from
+  integer header parsing and decode success/failure, so emulated-machine
+  behaviour is reproducible byte-for-byte across platforms; the decoded
+  PCM itself is deterministic per platform, but a few of Symphonia's
+  precomputed tables call `powf`, whose last-ulp rounding may differ
+  between libm implementations, so `--audio-wav` captures of MHI audio
+  are guaranteed identical run-to-run on one platform rather than across
+  operating systems.
 - **Mixer cadence**: reuses Toccata's causal-producer/non-causal-resampler
   split ([](toccata)'s "Mixer cadence and resampling") -- a causal
   producer decodes and evaluates queue/interrupt state at the board's own
@@ -529,15 +541,20 @@ content above.
   `Resampler` (`src/audio/resample.rs`, per-rate cached) pulls from that
   FIFO to the mixer's fixed rate, so the resampler's lookahead can never
   reorder when a descriptor completes or an interrupt raises.
-- **Savestates**: rather than reinterpret `mp3dec_t`'s raw FFI bytes, the
-  board keeps a field-for-field `DecoderSnapshot` shadow struct that
-  `serde` derives normally and copies to/from the live decoder state by
-  value, so an upstream field-layout change fails to compile instead of
-  silently deserializing into the wrong offsets. The board also retains
-  every not-yet-decoded byte of every queued descriptor and the in-flight
-  frame's un-played sample tail, so a save/restore cycle reproduces an
-  uninterrupted run's decoded output exactly -- the savestate approach is
-  re-decode of the retained, not-yet-completed bitstream, not a snapshot
+- **Savestates**: Symphonia keeps its cross-frame decoder state (Layer III
+  bit reservoir, IMDCT overlap, synthesis delay line) private, so the
+  board's `DecoderSnapshot` serializes a warmup history instead: the raw
+  bytes of the most recently submitted frames (a few KiB, bounded), which
+  a restore re-decodes into a fresh decoder with the output discarded.
+  The replay is exact because each piece of that state is a function of
+  the trailing few frames alone -- the reservoir holds at most the
+  trailing 2048 bytes of main data, and the overlap/synthesis state is
+  rewritten by each frame -- see the "Savestates" section of
+  `src/mhi.rs`'s module doc comment for the full argument. The board also
+  retains every not-yet-decoded byte of every queued descriptor and the
+  in-flight frame's un-played sample tail, so a save/restore cycle
+  reproduces an uninterrupted run's decoded output exactly -- the
+  savestate approach is re-decode of retained bitstream, not a snapshot
   of decoded PCM. This is proven bit-for-bit at the struct level
   in-process (`savestate_round_trip_reproduces_an_uninterrupted_runs_output`
   in `src/mhi.rs`'s own tests). `tests/mhi.rs`'s end-to-end equivalent
@@ -551,7 +568,9 @@ content above.
   MP3 input buffer, not yet root-caused to a specific missing field --
   see that test's long comment for the investigation.
 - **Savestate layout**: adding the `mhi_audio` ring to `Paula` and the
-  `BoardDevice::Mhi` variant bumped `savestate::STATE_VERSION` to **57**.
+  `BoardDevice::Mhi` variant bumped `savestate::STATE_VERSION` to **57**;
+  the decoder-snapshot reshape for the Symphonia move (issue #474) bumped
+  it again to **58**.
 - **Launcher**: the machine-configuration launcher's **I/O Ports** tab
   (Audio page) has a plain fit/don't-fit toggle for the board (same as
   Toccata, see [](toccata)'s "What's out of scope" section); host-side

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -2669,6 +2669,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lazy_static/lazy_static-1.5.0.crate",
+        "sha256": "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe",
+        "dest": "cargo/vendor/lazy_static-1.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe\", \"files\": {}}",
+        "dest": "cargo/vendor/lazy_static-1.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/leb128fmt/leb128fmt-0.1.0.crate",
         "sha256": "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2",
         "dest": "cargo/vendor/leb128fmt-0.1.0"
@@ -2968,19 +2981,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/minimp3-sys/minimp3-sys-0.3.2.crate",
-        "sha256": "e21c73734c69dc95696c9ed8926a2b393171d98b3f5f5935686a26a487ab9b90",
-        "dest": "cargo/vendor/minimp3-sys-0.3.2"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"e21c73734c69dc95696c9ed8926a2b393171d98b3f5f5935686a26a487ab9b90\", \"files\": {}}",
-        "dest": "cargo/vendor/minimp3-sys-0.3.2",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.8.9.crate",
         "sha256": "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316",
         "dest": "cargo/vendor/miniz_oxide-0.8.9"
@@ -3111,6 +3111,19 @@
         "type": "inline",
         "contents": "{\"package\": \"df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405\", \"files\": {}}",
         "dest": "cargo/vendor/nom-8.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-complex/num-complex-0.4.6.crate",
+        "sha256": "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495",
+        "dest": "cargo/vendor/num-complex-0.4.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495\", \"files\": {}}",
+        "dest": "cargo/vendor/num-complex-0.4.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4892,6 +4905,32 @@
         "type": "inline",
         "contents": "{\"package\": \"13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292\", \"files\": {}}",
         "dest": "cargo/vendor/subtle-2.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/symphonia-bundle-mp3/symphonia-bundle-mp3-0.6.1.crate",
+        "sha256": "98ea5ffc8716bff677dfb3b01b420c7b758de901a72b8c330bf2040ab74b4add",
+        "dest": "cargo/vendor/symphonia-bundle-mp3-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"98ea5ffc8716bff677dfb3b01b420c7b758de901a72b8c330bf2040ab74b4add\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-bundle-mp3-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/symphonia-core/symphonia-core-0.6.1.crate",
+        "sha256": "01c412864d599d4750d0c3d684d7e093ec05e5309681ef5252cc1096a437f6e0",
+        "dest": "cargo/vendor/symphonia-core-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"01c412864d599d4750d0c3d684d7e093ec05e5309681ef5252cc1096a437f6e0\", \"files\": {}}",
+        "dest": "cargo/vendor/symphonia-core-0.6.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/packaging/windows/build-zip.ps1
+++ b/packaging/windows/build-zip.ps1
@@ -4,14 +4,19 @@
 # .github/workflows/windows.yml.
 #
 # What it does:
-#   1. Builds the release binary for x86_64-pc-windows-msvc with the pinned
+#   1. Builds the release binary for the requested MSVC target (x86-64 by
+#      default, ARM64 with -Target aarch64-pc-windows-msvc) with the pinned
 #      dependency graph. The CRT is statically linked (see .cargo/config.toml),
 #      so the bundle needs no Visual C++ Redistributable.
 #   2. Stages a folder holding copperline.exe with a sibling aros\ directory,
 #      which is the first location romsearch.rs probes, so the bundled AROS
 #      ROM is found with no configuration.
-#   3. Zips the folder into Copperline-<version>-win-x64.zip, mirroring the
-#      AppImage/Homebrew version naming so release assets are self-describing.
+#   3. Zips the folder into Copperline-<version>-win-<x64|arm64>.zip,
+#      mirroring the AppImage/Homebrew version naming so release assets are
+#      self-describing.
+param(
+    [string]$Target = "x86_64-pc-windows-msvc"
+)
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
@@ -19,11 +24,16 @@ $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = (Resolve-Path (Join-Path $here "..\..")).Path
 Set-Location $repoRoot
 
-$target = "x86_64-pc-windows-msvc"
+$target = $Target
+$arch = switch ($target) {
+    "x86_64-pc-windows-msvc" { "x64" }
+    "aarch64-pc-windows-msvc" { "arm64" }
+    default { throw "unsupported target $target" }
+}
 
 # Version from Cargo.toml, matching the AppImage/Homebrew naming convention.
 $version = (Select-String -Path "Cargo.toml" -Pattern '^version\s*=\s*"([^"]+)"').Matches[0].Groups[1].Value
-$stageName = "Copperline-$version-win-x64"
+$stageName = "Copperline-$version-win-$arch"
 $stage = Join-Path $repoRoot $stageName
 $zipPath = Join-Path $repoRoot "$stageName.zip"
 

--- a/src/mhi.rs
+++ b/src/mhi.rs
@@ -59,8 +59,12 @@
 //! bytes of main data (a frame's `main_data_begin` can reach back at most
 //! 511 of them), the IMDCT overlap is fully rewritten by each decoded
 //! frame, and the synthesis filterbank's 16-block delay line is shallower
-//! than one frame's 36 blocks -- and the history is kept deep enough
-//! (`WARMUP_HISTORY_MIN_BYTES`/`_FRAMES`) to cover all of it. The board
+//! than one frame's 36 blocks -- and the history is kept deep enough to
+//! cover all of it: byte/frame floors for the reservoir span, plus a hold
+//! on the last two *decoded* frames so a run of rejected header-shaped
+//! junk (which touches only reservoir state) cannot evict the frames the
+//! overlap/synthesis state actually came from (`WARMUP_HISTORY_*`,
+//! `Decoder::trim_history`). The board
 //! additionally keeps every not-yet-decoded byte of every queued descriptor
 //! (`bitstream`/`desc_lengths`) and the in-flight decoded frame's un-played
 //! sample tail (`current_frame`), so a save/restore cycle reproduces an
@@ -176,14 +180,31 @@ const MAX_RESYNC_ATTEMPTS_PER_TICK: u32 = 64;
 const MPEG_HEADER_LEN: usize = 4;
 
 /// Savestate warmup-history bounds (see the module doc comment's
-/// "Savestates"): enough raw frame bytes to cover Symphonia's whole
-/// 2048-byte bit-reservoir buffer with margin for the header/side-info
-/// overhead raw frames carry over main data, and enough whole frames that
-/// the two most recent ones -- the only ones whose spectral output still
-/// influences the IMDCT-overlap/synthesis state -- always re-decode from
-/// fully covered reservoir data.
+/// "Savestates" and `Decoder::trim_history`).
+///
+/// `MIN_BYTES`/`MIN_FRAMES`: enough raw frame bytes to cover Symphonia's
+/// whole 2048-byte bit-reservoir buffer with margin for the header/
+/// side-info overhead raw frames carry over main data, and enough whole
+/// frames for re-decode context.
+///
+/// `MIN_DECODED`: the two most recent *successfully decoded* frames are
+/// the only ones whose spectral output still shapes the IMDCT-overlap/
+/// synthesis state (a rejected frame leaves both untouched -- its only
+/// state effect is on the bit reservoir), so trimming never drops a
+/// decoded frame unless at least this many newer decoded frames remain --
+/// otherwise a run of undecodable header-shaped junk would evict exactly
+/// the state the restore replay exists to rebuild.
+///
+/// `MAX_BYTES`/`MAX_FRAMES`: hard caps that override that hold, so a
+/// hostile guest feeding unbounded undecodable junk after real audio
+/// cannot grow the history without limit. When they bite, a savestate
+/// taken mid-flood loses only the pre-junk overlap tail of the next
+/// decoded frame's PCM; register-visible state never depends on it.
 const WARMUP_HISTORY_MIN_BYTES: usize = 4096;
 const WARMUP_HISTORY_MIN_FRAMES: usize = 4;
+const WARMUP_HISTORY_MIN_DECODED: usize = 2;
+const WARMUP_HISTORY_MAX_BYTES: usize = 16 * 1024;
+const WARMUP_HISTORY_MAX_FRAMES: usize = 256;
 
 /// The board's transport state (`STATUS`, `0x04`). Deliberately its own
 /// numbering -- see the register map's note on why this does not match
@@ -210,7 +231,9 @@ impl Status {
 /// Serializable stand-in for the decoder's private cross-frame state: the
 /// raw bytes of the frames most recently fed to it, which a restore
 /// re-decodes (output discarded) to rebuild that state exactly. See the
-/// module doc comment's "Savestates" for why this replay is exact.
+/// module doc comment's "Savestates" for why this replay is exact. Only
+/// the bytes are carried; each entry's decode outcome is recomputed by
+/// the replay itself.
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 struct DecoderSnapshot {
     history: Vec<Vec<u8>>,
@@ -283,11 +306,24 @@ struct Decoder {
     /// change, so a genuinely respec'd stream gets a fresh decoder -- see
     /// `submit_frame`.
     spec: Option<(u32, bool)>,
-    /// Raw bytes of the most recent frames fed to `mpa` (decoded and
-    /// rejected alike -- a failed decode can advance reservoir state too),
-    /// oldest first, trimmed to the `WARMUP_HISTORY_*` bounds.
-    history: VecDeque<Vec<u8>>,
+    /// The most recent frames fed to `mpa` (decoded and rejected alike --
+    /// a post-side-info rejection still advances reservoir state), oldest
+    /// first, trimmed by `trim_history`.
+    history: VecDeque<HistoryFrame>,
     history_bytes: usize,
+    /// How many `history` entries have `decoded` set -- kept alongside so
+    /// `trim_history` need not rescan the deque.
+    history_decoded: usize,
+}
+
+/// One warmup-history entry: an exactly-cut frame previously fed to the
+/// decoder, and whether it decoded. Rejected frames matter to the restore
+/// replay too (reservoir state), but only decoded frames refresh the
+/// overlap/synthesis state the trim policy must preserve -- see
+/// `WARMUP_HISTORY_MIN_DECODED`.
+struct HistoryFrame {
+    bytes: Vec<u8>,
+    decoded: bool,
 }
 
 /// One decoded frame's stereo samples and native sample rate.
@@ -300,6 +336,7 @@ impl Decoder {
             spec: None,
             history: VecDeque::new(),
             history_bytes: 0,
+            history_decoded: 0,
         }
     }
 
@@ -334,6 +371,26 @@ impl Decoder {
                 return (0, None);
             }
             let frame = self.submit_frame(&input[..frame_len], rate, mono);
+            if frame.is_none() {
+                // The candidate carried a header-shaped word but its
+                // declared frame failed to decode -- a fake sync inside
+                // junk, or a corrupt encode. Its declared length cannot be
+                // trusted to delimit anything: consuming it wholesale
+                // could swallow a real frame whose header sits inside that
+                // span. Resume the sync hunt at the next header candidate
+                // within the span when one exists; only when nothing
+                // header-shaped hides inside it is the whole span skipped.
+                // (The failed attempt still advanced decoder state, which
+                // the warmup history has recorded.)
+                let scan_end = frame_len.min(input.len() - MPEG_HEADER_LEN + 1);
+                for j in 1..scan_end {
+                    let hdr = [input[j], input[j + 1], input[j + 2], input[j + 3]];
+                    if parse_frame_candidate(hdr).is_some() {
+                        return (j as u32, None);
+                    }
+                }
+                return (frame_len as u32, None);
+            }
             return (frame_len as u32, frame);
         }
         // No candidate anywhere: everything up to the last possible header
@@ -342,10 +399,12 @@ impl Decoder {
         ((input.len() - (MPEG_HEADER_LEN - 1)) as u32, None)
     }
 
-    /// Feed one exactly-cut frame to the decoder, recording it in the
-    /// warmup history. A decode failure here is the "fake sync header that
-    /// passes the header check but fails Layer III decode" case: the
-    /// caller still consumes the frame's bytes as junk.
+    /// Feed one exactly-cut frame to the decoder, recording the attempt
+    /// (and its outcome) in the warmup history. A decode failure here is
+    /// the "fake sync header that passes the header check but fails Layer
+    /// III decode" case: the caller consumes a single byte and rehunts
+    /// (see `decode_frame`); the attempt still lands in the history
+    /// because a post-side-info rejection advances reservoir state.
     fn submit_frame(&mut self, frame: &[u8], rate: u32, mono: bool) -> Option<DecodedFrame> {
         if self.spec.is_some_and(|spec| spec != (rate, mono)) {
             // A mid-stream sample-rate/channel change is a new stream:
@@ -355,39 +414,59 @@ impl Decoder {
             *self = Decoder::new();
         }
         self.spec = Some((rate, mono));
-        self.history.push_back(frame.to_vec());
+        let packet = Packet::new(0, Timestamp::ZERO, Duration::ZERO, frame);
+        let result = match self.mpa.decode_ref(&packet.as_packet_ref()) {
+            Ok(GenericAudioBufferRef::F32(buf)) => {
+                let samples: Option<Vec<(f32, f32)>> = if mono {
+                    buf.plane(0).map(|p| p.iter().map(|&v| (v, v)).collect())
+                } else {
+                    buf.plane_pair(0, 1)
+                        .map(|(l, r)| l.iter().zip(r).map(|(&l, &r)| (l, r)).collect())
+                };
+                samples.filter(|s| !s.is_empty()).map(|s| (s, rate))
+            }
+            // MpaDecoder only ever produces f32 buffers.
+            Ok(_) => None,
+            Err(_) => None,
+        };
+        self.history.push_back(HistoryFrame {
+            bytes: frame.to_vec(),
+            decoded: result.is_some(),
+        });
         self.history_bytes += frame.len();
+        self.history_decoded += usize::from(result.is_some());
+        self.trim_history();
+        result
+    }
+
+    /// Trim the warmup history to its bounds. A rejected front entry goes
+    /// as soon as the byte/frame floors stay covered; a *decoded* front
+    /// entry is additionally held until at least
+    /// `WARMUP_HISTORY_MIN_DECODED` newer decoded frames exist, so a run
+    /// of rejected header-shaped junk can never evict the successes whose
+    /// overlap/synthesis state the restore replay rebuilds. The hard caps
+    /// override that hold -- see the `WARMUP_HISTORY_*` doc comment for
+    /// what is (and is not) lost when they bite.
+    fn trim_history(&mut self) {
         while self.history.len() > WARMUP_HISTORY_MIN_FRAMES {
-            let front_len = self.history.front().map_or(0, Vec::len);
-            if self.history_bytes - front_len < WARMUP_HISTORY_MIN_BYTES {
+            let front = self.history.front().expect("len checked above");
+            if self.history_bytes - front.bytes.len() < WARMUP_HISTORY_MIN_BYTES {
                 break;
             }
-            self.history.pop_front();
-            self.history_bytes -= front_len;
+            let over_cap = self.history.len() > WARMUP_HISTORY_MAX_FRAMES
+                || self.history_bytes > WARMUP_HISTORY_MAX_BYTES;
+            if front.decoded && self.history_decoded <= WARMUP_HISTORY_MIN_DECODED && !over_cap {
+                break;
+            }
+            let front = self.history.pop_front().expect("len checked above");
+            self.history_bytes -= front.bytes.len();
+            self.history_decoded -= usize::from(front.decoded);
         }
-        let packet = Packet::new(0, Timestamp::ZERO, Duration::ZERO, frame);
-        let Ok(decoded) = self.mpa.decode_ref(&packet.as_packet_ref()) else {
-            return None;
-        };
-        let GenericAudioBufferRef::F32(buf) = decoded else {
-            // MpaDecoder only ever produces f32 buffers.
-            return None;
-        };
-        let samples: Vec<(f32, f32)> = if mono {
-            buf.plane(0)?.iter().map(|&v| (v, v)).collect()
-        } else {
-            let (left, right) = buf.plane_pair(0, 1)?;
-            left.iter().zip(right).map(|(&l, &r)| (l, r)).collect()
-        };
-        if samples.is_empty() {
-            return None;
-        }
-        Some((samples, rate))
     }
 
     fn snapshot(&self) -> DecoderSnapshot {
         DecoderSnapshot {
-            history: self.history.iter().cloned().collect(),
+            history: self.history.iter().map(|f| f.bytes.clone()).collect(),
         }
     }
 
@@ -396,9 +475,11 @@ impl Decoder {
         for frame in &snapshot.history {
             // Replay through the exact live-decode path (spec-change reset
             // included), discarding the PCM: only the decoder state
-            // matters. The guards cannot fail for a history this module
-            // wrote itself; they keep a hand-corrupted savestate from
-            // panicking.
+            // matters. Decode is deterministic, so each entry's `decoded`
+            // flag (which the snapshot does not carry) rebuilds itself to
+            // the value the live decoder recorded. The guards cannot fail
+            // for a history this module wrote itself; they keep a
+            // hand-corrupted savestate from panicking.
             if frame.len() < MPEG_HEADER_LEN {
                 continue;
             }
@@ -1100,14 +1181,16 @@ mod tests {
     /// granule, past the 576/2 = 288 spectral-pair maximum the Layer III
     /// format itself allows, so any conforming decoder must reject the
     /// frame -- a *deterministically* undecodable body (an integer-domain
-    /// side-info check, not a probabilistic Huffman desync) that still
-    /// consumes the header-declared frame length as junk. This is exactly
-    /// the "fake sync header that passes the header check but fails Layer
-    /// III decode" shape the resync-budget bug describes. The seed keeps
-    /// frames distinguishable via the same header don't-care bit
-    /// `mp3_frame` uses; 0xFF body bytes never alias a Layer III frame
-    /// header (0xFF 0xFF parses as Layer I with an invalid bitrate index),
-    /// so the junk between real headers contains no nested candidates.
+    /// side-info check, not a probabilistic Huffman desync) that the
+    /// packetizer then skips in one resync attempt, whole-span, since
+    /// nothing header-shaped hides inside it (see `decode_frame`'s
+    /// rejected-candidate scan). This is exactly the "fake sync header
+    /// that passes the header check but fails Layer III decode" shape the
+    /// resync-budget bug describes. The seed keeps frames distinguishable
+    /// via the same header don't-care bit `mp3_frame` uses; 0xFF body
+    /// bytes never alias a Layer III frame header (0xFF 0xFF parses as
+    /// Layer I with an invalid bitrate index), so the junk between real
+    /// headers contains no nested candidates.
     fn corrupt_frame(bitrate_kbps: u32, seed: u8) -> Vec<u8> {
         let mut frame = mp3_frame(bitrate_kbps, seed);
         for b in frame.iter_mut().skip(4) {
@@ -1600,6 +1683,82 @@ mod tests {
             completed_second,
             "a valid frame following a corrupted region must still decode and complete"
         );
+    }
+
+    /// Feed `bytes` through `Decoder::decode_frame` the way the board's
+    /// resync loop does -- consuming whatever each call reports, stopping
+    /// on "wait for more" -- and return the first decoded frame, if any.
+    fn drive_decoder(decoder: &mut Decoder, bytes: &[u8]) -> Option<DecodedFrame> {
+        let mut pos = 0usize;
+        let mut guard = 0u32;
+        while pos < bytes.len() {
+            let (consumed, frame) = decoder.decode_frame(&bytes[pos..]);
+            if frame.is_some() {
+                return frame;
+            }
+            if consumed == 0 {
+                return None;
+            }
+            pos += consumed as usize;
+            guard += 1;
+            assert!(guard < 10_000, "resync must make byte progress");
+        }
+        None
+    }
+
+    /// Regression test for a PR #479 review finding: a fake sync whose
+    /// declared frame length spans the start of a real frame must not
+    /// swallow it. On decode failure the packetizer steps a single byte
+    /// and resyncs (a fake header's declared span is not trusted to
+    /// delimit anything), so the real frame is still found and decoded.
+    #[test]
+    fn a_real_frame_starting_inside_a_fake_frames_declared_span_is_still_found() {
+        let mut decoder = Decoder::new();
+        // The first 30 bytes of a corrupt frame -- a valid 128 kbps header
+        // declaring a 417-byte frame, all-ones body -- then a complete
+        // real frame: the fake header's declared span covers the real
+        // frame's start, so consuming the declared length would skip it.
+        let mut stream = corrupt_frame(128, 1)[..30].to_vec();
+        stream.extend_from_slice(&mp3_frame(128, 2));
+        let (samples, rate) =
+            drive_decoder(&mut decoder, &stream).expect("the real frame must still be found");
+        assert_eq!(rate, 44_100);
+        assert_eq!(samples.len(), 1152);
+    }
+
+    /// Regression test for a PR #479 review finding: a long run of
+    /// undecodable header-shaped frames must not evict the last
+    /// successfully decoded frames from the savestate warmup history --
+    /// rejected frames only advance reservoir state, while the live
+    /// decoder's overlap/synthesis state still comes from those last
+    /// successes, so only a replay that includes them can rebuild it. A
+    /// stream of nothing but junk must meanwhile stay hard-bounded
+    /// instead of growing the history forever.
+    #[test]
+    fn warmup_history_keeps_the_last_decoded_frames_across_a_junk_flood_and_stays_bounded() {
+        let mut decoder = Decoder::new();
+        for seed in 0..3 {
+            drive_decoder(&mut decoder, &mp3_frame(128, seed)).expect("setup frame must decode");
+        }
+        assert!(decoder.history_decoded >= WARMUP_HISTORY_MIN_DECODED);
+
+        // Far more junk than WARMUP_HISTORY_MIN_BYTES of failed attempts:
+        // under byte/frame floors alone this evicted the decoded frames.
+        drive_decoder(&mut decoder, &garbage_stream(8 * 1024, 0x5A));
+        assert!(
+            decoder.history_decoded >= WARMUP_HISTORY_MIN_DECODED,
+            "rejected frames must not evict the last decoded frames from the warmup history"
+        );
+
+        // A truly unbounded junk flood saturates at the hard caps rather
+        // than growing without limit (here it also finally releases the
+        // decoded frames -- the documented, bounded trade-off).
+        drive_decoder(&mut decoder, &garbage_stream(64 * 1024, 0xA5));
+        assert!(
+            decoder.history_bytes <= WARMUP_HISTORY_MAX_BYTES + MAX_FRAME_INPUT,
+            "history bytes must stay hard-bounded under a junk flood"
+        );
+        assert!(decoder.history.len() <= WARMUP_HISTORY_MAX_FRAMES + 1);
     }
 
     /// Regression test for the "PAUSE keeps draining audio" bug: `PAUSE`

--- a/src/mhi.rs
+++ b/src/mhi.rs
@@ -9,47 +9,62 @@
 //!
 //! ## Decoder choice
 //!
-//! Decoding uses [`minimp3-sys`](https://crates.io/crates/minimp3-sys), MIT-
-//! licensed bindgen bindings (`build.rs` compiles the bundled C through the
-//! `cc` crate -- clean on macOS/Linux/Windows, no vendored dependency and no
-//! system minimp3) around lieff/minimp3.c itself (CC0). This module talks to
-//! the raw `mp3dec_init`/`mp3dec_decode_frame` FFI directly (see
-//! [`Decoder`]) rather than going through a higher-level wrapper crate: the
-//! board needs to feed the decoder byte-queue-at-a-time from a doorbell-fed
-//! bitstream and snapshot its cross-frame state for savestates, neither of
-//! which a `Read`-based wrapper's ownership model fits.
+//! Decoding uses [Symphonia](https://crates.io/crates/symphonia-bundle-mp3)'s
+//! MPEG audio decoder (`MpaDecoder`, MPL-2.0), with only its Layer III
+//! feature enabled to match the board's `CAPS` register. Pure Rust matters
+//! here: the previous decoder (`minimp3-sys`) compiled a vendored C copy of
+//! minimp3 whose SIMD detection broke the whole default build on MSVC ARM64
+//! hosts (issue #474), and it was the last C compile in the default feature
+//! set.
 //!
-//! `mp3dec_t` is built here **without** `MINIMP3_FLOAT_OUTPUT`, i.e.
-//! `mp3d_sample_t` is `int16_t`: the synthesis filterbank's own math is
-//! still IEEE-754 float internally (there is no fully fixed-point mode in
-//! upstream minimp3), but the *output* is quantized to int16 inside the C
-//! library before this module ever sees it, exactly the "C float path"
-//! every other minimp3 consumer relies on for platform-independent, bit-
-//! exact decode -- ordinary `+`/`-`/`*`/`/` on `f32`/`f64` is IEEE-754-exact
-//! on every target this project builds for (no x87, no fast-math), and
-//! minimp3 uses no transcendental libm calls in its hot decode path (its
-//! DCT/window tables are compile-time constants). This module then converts
-//! the resulting `i16` PCM to `f32` the same way `Ad1848::produce_one_sample`
-//! does (`f32::from(sample) / 32768.0`), so the board's own downstream
-//! mixing/resampling stays in the project's usual float domain without
-//! reintroducing any platform-dependent step.
+//! `MpaDecoder` is packet-based -- each call decodes exactly one whole MPEG
+//! frame handed to it as a `Packet` -- but the board is fed an arbitrary
+//! byte queue by doorbell-committed descriptors, so [`Decoder`] carries its
+//! own packetizer: it hunts for a Layer III frame header, computes the
+//! frame's exact byte length from the header fields (the same ISO 11172-3
+//! slot arithmetic Symphonia's own header parser applies, so a frame this
+//! module cuts is never rejected for its length), and feeds one frame per
+//! decode call. Bytes before a frame candidate, headers whose declared
+//! frame then fails to decode (fake syncs inside junk, corrupt encodes),
+//! free-format frames (bitrate index 0 -- not a CAPS-declared capability,
+//! and unsupported by Symphonia), and non-Layer-III frames are all consumed
+//! as junk, the resync-across-garbage behaviour a real decoder exhibits and
+//! `docs/internals/mhi.md`'s "Undecodable bitstream content" specifies.
+//!
+//! Determinism: everything register-visible -- descriptor pacing,
+//! completion counts, interrupts, `STATUS` -- derives from integer header
+//! parsing (frame length, sample rate, sample count) and from decode
+//! success/failure, which Symphonia decides in pure bitstream/integer
+//! logic; none of it depends on decoded sample values. Emulated-machine
+//! behaviour therefore stays reproducible byte-for-byte across platforms.
+//! The decoded PCM itself is deterministic run-to-run on any one platform,
+//! but a few of Symphonia's precomputed tables call `powf`, whose last-ulp
+//! rounding may differ between platform libm implementations, so
+//! `--audio-wav` captures of MHI audio are guaranteed identical per
+//! platform rather than across operating systems (decoded samples feed
+//! only the audio mix, never register state or timing).
 //!
 //! ## Savestates
 //!
-//! The decoder's cross-frame state (`mp3dec_t`'s MDCT overlap, QMF state,
-//! and 511-byte bit reservoir) is genuine machine state -- restoring
-//! mid-stream without it would audibly glitch the next frame or two. Rather
-//! than reinterpret the raw FFI struct's bytes (a `size_of` canary can catch
-//! a layout change but not silently-compatible-looking corruption), this
-//! module keeps a field-for-field [`DecoderSnapshot`] shadow struct that
-//! `serde` derives normally (via `serde-big-array` for the two oversized
-//! float arrays) and copies to/from the live `mp3dec_t` by value -- a
-//! genuine upstream field change fails to *compile* here instead of
-//! deserializing into the wrong offsets. The board additionally keeps every
-//! not-yet-decoded byte of every queued descriptor (`bitstream`/
-//! `desc_lengths`) and the in-flight decoded frame's un-played sample tail
-//! (`current_frame`), so a save/restore cycle reproduces an uninterrupted
-//! run's output exactly -- proved by
+//! The decoder's cross-frame state (Layer III bit reservoir, IMDCT overlap,
+//! and the polyphase-synthesis delay line) is genuine machine state --
+//! restoring mid-stream without it would audibly glitch the next frame or
+//! two. Symphonia keeps that state private, so rather than serializing
+//! decoder internals, [`Decoder`] retains the raw bytes of the most
+//! recently submitted frames (`history`, a few KiB) and a restore
+//! re-decodes them into a fresh decoder, discarding the output
+//! ([`DecoderSnapshot`]). That reproduces the live decoder's state exactly
+//! because every piece of cross-frame state is a function of the trailing
+//! few frames alone: the bit reservoir holds at most the trailing 2048
+//! bytes of main data (a frame's `main_data_begin` can reach back at most
+//! 511 of them), the IMDCT overlap is fully rewritten by each decoded
+//! frame, and the synthesis filterbank's 16-block delay line is shallower
+//! than one frame's 36 blocks -- and the history is kept deep enough
+//! (`WARMUP_HISTORY_MIN_BYTES`/`_FRAMES`) to cover all of it. The board
+//! additionally keeps every not-yet-decoded byte of every queued descriptor
+//! (`bitstream`/`desc_lengths`) and the in-flight decoded frame's un-played
+//! sample tail (`current_frame`), so a save/restore cycle reproduces an
+//! uninterrupted run's output exactly -- proved by
 //! `tests::savestate_round_trip_reproduces_an_uninterrupted_runs_output`.
 
 use crate::audio::resample::Resampler;
@@ -57,6 +72,12 @@ use crate::audio::MIX_SAMPLE_RATE;
 use crate::chipset::paula::{MhiAudioRing, PAULA_CLOCK_HZ};
 use crate::zorro_device::{DeviceHost, ZorroDevice};
 use std::collections::{HashMap, VecDeque};
+use symphonia_bundle_mp3::MpaDecoder;
+use symphonia_core::audio::{Audio, GenericAudioBufferRef};
+use symphonia_core::codecs::audio::well_known::CODEC_ID_MP3;
+use symphonia_core::codecs::audio::{AudioCodecParameters, AudioDecoder, AudioDecoderOptions};
+use symphonia_core::packet::Packet;
+use symphonia_core::units::{Duration, Timestamp};
 
 // Register offsets (word-aligned, within the board's 64K window). See
 // docs/internals/mhi.md's "Register map".
@@ -128,15 +149,15 @@ const MAX_STALL_TICKS: u64 = (PAULA_CLOCK_HZ / 10) as u64;
 /// a stalled consumer, not a buffering requirement.
 const DECODED_CAPACITY: usize = 4096;
 
-/// Bytes offered to `mp3dec_decode_frame` per call: comfortably more than
-/// the largest legal Layer III frame (1440 bytes at 320 kbps/32 kHz; MPEG-2
-/// LSF frames are smaller still), so a full frame is always visible in one
-/// call once its bytes are queued.
+/// Bytes offered to `Decoder::decode_frame` per call: comfortably more than
+/// the largest legal Layer III frame (1441 bytes at 320 kbps/32 kHz padded;
+/// MPEG-2 LSF frames are smaller still), so a full frame is always visible
+/// in one call once its bytes are queued.
 const MAX_FRAME_INPUT: usize = 4096;
 
-/// Bound on how many resync attempts (calls into `mp3dec_decode_frame` that
+/// Bound on how many resync attempts (`Decoder::decode_frame` calls that
 /// find no valid frame -- junk/ID3 bytes, or a fake sync header that passes
-/// minimp3's header check but fails Layer III decode) a single
+/// the header check but fails Layer III decode) a single
 /// `decode_next_frame` call performs before yielding back to its caller.
 /// Real decoder firmware does not spend an unbounded slice of one
 /// scheduling tick hunting for the next sync word either; it budgets a
@@ -151,12 +172,18 @@ const MAX_FRAME_INPUT: usize = 4096;
 /// within one tick, exactly as it always has.
 const MAX_RESYNC_ATTEMPTS_PER_TICK: u32 = 64;
 
-/// `MINIMP3_MAX_SAMPLES_PER_FRAME`: 1152 samples * 2 channels, interleaved.
-const MAX_SAMPLES_PER_FRAME: usize = 1152 * 2;
+/// The byte length of an MPEG audio frame header.
+const MPEG_HEADER_LEN: usize = 4;
 
-const MDCT_OVERLAP_LEN: usize = 2 * 9 * 32;
-const QMF_STATE_LEN: usize = 15 * 2 * 32;
-const RESERV_BUF_LEN: usize = 511;
+/// Savestate warmup-history bounds (see the module doc comment's
+/// "Savestates"): enough raw frame bytes to cover Symphonia's whole
+/// 2048-byte bit-reservoir buffer with margin for the header/side-info
+/// overhead raw frames carry over main data, and enough whole frames that
+/// the two most recent ones -- the only ones whose spectral output still
+/// influences the IMDCT-overlap/synthesis state -- always re-decode from
+/// fully covered reservoir data.
+const WARMUP_HISTORY_MIN_BYTES: usize = 4096;
+const WARMUP_HISTORY_MIN_FRAMES: usize = 4;
 
 /// The board's transport state (`STATUS`, `0x04`). Deliberately its own
 /// numbering -- see the register map's note on why this does not match
@@ -180,105 +207,211 @@ impl Status {
     }
 }
 
-/// Field-for-field shadow of `minimp3_sys::mp3dec_t`, serde-derivable so a
-/// savestate carries the decoder's cross-frame reservoir/filterbank state
-/// without reinterpreting raw FFI bytes. See the module doc comment.
+/// Serializable stand-in for the decoder's private cross-frame state: the
+/// raw bytes of the frames most recently fed to it, which a restore
+/// re-decodes (output discarded) to rebuild that state exactly. See the
+/// module doc comment's "Savestates" for why this replay is exact.
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 struct DecoderSnapshot {
-    #[serde(with = "serde_big_array::BigArray")]
-    mdct_overlap: [f32; MDCT_OVERLAP_LEN],
-    #[serde(with = "serde_big_array::BigArray")]
-    qmf_state: [f32; QMF_STATE_LEN],
-    reserv: i32,
-    free_format_bytes: i32,
-    header: [u8; 4],
-    #[serde(with = "serde_big_array::BigArray")]
-    reserv_buf: [u8; RESERV_BUF_LEN],
+    history: Vec<Vec<u8>>,
 }
 
-/// Thin safe wrapper around the raw `mp3dec_t`/`mp3dec_decode_frame` FFI
-/// (see the module doc comment for why this talks to the raw bindings
-/// rather than a higher-level decoder crate).
-struct Decoder(minimp3_sys::mp3dec_t);
+fn new_mpa_decoder() -> MpaDecoder {
+    let mut params = AudioCodecParameters::new();
+    params.for_codec(CODEC_ID_MP3);
+    // Cannot fail: MP3 support is compiled into symphonia-bundle-mp3 by
+    // this crate's dependency declaration, and `try_new` checks nothing
+    // beyond the codec ID.
+    MpaDecoder::try_new(&params, &AudioDecoderOptions::default())
+        .expect("symphonia-bundle-mp3 is built with its mp3 feature")
+}
+
+/// Pre-parse of a possible Layer III frame header: the frame's total byte
+/// length (header included), sample rate, and whether it is mono. `None`
+/// for anything the board treats as plain junk bytes -- no sync word, an
+/// MPEG version/layer outside `CAPS` (Layer III only), free format
+/// (bitrate index 0), or reserved bitrate/sample-rate indices. The length
+/// arithmetic mirrors Symphonia's own header parser (ISO 11172-3 section
+/// 2.4.3.1: 144 bitrate/sample-rate slots for MPEG-1, 72 for the MPEG-2/2.5
+/// half-rate frames, 1-byte slots for Layer III), so a frame cut to this
+/// length is never rejected by the decoder's own packet-length check.
+fn parse_frame_candidate(hdr: [u8; 4]) -> Option<(usize, u32, bool)> {
+    let h = u32::from_be_bytes(hdr);
+    if h & 0xFFE0_0000 != 0xFFE0_0000 {
+        return None;
+    }
+    let version = (h >> 19) & 0x3; // 00 = MPEG-2.5, 10 = MPEG-2, 11 = MPEG-1
+    let layer = (h >> 17) & 0x3; // 01 = Layer III
+    let bitrate_idx = ((h >> 12) & 0xF) as usize;
+    let sr_idx = ((h >> 10) & 0x3) as usize;
+    if version == 0b01 || layer != 0b01 || bitrate_idx == 0 || bitrate_idx == 0xF || sr_idx == 3 {
+        return None;
+    }
+    // Bit rates in kbit/s, indexed by the header's bitrate field.
+    const KBPS_MPEG1_L3: [u32; 15] = [
+        0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320,
+    ];
+    const KBPS_MPEG2_L3: [u32; 15] = [0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160];
+    const RATES: [[u32; 3]; 4] = [
+        [11_025, 12_000, 8_000],  // 00: MPEG-2.5
+        [0, 0, 0],                // 01: reserved (rejected above)
+        [22_050, 24_000, 16_000], // 10: MPEG-2
+        [44_100, 48_000, 32_000], // 11: MPEG-1
+    ];
+    let mpeg1 = version == 0b11;
+    let kbps = if mpeg1 {
+        KBPS_MPEG1_L3[bitrate_idx]
+    } else {
+        KBPS_MPEG2_L3[bitrate_idx]
+    };
+    let rate = RATES[version as usize][sr_idx];
+    let padding = (h >> 9) & 1;
+    let factor: u32 = if mpeg1 { 144 } else { 72 };
+    let total = (factor * (kbps * 1000) / rate + padding) as usize;
+    let mono = (h >> 6) & 0x3 == 0b11;
+    Some((total, rate, mono))
+}
+
+/// Byte-queue front end around Symphonia's packet-based [`MpaDecoder`]:
+/// packetizes the board's doorbell-fed bitstream into whole Layer III
+/// frames (see the module doc comment's "Decoder choice") and keeps the
+/// savestate warmup history.
+struct Decoder {
+    mpa: MpaDecoder,
+    /// The (sample rate, mono) signal spec `mpa`'s output buffer locked to
+    /// at its first decode. [`MpaDecoder`] rejects a mid-stream spec
+    /// change, so a genuinely respec'd stream gets a fresh decoder -- see
+    /// `submit_frame`.
+    spec: Option<(u32, bool)>,
+    /// Raw bytes of the most recent frames fed to `mpa` (decoded and
+    /// rejected alike -- a failed decode can advance reservoir state too),
+    /// oldest first, trimmed to the `WARMUP_HISTORY_*` bounds.
+    history: VecDeque<Vec<u8>>,
+    history_bytes: usize,
+}
+
+/// One decoded frame's stereo samples and native sample rate.
+type DecodedFrame = (Vec<(f32, f32)>, u32);
 
 impl Decoder {
     fn new() -> Self {
-        // SAFETY: `mp3dec_t` is a plain-old-data struct (float/int/byte
-        // arrays, no pointers); zero is a valid bit pattern for every
-        // field, and `mp3dec_init` only ever sets `header[0] = 0` (already
-        // true after zeroing) -- see minimp3.c's own `mp3dec_init`.
-        let mut raw: minimp3_sys::mp3dec_t = unsafe { std::mem::zeroed() };
-        unsafe { minimp3_sys::mp3dec_init(&mut raw) };
-        Decoder(raw)
+        Decoder {
+            mpa: new_mpa_decoder(),
+            spec: None,
+            history: VecDeque::new(),
+            history_bytes: 0,
+        }
     }
 
-    /// Decode at most one frame (skipping any leading junk/sync-search
-    /// bytes minimp3 itself walks past) from `input`. Returns the number of
-    /// bytes minimp3 advanced past (0 means "not enough data buffered to
-    /// make progress -- wait for more") and, when a real audio frame was
-    /// decoded (as opposed to skipped junk), its channel-interleaved i16
-    /// samples, sample rate, and channel count.
-    fn decode_frame(&mut self, input: &[u8]) -> (u32, Option<(Vec<i16>, u32, usize)>) {
-        let mut pcm = [0i16; MAX_SAMPLES_PER_FRAME];
-        let mut info: minimp3_sys::mp3dec_frame_info_t = unsafe { std::mem::zeroed() };
-        // SAFETY: `input` outlives the call, `pcm` is sized for the
-        // documented maximum, and `info` is a plain-old-data out-param.
-        let samples = unsafe {
-            minimp3_sys::mp3dec_decode_frame(
-                &mut self.0,
-                input.as_ptr(),
-                input.len() as std::os::raw::c_int,
-                pcm.as_mut_ptr(),
-                &mut info,
-            )
-        };
-        let consumed = info.frame_bytes.max(0) as u32;
-        if samples <= 0 {
-            return (consumed, None);
+    /// Decode at most one frame's worth of progress from `input` (the
+    /// front of the board's bitstream queue). Returns how many bytes the
+    /// board should consume (0 means "not enough data buffered to make
+    /// progress -- wait for more") and, when a real audio frame was decoded
+    /// (as opposed to skipped junk), its stereo samples and sample rate.
+    fn decode_frame(&mut self, input: &[u8]) -> (u32, Option<DecodedFrame>) {
+        if input.len() < MPEG_HEADER_LEN {
+            // Too short to even hold a header: wait (a later doorbell may
+            // extend it; the caller's stall reclaim bounds how long when
+            // the stream truly ended here).
+            return (0, None);
         }
-        let channels = info.channels.max(1) as usize;
-        let count = samples as usize * channels;
-        (
-            consumed,
-            Some((pcm[..count].to_vec(), info.hz.max(0) as u32, channels)),
-        )
+        for i in 0..=(input.len() - MPEG_HEADER_LEN) {
+            let hdr = [input[i], input[i + 1], input[i + 2], input[i + 3]];
+            let Some((frame_len, rate, mono)) = parse_frame_candidate(hdr) else {
+                continue;
+            };
+            if i > 0 {
+                // Junk ahead of the candidate: consume just that, and let
+                // the caller's resync loop revisit the candidate once it
+                // sits at the queue front.
+                return (i as u32, None);
+            }
+            if input.len() < frame_len {
+                // A candidate frame not all of whose bytes are buffered
+                // yet: a genuine incomplete trailing frame, or a fake sync
+                // whose declared length overshoots the queued bytes --
+                // either way, wait (bounded by the caller's stall reclaim).
+                return (0, None);
+            }
+            let frame = self.submit_frame(&input[..frame_len], rate, mono);
+            return (frame_len as u32, frame);
+        }
+        // No candidate anywhere: everything up to the last possible header
+        // prefix is junk (a real header may straddle into bytes a later
+        // doorbell supplies, so the trailing 3 bytes stay queued).
+        ((input.len() - (MPEG_HEADER_LEN - 1)) as u32, None)
+    }
+
+    /// Feed one exactly-cut frame to the decoder, recording it in the
+    /// warmup history. A decode failure here is the "fake sync header that
+    /// passes the header check but fails Layer III decode" case: the
+    /// caller still consumes the frame's bytes as junk.
+    fn submit_frame(&mut self, frame: &[u8], rate: u32, mono: bool) -> Option<DecodedFrame> {
+        if self.spec.is_some_and(|spec| spec != (rate, mono)) {
+            // A mid-stream sample-rate/channel change is a new stream:
+            // cross-frame state cannot meaningfully carry across it, so
+            // start over with a fresh decoder (and a fresh history -- the
+            // old stream's frames must not be replayed into it on restore).
+            *self = Decoder::new();
+        }
+        self.spec = Some((rate, mono));
+        self.history.push_back(frame.to_vec());
+        self.history_bytes += frame.len();
+        while self.history.len() > WARMUP_HISTORY_MIN_FRAMES {
+            let front_len = self.history.front().map_or(0, Vec::len);
+            if self.history_bytes - front_len < WARMUP_HISTORY_MIN_BYTES {
+                break;
+            }
+            self.history.pop_front();
+            self.history_bytes -= front_len;
+        }
+        let packet = Packet::new(0, Timestamp::ZERO, Duration::ZERO, frame);
+        let Ok(decoded) = self.mpa.decode_ref(&packet.as_packet_ref()) else {
+            return None;
+        };
+        let GenericAudioBufferRef::F32(buf) = decoded else {
+            // MpaDecoder only ever produces f32 buffers.
+            return None;
+        };
+        let samples: Vec<(f32, f32)> = if mono {
+            buf.plane(0)?.iter().map(|&v| (v, v)).collect()
+        } else {
+            let (left, right) = buf.plane_pair(0, 1)?;
+            left.iter().zip(right).map(|(&l, &r)| (l, r)).collect()
+        };
+        if samples.is_empty() {
+            return None;
+        }
+        Some((samples, rate))
     }
 
     fn snapshot(&self) -> DecoderSnapshot {
         DecoderSnapshot {
-            mdct_overlap: flatten_mdct(&self.0.mdct_overlap),
-            qmf_state: self.0.qmf_state,
-            reserv: self.0.reserv,
-            free_format_bytes: self.0.free_format_bytes,
-            header: self.0.header,
-            reserv_buf: self.0.reserv_buf,
+            history: self.history.iter().cloned().collect(),
         }
     }
 
     fn restore(snapshot: &DecoderSnapshot) -> Self {
-        Decoder(minimp3_sys::mp3dec_t {
-            mdct_overlap: unflatten_mdct(&snapshot.mdct_overlap),
-            qmf_state: snapshot.qmf_state,
-            reserv: snapshot.reserv,
-            free_format_bytes: snapshot.free_format_bytes,
-            header: snapshot.header,
-            reserv_buf: snapshot.reserv_buf,
-        })
+        let mut decoder = Decoder::new();
+        for frame in &snapshot.history {
+            // Replay through the exact live-decode path (spec-change reset
+            // included), discarding the PCM: only the decoder state
+            // matters. The guards cannot fail for a history this module
+            // wrote itself; they keep a hand-corrupted savestate from
+            // panicking.
+            if frame.len() < MPEG_HEADER_LEN {
+                continue;
+            }
+            if let Some((len, rate, mono)) =
+                parse_frame_candidate([frame[0], frame[1], frame[2], frame[3]])
+            {
+                if len == frame.len() {
+                    let _ = decoder.submit_frame(frame, rate, mono);
+                }
+            }
+        }
+        decoder
     }
-}
-
-fn flatten_mdct(a: &[[f32; 288]; 2]) -> [f32; MDCT_OVERLAP_LEN] {
-    let mut out = [0f32; MDCT_OVERLAP_LEN];
-    out[..288].copy_from_slice(&a[0]);
-    out[288..].copy_from_slice(&a[1]);
-    out
-}
-
-fn unflatten_mdct(a: &[f32; MDCT_OVERLAP_LEN]) -> [[f32; 288]; 2] {
-    let mut out = [[0f32; 288]; 2];
-    out[0].copy_from_slice(&a[..288]);
-    out[1].copy_from_slice(&a[288..]);
-    out
 }
 
 impl serde::Serialize for Decoder {
@@ -629,10 +762,10 @@ impl Mhi {
         completed
     }
 
-    /// Decode at most one real audio frame, skipping any junk minimp3
+    /// Decode at most one real audio frame, skipping any junk the decoder
     /// walks past first. `None` means no frame is available right now --
-    /// either the bitstream is empty, what's buffered isn't enough for
-    /// minimp3 to make progress (should not arise with whole-buffer CBR
+    /// either the bitstream is empty, what's buffered isn't enough for the
+    /// decoder to make progress (should not arise with whole-buffer CBR
     /// descriptors, the M1-M2 target), or this call's bounded resync budget
     /// (`MAX_RESYNC_ATTEMPTS_PER_TICK`) ran out while still hunting for the
     /// next real frame -- the caller (`acquire_next_frame`, from
@@ -658,8 +791,7 @@ impl Mhi {
                 return None;
             }
             self.pending_completes += self.consume_bytes(consumed);
-            if let Some((samples_i16, rate, channels)) = frame {
-                let samples = to_stereo_f32(&samples_i16, channels);
+            if let Some((samples, rate)) = frame {
                 self.native_rate = rate;
                 let completes = std::mem::take(&mut self.pending_completes);
                 return Some(CurrentFrame {
@@ -814,23 +946,6 @@ impl Mhi {
     }
 }
 
-fn to_stereo_f32(samples: &[i16], channels: usize) -> Vec<(f32, f32)> {
-    if channels <= 1 {
-        samples
-            .iter()
-            .map(|&s| {
-                let v = f32::from(s) / 32768.0;
-                (v, v)
-            })
-            .collect()
-    } else {
-        samples
-            .chunks_exact(2)
-            .map(|pair| (f32::from(pair[0]) / 32768.0, f32::from(pair[1]) / 32768.0))
-            .collect()
-    }
-}
-
 impl Default for Mhi {
     fn default() -> Self {
         Self::new()
@@ -934,21 +1049,19 @@ mod tests {
     /// hand-assembling a minimal valid frame header and an all-zero side-
     /// info/main-data body. An all-zero body is not a corner-cutting
     /// shortcut: it is the only way to hand-author a *guaranteed-valid*
-    /// Layer III frame without a real encoder (arbitrary/pseudo-random main
-    /// data almost always desyncs the Huffman decode -- confirmed
-    /// empirically against minimp3 itself -- and minimp3 then reports it as
-    /// unusable junk, `samples == 0`, rather than as a completed frame).
-    /// All-zero side info decodes to `big_values == 0`/`part2_3_length ==
-    /// 0`, i.e. a frame with no spectral lines at all -- digital silence,
-    /// but a genuinely *decoded* one (`samples == 1152`, a real
-    /// `frame_bytes` consumed from the bitstream, the QMF/MDCT overlap
-    /// state genuinely advanced) rather than skipped junk. That is exactly
-    /// what these tests need: real frame boundaries, real byte consumption,
-    /// real pacing -- payload *audibility* is not part of any claim they
-    /// make (the payload seed only nudges header/reserved bits that don't
-    /// change decode validity, so consecutive frames stay distinguishable
-    /// at the register/bitstream level without one of them landing on an
-    /// invalid encoding).
+    /// Layer III frame without a real encoder (arbitrary main data risks
+    /// desyncing the Huffman decode, which the decoder then reports as
+    /// unusable junk rather than as a completed frame). All-zero side info
+    /// decodes to `big_values == 0`/`part2_3_length == 0`, i.e. a frame
+    /// with no spectral lines at all -- digital silence, but a genuinely
+    /// *decoded* one (1152 samples, a real frame length consumed from the
+    /// bitstream, the reservoir/overlap/synthesis state genuinely advanced)
+    /// rather than skipped junk. That is exactly what these tests need:
+    /// real frame boundaries, real byte consumption, real pacing -- payload
+    /// *audibility* is not part of any claim they make (the payload seed
+    /// only nudges header/reserved bits that don't change decode validity,
+    /// so consecutive frames stay distinguishable at the register/bitstream
+    /// level without one of them landing on an invalid encoding).
     fn mp3_frame(bitrate_kbps: u32, payload_seed: u8) -> Vec<u8> {
         // MPEG-1 Layer III header: sync (11) | version=11 (MPEG1) | layer=01
         // (Layer III) | protection=1 (no CRC) | bitrate index | sample-rate
@@ -981,20 +1094,24 @@ mod tests {
         frame
     }
 
-    /// A `mp3_frame`-shaped header (so minimp3's header check passes and it
-    /// commits to decoding a whole frame's worth of bytes) with a
-    /// pseudo-random, non-zero body -- per `mp3_frame`'s own doc comment,
-    /// arbitrary main data almost always desyncs the Huffman decode, so
-    /// minimp3 reports the frame as unusable junk (`samples == 0`) while
-    /// still consuming the header-declared frame length. This is exactly
-    /// the "fake sync header that passes minimp3's header checks but fails
-    /// Layer III decode" shape the resync-budget bug describes.
+    /// A `mp3_frame`-shaped header (so the packetizer's header check passes
+    /// and the decoder commits to a whole frame's worth of bytes) with an
+    /// all-ones body: all-ones side info declares `big_values` = 511 per
+    /// granule, past the 576/2 = 288 spectral-pair maximum the Layer III
+    /// format itself allows, so any conforming decoder must reject the
+    /// frame -- a *deterministically* undecodable body (an integer-domain
+    /// side-info check, not a probabilistic Huffman desync) that still
+    /// consumes the header-declared frame length as junk. This is exactly
+    /// the "fake sync header that passes the header check but fails Layer
+    /// III decode" shape the resync-budget bug describes. The seed keeps
+    /// frames distinguishable via the same header don't-care bit
+    /// `mp3_frame` uses; 0xFF body bytes never alias a Layer III frame
+    /// header (0xFF 0xFF parses as Layer I with an invalid bitrate index),
+    /// so the junk between real headers contains no nested candidates.
     fn corrupt_frame(bitrate_kbps: u32, seed: u8) -> Vec<u8> {
         let mut frame = mp3_frame(bitrate_kbps, seed);
-        let mut s = seed;
         for b in frame.iter_mut().skip(4) {
-            s = s.wrapping_mul(37).wrapping_add(11);
-            *b = s | 1; // never all-zero (all-zero body decodes as valid silence)
+            *b = 0xFF;
         }
         frame
     }
@@ -1565,10 +1682,10 @@ mod tests {
 
     /// Regression test for the "stalled trailing frame never reclaimed"
     /// bug: a final queued descriptor whose tail is a truncated MP3 frame
-    /// (fewer bytes than minimp3 needs to make any decode progress, so
-    /// `decode_frame` reports `consumed == 0` on every attempt) must not
-    /// wedge `STATUS == PLAYING`/`QUEUE_COUNT == 1` forever when no further
-    /// doorbell ever arrives to complete it.
+    /// (a valid header whose declared frame length exceeds the queued
+    /// bytes, so `decode_frame` reports `consumed == 0` on every attempt)
+    /// must not wedge `STATUS == PLAYING`/`QUEUE_COUNT == 1` forever when
+    /// no further doorbell ever arrives to complete it.
     #[test]
     fn a_frame_split_at_the_last_queued_buffer_eventually_reclaims_the_descriptor() {
         let mut board = Mhi::new();

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -193,7 +193,12 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      BoardDevice gained the Mhi variant (the virtual MPEG audio decoder
 //      board, `[mhi]`, feature-gated behind `mhi`), appended at the end of
 //      the enum.
-pub const STATE_VERSION: u32 = 57;
+//  58: The MHI board's decoder snapshot changed shape: the minimp3
+//      field-for-field `mp3dec_t` shadow became a Symphonia warmup history
+//      (the raw bytes of the most recently decoded frames, re-decoded on
+//      restore) when the decoder moved to pure Rust for MSVC ARM64 hosts
+//      (issue #474).
+pub const STATE_VERSION: u32 = 58;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {


### PR DESCRIPTION
## Summary

Two commits, both aimed at #474:

1. **`mhi:` replace minimp3-sys with Symphonia's pure-Rust MPEG decoder.** `minimp3-sys` fails to compile on `aarch64-pc-windows-msvc` (its vendored `minimp3.h` promises NEON for `_M_ARM64` but only detects it via GCC/Clang macros). The MHI board now decodes through `symphonia-bundle-mp3` 0.6 (MPL-2.0, Layer III feature only, matching the board's `CAPS` register) - the "possible real fix" from the issue. This also removes the last C compile from the default feature set (`cargo tree -e build -i cc` is now empty).
2. **`ci:` build, test, and release Windows ARM64.** `windows.yml` becomes a two-leg matrix (`windows-latest`/x86-64 + `windows-11-arm`/aarch64) across all five jobs, so ARM64 gets the zip boot smoke, unit suites, and probe golden renders on every PR, and tags ship both `win-x64` and `win-arm64` zips.

## Design notes (commit 1)

- Symphonia's `MpaDecoder` is packet-based (exactly one whole frame per packet), so `src/mhi.rs` gains a packetizer that cuts the doorbell-fed byte queue into frames using the same ISO 11172-3 header/length arithmetic Symphonia's own parser applies. Junk bytes, fake syncs, free-format, and non-Layer-III headers are consumed as resync junk per `docs/internals/mhi.md`'s contract.
- Register-visible behaviour (pacing, completions, interrupts) still derives purely from integer header parsing and decode success/failure, so emulation determinism is unchanged across platforms. Decoded PCM is deterministic per platform; a cross-OS `--audio-wav` byte-identity caveat is documented (Symphonia's precomputed tables use `powf`).
- Savestates: Symphonia keeps decoder state private, so `DecoderSnapshot` becomes a bounded warmup history (raw bytes of the last >= 4 frames / >= 4 KiB, re-decoded on restore). Exact because the bit reservoir reaches back at most 2048 bytes of main data and overlap/synthesis state is a function of the last two frames - full argument in the module doc. `STATE_VERSION` 57 -> 58.
- The `corrupt_frame` test helper now builds *deterministically* undecodable frames (all-ones side info declares `big_values` = 511 > the format's 288 maximum, an integer-domain check) instead of relying on probabilistic Huffman desync.
- `packaging/flatpak/cargo-sources.json` regenerated with the repo script.

## Verification

- Full unit suite (2,745 tests), `clippy --all-targets --all-features -- -D warnings`, `fmt --check`, `--no-default-features` check, and all nested lockfiles resolving `--locked`: clean.
- `tests/mhi.rs` M1 + all three M2 integration tests pass against the real MHIplay devkit client and a CBR MP3 fixture: the decoded 440 Hz tone reaches `--audio-wav`, playback is byte-identical across runs, and a mid-playback savestate resume aligns at shift 16 / mse 3.2e-5 - the same tolerance the previous decoder held (documented in mhi.md's implementation notes).
- Packetizer arithmetic cross-checked against real ffmpeg/lame output (MPEG-1/2/2.5, CBR/VBR, mono/stereo, 44.1 kHz padding cadence): zero frame rejections, ID3 tags junk-skipped.
- CI note for reviewers: `windows-11-arm` may not ship rustup; the workflow installs it when absent (no-op on x64).

Fixes #474