### PR TITLE
gamelib: walk into a shelf of unpacked games instead of listing it as one

### DIFF
--- a/src/gamelib/scan.rs
+++ b/src/gamelib/scan.rs
@@ -608,10 +608,11 @@ fn walk(root: &Path, dir: &Path, depth: usize, walked: &mut usize, out: &mut Vec
             if !crate::package::worth_walking(&name) {
                 continue;
             }
-            // A directory with a slave under it is one game, and is not
-            // looked inside for more: a game's own data directories are
-            // not each a game of their own.
-            match crate::package::holds_a_slave(&path) {
+            // A directory that is one game is listed and not looked
+            // inside for more; a shelf of games -- a collection filed by
+            // letter or by genre -- is walked into. `one_game` is what
+            // tells them apart.
+            match crate::package::one_game(&path) {
                 true => out.extend(relative(&path)),
                 false => walk(root, &path, depth + 1, walked, out),
             }
@@ -841,6 +842,48 @@ mod tests {
         assert_eq!(
             found,
             ["A/B/Three_v1.0.LHA", "A/Two_v1.0.lha", "One_v1.0.lha"]
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_collection_of_unpacked_games_filed_by_letter_lists_each_game() {
+        // The layout from issue 469: games unpacked onto disk and filed
+        // under a/, b/ and so on. Each letter folder answered "there is a
+        // slave under me" and was swallowed as one game, so the list held
+        // the letters and none of what was under them.
+        let dir = scratch("letters");
+        std::fs::create_dir_all(dir.join("a/AlienBreed/data")).unwrap();
+        std::fs::write(dir.join("a/AlienBreed/AlienBreed.slave"), b"x").unwrap();
+        std::fs::create_dir_all(dir.join("a/AnotherWorld")).unwrap();
+        std::fs::write(dir.join("a/AnotherWorld/AnotherWorld.slave"), b"x").unwrap();
+        // A letter folder mixing an archive in beside an unpacked game.
+        std::fs::create_dir_all(dir.join("b/Barbarian")).unwrap();
+        std::fs::write(dir.join("b/Barbarian/Barbarian.slave"), b"x").unwrap();
+        std::fs::write(dir.join("b/Benefactor_v1.0.lha"), b"x").unwrap();
+        // An unpacked .lha keeps its wrapper as one game, not two.
+        std::fs::create_dir_all(dir.join("a/Aladdin_v1/Aladdin")).unwrap();
+        std::fs::write(dir.join("a/Aladdin_v1/Aladdin/Aladdin.Slave"), b"x").unwrap();
+        std::fs::write(dir.join("a/Aladdin_v1/Aladdin.info"), b"x").unwrap();
+        // A letter folder holding a single unpacked game has exactly a
+        // wrapper's shape, and is taken for one: listed under the
+        // letter, and it still boots. The ambiguity is real; this pins
+        // which way it falls.
+        std::fs::create_dir_all(dir.join("c/Cabal")).unwrap();
+        std::fs::write(dir.join("c/Cabal/Cabal.slave"), b"x").unwrap();
+
+        let mut found = packages(&dir);
+        found.sort();
+        assert_eq!(
+            found,
+            [
+                "a/Aladdin_v1",
+                "a/AlienBreed",
+                "a/AnotherWorld",
+                "b/Barbarian",
+                "b/Benefactor_v1.0.lha",
+                "c"
+            ]
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/gamelib/scan.rs
+++ b/src/gamelib/scan.rs
@@ -871,6 +871,12 @@ mod tests {
         // which way it falls.
         std::fs::create_dir_all(dir.join("c/Cabal")).unwrap();
         std::fs::write(dir.join("c/Cabal/Cabal.slave"), b"x").unwrap();
+        // A genre level over a single letter: the sole branch must not
+        // read as a wrapper when what it wraps is a shelf.
+        std::fs::create_dir_all(dir.join("shooter/d/Datastorm")).unwrap();
+        std::fs::write(dir.join("shooter/d/Datastorm/Datastorm.slave"), b"x").unwrap();
+        std::fs::create_dir_all(dir.join("shooter/d/Disposable")).unwrap();
+        std::fs::write(dir.join("shooter/d/Disposable/Disposable.slave"), b"x").unwrap();
 
         let mut found = packages(&dir);
         found.sort();
@@ -882,7 +888,9 @@ mod tests {
                 "a/AnotherWorld",
                 "b/Barbarian",
                 "b/Benefactor_v1.0.lha",
-                "c"
+                "c",
+                "shooter/d/Datastorm",
+                "shooter/d/Disposable"
             ]
         );
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/package.rs
+++ b/src/package.rs
@@ -222,16 +222,75 @@ pub fn read_first(path: &Path, want: impl Fn(&Path) -> bool) -> Result<Option<Ve
     }
 }
 
+/// Whether a directory is one game rather than a shelf of them.
+///
+/// This is the test a scan applies to the *children* of the library, and
+/// never to the library itself, which of course has slaves somewhere under
+/// it. The trouble is that so does everything in between: a collection
+/// filed by letter answers "there is a slave down there" for `A/` just as
+/// `Aladdin_v1/` does, and taking the first yes for a game swallowed a
+/// whole shelf as one entry.
+///
+/// So the question is asked in two parts. A `.slave` directly inside makes
+/// it a game outright -- the shape an unpacked game has, and what stops a
+/// game's own data directories being games of their own. Without one, it
+/// is a game only as a *wrapper*: exactly one subdirectory with a slave
+/// under it and no packages of its own, which is what an unpacked `.lha`
+/// looks like -- `Aladdin_v1/Aladdin/Aladdin.Slave` beside an icon.
+/// Anything else -- several slave-holding subdirectories, or packages
+/// mixed in beside them -- is a shelf, and the scan walks into it.
+///
+/// A shelf holding a single game is genuinely indistinguishable from a
+/// wrapper and is taken for one; it still lists and still boots, under the
+/// shelf's name.
+pub fn one_game(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    let mut subdirs = Vec::new();
+    let mut packages = false;
+    for entry in entries.flatten() {
+        let Ok(kind) = entry.file_type() else {
+            continue;
+        };
+        if kind.is_symlink() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("._") {
+            continue;
+        }
+        if kind.is_dir() {
+            if worth_walking(&name) {
+                subdirs.push(entry.path());
+            }
+        } else if is_slave_name(&name) {
+            return true;
+        } else if Kind::of_name(&name).is_some() {
+            packages = true;
+        }
+    }
+    if packages {
+        return false;
+    }
+    let mut holding = 0;
+    for sub in &subdirs {
+        if holds_a_slave(sub) {
+            holding += 1;
+            if holding > 1 {
+                return false;
+            }
+        }
+    }
+    holding == 1
+}
+
 /// Whether a `.slave` sits anywhere within `dir`, within a few levels.
 ///
-/// This is the test a scan applies to the *children* of a game folder, and
-/// never to the folder itself -- a library holds games, so a slave is
-/// somewhere under it too, and asking of the library would answer yes and
-/// mean nothing. Walking down and stopping at the first child that says
-/// yes is what picks out `Aladdin_v1/` from a folder of a hundred like it.
-///
-/// The depth limit is what stops the question from reading somebody's
-/// whole home directory when the answer is no.
+/// What [`one_game`] asks of a wrapper's subdirectories. The depth limit
+/// is what stops the question from reading somebody's whole home
+/// directory when the answer is no.
 pub fn holds_a_slave(dir: &Path) -> bool {
     fn look(dir: &Path, depth: usize) -> bool {
         if depth > FOLDER_SLAVE_DEPTH {
@@ -493,6 +552,49 @@ mod tests {
             listed,
             ["Aaa.slave", "data/Bbb.slave", "data/deep/Zzz.slave"].map(PathBuf::from)
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn one_game_tells_a_game_from_a_shelf_of_them() {
+        let dir = std::env::temp_dir().join(format!("copperline-onegame-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        // An unpacked game: the slave sits at its root.
+        std::fs::create_dir_all(dir.join("AlienBreed/data")).unwrap();
+        std::fs::write(dir.join("AlienBreed/AlienBreed.slave"), b"x").unwrap();
+        assert!(one_game(&dir.join("AlienBreed")));
+
+        // A wrapper, which is what unpacking an .lha leaves: one
+        // subdirectory with the slave, an icon beside it.
+        std::fs::create_dir_all(dir.join("Aladdin_v1/Aladdin")).unwrap();
+        std::fs::write(dir.join("Aladdin_v1/Aladdin/Aladdin.Slave"), b"x").unwrap();
+        std::fs::write(dir.join("Aladdin_v1/Aladdin.info"), b"x").unwrap();
+        assert!(one_game(&dir.join("Aladdin_v1")));
+
+        // A letter folder holding two unpacked games is a shelf, not a
+        // game -- the bug that swallowed a collection filed by letter.
+        std::fs::create_dir_all(dir.join("a/AnotherWorld")).unwrap();
+        std::fs::write(dir.join("a/AnotherWorld/AnotherWorld.slave"), b"x").unwrap();
+        std::fs::create_dir_all(dir.join("a/Agony")).unwrap();
+        std::fs::write(dir.join("a/Agony/Agony.slave"), b"x").unwrap();
+        assert!(!one_game(&dir.join("a")));
+
+        // So is one mixing an archive in beside an unpacked game: taken
+        // for a game, the archive would never be listed.
+        std::fs::create_dir_all(dir.join("b/Barbarian")).unwrap();
+        std::fs::write(dir.join("b/Barbarian/Barbarian.slave"), b"x").unwrap();
+        std::fs::write(dir.join("b/Benefactor_v1.0.lha"), b"x").unwrap();
+        assert!(!one_game(&dir.join("b")));
+
+        // A folder with no slave anywhere under it is nothing at all.
+        std::fs::create_dir_all(dir.join("Screenshots")).unwrap();
+        std::fs::write(dir.join("Screenshots/one.png"), b"x").unwrap();
+        assert!(!one_game(&dir.join("Screenshots")));
+
+        // And a resource fork still does not make one.
+        std::fs::create_dir_all(dir.join("Junk")).unwrap();
+        std::fs::write(dir.join("Junk/._Game.Slave"), b"x").unwrap();
+        assert!(!one_game(&dir.join("Junk")));
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -235,15 +235,30 @@ pub fn read_first(path: &Path, want: impl Fn(&Path) -> bool) -> Result<Option<Ve
 /// it a game outright -- the shape an unpacked game has, and what stops a
 /// game's own data directories being games of their own. Without one, it
 /// is a game only as a *wrapper*: exactly one subdirectory with a slave
-/// under it and no packages of its own, which is what an unpacked `.lha`
-/// looks like -- `Aladdin_v1/Aladdin/Aladdin.Slave` beside an icon.
-/// Anything else -- several slave-holding subdirectories, or packages
-/// mixed in beside them -- is a shelf, and the scan walks into it.
+/// under it, no packages of its own, and that subdirectory itself one
+/// game, which is what an unpacked `.lha` looks like --
+/// `Aladdin_v1/Aladdin/Aladdin.Slave` beside an icon. Anything else --
+/// several slave-holding subdirectories, packages mixed in beside them,
+/// or a sole subdirectory that is itself a shelf, as a genre folder over
+/// one letter is -- is a shelf, and the scan walks into it.
 ///
 /// A shelf holding a single game is genuinely indistinguishable from a
 /// wrapper and is taken for one; it still lists and still boots, under the
 /// shelf's name.
 pub fn one_game(dir: &Path) -> bool {
+    one_game_within(dir, 0)
+}
+
+/// How many wrappers may sit around a game before the search calls the
+/// whole stack a shelf and walks in instead. Real packages wrap once;
+/// walking in is the safe answer for anything stranger, since the walk is
+/// bounded and lists whatever games it reaches.
+const WRAPPER_DEPTH: usize = 3;
+
+fn one_game_within(dir: &Path, depth: usize) -> bool {
+    if depth > WRAPPER_DEPTH {
+        return false;
+    }
     let Ok(entries) = std::fs::read_dir(dir) else {
         return false;
     };
@@ -274,16 +289,23 @@ pub fn one_game(dir: &Path) -> bool {
     if packages {
         return false;
     }
-    let mut holding = 0;
-    for sub in &subdirs {
-        if holds_a_slave(sub) {
-            holding += 1;
-            if holding > 1 {
+    let mut sole = None;
+    for sub in subdirs {
+        if holds_a_slave(&sub) {
+            if sole.is_some() {
                 return false;
             }
+            sole = Some(sub);
         }
     }
-    holding == 1
+    // A sole slave-holding subdirectory makes a wrapper only if it is
+    // itself one game. Reduced to "has a slave somewhere", a genre folder
+    // over a single letter of games would be a wrapper too, and the shelf
+    // under it would be swallowed whole.
+    match sole {
+        Some(sub) => one_game_within(&sub, depth + 1),
+        None => false,
+    }
 }
 
 /// Whether a `.slave` sits anywhere within `dir`, within a few levels.
@@ -585,6 +607,16 @@ mod tests {
         std::fs::write(dir.join("b/Barbarian/Barbarian.slave"), b"x").unwrap();
         std::fs::write(dir.join("b/Benefactor_v1.0.lha"), b"x").unwrap();
         assert!(!one_game(&dir.join("b")));
+
+        // A genre folder over a single letter of games has one
+        // slave-holding subdirectory, like a wrapper -- but that
+        // subdirectory is a shelf, so the genre folder is one too.
+        std::fs::create_dir_all(dir.join("Action/A/Agony")).unwrap();
+        std::fs::write(dir.join("Action/A/Agony/Agony.slave"), b"x").unwrap();
+        std::fs::create_dir_all(dir.join("Action/A/AlienBreed2")).unwrap();
+        std::fs::write(dir.join("Action/A/AlienBreed2/AlienBreed2.slave"), b"x").unwrap();
+        assert!(!one_game(&dir.join("Action")));
+        assert!(!one_game(&dir.join("Action/A")));
 
         // A folder with no slave anywhere under it is nothing at all.
         std::fs::create_dir_all(dir.join("Screenshots")).unwrap();


### PR DESCRIPTION
## Summary

The WHDLoad Library scan is recursive, but it swallowed whole sub-folders as single games. The walk in `gamelib::scan` asked `package::holds_a_slave` of each subdirectory and took the first yes for "this is one game, do not look inside". That test answers yes for anything with a `.slave` up to three levels down -- which is just as true of a letter folder holding *unpacked* games (`whdload/a/AlienBreed/AlienBreed.slave`) as it is of a game folder. Each letter folder collapsed into one bogus entry named `a`, `b`, ..., and nothing beneath it was listed. Archive collections (`a/*.lha`) were unaffected, which is how this survived since the library shipped in v0.16.0 -- and `docs/guide/whdload.md` already promises that folders filed by letter work, so this brings behaviour in line with what is documented (no docs change needed).

## The fix

A new `package::one_game(dir)` replaces `holds_a_slave` in the walk. A directory is one game when:

- a `.slave` sits directly in it (the shape an unpacked game has), or
- it wraps exactly one slave-holding subdirectory with no package archives beside it (the shape unpacking an `.lha` leaves -- `Aladdin_v1/Aladdin/Aladdin.Slave` beside an icon).

Anything else -- several slave-holding subdirectories, or archives mixed in beside them -- is a shelf, and the walk descends into it.

One residual, documented on `one_game` and pinned in the tests: a shelf holding a *single* unpacked game is structurally identical to a wrapper and is still taken for one. It lists under the shelf's name and boots correctly either way.

## Verification

- New regression tests: `one_game_tells_a_game_from_a_shelf_of_them` (package.rs) and `a_collection_of_unpacked_games_filed_by_letter_lists_each_game` (scan.rs); the latter reproduces the reported layout and fails before the fix.
- Full unit suite (2,709 tests), `cargo clippy --all-targets`, and `cargo fmt --check`: clean.

Fixes #469
