### PR TITLE
config: Coppersynth TOML key consistency 

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -754,6 +754,16 @@ floppy_sounds_volume = 100
 # mt32_pcm_rom = "~/Amiga/MT32_PCM.ROM"
 # mt32_panel = true          # the module's front panel, under the display
 # mt32_lcd = "mt32"          # mt32 (default), superjv, sseries, or oled
+#
+# Coppersynth, the built-in General MIDI synthesizer
+# (docs/guide/coppersynth.md). midi_out = "coppersynth" plays to it; no
+# files needed, the GeneralUser GS bank is inside the executable. MT-32
+# games work through a translation layer.
+# midi_out = "coppersynth"
+# coppersynth_soundfont = "/path/to/bank.sf2"  # override the bundled bank
+# coppersynth_mt32_mode = "auto"  # auto (translate once MT-32 sysex is
+#                                 # seen), on, or off
+# coppersynth_panel = true        # the front panel, under the display
 
 
 # Parallel (Centronics) port peripheral. With no section the connector is
@@ -775,16 +785,6 @@ floppy_sounds_volume = 100
 #              with the `frontend` feature (it uses cpal, like live audio output).
 # --parallel DEVICE overrides this per run; --sampler-audio-input /
 # --sampler-input-gain imply "sampler".
-# # Coppersynth, the built-in General MIDI synthesizer, selected with
-# midi_out = "coppersynth" under [serial]. No files needed: the GeneralUser GS
-# bank is inside the executable. `soundfont` (or COPPERLINE_SOUNDFONT,
-# or an .sf2 beside the executable) plays a different bank. MT-32 games
-# work through a translation layer.
-# [coppersynth]
-# soundfont = "/path/to/GeneralUser-GS.sf2"  # override the bundled default
-# mt32_mode = "auto"          # auto (translate once MT-32 sysex is seen),
-#                             # on, or off
-# panel = true                # start with the front panel shown
 
 [parallel]
 # device = "printer"

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1198,8 +1198,8 @@ Paula's serial in/out is connected:
   on the host, and brings its own `mt32_*` keys with it; see
   [the MT-32 chapter](mt32.md). `midi_out` may also be `"coppersynth"` --
   Coppersynth, the built-in General MIDI synthesizer, which needs no
-  ROMs at all; see [the Coppersynth chapter](coppersynth.md) and the
-  `[coppersynth]` section below.
+  ROMs at all and brings its own `coppersynth_*` keys with it; see
+  [the Coppersynth chapter](coppersynth.md).
 - `tcp` -- serial in/out is bridged to a host TCP port, like UAE's `TCP:`
   device. `listen` sets the bind address (default `127.0.0.1:1234`);
   connect with e.g. `nc`, `socat`, or a raw-mode telnet client.
@@ -1231,26 +1231,6 @@ takes a `host:port`, with an IPv6 literal in brackets
 
 The browser build has its own serial transport (the page bridges the port
 to a WebSocket); see [the browser chapter](browser.md).
-
-## `[coppersynth]` -- Coppersynth
-
-```toml
-[coppersynth]
-# soundfont = "/path/to/bank.sf2"   # override the built-in bank
-# mt32_mode = "auto"                # auto, on, or off
-# panel = true                      # start with the front panel shown
-```
-
-Coppersynth's own keys, in force when `[serial] midi_out = "coppersynth"`. The
-built-in bank (GeneralUser GS) is inside the executable, so none of them
-is required: `soundfont` plays a different bank (`.sf2`, or a `.zip`
-holding one; the `COPPERLINE_SOUNDFONT` environment variable and an
-`.sf2` beside the executable are also honoured), `mt32_mode` sets how
-MT-32 games are translated, and `panel` starts the session with the
-front panel under the display. All three are on the launcher's
-**I/O Ports** tab once Coppersynth is the MIDI output, and in the
-menu's **Coppersynth** category while it plays; see
-[the Coppersynth chapter](coppersynth.md).
 
 ## `[parallel]` -- Centronics parallel port
 

--- a/docs/guide/coppersynth.md
+++ b/docs/guide/coppersynth.md
@@ -26,19 +26,27 @@ In the configuration file:
 [serial]
 mode = "midi"
 midi_out = "coppersynth"
-
-[coppersynth]
-# soundfont = "/path/to/bank.sf2"   # override the built-in bank
-# mt32_mode = "auto"                # auto, on, or off
-# panel = true                      # start with the front panel shown
+# coppersynth_soundfont = "/path/to/bank.sf2"  # override the built-in bank
+# coppersynth_mt32_mode = "auto"               # auto, on, or off
+# coppersynth_panel = true                     # start with the front panel shown
 ```
+
+## `[serial]` keys
+
+| Key | Values | Meaning |
+|---|---|---|
+| `midi_out` | `"coppersynth"` | Play to the built-in synthesizer instead of a host endpoint |
+| `coppersynth_soundfont` | path | A bank to play instead of the built-in one (`.sf2`, or a `.zip` holding one) |
+| `coppersynth_mt32_mode` | `"auto"`, `"on"`, `"off"` | How MT-32 traffic is translated (default `"auto"`) |
+| `coppersynth_panel` | `true`/`false` | Show the front panel (default `false`) |
 
 ## Soundfonts
 
 Coppersynth carries its own bank -- **GeneralUser GS** by S. Christian
 Collins, an instrument library in its own right with the complete General
 MIDI sound set, SFX bank and drum kits included, at a very reasonable
-size -- and needs no files. To play a different one, set `[coppersynth] soundfont`,
+size -- and needs no files. To play a different one, set
+`[serial] coppersynth_soundfont`,
 use the launcher's **Browse**, or press the panel's **LOAD** button in a
 running session; `.sf2` files and `.zip` archives containing one both
 load, and **Reset** puts the built-in bank back. A bank with defects
@@ -60,7 +68,8 @@ CM-64/32L drum kit, MT-32 rhythm selects it automatically.
 
 ## The front panel
 
-**Front panel** in the launcher row, the menu toggle, or `[coppersynth] panel`
+**Front panel** in the launcher row, the menu toggle, or
+`[serial] coppersynth_panel`
 puts the module's fascia under the display: the backlit LCD with the part
 values, the sixteen-part level meters, and the sound's name -- a game's
 MT-32 instrument uploads show under their own names. Buttons press with a

--- a/src/config.rs
+++ b/src/config.rs
@@ -359,9 +359,6 @@ pub struct Config {
     /// electrically disconnected, so CIA-A strobes receive no FLAG acknowledge
     /// and port-B reads see the CIA's own pin state.
     pub parallel: ParallelConfig,
-    /// The `[coppersynth]` section, resolved: soundfont path (still optional --
-    /// the search path answers at attach time) and translation mode.
-    pub csynth: CsynthConfig,
 }
 
 /// How much of the overscan field the window presents. The
@@ -845,6 +842,15 @@ pub struct SerialConfig {
     pub mt32_panel: bool,
     /// How that panel's display is lit.
     pub mt32_lcd: Mt32Lcd,
+    /// Coppersynth's soundfont (.sf2, or a .zip holding one). A path
+    /// option like the ROMs above: the bundled default's search path is
+    /// consulted when the device is attached, not here, so a config that
+    /// never selects the synth never demands the file.
+    pub coppersynth_soundfont: Option<PathBuf>,
+    /// Coppersynth's MT-32 mode: "auto" (default), "on", or "off".
+    pub coppersynth_mt32_mode: Option<String>,
+    /// Show Coppersynth's front panel under the status bar (default false).
+    pub coppersynth_panel: bool,
     /// TCP listen address for [`SerialMode::Tcp`]; `None` means
     /// [`SERIAL_TCP_DEFAULT_LISTEN`].
     pub listen: Option<String>,
@@ -2276,7 +2282,6 @@ impl Default for Config {
             port_devices: [PortDevice::Mouse, PortDevice::Joystick],
             serial: SerialConfig::default(),
             parallel: ParallelConfig::default(),
-            csynth: CsynthConfig::default(),
             paths: crate::pathconf::Paths::default(),
         }
     }
@@ -2908,16 +2913,6 @@ pub struct RawConfig {
     pub(crate) serial: RawSerial,
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) parallel: RawParallel,
-    // The section is named for the synth; the field keeps the crate's
-    // internal shorthand, and the alias forgives configs saved before
-    // the section earned its name.
-    #[serde(
-        default,
-        rename = "coppersynth",
-        alias = "gm",
-        skip_serializing_if = "is_default"
-    )]
-    pub(crate) csynth: RawCsynth,
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) whdload: RawWhdload,
     /// `[[filesys]]` host-directory mount entries, in file order.
@@ -3255,6 +3250,18 @@ pub(crate) struct RawSerial {
     /// Its display: "mt32" (default), "superjv", "sseries", or "oled".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) mt32_lcd: Option<String>,
+    /// Coppersynth's soundfont (.sf2, or a .zip holding one); unset means
+    /// the bundled default's search path (COPPERLINE_SOUNDFONT, beside
+    /// the executable, share/).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) coppersynth_soundfont: Option<String>,
+    /// Coppersynth's MT-32 mode: "auto" (default; translates once MT-32
+    /// sysex is seen), "on", or "off".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) coppersynth_mt32_mode: Option<String>,
+    /// Show Coppersynth's front panel under the status bar (default false).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) coppersynth_panel: Option<bool>,
     /// TCP listen address; tcp mode only. Defaults to 127.0.0.1:1234.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) listen: Option<String>,
@@ -3264,25 +3271,6 @@ pub(crate) struct RawSerial {
 }
 
 /// `[parallel]` peripheral selection for the Amiga Centronics parallel port.
-/// `[coppersynth]`: the built-in Coppersynth synthesizer, selected with
-/// `[serial] midi_out = "coppersynth"`. No ROMs: a soundfont supplies the sounds,
-/// and the bundled GeneralUser GS is found without configuration.
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct RawCsynth {
-    /// Soundfont (.sf2) path; unset means the bundled default's search
-    /// path (COPPERLINE_SOUNDFONT, beside the executable, share/).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) soundfont: Option<String>,
-    /// MT-32 mode: "auto" (default; translates once MT-32 sysex is
-    /// seen), "on", or "off".
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) mt32_mode: Option<String>,
-    /// Whether the front panel is up when a session starts.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) panel: Option<bool>,
-}
-
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawParallel {
@@ -4383,9 +4371,27 @@ impl TryFrom<RawConfig> for Config {
             },
             mt32_pcm_rom: raw.serial.mt32_pcm_rom.as_ref().map(PathBuf::from),
             mt32_panel: raw.serial.mt32_panel.unwrap_or(defaults.serial.mt32_panel),
+            coppersynth_soundfont: raw.serial.coppersynth_soundfont.as_ref().map(PathBuf::from),
+            coppersynth_mt32_mode: raw.serial.coppersynth_mt32_mode.clone(),
+            coppersynth_panel: raw
+                .serial
+                .coppersynth_panel
+                .unwrap_or(defaults.serial.coppersynth_panel),
             listen: raw.serial.listen.clone(),
             connect: raw.serial.connect.clone(),
         };
+        if let Some(mode) = serial.coppersynth_mt32_mode.as_deref() {
+            let m = mode.trim();
+            if !(m.eq_ignore_ascii_case("auto")
+                || m.eq_ignore_ascii_case("on")
+                || m.eq_ignore_ascii_case("off"))
+            {
+                bail!(
+                    "[serial] coppersynth_mt32_mode must be \"auto\", \"on\", or \"off\", \
+                     got {mode:?}"
+                );
+            }
+        }
 
         let ide = IdeConfig {
             master: raw.ide.master.map(drive_image).transpose()?,
@@ -4982,7 +4988,6 @@ impl TryFrom<RawConfig> for Config {
             port_devices,
             serial,
             parallel: resolve_parallel(raw.parallel)?,
-            csynth: resolve_csynth(raw.csynth)?,
             paths: raw.paths,
         })
     }
@@ -4993,33 +4998,6 @@ impl TryFrom<RawConfig> for Config {
 /// (back-compat with the original `[parallel] output = "..."`) and otherwise the
 /// port is empty. Rejects a printer with no capture path and an out-of-range
 /// sampler gain.
-/// The `[coppersynth]` section, validated. The soundfont stays a path option --
-/// the search path is consulted when the device is attached, not here,
-/// so a config that never selects the synth never demands the file.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct CsynthConfig {
-    pub soundfont: Option<PathBuf>,
-    pub mt32_mode: Option<String>,
-    pub panel: bool,
-}
-
-fn resolve_csynth(raw: RawCsynth) -> Result<CsynthConfig> {
-    if let Some(mode) = raw.mt32_mode.as_deref() {
-        let m = mode.trim();
-        if !(m.eq_ignore_ascii_case("auto")
-            || m.eq_ignore_ascii_case("on")
-            || m.eq_ignore_ascii_case("off"))
-        {
-            bail!("[coppersynth] mt32_mode must be \"auto\", \"on\", or \"off\", got {mode:?}");
-        }
-    }
-    Ok(CsynthConfig {
-        soundfont: raw.soundfont.map(PathBuf::from),
-        mt32_mode: raw.mt32_mode,
-        panel: raw.panel.unwrap_or(false),
-    })
-}
-
 fn resolve_parallel(raw: RawParallel) -> Result<ParallelConfig> {
     let device = match raw.device.as_deref() {
         Some(s) => parse_parallel_device(s)?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -10290,6 +10290,41 @@ mod tests {
     }
 
     #[test]
+    fn serial_section_carries_the_coppersynth_keys() -> Result<()> {
+        // All three keys parse under [serial], like the MT-32's.
+        let text = "[serial]\nmode = \"midi\"\nmidi_out = \"coppersynth\"\n\
+                    coppersynth_soundfont = \"bank.sf2\"\n\
+                    coppersynth_mt32_mode = \"on\"\ncoppersynth_panel = true\n";
+        let cfg = parse_config(text)?;
+        assert_eq!(
+            cfg.serial.coppersynth_soundfont.as_deref(),
+            Some(std::path::Path::new("bank.sf2"))
+        );
+        assert_eq!(cfg.serial.coppersynth_mt32_mode.as_deref(), Some("on"));
+        assert!(cfg.serial.coppersynth_panel);
+
+        // They serialize back under [serial] and survive the round trip
+        // -- the text a launcher Save writes must load again.
+        let raw: RawConfig = toml::from_str(text)?;
+        let written = raw.to_toml_string()?;
+        for key in [
+            "coppersynth_soundfont",
+            "coppersynth_mt32_mode",
+            "coppersynth_panel",
+        ] {
+            assert!(written.contains(key), "{key} missing from:\n{written}");
+        }
+        let reloaded = parse_config(&written)?;
+        assert_eq!(reloaded.serial.coppersynth_mt32_mode.as_deref(), Some("on"));
+
+        // The rejection names the key exactly as [serial] spells it, so
+        // a launcher-saved config that goes stale says where to look.
+        let err = parse_config("[serial]\ncoppersynth_mt32_mode = \"maybe\"\n").unwrap_err();
+        assert!(err.to_string().contains("coppersynth_mt32_mode"), "{err:#}");
+        Ok(())
+    }
+
+    #[test]
     fn serial_section_selects_tcp_connect_and_address() -> Result<()> {
         let cfg =
             parse_config("[serial]\nmode = \"tcp-connect\"\nconnect = \"bbs.example.com:1337\"\n")?;

--- a/src/csynth/mod.rs
+++ b/src/csynth/mod.rs
@@ -27,7 +27,7 @@ pub const SOUNDFONT_NAME: &str = "GeneralUser-GS.sf2";
 /// needs no file at all: Coppersynth embeds its own.
 pub const SOUNDFONT_ZIP_NAME: &str = "GeneralUser-GS.zip";
 
-/// The `[coppersynth]` settings the device is fitted with.
+/// The `[serial] coppersynth_*` settings the device is fitted with.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CsynthOptions {
     /// An explicit soundfont; unset means the search path below.
@@ -44,13 +44,13 @@ impl CsynthOptions {
             Some(s) if s.eq_ignore_ascii_case("on") => Ok(Mt32Mode::On),
             Some(s) if s.eq_ignore_ascii_case("off") => Ok(Mt32Mode::Off),
             Some(other) => Err(anyhow!(
-                "[coppersynth] mt32_mode must be \"auto\", \"on\", or \"off\", got {other:?}"
+                "[serial] coppersynth_mt32_mode must be \"auto\", \"on\", or \"off\", got {other:?}"
             )),
         }
     }
 }
 
-/// Which soundfont overrides the bundled bank, if any: `[coppersynth] soundfont`
+/// Which soundfont overrides the bundled bank, if any: `[serial] coppersynth_soundfont`
 /// first, then `COPPERLINE_SOUNDFONT`, then a file placed beside the
 /// executable or in the `share/copperline` layout an installed package
 /// uses. `None` means Coppersynth's own bundled GeneralUser GS -- there
@@ -61,7 +61,7 @@ pub fn find_soundfont(explicit: Option<&std::path::Path>) -> Result<Option<PathB
             return Ok(Some(path.to_path_buf()));
         }
         return Err(anyhow!(
-            "[coppersynth] soundfont {} does not exist",
+            "[serial] coppersynth_soundfont {} does not exist",
             path.display()
         ));
     }

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2057,8 +2057,8 @@ fn build_serial_sink(cfg: &Config) -> Result<Box<dyn crate::serial::SerialSink>>
             #[cfg(feature = "coppersynth")]
             {
                 sink.set_csynth_options(crate::csynth::CsynthOptions {
-                    soundfont: cfg.csynth.soundfont.clone(),
-                    mt32_mode: cfg.csynth.mt32_mode.clone(),
+                    soundfont: cfg.serial.coppersynth_soundfont.clone(),
+                    mt32_mode: cfg.serial.coppersynth_mt32_mode.clone(),
                 });
                 if wants_csynth {
                     sink.set_output_endpoint(Some(crate::config::MIDI_OUT_CSYNTH));

--- a/src/main.rs
+++ b/src/main.rs
@@ -2463,7 +2463,7 @@ fn main() -> Result<()> {
     );
     #[cfg(feature = "coppersynth")]
     video::set_csynth_panel_shown(
-        cfg.csynth.panel
+        cfg.serial.coppersynth_panel
             && serial_midi
             && config::midi_out_is_csynth(cfg.serial.midi_out.as_deref()),
     );

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -502,7 +502,8 @@ impl MidiSerialSink {
         self.csynth_selected = false;
     }
 
-    /// The `[coppersynth]` settings the synth is fitted with when selected.
+    /// The `[serial] coppersynth_*` settings the synth is fitted with when
+    /// selected.
     #[cfg(feature = "coppersynth")]
     pub fn set_csynth_options(&mut self, options: crate::csynth::CsynthOptions) {
         self.csynth_options = options;

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -2228,7 +2228,7 @@ pub struct MachineSetup {
     mt32_pcm_rom: Option<PathBuf>,
     mt32_panel: bool,
     mt32_lcd: Mt32Lcd,
-    /// Coppersynth's soundfont and translation mode ([coppersynth]).
+    /// Coppersynth's soundfont and translation mode ([serial] coppersynth_*).
     csynth_soundfont: Option<PathBuf>,
     csynth_mt32_mode: Option<String>,
     csynth_panel: bool,
@@ -2501,9 +2501,9 @@ impl MachineSetup {
             mt32_pcm_rom: cfg.serial.mt32_pcm_rom.clone(),
             mt32_panel: cfg.serial.mt32_panel,
             mt32_lcd: cfg.serial.mt32_lcd,
-            csynth_soundfont: cfg.csynth.soundfont.clone(),
-            csynth_mt32_mode: cfg.csynth.mt32_mode.clone(),
-            csynth_panel: cfg.csynth.panel,
+            csynth_soundfont: cfg.serial.coppersynth_soundfont.clone(),
+            csynth_mt32_mode: cfg.serial.coppersynth_mt32_mode.clone(),
+            csynth_panel: cfg.serial.coppersynth_panel,
             menu_scale: cfg.menu_scale,
             tint: cfg.tint,
             start_fullscreen: cfg.full_screen,
@@ -2979,17 +2979,17 @@ impl MachineSetup {
         if self.mt32_lcd != base.serial.mt32_lcd {
             raw.serial.mt32_lcd = Some(self.mt32_lcd.label().to_string());
         }
-        if self.csynth_soundfont != base.csynth.soundfont {
-            raw.csynth.soundfont = self
+        if self.csynth_soundfont != base.serial.coppersynth_soundfont {
+            raw.serial.coppersynth_soundfont = self
                 .csynth_soundfont
                 .as_ref()
                 .map(|p| p.display().to_string());
         }
-        if self.csynth_mt32_mode != base.csynth.mt32_mode {
-            raw.csynth.mt32_mode = self.csynth_mt32_mode.clone();
+        if self.csynth_mt32_mode != base.serial.coppersynth_mt32_mode {
+            raw.serial.coppersynth_mt32_mode = self.csynth_mt32_mode.clone();
         }
-        if self.csynth_panel != base.csynth.panel {
-            raw.csynth.panel = Some(self.csynth_panel);
+        if self.csynth_panel != base.serial.coppersynth_panel {
+            raw.serial.coppersynth_panel = Some(self.csynth_panel);
         }
         if self.menu_scale != base.menu_scale {
             raw.display.menu_scale = Some(self.menu_scale.label().to_string());
@@ -3279,9 +3279,9 @@ impl MachineSetup {
         self.mt32_pcm_rom = base.serial.mt32_pcm_rom.clone();
         self.mt32_panel = base.serial.mt32_panel;
         self.mt32_lcd = base.serial.mt32_lcd;
-        self.csynth_soundfont = base.csynth.soundfont.clone();
-        self.csynth_mt32_mode = base.csynth.mt32_mode.clone();
-        self.csynth_panel = base.csynth.panel;
+        self.csynth_soundfont = base.serial.coppersynth_soundfont.clone();
+        self.csynth_mt32_mode = base.serial.coppersynth_mt32_mode.clone();
+        self.csynth_panel = base.serial.coppersynth_panel;
         self.start_fullscreen = base.full_screen;
         self.show_status_bar = base.status_bar;
         self.floppy_sounds = base.audio.floppy_sounds;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -10039,7 +10039,7 @@ impl App {
                 .bus_mut()
                 .midi_serial_mut()
                 .is_some_and(|sink| sink.csynth_selected());
-            self.set_csynth_panel_shown(fitted && cfg.csynth.panel);
+            self.set_csynth_panel_shown(fitted && cfg.serial.coppersynth_panel);
         }
         self.ui.menu_open = false;
         self.ui.panel = None;


### PR DESCRIPTION
The `[coppersynth]` section was the odd one out: the MT-32's settings are `mt32_`-prefixed keys under `[serial]`, and the other built-in synth's belong beside them.

`coppersynth_soundfont`, `coppersynth_mt32_mode` and `coppersynth_panel` replace the section — launcher save/load, validation, error strings and docs all follow (the Coppersynth chapter gains a `[serial]` keys table matching the MT-32's). The old section is gone entirely.
