### PR TITLE
Feature/launcher UI sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "coppersynth"
 version = "0.9.1"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=db147d9a7058e72e7eeb85690b3954af7b7c5a2f#db147d9a7058e72e7eeb85690b3954af7b7c5a2f"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=e575a9801958641caef76b402672fedf4b2288d1#e575a9801958641caef76b402672fedf4b2288d1"
 dependencies = [
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,8 +601,8 @@ dependencies = [
 
 [[package]]
 name = "coppersynth"
-version = "0.9.0"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=792d711592845eb6c592623441696ded65db3eb2#792d711592845eb6c592623441696ded65db3eb2"
+version = "0.9.1"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=db147d9a7058e72e7eeb85690b3954af7b7c5a2f#db147d9a7058e72e7eeb85690b3954af7b7c5a2f"
 dependencies = [
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "coppersynth"
 version = "0.9.0"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=2f0920d72497be34ba38b7b2c0b77ef667562c34#2f0920d72497be34ba38b7b2c0b77ef667562c34"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=792d711592845eb6c592623441696ded65db3eb2#792d711592845eb6c592623441696ded65db3eb2"
 dependencies = [
  "zip",
 ]
@@ -3746,7 +3746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "coppersynth"
 version = "0.9.1"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=253cf8cbf9df76aba4a9fc59a90d2bbe6b1662aa#253cf8cbf9df76aba4a9fc59a90d2bbe6b1662aa"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=c112ca84eb962ff482a52eb46113c3765092caa6#c112ca84eb962ff482a52eb46113c3765092caa6"
 dependencies = [
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "coppersynth"
 version = "0.9.1"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=e575a9801958641caef76b402672fedf4b2288d1#e575a9801958641caef76b402672fedf4b2288d1"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=253cf8cbf9df76aba4a9fc59a90d2bbe6b1662aa#253cf8cbf9df76aba4a9fc59a90d2bbe6b1662aa"
 dependencies = [
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "792d711592845eb6c592623441696ded65db3eb2", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "db147d9a7058e72e7eeb85690b3954af7b7c5a2f", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "db147d9a7058e72e7eeb85690b3954af7b7c5a2f", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "e575a9801958641caef76b402672fedf4b2288d1", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "2f0920d72497be34ba38b7b2c0b77ef667562c34", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "792d711592845eb6c592623441696ded65db3eb2", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "e575a9801958641caef76b402672fedf4b2288d1", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "253cf8cbf9df76aba4a9fc59a90d2bbe6b1662aa", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "253cf8cbf9df76aba4a9fc59a90d2bbe6b1662aa", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "c112ca84eb962ff482a52eb46113c3765092caa6", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/docs/guide/coppersynth.md
+++ b/docs/guide/coppersynth.md
@@ -98,18 +98,20 @@ The front panel has a few extra features similar to an SC-55.
 Latch/hold buttons with a right click on a switched-off unit, then
 press **POWER**.
 
-- Both **INSTRUMENT** buttons "reset" the unit and reload the builtin
-  SoundFont.
-- **INSTRUMENT ►** asks `MT-32, Sure?` with the ALL and MUTE lamps
-  flashing: **ALL** forces MT-32 mode on, **MUTE** forces it off, and
-  the choice lands in the configuration like the menu's.
+- **INSTRUMENT ◄** asks `Init MT-32, Sure?` with the ALL and MUTE
+  lamps flashing: **ALL** forces MT-32 mode on, **MUTE** forces it
+  off, and the choice lands in the configuration like the menu's.
+- **INSTRUMENT ►** asks `Init SoundFont,Sure?` the same way: **ALL**
+  holds the screen at `Initializing...` for a moment, reloads the
+  builtin SoundFont and boots; **MUTE** carries on with the loaded
+  one.
 - Both **PART** buttons start demo mode: the part box reads `S-1` and
   the unit plays its two bundled songs through its own engine. **ALL**
   plays, **MUTE** stops, the **PART** arrows change song. Power off to
   leave.
 - Both **MIDI CH** and both **INSTRUMENT** buttons show the Coppersynth
-  version and build date on the way up -- the fourth latch switches the
-  unit on by itself.
+  version and build date on the way up (**ALL** or **MUTE** carries on
+  the boot) -- the fourth latch switches the unit on by itself.
 
 ## Building without it
 

--- a/docs/guide/coppersynth.md
+++ b/docs/guide/coppersynth.md
@@ -15,7 +15,7 @@ plays MIDI music and Amiga sound effects gets both.
 The serial port has to be in MIDI mode with Coppersynth as its output. In
 the launcher, that is the **I/O Ports** tab (its Serial Port page): set
 **Device / Mode** to `MIDI`, then **MIDI output** to `Coppersynth`.
-Choosing it reveals the rest of the rows: the soundfont, the front panel,
+Choosing it reveals the rest of the rows: the SoundFont, the front panel,
 and MT-32 mode. In a running session the same choice is under the menu's
 **MIDI Out**, where Coppersynth is always offered. On the command line,
 `--midi-out coppersynth` selects it and implies MIDI mode.
@@ -49,7 +49,8 @@ size -- and needs no files. To play a different one, set
 `[serial] coppersynth_soundfont`,
 use the launcher's **Browse**, or press the panel's **LOAD** button in a
 running session; `.sf2` files and `.zip` archives containing one both
-load, and **Reset** puts the built-in bank back. A bank with defects
+load, and the launcher's **Clear** (the menu's **Reset**) puts the
+built-in bank back. A bank with defects
 (loop points past its data are common in rips) is repaired at load rather
 than refused, and the log says what the mending cost. A bank that does
 not fill all 128 programs keeps honest numbering: an unfilled slot shows

--- a/docs/guide/coppersynth.md
+++ b/docs/guide/coppersynth.md
@@ -40,7 +40,7 @@ midi_out = "coppersynth"
 | `coppersynth_mt32_mode` | `"auto"`, `"on"`, `"off"` | How MT-32 traffic is translated (default `"auto"`) |
 | `coppersynth_panel` | `true`/`false` | Show the front panel (default `false`) |
 
-## Soundfonts
+## SoundFonts
 
 Coppersynth carries its own bank -- **GeneralUser GS** by S. Christian
 Collins, an instrument library in its own right with the complete General

--- a/docs/guide/coppersynth.md
+++ b/docs/guide/coppersynth.md
@@ -103,7 +103,7 @@ press **POWER**.
   off, and the choice lands in the configuration like the menu's.
 - **INSTRUMENT ►** asks `Init SoundFont,Sure?` the same way: **ALL**
   holds the screen at `Initializing...` for a moment, reloads the
-  builtin SoundFont and boots; **MUTE** carries on with the loaded
+  built-in SoundFont and boots; **MUTE** carries on with the loaded
   one.
 - Both **PART** buttons start demo mode: the part box reads `S-1` and
   the unit plays its two bundled songs through its own engine. **ALL**

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -506,9 +506,10 @@ The layout is:
   16-bit word -- plus chip/fast/slow/motherboard/accelerator/Zorro III RAM),
   *ROM*
   (Kickstart and
-  extended ROM, each with a greyed line under it naming what the chosen
-  image is -- `Kickstart 3.1 (40.68) A1200` -- identified by checksum rather
-  than by file name, and left blank for an image Copperline does not know;
+  extended ROM; the Kickstart row carries **Name**, **Version** and
+  **Revision** lines naming what the chosen image is, identified by
+  checksum rather than by file name -- blank for an image Copperline does
+  not know, and read from the image itself for the bundled AROS;
   see [](configuration)),
   *Floppy* (drive count and speed, then each wired drive as a
   greyed **DFn:** heading with its indented disk image and write-protect;

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -2,8 +2,8 @@
     {
         "type": "git",
         "url": "https://github.com/copperlinehq/coppersynth",
-        "commit": "253cf8cbf9df76aba4a9fc59a90d2bbe6b1662aa",
-        "dest": "flatpak-cargo/git/coppersynth-253cf8c"
+        "commit": "c112ca84eb962ff482a52eb46113c3765092caa6",
+        "dest": "flatpak-cargo/git/coppersynth-c112ca8"
     },
     {
         "type": "git",
@@ -826,7 +826,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-253cf8c/.\" \"cargo/vendor/coppersynth\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-c112ca8/.\" \"cargo/vendor/coppersynth\""
         ]
     },
     {
@@ -6989,7 +6989,7 @@
     },
     {
         "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"253cf8cbf9df76aba4a9fc59a90d2bbe6b1662aa\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"c112ca84eb962ff482a52eb46113c3765092caa6\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -2,8 +2,8 @@
     {
         "type": "git",
         "url": "https://github.com/copperlinehq/coppersynth",
-        "commit": "db147d9a7058e72e7eeb85690b3954af7b7c5a2f",
-        "dest": "flatpak-cargo/git/coppersynth-db147d9"
+        "commit": "e575a9801958641caef76b402672fedf4b2288d1",
+        "dest": "flatpak-cargo/git/coppersynth-e575a98"
     },
     {
         "type": "git",
@@ -826,7 +826,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-db147d9/.\" \"cargo/vendor/coppersynth\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-e575a98/.\" \"cargo/vendor/coppersynth\""
         ]
     },
     {
@@ -6989,7 +6989,7 @@
     },
     {
         "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"db147d9a7058e72e7eeb85690b3954af7b7c5a2f\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"e575a9801958641caef76b402672fedf4b2288d1\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -2,8 +2,8 @@
     {
         "type": "git",
         "url": "https://github.com/copperlinehq/coppersynth",
-        "commit": "e575a9801958641caef76b402672fedf4b2288d1",
-        "dest": "flatpak-cargo/git/coppersynth-e575a98"
+        "commit": "253cf8cbf9df76aba4a9fc59a90d2bbe6b1662aa",
+        "dest": "flatpak-cargo/git/coppersynth-253cf8c"
     },
     {
         "type": "git",
@@ -826,7 +826,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-e575a98/.\" \"cargo/vendor/coppersynth\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-253cf8c/.\" \"cargo/vendor/coppersynth\""
         ]
     },
     {
@@ -6989,7 +6989,7 @@
     },
     {
         "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"e575a9801958641caef76b402672fedf4b2288d1\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"253cf8cbf9df76aba4a9fc59a90d2bbe6b1662aa\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -2,8 +2,8 @@
     {
         "type": "git",
         "url": "https://github.com/copperlinehq/coppersynth",
-        "commit": "2f0920d72497be34ba38b7b2c0b77ef667562c34",
-        "dest": "flatpak-cargo/git/coppersynth-2f0920d"
+        "commit": "db147d9a7058e72e7eeb85690b3954af7b7c5a2f",
+        "dest": "flatpak-cargo/git/coppersynth-db147d9"
     },
     {
         "type": "git",
@@ -826,12 +826,12 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-2f0920d/.\" \"cargo/vendor/coppersynth\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-db147d9/.\" \"cargo/vendor/coppersynth\""
         ]
     },
     {
         "type": "inline",
-        "contents": "[package]\nname = \"coppersynth\"\nversion = \"0.9.0\"\nauthors = [\"Lee Hobson\"]\nedition = \"2021\"\nlicense = \"MIT\"\ndescription = \"Copperline's General MIDI sound module: a Sound Canvas-flavoured SoundFont synth with an MT-32 translation layer and front panel model\"\nrepository = \"https://github.com/CopperlineHQ/Coppersynth\"\npublish = false\n\n[dependencies.zip]\nversion = \"8\"\ndefault-features = false\nfeatures = [\"deflate\"]\n\n[build-dependencies]\nzip = \"8\"\n",
+        "contents": "[package]\nname = \"coppersynth\"\nversion = \"0.9.1\"\nauthors = [\"Lee Hobson\"]\nedition = \"2021\"\nlicense = \"MIT\"\ndescription = \"Copperline's General MIDI sound module: a Sound Canvas-flavoured SoundFont synth with an MT-32 translation layer and front panel model\"\nrepository = \"https://github.com/CopperlineHQ/Coppersynth\"\npublish = false\n\n[dependencies.zip]\nversion = \"8\"\ndefault-features = false\nfeatures = [\"deflate\"]\n\n[build-dependencies]\nzip = \"8\"\n",
         "dest": "cargo/vendor/coppersynth",
         "dest-filename": "Cargo.toml"
     },
@@ -6989,7 +6989,7 @@
     },
     {
         "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"2f0920d72497be34ba38b7b2c0b77ef667562c34\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"db147d9a7058e72e7eeb85690b3954af7b7c5a2f\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/src/csynth/mod.rs
+++ b/src/csynth/mod.rs
@@ -255,6 +255,13 @@ impl CsynthDevice {
         self.panel.power_on_held(held);
     }
 
+    /// Open this freshly attached panel on the Initializing... hold:
+    /// the unit was rebuilt mid-reset, and the hold serves its second
+    /// before the ordinary boot, as if the panel had survived.
+    pub fn panel_begin_initializing(&mut self) {
+        self.panel.begin_initializing();
+    }
+
     /// A semantic press from the window's panel.
     pub fn panel_button(&mut self, button: Button) -> Option<PanelRequest> {
         self.feed_panel();

--- a/src/romdb.rs
+++ b/src/romdb.rs
@@ -120,6 +120,45 @@ pub fn describe_file(path: &Path) -> Option<Identified> {
     describe(&std::fs::read(path).ok()?)
 }
 
+/// The version pair a ROM image says for itself, read from the image
+/// rather than the checksum table: the ROM header's version.revision
+/// words, and the first `$VER:` cookie's own number (exec.library's,
+/// in a Kickstart-shaped ROM). Either half may be missing; a file that
+/// cannot be read yields nothing. This is how the bundled AROS -- which
+/// no checksum table names, and which moves between releases -- gets
+/// its numbers into the launcher's identification table.
+pub fn rom_self_versions(path: &Path) -> Option<(String, String)> {
+    let len = std::fs::metadata(path).ok()?.len();
+    if len == 0 || len > MAX_ROM_FILE_BYTES {
+        return None;
+    }
+    let data = std::fs::read(path).ok()?;
+    let header = if data.len() >= 16 {
+        let ver = u16::from_be_bytes([data[12], data[13]]);
+        let rev = u16::from_be_bytes([data[14], data[15]]);
+        format!("{ver}.{rev}")
+    } else {
+        String::new()
+    };
+    let cookie = data
+        .windows(6)
+        .position(|w| w == b"$VER: ")
+        .map(|i| {
+            let tail = &data[i + 6..(i + 128).min(data.len())];
+            let line: String = tail
+                .iter()
+                .take_while(|&&b| b != 0 && b != b'\r' && b != b'\n')
+                .map(|&b| b as char)
+                .collect();
+            line.split_whitespace()
+                .find(|w| w.chars().next().is_some_and(|c| c.is_ascii_digit()) && w.contains('.'))
+                .unwrap_or_default()
+                .to_string()
+        })
+        .unwrap_or_default();
+    Some((header, cookie))
+}
+
 /// The raw table lookup: an exact (CRC-32, length) match, with no
 /// normalisation of its own.
 pub fn identify_crc(crc: u32, len: usize) -> Option<&'static RomEntry> {

--- a/src/romdb.rs
+++ b/src/romdb.rs
@@ -126,7 +126,7 @@ pub fn describe_file(path: &Path) -> Option<Identified> {
 /// in a Kickstart-shaped ROM). Either half may be missing; a file that
 /// cannot be read yields nothing. This is how the bundled AROS -- which
 /// no checksum table names, and which moves between releases -- gets
-/// its numbers into the launcher's identification table.
+/// its numbers into the launcher's identification lines.
 pub fn rom_self_versions(path: &Path) -> Option<(String, String)> {
     let len = std::fs::metadata(path).ok()?.len();
     if len == 0 || len > MAX_ROM_FILE_BYTES {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -961,7 +961,7 @@ const MEMORY_ROWS: [Row; 8] = [
 // ("Kickstart", "3.1", "40.68"), since a ROM file's name says only what
 // its dumper called it. The table stands whether or not an image is
 // loaded; empty cells mean an empty (or unrecognised) slot.
-const ROM_ROWS: [Row; 8] = [
+const ROM_ROWS: [Row; 7] = [
     section_header("Primary ROM:"),
     row(F::Rom, "  Kickstart ROM", PathRow),
     // What the chosen image is, one greyed line per fact, indented
@@ -969,8 +969,6 @@ const ROM_ROWS: [Row; 8] = [
     row(F::Rom, "Name", RowKind::RomInfo),
     row(F::Rom, "Version", RowKind::RomInfo),
     row(F::Rom, "Revision", RowKind::RomInfo),
-    // A blank header as a spacer before the next section.
-    section_header(""),
     section_header("Extended ROM:"),
     row(F::ExtendedRom, "  Extended ROM", PathRow),
 ];
@@ -9971,7 +9969,6 @@ mod tests {
                 ("Name", RowKind::RomInfo, F::Rom),
                 ("Version", RowKind::RomInfo, F::Rom),
                 ("Revision", RowKind::RomInfo, F::Rom),
-                ("", RowKind::SectionHeader, F::SectionHeader),
                 ("Extended ROM:", RowKind::SectionHeader, F::SectionHeader),
                 ("  Extended ROM", RowKind::Path, F::ExtendedRom),
             ]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -717,11 +717,11 @@ pub enum RowKind {
     /// A hard-drive image: a path with Browse/Clear, plus an editable
     /// volume-name field (used when the image is a host directory).
     Drive,
-    /// The greyed column headers of a ROM row's identification table.
-    RomInfoHeader,
-    /// The identification itself: Name / Version / Revision cells, blank
-    /// when the slot is empty or the image is unrecognised.
-    RomInfoValue,
+    /// One greyed line of a ROM row's identification -- the row's label
+    /// says which fact it carries (Name, Version, Revision), and the
+    /// value follows it. Blank after the prefix when the image is
+    /// unrecognised.
+    RomInfo,
     /// A non-interactive greyed heading that groups the rows beneath it
     /// (e.g. the `Serial:` / `Parallel:` sections of the I/O Ports tab). Its
     /// `field` is inert.
@@ -961,14 +961,15 @@ const MEMORY_ROWS: [Row; 8] = [
 // ("Kickstart", "3.1", "40.68"), since a ROM file's name says only what
 // its dumper called it. The table stands whether or not an image is
 // loaded; empty cells mean an empty (or unrecognised) slot.
-const ROM_ROWS: [Row; 7] = [
+const ROM_ROWS: [Row; 8] = [
     section_header("Primary ROM:"),
     row(F::Rom, "  Kickstart ROM", PathRow),
-    row(F::Rom, "", RowKind::RomInfoHeader),
-    row(F::Rom, "", RowKind::RomInfoValue),
-    // A blank header as a spacer: the next section starts a row clear
-    // of the table. The extended slot gets no table of its own -- the
-    // checksum table rarely names one, and a blank grid says nothing.
+    // What the chosen image is, one greyed line per fact, indented
+    // under its row. The label picks which fact the line carries.
+    row(F::Rom, "Name", RowKind::RomInfo),
+    row(F::Rom, "Version", RowKind::RomInfo),
+    row(F::Rom, "Revision", RowKind::RomInfo),
+    // A blank header as a spacer before the next section.
     section_header(""),
     section_header("Extended ROM:"),
     row(F::ExtendedRom, "  Extended ROM", PathRow),
@@ -9967,8 +9968,9 @@ mod tests {
             [
                 ("Primary ROM:", RowKind::SectionHeader, F::SectionHeader),
                 ("  Kickstart ROM", RowKind::Path, F::Rom),
-                ("", RowKind::RomInfoHeader, F::Rom),
-                ("", RowKind::RomInfoValue, F::Rom),
+                ("Name", RowKind::RomInfo, F::Rom),
+                ("Version", RowKind::RomInfo, F::Rom),
+                ("Revision", RowKind::RomInfo, F::Rom),
                 ("", RowKind::SectionHeader, F::SectionHeader),
                 ("Extended ROM:", RowKind::SectionHeader, F::SectionHeader),
                 ("  Extended ROM", RowKind::Path, F::ExtendedRom),

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -7914,8 +7914,14 @@ impl LauncherState {
                 continue;
             }
             if !version.is_empty() {
+                // Only a numeric token is the revision: the parentheses
+                // also carry variants ("Kickstart 1.0 A1000 (NTSC)"),
+                // which are not one.
                 if revision.is_empty() && word.starts_with('(') && word.ends_with(')') {
-                    revision = word[1..word.len() - 1].to_string();
+                    let inner = &word[1..word.len() - 1];
+                    if !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit() || c == '.') {
+                        revision = inner.to_string();
+                    }
                 }
                 // Everything after the version that is not the revision
                 // is the model list, which is not shown.
@@ -9964,6 +9970,12 @@ mod tests {
                 "3.1".to_string(),
                 "40.68".to_string()
             )
+        );
+        // A parenthesized variant is not a revision.
+        probe.set_rom_note_for_test(F::Rom, "Kickstart 1.0 A1000 (NTSC)");
+        assert_eq!(
+            probe.rom_note_cells(F::Rom),
+            ("Kickstart".to_string(), "1.0".to_string(), String::new())
         );
         // The bundled AROS carries numbers read off the image itself,
         // so they follow releases.

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -963,11 +963,11 @@ const MEMORY_ROWS: [Row; 8] = [
 // loaded; empty cells mean an empty (or unrecognised) slot.
 const ROM_ROWS: [Row; 8] = [
     section_header("Primary ROM:"),
-    row(F::Rom, "Kickstart ROM", PathRow),
+    row(F::Rom, "  Kickstart ROM", PathRow),
     row(F::Rom, "", RowKind::RomInfoHeader),
     row(F::Rom, "", RowKind::RomInfoValue),
     section_header("Extended ROM:"),
-    row(F::ExtendedRom, "Extended ROM", PathRow),
+    row(F::ExtendedRom, "  Extended ROM", PathRow),
     row(F::ExtendedRom, "", RowKind::RomInfoHeader),
     row(F::ExtendedRom, "", RowKind::RomInfoValue),
 ];
@@ -6557,6 +6557,13 @@ impl FsFamily {
 struct RomNote {
     path: Option<PathBuf>,
     text: Option<String>,
+    /// Whether the slot has been synced at all: the bundled default
+    /// (path None) must still seed its cells once.
+    seeded: bool,
+    /// The identification split for the tab's table: Name, Version and
+    /// Revision cells, computed when the path changes rather than per
+    /// draw (the bundled AROS reads its numbers off the image file).
+    cells: (String, String, String),
 }
 
 /// The full interactive state of the open configuration panel.
@@ -7850,26 +7857,72 @@ impl LauncherState {
     pub fn sync_rom_notes(&mut self) {
         for (slot, field) in [(0, F::Rom), (1, F::ExtendedRom)] {
             let path = self.setup.path(field).map(Path::to_path_buf);
-            if self.rom_notes[slot].path == path {
+            if self.rom_notes[slot].seeded && self.rom_notes[slot].path == path {
                 continue;
             }
             self.rom_notes[slot].text = path.as_deref().and_then(crate::config::rom_identification);
+            self.rom_notes[slot].cells = Self::rom_cells_for(
+                slot,
+                path.as_deref(),
+                self.rom_notes[slot].text.as_deref(),
+                self.setup.path(F::Rom).is_none(),
+            );
             self.rom_notes[slot].path = path;
+            self.rom_notes[slot].seeded = true;
         }
     }
 
-    /// The identification split for the ROM tab's table: Name, Version
-    /// and Revision cells. Empty strings when the slot is empty or the
-    /// image is unrecognised.
-    ///
-    /// The identification labels read "Kickstart 3.1 (40.68) A1200":
-    /// name words first, a marketing version, the ROM's own revision in
-    /// parentheses, then the models -- which have no column, and are
-    /// dropped. A label with no version ("bundled AROS") is all name.
-    pub fn rom_note_cells(&self, field: LauncherField) -> (String, String, String) {
-        let Some(note) = self.rom_note(field) else {
-            return (String::new(), String::new(), String::new());
+    /// The table cells for one slot: a checksum-named image splits its
+    /// label; an AROS image -- chosen or bundled -- reads its numbers off
+    /// the file itself, so they follow the bundled ROM between releases.
+    fn rom_cells_for(
+        slot: usize,
+        path: Option<&Path>,
+        text: Option<&str>,
+        main_is_bundled: bool,
+    ) -> (String, String, String) {
+        let aros_cells = |file: &Path| {
+            let (version, revision) = crate::romdb::rom_self_versions(file).unwrap_or_default();
+            ("AROS".to_string(), version, revision)
         };
+        match (path, text) {
+            (Some(p), Some("bundled AROS")) => aros_cells(p),
+            (_, Some(note)) => Self::split_identification(note),
+            (Some(_), None) => (String::new(), String::new(), String::new()),
+            (None, _) => {
+                // An empty slot runs the bundled AROS -- the extended
+                // half only alongside the bundled main.
+                if slot == 1 && !main_is_bundled {
+                    return (String::new(), String::new(), String::new());
+                }
+                let Some(bundle) = crate::romsearch::find_bundled_aros() else {
+                    return (String::new(), String::new(), String::new());
+                };
+                aros_cells(if slot == 0 {
+                    &bundle.main
+                } else {
+                    &bundle.extended
+                })
+            }
+        }
+    }
+
+    /// The identification for the ROM tab's table: Name, Version and
+    /// Revision cells, from the cache [`Self::sync_rom_notes`] keeps.
+    pub fn rom_note_cells(&self, field: LauncherField) -> (String, String, String) {
+        let slot = match field {
+            F::Rom => 0,
+            F::ExtendedRom => 1,
+            _ => return (String::new(), String::new(), String::new()),
+        };
+        self.rom_notes[slot].cells.clone()
+    }
+
+    /// Split a checksum label into the table's columns. The labels read
+    /// "Kickstart 3.1 (40.68) A1200": name words first, a marketing
+    /// version, the ROM's own revision in parentheses, then the models
+    /// -- which have no column, and are dropped.
+    fn split_identification(note: &str) -> (String, String, String) {
         let mut name_words: Vec<&str> = Vec::new();
         let mut version = String::new();
         let mut revision = String::new();
@@ -7915,6 +7968,8 @@ impl LauncherState {
         };
         self.rom_notes[slot].path = self.setup.path(field).map(Path::to_path_buf);
         self.rom_notes[slot].text = Some(text.to_string());
+        self.rom_notes[slot].cells = Self::split_identification(text);
+        self.rom_notes[slot].seeded = true;
     }
 
     /// The text field currently being edited, if any.
@@ -9909,11 +9964,11 @@ mod tests {
             shape,
             [
                 ("Primary ROM:", RowKind::SectionHeader, F::SectionHeader),
-                ("Kickstart ROM", RowKind::Path, F::Rom),
+                ("  Kickstart ROM", RowKind::Path, F::Rom),
                 ("", RowKind::RomInfoHeader, F::Rom),
                 ("", RowKind::RomInfoValue, F::Rom),
                 ("Extended ROM:", RowKind::SectionHeader, F::SectionHeader),
-                ("Extended ROM", RowKind::Path, F::ExtendedRom),
+                ("  Extended ROM", RowKind::Path, F::ExtendedRom),
                 ("", RowKind::RomInfoHeader, F::ExtendedRom),
                 ("", RowKind::RomInfoValue, F::ExtendedRom),
             ]
@@ -9931,14 +9986,23 @@ mod tests {
                 "40.68".to_string()
             )
         );
-        probe.set_rom_note_for_test(F::Rom, "bundled AROS");
+        // The bundled AROS pair fills both slots' tables with numbers
+        // read off the images themselves, so they follow releases.
+        let bundled = LauncherState::new(MachineSetup::default());
+        for field in [F::Rom, F::ExtendedRom] {
+            let (name, version, revision) = bundled.rom_note_cells(field);
+            assert_eq!(name, "AROS");
+            assert!(
+                !version.is_empty() && !revision.is_empty(),
+                "the AROS image carries its own numbers"
+            );
+        }
+        // An unrecognised image is an empty table, not a missing one.
+        let mut setup = MachineSetup::default();
+        setup.set_path(F::Rom, std::path::PathBuf::from("mystery-dump.rom"));
+        let unknown = LauncherState::new(setup);
         assert_eq!(
-            probe.rom_note_cells(F::Rom),
-            ("bundled AROS".to_string(), String::new(), String::new())
-        );
-        // An empty slot is an empty table, not a missing one.
-        assert_eq!(
-            probe.rom_note_cells(F::ExtendedRom),
+            unknown.rom_note_cells(F::Rom),
             (String::new(), String::new(), String::new())
         );
 

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -717,6 +717,11 @@ pub enum RowKind {
     /// A hard-drive image: a path with Browse/Clear, plus an editable
     /// volume-name field (used when the image is a host directory).
     Drive,
+    /// The greyed column headers of a ROM row's identification table.
+    RomInfoHeader,
+    /// The identification itself: Name / Version / Revision cells, blank
+    /// when the slot is empty or the image is unrecognised.
+    RomInfoValue,
     /// A non-interactive greyed heading that groups the rows beneath it
     /// (e.g. the `Serial:` / `Parallel:` sections of the I/O Ports tab). Its
     /// `field` is inert.
@@ -927,36 +932,44 @@ const SYSTEM_ROWS: [Row; 7] = [
     row(F::Agnus, "Agnus", Cycle),
     row(F::Denise, "Denise", Cycle),
     row(F::Video, "Video", Cycle),
-    row(F::Rtc, "Real-time clock", Toggle),
-    row(F::Identify, "Identify board", Toggle),
+    row(F::Rtc, "Real-time clock", Cycle),
+    row(F::Identify, "Identify board", Cycle),
     row(F::Rtg, "RTG card", Cycle),
 ];
 const CPU_ROWS: [Row; 6] = [
     row(F::Cpu, "CPU", Cycle),
-    row(F::Fpu, "FPU (68881/2)", Toggle),
+    row(F::Fpu, "FPU (68881/2)", Cycle),
     row(F::Clock, "Clock", Cycle),
-    row(F::Icache, "Instruction cache", Toggle),
-    row(F::Dcache, "Data cache", Toggle),
-    row(F::Jit, "JIT accelerator", Toggle),
+    row(F::Icache, "Instruction cache", Cycle),
+    row(F::Dcache, "Data cache", Cycle),
+    row(F::Jit, "JIT accelerator", Cycle),
 ];
 const MEMORY_ROWS: [Row; 8] = [
-    row(F::RamInit, "Power-on fill", Cycle),
-    row(F::RamPattern, "Fill pattern", RowKind::Text),
     row(F::ChipRam, "Chip RAM", Cycle),
     row(F::FastRam, "Fast RAM", Cycle),
     row(F::SlowRam, "Slow RAM", Cycle),
+    // Below the sizes most people came for: what the bits hold at
+    // power-on, and (only while the fill is Fixed) the word they hold.
+    row(F::RamInit, "Power-on fill", Cycle),
+    row(F::RamPattern, "Fill pattern", RowKind::Text),
     row(F::MbRam, "Motherboard RAM", Cycle),
     row(F::AccelRam, "Accelerator RAM", Cycle),
     row(F::Z3Ram, "Zorro III RAM", Cycle),
 ];
-// Each ROM row is followed by a greyed line naming what the chosen image
-// checksums to ("Kickstart 3.1 (40.68) A1200"), since a ROM file's name says
-// only what its dumper called it.
-const ROM_ROWS: [Row; 4] = [
+// Each ROM row is followed by a greyed table naming what the chosen
+// image checksums to, split into Name / Version / Revision columns
+// ("Kickstart", "3.1", "40.68"), since a ROM file's name says only what
+// its dumper called it. The table stands whether or not an image is
+// loaded; empty cells mean an empty (or unrecognised) slot.
+const ROM_ROWS: [Row; 8] = [
+    section_header("Primary ROM:"),
     row(F::Rom, "Kickstart ROM", PathRow),
-    row(F::Rom, "", RowKind::Note),
+    row(F::Rom, "", RowKind::RomInfoHeader),
+    row(F::Rom, "", RowKind::RomInfoValue),
+    section_header("Extended ROM:"),
     row(F::ExtendedRom, "Extended ROM", PathRow),
-    row(F::ExtendedRom, "", RowKind::Note),
+    row(F::ExtendedRom, "", RowKind::RomInfoHeader),
+    row(F::ExtendedRom, "", RowKind::RomInfoValue),
 ];
 // Each drive is a greyed "DFn:" heading with its settings indented under it. The
 // heading is keyed on the drive's image field so `row_hidden` drops it along
@@ -1144,7 +1157,7 @@ const SERIAL_ROWS_CSYNTH: [Row; 6] = [
     row(F::SerialMode, "  Device / Mode", Cycle),
     row(F::MidiIn, "  MIDI input", Cycle),
     row(F::MidiOut, "  MIDI output", Cycle),
-    row(F::CsynthSoundfont, "  Soundfont", PathRow),
+    row(F::CsynthSoundfont, "  SoundFont", PathRow),
     row(F::CsynthPanel, "  Front panel", Cycle),
     row(F::CsynthMt32Mode, "  MT-32 mode", Cycle),
 ];
@@ -1162,9 +1175,9 @@ const PARALLEL_ROWS_SAMPLER: [Row; 3] = [
     row(F::SamplerGain, "  Input gain", Cycle),
 ];
 const ETHERNET_ROWS: [Row; 4] = [
-    row(F::Ethernet, "  A2065 board", Cycle),
+    row(F::Ethernet, "  A2065", Cycle),
     row(F::EthernetInterface, "  Host adapter", Cycle),
-    row(F::HostSocket, "  HostSocket board", Cycle),
+    row(F::HostSocket, "  HostSocket", Cycle),
     row(F::HostSocketInterface, "  Host adapter", Cycle),
 ];
 // Both boards are a single fit/don't-fit toggle -- no host backend, no other
@@ -1173,23 +1186,23 @@ const ETHERNET_ROWS: [Row; 4] = [
 // intentionally stay command-line/config-file only and have no row here.
 #[cfg(feature = "mhi")]
 const SOUND_ROWS: [Row; 2] = [
-    row(F::Toccata, "  Toccata board", Toggle),
-    row(F::Mhi, "  MHI decoder board", Toggle),
+    row(F::Toccata, "  Toccata", Cycle),
+    row(F::Mhi, "  MHI decoder", Cycle),
 ];
 #[cfg(not(feature = "mhi"))]
-const SOUND_ROWS: [Row; 1] = [row(F::Toccata, "  Toccata board", Toggle)];
+const SOUND_ROWS: [Row; 1] = [row(F::Toccata, "  Toccata", Cycle)];
 // The A/V & Emu tab is split into three categories switched via the top nav row.
 // The Video category also carries the CRT-shader controls (a picture setting).
 const VIDEO_ROWS: [Row; 13] = [
-    row(F::StartFullscreen, "Start fullscreen", Toggle),
-    row(F::ShowStatusBar, "Status bar", Toggle),
+    row(F::StartFullscreen, "Start fullscreen", Cycle),
+    row(F::ShowStatusBar, "Status bar", Cycle),
     row(F::Bezel, "Monitor bezel", Cycle),
-    row(F::PerfOverlay, "Perf overlay", Toggle),
+    row(F::PerfOverlay, "Perf overlay", Cycle),
     row(F::MenuScale, "Menu size", Cycle),
     row(F::Overscan, "Overscan", Cycle),
     row(F::PixelAspect, "Pixel aspect", Cycle),
     row(F::Scaling, "Scaling", Cycle),
-    row(F::Deinterlace, "Deinterlace", Toggle),
+    row(F::Deinterlace, "Deinterlace", Cycle),
     row(F::Tint, "Screen tint", Cycle),
     row(F::Phosphor, "Phosphor", Cycle),
     row(F::Shader, "CRT shader", Cycle),
@@ -1200,20 +1213,20 @@ const AUDIO_ROWS: [Row; 6] = [
     row(F::AudioChannelMode, "Channel mode", Cycle),
     row(F::AudioStereoSeparation, "Stereo separation", Cycle),
     row(F::AudioFilter, "Audio filter", Cycle),
-    row(F::FloppySounds, "Floppy sounds", Toggle),
+    row(F::FloppySounds, "Floppy sounds", Cycle),
     row(F::FloppyVolume, "Floppy volume", Cycle),
 ];
 #[cfg(not(feature = "game-library"))]
 const EMULATION_ROWS: [Row; 4] = [
-    row(F::PowerOn, "Power on startup", Toggle),
-    row(F::RealtimePriority, "Realtime priority", Toggle),
+    row(F::PowerOn, "Power on startup", Cycle),
+    row(F::RealtimePriority, "Realtime priority", Cycle),
     row(F::PacingBudget, "Pacing budget", Cycle),
     row(F::Warp, "Warp speed", Cycle),
 ];
 #[cfg(feature = "game-library")]
 const EMULATION_ROWS: [Row; 5] = [
-    row(F::PowerOn, "Power on startup", Toggle),
-    row(F::RealtimePriority, "Realtime priority", Toggle),
+    row(F::PowerOn, "Power on startup", Cycle),
+    row(F::RealtimePriority, "Realtime priority", Cycle),
     row(F::PacingBudget, "Pacing budget", Cycle),
     row(F::Warp, "Warp speed", Cycle),
     // Off, the strip loses its WHDLoad entry and the pages behind it stop
@@ -1395,7 +1408,7 @@ fn io_networking_rows() -> Vec<Row> {
 }
 
 fn io_audio_rows() -> Vec<Row> {
-    let mut rows = vec![section_header("Audio:")];
+    let mut rows = vec![section_header("Sound Card:")];
     rows.extend_from_slice(&SOUND_ROWS);
     rows
 }
@@ -3362,6 +3375,10 @@ impl MachineSetup {
             F::Df1Image | F::Df1WriteProtect => self.floppy_drives < 2,
             F::Df2Image | F::Df2WriteProtect => self.floppy_drives < 3,
             F::Df3Image | F::Df3WriteProtect => self.floppy_drives < 4,
+            // The word only exists while the fill is Fixed; the other
+            // fills have nothing to edit, so the row goes rather than
+            // sitting greyed under a setting most people never touch.
+            F::RamPattern => !matches!(self.ram_init, RamInit::Pattern { .. }),
             F::EthernetInterface => {
                 !matches!(self.a2065_net.as_ref(), Some(NetConfig::Bridge { .. }))
             }
@@ -3429,10 +3446,7 @@ impl MachineSetup {
                 !matches!(self.cpu, CpuModel::M68000 | CpuModel::M68010),
                 "needs 68020+",
             ),
-            F::RamPattern => reason(
-                matches!(self.ram_init, RamInit::Pattern { .. }),
-                "select Fixed fill",
-            ),
+
             F::Z3Ram => reason(cpu_is_32bit(self.cpu), "needs 32-bit CPU"),
             // The CPU-slot space at $08000000 is beyond a 24-bit bus too.
             F::AccelRam => reason(cpu_is_32bit(self.cpu), "needs 32-bit CPU"),
@@ -3631,6 +3645,12 @@ impl MachineSetup {
             F::Mhi => self.mhi,
             _ => false,
         }
+    }
+
+    /// Whether the SCSI controller is the A4091, whose boot ROM has a
+    /// bundled default the row reads as one.
+    pub fn scsi_controller_is_a4091(&self) -> bool {
+        matches!(self.scsi_controller, Some(ScsiController::A4091))
     }
 
     /// The current path of a path field, if any.
@@ -4127,6 +4147,22 @@ impl MachineSetup {
             F::MenuScale => self.menu_scale.menu_label().to_string(),
             F::Mt32Lcd => self.mt32_lcd.menu_label().to_string(),
             F::Mt32Panel => enabled_label(self.mt32_panel),
+            F::Rtc => enabled_label(self.rtc),
+            F::Identify => enabled_label(self.identify),
+            F::Fpu => enabled_label(self.fpu),
+            F::Icache => enabled_label(self.icache),
+            F::Dcache => enabled_label(self.dcache),
+            F::Jit => enabled_label(self.jit),
+            F::StartFullscreen => enabled_label(self.start_fullscreen),
+            F::ShowStatusBar => enabled_label(self.show_status_bar),
+            F::PerfOverlay => enabled_label(self.perf_overlay),
+            F::Deinterlace => enabled_label(self.deinterlace),
+            F::FloppySounds => enabled_label(self.floppy_sounds),
+            F::PowerOn => enabled_label(self.power_on),
+            F::RealtimePriority => enabled_label(self.realtime_priority),
+            F::Toccata => enabled_label(self.toccata),
+            #[cfg(feature = "mhi")]
+            F::Mhi => enabled_label(self.mhi),
             #[cfg(feature = "coppersynth")]
             F::CsynthPanel => enabled_label(self.csynth_panel),
             F::Phosphor => {
@@ -4374,6 +4410,11 @@ impl MachineSetup {
             F::WhdloadWhdPackage | F::WhdloadSkickPackage => self.path_label(field, "(none)"),
             // Path/drive fields: the file name, or a placeholder.
             F::Rom => self.path_label(field, "(bundled AROS)"),
+            // The A4091 autoboots from a bundled open-source ROM when no
+            // image names one; the other controllers have no such default.
+            F::ScsiRom if self.scsi_controller_is_a4091() => {
+                self.path_label(field, "(bundled A4091 ROM)")
+            }
             _ if rows_contains_kind(field, RowKind::Path)
                 || rows_contains_kind(field, RowKind::Drive)
                 || rows_contains_kind(field, RowKind::FloppyMedia) =>
@@ -4560,6 +4601,22 @@ impl MachineSetup {
             }
             // Two states cycle the same either way round.
             F::Mt32Panel => self.mt32_panel = !self.mt32_panel,
+            F::Rtc => self.rtc = !self.rtc,
+            F::Identify => self.identify = !self.identify,
+            F::Fpu => self.fpu = !self.fpu,
+            F::Icache => self.icache = !self.icache,
+            F::Dcache => self.dcache = !self.dcache,
+            F::Jit => self.jit = !self.jit,
+            F::StartFullscreen => self.start_fullscreen = !self.start_fullscreen,
+            F::ShowStatusBar => self.show_status_bar = !self.show_status_bar,
+            F::PerfOverlay => self.perf_overlay = !self.perf_overlay,
+            F::Deinterlace => self.deinterlace = !self.deinterlace,
+            F::FloppySounds => self.floppy_sounds = !self.floppy_sounds,
+            F::PowerOn => self.power_on = !self.power_on,
+            F::RealtimePriority => self.realtime_priority = !self.realtime_priority,
+            F::Toccata => self.toccata = !self.toccata,
+            #[cfg(feature = "mhi")]
+            F::Mhi => self.mhi = !self.mhi,
             #[cfg(feature = "coppersynth")]
             F::CsynthPanel => self.csynth_panel = !self.csynth_panel,
             F::PixelAspect => {
@@ -4853,12 +4910,6 @@ impl MachineSetup {
     /// Flip a toggle field (no-op if the field is not a toggle).
     pub fn toggle(&mut self, field: LauncherField) {
         match field {
-            F::Rtc => self.rtc = !self.rtc,
-            F::Identify => self.identify = !self.identify,
-            F::Fpu => self.fpu = !self.fpu,
-            F::Icache => self.icache = !self.icache,
-            F::Dcache => self.dcache = !self.dcache,
-            F::Jit => self.jit = !self.jit,
             F::Df0WriteProtect | F::Df1WriteProtect | F::Df2WriteProtect | F::Df3WriteProtect
                 if Self::drive_protect_bay(field).is_some() =>
             {
@@ -4872,16 +4923,6 @@ impl MachineSetup {
             F::Df1WriteProtect => self.df_write_protected[1] = !self.df_write_protected[1],
             F::Df2WriteProtect => self.df_write_protected[2] = !self.df_write_protected[2],
             F::Df3WriteProtect => self.df_write_protected[3] = !self.df_write_protected[3],
-            F::FloppySounds => self.floppy_sounds = !self.floppy_sounds,
-            F::StartFullscreen => self.start_fullscreen = !self.start_fullscreen,
-            F::ShowStatusBar => self.show_status_bar = !self.show_status_bar,
-            F::Deinterlace => self.deinterlace = !self.deinterlace,
-            F::PerfOverlay => self.perf_overlay = !self.perf_overlay,
-            F::PowerOn => self.power_on = !self.power_on,
-            F::RealtimePriority => self.realtime_priority = !self.realtime_priority,
-            F::Toccata => self.toccata = !self.toccata,
-            #[cfg(feature = "mhi")]
-            F::Mhi => self.mhi = !self.mhi,
             _ => {}
         }
     }
@@ -7817,6 +7858,42 @@ impl LauncherState {
         }
     }
 
+    /// The identification split for the ROM tab's table: Name, Version
+    /// and Revision cells. Empty strings when the slot is empty or the
+    /// image is unrecognised.
+    ///
+    /// The identification labels read "Kickstart 3.1 (40.68) A1200":
+    /// name words first, a marketing version, the ROM's own revision in
+    /// parentheses, then the models -- which have no column, and are
+    /// dropped. A label with no version ("bundled AROS") is all name.
+    pub fn rom_note_cells(&self, field: LauncherField) -> (String, String, String) {
+        let Some(note) = self.rom_note(field) else {
+            return (String::new(), String::new(), String::new());
+        };
+        let mut name_words: Vec<&str> = Vec::new();
+        let mut version = String::new();
+        let mut revision = String::new();
+        for word in note.split_whitespace() {
+            if version.is_empty()
+                && word.chars().next().is_some_and(|c| c.is_ascii_digit())
+                && word.contains('.')
+            {
+                version = word.to_string();
+                continue;
+            }
+            if !version.is_empty() {
+                if revision.is_empty() && word.starts_with('(') && word.ends_with(')') {
+                    revision = word[1..word.len() - 1].to_string();
+                }
+                // Everything after the version that is not the revision
+                // is the model list, which has no column.
+                continue;
+            }
+            name_words.push(word);
+        }
+        (name_words.join(" "), version, revision)
+    }
+
     /// What the image on a ROM row was identified as, for its [`RowKind::Note`]
     /// line. `None` for an image no checksum names, and for every other field.
     pub fn rom_note(&self, field: LauncherField) -> Option<&str> {
@@ -8778,8 +8855,11 @@ mod tests {
 
         setup.cycle(F::RamInit, true);
         assert_eq!(setup.value_label(F::RamInit), "Zero");
-        assert!(!setup.applies(F::RamPattern));
+        // The pattern row disappears rather than greying: it only
+        // exists while the fill is Fixed.
+        assert!(setup.row_hidden(F::RamPattern));
         setup.cycle(F::RamInit, false);
+        assert!(!setup.row_hidden(F::RamPattern));
         assert_eq!(setup.value_label(F::RamPattern), "0xDEAD");
 
         setup.cycle(F::RamInit, false);
@@ -9828,11 +9908,38 @@ mod tests {
         assert_eq!(
             shape,
             [
+                ("Primary ROM:", RowKind::SectionHeader, F::SectionHeader),
                 ("Kickstart ROM", RowKind::Path, F::Rom),
-                ("", RowKind::Note, F::Rom),
+                ("", RowKind::RomInfoHeader, F::Rom),
+                ("", RowKind::RomInfoValue, F::Rom),
+                ("Extended ROM:", RowKind::SectionHeader, F::SectionHeader),
                 ("Extended ROM", RowKind::Path, F::ExtendedRom),
-                ("", RowKind::Note, F::ExtendedRom),
+                ("", RowKind::RomInfoHeader, F::ExtendedRom),
+                ("", RowKind::RomInfoValue, F::ExtendedRom),
             ]
+        );
+
+        // The identification splits into the table's three columns; the
+        // models after the revision have no column and are dropped.
+        let mut probe = LauncherState::new(MachineSetup::default());
+        probe.set_rom_note_for_test(F::Rom, "Kickstart 3.1 (40.68) A1200");
+        assert_eq!(
+            probe.rom_note_cells(F::Rom),
+            (
+                "Kickstart".to_string(),
+                "3.1".to_string(),
+                "40.68".to_string()
+            )
+        );
+        probe.set_rom_note_for_test(F::Rom, "bundled AROS");
+        assert_eq!(
+            probe.rom_note_cells(F::Rom),
+            ("bundled AROS".to_string(), String::new(), String::new())
+        );
+        // An empty slot is an empty table, not a missing one.
+        assert_eq!(
+            probe.rom_note_cells(F::ExtendedRom),
+            (String::new(), String::new(), String::new())
         );
 
         let mut state = LauncherState::new(MachineSetup::default());
@@ -10728,7 +10835,7 @@ mod tests {
         assert!(s.toggle_value(LauncherField::Deinterlace));
         assert_eq!(s.to_raw().display.deinterlace, None);
 
-        s.toggle(LauncherField::Deinterlace);
+        s.cycle(LauncherField::Deinterlace, true);
         assert!(!s.toggle_value(LauncherField::Deinterlace));
         assert_eq!(s.to_raw().display.deinterlace, Some(false));
 
@@ -12424,7 +12531,7 @@ mod tests {
         assert!(r.iter().any(|x| x.field == LauncherField::Ethernet));
         // Audio page: the Toccata board toggle, and (in an `mhi` build)
         // the MHI board toggle alongside it.
-        assert_eq!(header(LauncherTab::IoAudio), ["Audio:"]);
+        assert_eq!(header(LauncherTab::IoAudio), ["Sound Card:"]);
         let r = rows(
             LauncherTab::IoAudio,
             ParallelDevice::None,
@@ -12555,9 +12662,9 @@ mod tests {
         #[cfg(feature = "mhi")]
         assert_eq!(s.to_raw().mhi.enabled, None);
 
-        s.toggle(LauncherField::Toccata);
+        s.cycle(LauncherField::Toccata, true);
         #[cfg(feature = "mhi")]
-        s.toggle(LauncherField::Mhi);
+        s.cycle(LauncherField::Mhi, true);
         assert!(s.toggle_value(LauncherField::Toccata));
         #[cfg(feature = "mhi")]
         assert!(s.toggle_value(LauncherField::Mhi));
@@ -12575,9 +12682,9 @@ mod tests {
         #[cfg(feature = "mhi")]
         assert!(reloaded.toggle_value(LauncherField::Mhi));
 
-        s.toggle(LauncherField::Toccata);
+        s.cycle(LauncherField::Toccata, false);
         #[cfg(feature = "mhi")]
-        s.toggle(LauncherField::Mhi);
+        s.cycle(LauncherField::Mhi, false);
         assert!(!s.toggle_value(LauncherField::Toccata));
         #[cfg(feature = "mhi")]
         assert!(!s.toggle_value(LauncherField::Mhi));
@@ -13184,8 +13291,8 @@ mod tests {
         assert!(s.toggle_value(LauncherField::ShowStatusBar));
 
         // Flip both; the non-default values now persist to [display].
-        s.toggle(LauncherField::StartFullscreen);
-        s.toggle(LauncherField::ShowStatusBar);
+        s.cycle(LauncherField::StartFullscreen, true);
+        s.cycle(LauncherField::ShowStatusBar, true);
         let raw = s.to_raw();
         assert_eq!(raw.display.full_screen, Some(true));
         assert_eq!(raw.display.status_bar, Some(false));

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -961,13 +961,18 @@ const MEMORY_ROWS: [Row; 8] = [
 // ("Kickstart", "3.1", "40.68"), since a ROM file's name says only what
 // its dumper called it. The table stands whether or not an image is
 // loaded; empty cells mean an empty (or unrecognised) slot.
-const ROM_ROWS: [Row; 8] = [
+const ROM_ROWS: [Row; 11] = [
     section_header("Primary ROM:"),
     row(F::Rom, "  Kickstart ROM", PathRow),
+    // Blank headers as spacers: the table sits a row clear of the path
+    // above it, and the next section starts a row clear of the table.
+    section_header(""),
     row(F::Rom, "", RowKind::RomInfoHeader),
     row(F::Rom, "", RowKind::RomInfoValue),
+    section_header(""),
     section_header("Extended ROM:"),
     row(F::ExtendedRom, "  Extended ROM", PathRow),
+    section_header(""),
     row(F::ExtendedRom, "", RowKind::RomInfoHeader),
     row(F::ExtendedRom, "", RowKind::RomInfoValue),
 ];
@@ -9965,10 +9970,13 @@ mod tests {
             [
                 ("Primary ROM:", RowKind::SectionHeader, F::SectionHeader),
                 ("  Kickstart ROM", RowKind::Path, F::Rom),
+                ("", RowKind::SectionHeader, F::SectionHeader),
                 ("", RowKind::RomInfoHeader, F::Rom),
                 ("", RowKind::RomInfoValue, F::Rom),
+                ("", RowKind::SectionHeader, F::SectionHeader),
                 ("Extended ROM:", RowKind::SectionHeader, F::SectionHeader),
                 ("  Extended ROM", RowKind::Path, F::ExtendedRom),
+                ("", RowKind::SectionHeader, F::SectionHeader),
                 ("", RowKind::RomInfoHeader, F::ExtendedRom),
                 ("", RowKind::RomInfoValue, F::ExtendedRom),
             ]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -717,10 +717,10 @@ pub enum RowKind {
     /// A hard-drive image: a path with Browse/Clear, plus an editable
     /// volume-name field (used when the image is a host directory).
     Drive,
-    /// One greyed line of a ROM row's identification -- the row's label
-    /// says which fact it carries (Name, Version, Revision), and the
-    /// value follows it. Blank after the prefix when the image is
-    /// unrecognised.
+    /// One line of a ROM row's identification -- the row's label says
+    /// which fact it carries (Name, Version, Revision) and draws as a
+    /// greyed prefix, with the value in full text colour after it.
+    /// Blank after the prefix when the image is unrecognised.
     RomInfo,
     /// A non-interactive greyed heading that groups the rows beneath it
     /// (e.g. the `Serial:` / `Parallel:` sections of the I/O Ports tab). Its
@@ -729,12 +729,6 @@ pub enum RowKind {
     /// The greyed `Drive` / `Priority` / `Status` column titles above the Boot
     /// Priority rows. Non-interactive; its `field` is inert.
     BootpriHeader,
-    /// A greyed, non-interactive line under the row it belongs to, carrying
-    /// something looked up rather than set: the ROM tab's identification of
-    /// the chosen image (see [`crate::romdb`]). Its `field` is the row it
-    /// annotates, so it is hidden and greyed along with it, and it draws
-    /// nothing when there is nothing to say.
-    Note,
     /// A floppy drive's media row: an image path with Browse/Clear, or the
     /// real interface in use with a Configure button once bridged.
     FloppyMedia,
@@ -956,16 +950,15 @@ const MEMORY_ROWS: [Row; 8] = [
     row(F::AccelRam, "Accelerator RAM", Cycle),
     row(F::Z3Ram, "Zorro III RAM", Cycle),
 ];
-// Each ROM row is followed by a greyed table naming what the chosen
-// image checksums to, split into Name / Version / Revision columns
+// The Kickstart row carries its identification beneath it -- what the
+// chosen image checksums to, split into Name / Version / Revision lines
 // ("Kickstart", "3.1", "40.68"), since a ROM file's name says only what
-// its dumper called it. The table stands whether or not an image is
-// loaded; empty cells mean an empty (or unrecognised) slot.
+// its dumper called it. The lines stand whether or not an image is
+// loaded; a blank value means an empty (or unrecognised) slot.
 const ROM_ROWS: [Row; 7] = [
     section_header("Primary ROM:"),
     row(F::Rom, "  Kickstart ROM", PathRow),
-    // What the chosen image is, one greyed line per fact, indented
-    // under its row. The label picks which fact the line carries.
+    // The label picks which fact the line carries.
     row(F::Rom, "Name", RowKind::RomInfo),
     row(F::Rom, "Version", RowKind::RomInfo),
     row(F::Rom, "Revision", RowKind::RomInfo),
@@ -3447,7 +3440,6 @@ impl MachineSetup {
                 !matches!(self.cpu, CpuModel::M68000 | CpuModel::M68010),
                 "needs 68020+",
             ),
-
             F::Z3Ram => reason(cpu_is_32bit(self.cpu), "needs 32-bit CPU"),
             // The CPU-slot space at $08000000 is beyond a 24-bit bus too.
             F::AccelRam => reason(cpu_is_32bit(self.cpu), "needs 32-bit CPU"),
@@ -6561,9 +6553,9 @@ struct RomNote {
     /// Whether the slot has been synced at all: the bundled default
     /// (path None) must still seed its cells once.
     seeded: bool,
-    /// The identification split for the tab's table: Name, Version and
-    /// Revision cells, computed when the path changes rather than per
-    /// draw (the bundled AROS reads its numbers off the image file).
+    /// The identification split into its Name, Version and Revision
+    /// facts, computed when the path changes rather than per draw (the
+    /// bundled AROS reads its numbers off the image file).
     cells: (String, String, String),
 }
 
@@ -7862,26 +7854,22 @@ impl LauncherState {
                 continue;
             }
             self.rom_notes[slot].text = path.as_deref().and_then(crate::config::rom_identification);
-            self.rom_notes[slot].cells = Self::rom_cells_for(
-                slot,
-                path.as_deref(),
-                self.rom_notes[slot].text.as_deref(),
-                self.setup.path(F::Rom).is_none(),
-            );
+            // Only the Kickstart row draws identification lines; the
+            // extended slot keeps just its raw text.
+            if slot == 0 {
+                self.rom_notes[slot].cells =
+                    Self::rom_cells_for(path.as_deref(), self.rom_notes[slot].text.as_deref());
+            }
             self.rom_notes[slot].path = path;
             self.rom_notes[slot].seeded = true;
         }
     }
 
-    /// The table cells for one slot: a checksum-named image splits its
-    /// label; an AROS image -- chosen or bundled -- reads its numbers off
-    /// the file itself, so they follow the bundled ROM between releases.
-    fn rom_cells_for(
-        slot: usize,
-        path: Option<&Path>,
-        text: Option<&str>,
-        main_is_bundled: bool,
-    ) -> (String, String, String) {
+    /// The Kickstart row's identification facts: a checksum-named image
+    /// splits its label; an AROS image -- chosen or bundled -- reads its
+    /// numbers off the file itself, so they follow the bundled ROM
+    /// between releases.
+    fn rom_cells_for(path: Option<&Path>, text: Option<&str>) -> (String, String, String) {
         let aros_cells = |file: &Path| {
             let (version, revision) = crate::romdb::rom_self_versions(file).unwrap_or_default();
             ("AROS".to_string(), version, revision)
@@ -7890,39 +7878,29 @@ impl LauncherState {
             (Some(p), Some("bundled AROS")) => aros_cells(p),
             (_, Some(note)) => Self::split_identification(note),
             (Some(_), None) => (String::new(), String::new(), String::new()),
-            (None, _) => {
-                // An empty slot runs the bundled AROS -- the extended
-                // half only alongside the bundled main.
-                if slot == 1 && !main_is_bundled {
-                    return (String::new(), String::new(), String::new());
-                }
-                let Some(bundle) = crate::romsearch::find_bundled_aros() else {
-                    return (String::new(), String::new(), String::new());
-                };
-                aros_cells(if slot == 0 {
-                    &bundle.main
-                } else {
-                    &bundle.extended
-                })
-            }
+            // An empty slot boots the bundled AROS.
+            (None, _) => match crate::romsearch::find_bundled_aros() {
+                Some(bundle) => aros_cells(&bundle.main),
+                None => (String::new(), String::new(), String::new()),
+            },
         }
     }
 
-    /// The identification for the ROM tab's table: Name, Version and
-    /// Revision cells, from the cache [`Self::sync_rom_notes`] keeps.
+    /// The identification lines' facts -- Name, Version and Revision --
+    /// from the cache [`Self::sync_rom_notes`] keeps. Only the Kickstart
+    /// row has them.
     pub fn rom_note_cells(&self, field: LauncherField) -> (String, String, String) {
-        let slot = match field {
-            F::Rom => 0,
-            F::ExtendedRom => 1,
-            _ => return (String::new(), String::new(), String::new()),
-        };
-        self.rom_notes[slot].cells.clone()
+        if field == F::Rom {
+            self.rom_notes[0].cells.clone()
+        } else {
+            (String::new(), String::new(), String::new())
+        }
     }
 
-    /// Split a checksum label into the table's columns. The labels read
+    /// Split a checksum label into its three facts. The labels read
     /// "Kickstart 3.1 (40.68) A1200": name words first, a marketing
     /// version, the ROM's own revision in parentheses, then the models
-    /// -- which have no column, and are dropped.
+    /// -- which have no line of their own, and are dropped.
     fn split_identification(note: &str) -> (String, String, String) {
         let mut name_words: Vec<&str> = Vec::new();
         let mut version = String::new();
@@ -7940,7 +7918,7 @@ impl LauncherState {
                     revision = word[1..word.len() - 1].to_string();
                 }
                 // Everything after the version that is not the revision
-                // is the model list, which has no column.
+                // is the model list, which is not shown.
                 continue;
             }
             name_words.push(word);
@@ -7948,8 +7926,9 @@ impl LauncherState {
         (name_words.join(" "), version, revision)
     }
 
-    /// What the image on a ROM row was identified as, for its [`RowKind::Note`]
-    /// line. `None` for an image no checksum names, and for every other field.
+    /// What the image on a ROM row was identified as: the raw checksum
+    /// label the identification lines split from. `None` for an image no
+    /// checksum names, and for every other field.
     pub fn rom_note(&self, field: LauncherField) -> Option<&str> {
         let slot = match field {
             F::Rom => 0,
@@ -9974,8 +9953,8 @@ mod tests {
             ]
         );
 
-        // The identification splits into the table's three columns; the
-        // models after the revision have no column and are dropped.
+        // The identification splits into its three facts; the models
+        // after the revision are dropped.
         let mut probe = LauncherState::new(MachineSetup::default());
         probe.set_rom_note_for_test(F::Rom, "Kickstart 3.1 (40.68) A1200");
         assert_eq!(
@@ -9986,8 +9965,8 @@ mod tests {
                 "40.68".to_string()
             )
         );
-        // The bundled AROS pair fills both slots' tables with numbers
-        // read off the images themselves, so they follow releases.
+        // The bundled AROS carries numbers read off the image itself,
+        // so they follow releases.
         let bundled = LauncherState::new(MachineSetup::default());
         let (name, version, revision) = bundled.rom_note_cells(F::Rom);
         assert_eq!(name, "AROS");
@@ -9995,7 +9974,7 @@ mod tests {
             !version.is_empty() && !revision.is_empty(),
             "the AROS image carries its own numbers"
         );
-        // An unrecognised image is an empty table, not a missing one.
+        // An unrecognised image leaves the values blank.
         let mut setup = MachineSetup::default();
         setup.set_path(F::Rom, std::path::PathBuf::from("mystery-dump.rom"));
         let unknown = LauncherState::new(setup);

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -961,20 +961,17 @@ const MEMORY_ROWS: [Row; 8] = [
 // ("Kickstart", "3.1", "40.68"), since a ROM file's name says only what
 // its dumper called it. The table stands whether or not an image is
 // loaded; empty cells mean an empty (or unrecognised) slot.
-const ROM_ROWS: [Row; 11] = [
+const ROM_ROWS: [Row; 7] = [
     section_header("Primary ROM:"),
     row(F::Rom, "  Kickstart ROM", PathRow),
-    // Blank headers as spacers: the table sits a row clear of the path
-    // above it, and the next section starts a row clear of the table.
-    section_header(""),
     row(F::Rom, "", RowKind::RomInfoHeader),
     row(F::Rom, "", RowKind::RomInfoValue),
+    // A blank header as a spacer: the next section starts a row clear
+    // of the table. The extended slot gets no table of its own -- the
+    // checksum table rarely names one, and a blank grid says nothing.
     section_header(""),
     section_header("Extended ROM:"),
     row(F::ExtendedRom, "  Extended ROM", PathRow),
-    section_header(""),
-    row(F::ExtendedRom, "", RowKind::RomInfoHeader),
-    row(F::ExtendedRom, "", RowKind::RomInfoValue),
 ];
 // Each drive is a greyed "DFn:" heading with its settings indented under it. The
 // heading is keyed on the drive's image field so `row_hidden` drops it along
@@ -9970,15 +9967,11 @@ mod tests {
             [
                 ("Primary ROM:", RowKind::SectionHeader, F::SectionHeader),
                 ("  Kickstart ROM", RowKind::Path, F::Rom),
-                ("", RowKind::SectionHeader, F::SectionHeader),
                 ("", RowKind::RomInfoHeader, F::Rom),
                 ("", RowKind::RomInfoValue, F::Rom),
                 ("", RowKind::SectionHeader, F::SectionHeader),
                 ("Extended ROM:", RowKind::SectionHeader, F::SectionHeader),
                 ("  Extended ROM", RowKind::Path, F::ExtendedRom),
-                ("", RowKind::SectionHeader, F::SectionHeader),
-                ("", RowKind::RomInfoHeader, F::ExtendedRom),
-                ("", RowKind::RomInfoValue, F::ExtendedRom),
             ]
         );
 
@@ -9997,14 +9990,12 @@ mod tests {
         // The bundled AROS pair fills both slots' tables with numbers
         // read off the images themselves, so they follow releases.
         let bundled = LauncherState::new(MachineSetup::default());
-        for field in [F::Rom, F::ExtendedRom] {
-            let (name, version, revision) = bundled.rom_note_cells(field);
-            assert_eq!(name, "AROS");
-            assert!(
-                !version.is_empty() && !revision.is_empty(),
-                "the AROS image carries its own numbers"
-            );
-        }
+        let (name, version, revision) = bundled.rom_note_cells(F::Rom);
+        assert_eq!(name, "AROS");
+        assert!(
+            !version.is_empty() && !revision.is_empty(),
+            "the AROS image carries its own numbers"
+        );
         // An unrecognised image is an empty table, not a missing one.
         let mut setup = MachineSetup::default();
         setup.set_path(F::Rom, std::path::PathBuf::from("mystery-dump.rom"));

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -853,9 +853,10 @@ fn serial_rows(s: &MenuState) -> Vec<MenuRow> {
         rows.push(MenuRow::submenu(
             CSYNTH_LABEL,
             vec![
+                MenuRow::submenu("MT-32 Mode", modes),
                 MenuRow::toggle("Front Panel", MenuAction::ToggleCsynthPanel, s.csynth_panel),
                 MenuRow::submenu(
-                    "Soundfont",
+                    "SoundFont",
                     vec![
                         MenuRow::action("Load...", MenuAction::LoadCsynthSoundfont),
                         // Nothing to undo while the default is in force.
@@ -863,7 +864,6 @@ fn serial_rows(s: &MenuState) -> Vec<MenuRow> {
                             .available(s.csynth_custom_font),
                     ],
                 ),
-                MenuRow::submenu("MT-32 Mode", modes),
             ],
         ));
     }

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -4334,7 +4334,7 @@ const LAUNCH_TOGGLE_W: usize = 64;
 const LAUNCH_ACTION_W: usize = 84;
 const LAUNCH_ACTION_H: usize = 22;
 const LAUNCH_BROWSE_W: usize = 66;
-const LAUNCH_CLEAR_W: usize = 54;
+const LAUNCH_CLEAR_W: usize = LAUNCH_BROWSE_W;
 /// Width of the path-preview text column before a path row's Browse/Clear
 /// buttons. The buttons sit just after it (near the other control widgets)
 /// rather than out at the panel's right edge; a long value is clipped to fit.
@@ -5562,16 +5562,16 @@ fn launcher_path_inherits(setup: &launcher::MachineSetup, field: LauncherField) 
     field.is_paths_field() && field != LauncherField::PathsBase && !setup.paths_is_set(field)
 }
 
-/// Whether the row's second button has anything to do: a Reset with the
-/// default already in force is shown but greyed, so the pair of buttons
-/// keeps its shape while saying there is nothing to undo.
+/// Whether the row's second button has anything to do: a Clear with
+/// nothing behind it is shown but greyed, so the pair of buttons keeps
+/// its shape while saying there is nothing to take away. The Paths page
+/// keeps its own arrangement -- its Reset only appears once something
+/// is set, so it is always live.
 fn launcher_clear_enabled(setup: &launcher::MachineSetup, field: LauncherField) -> bool {
-    #[cfg(feature = "coppersynth")]
-    if field == LauncherField::CsynthSoundfont {
-        return setup.path(field).is_some();
+    if field.is_paths_field() {
+        return true;
     }
-    let _ = (setup, field);
-    true
+    setup.path(field).is_some()
 }
 
 fn launcher_path_rects(rect: Rect, row_y: usize) -> (Rect, Rect) {
@@ -7803,9 +7803,14 @@ fn draw_launcher_row(
             Some(GreyedAs::DimmedValue | GreyedAs::DimmedReason)
         ) {
             if greyed_as != Some(GreyedAs::Blank) {
+                // Centred across the stepper span, where the value the
+                // row cannot have would sit.
+                let (prev, _, next) = launcher_cycle_rects(rect, row_y);
+                let span = (next.x + next.w).saturating_sub(prev.x);
+                let text_w = reason.chars().count() * font::GLYPH_W;
                 draw_panel_text(
                     frame,
-                    launcher_control_x(rect),
+                    prev.x + span.saturating_sub(text_w) / 2,
                     row_y + 8,
                     reason,
                     PANEL_TEXT_DIM,
@@ -8361,12 +8366,10 @@ fn draw_launcher_row(
             }
             if has_clear {
                 // "Reset" where the row goes back to a default rather
-                // than being emptied -- the Paths page, and the
-                // soundfont row. Everywhere else the button really does
-                // clear a path, and says so.
-                #[cfg(feature = "coppersynth")]
-                let resets = r.field.is_paths_field() || r.field == LauncherField::CsynthSoundfont;
-                #[cfg(not(feature = "coppersynth"))]
+                // than being emptied -- the Paths page. Everywhere else
+                // the button clears, and says so (the SoundFont row's
+                // clear also lands on the bundled default, but it wears
+                // the same word as its neighbours).
                 let resets = r.field.is_paths_field();
                 let label = if resets { "Reset" } else { "Clear" };
                 let enabled = launcher_clear_enabled(setup, r.field);

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -7699,11 +7699,14 @@ fn draw_launcher_row(
         // headings over a rule -- minus the clickability, plus a divider
         // between the columns. Its right edge lines up with the Clear
         // button above it, and every cell reads from the left.
-        let (_, clear) = launcher_path_rects(rect, row_y);
+        let (browse, _) = launcher_path_rects(rect, row_y);
+        // Left edge on the section heading's own x, right edge on the
+        // Browse button's left, so the table sits squarely in the column
+        // the rows above it use.
         let table = Rect {
-            x: launcher_pane_x(rect) + 8,
+            x: launcher_pane_x(rect),
             y: row_y,
-            w: (clear.x + clear.w).saturating_sub(launcher_pane_x(rect) + 8),
+            w: browse.x.saturating_sub(launcher_pane_x(rect)),
             h: 2 * LAUNCH_ROW_H - 4,
         };
         let col_w = table.w / 3;
@@ -7738,19 +7741,21 @@ fn draw_launcher_row(
                 let (cx, text) = cell_at(title, col);
                 draw_panel_text(frame, cx, table.y + 5, &text, PANEL_TEXT_DIM, 1, scale);
             }
-            // The rule under the headings, and a divider between columns.
+            // The grid: the rule under the headings and the column
+            // dividers run edge to edge, meeting the border, so every
+            // cell reads as a closed box.
             fill_rect(
                 frame,
                 scale_rect(
                     Rect {
-                        x: table.x + 2,
+                        x: table.x + 1,
                         y: table.y + LAUNCH_ROW_H - 4,
-                        w: table.w.saturating_sub(4),
+                        w: table.w.saturating_sub(2),
                         h: 1,
                     },
                     scale,
                 ),
-                BUTTON_EDGE_DARK,
+                BUTTON_EDGE_LIGHT,
                 scale,
             );
             for col in 1..3 {
@@ -7759,13 +7764,13 @@ fn draw_launcher_row(
                     scale_rect(
                         Rect {
                             x: table.x + col * col_w,
-                            y: table.y + 2,
+                            y: table.y + 1,
                             w: 1,
-                            h: table.h.saturating_sub(4),
+                            h: table.h.saturating_sub(2),
                         },
                         scale,
                     ),
-                    BUTTON_EDGE_DARK,
+                    BUTTON_EDGE_LIGHT,
                     scale,
                 );
             }
@@ -8391,19 +8396,25 @@ fn draw_launcher_row(
             let inherits = launcher_path_inherits(setup, r.field);
             let (value_color, text_x) = if inherits {
                 let text_w = text.chars().count() * font::GLYPH_W;
-                // The SoundFont default sits in line with the cycle
-                // value column, centred under the arrows of the rows
-                // around it rather than adrift in the wider path box.
-                #[cfg(feature = "coppersynth")]
-                if r.field == LauncherField::CsynthSoundfont {
-                    let (_, value_box, _) = launcher_cycle_rects(rect, row_y);
-                    let x = value_box.x + value_box.w.saturating_sub(text_w) / 2;
-                    (PANEL_TEXT_DIM, x)
+                // The bundled-ROM defaults read from the left like a
+                // chosen path would, just dimmed; the SoundFont default
+                // sits in line with the cycle value column, centred
+                // under the arrows of the rows around it; the Paths
+                // page's inherited rows keep their centred `(default)`.
+                if matches!(r.field, LauncherField::Rom | LauncherField::ScsiRom) {
+                    (PANEL_TEXT_DIM, value_x)
                 } else {
+                    #[cfg(feature = "coppersynth")]
+                    if r.field == LauncherField::CsynthSoundfont {
+                        let (_, value_box, _) = launcher_cycle_rects(rect, row_y);
+                        let x = value_box.x + value_box.w.saturating_sub(text_w) / 2;
+                        (PANEL_TEXT_DIM, x)
+                    } else {
+                        (PANEL_TEXT_DIM, value_x + avail.saturating_sub(text_w) / 2)
+                    }
+                    #[cfg(not(feature = "coppersynth"))]
                     (PANEL_TEXT_DIM, value_x + avail.saturating_sub(text_w) / 2)
                 }
-                #[cfg(not(feature = "coppersynth"))]
-                (PANEL_TEXT_DIM, value_x + avail.saturating_sub(text_w) / 2)
             } else {
                 (PANEL_TEXT, value_x)
             };

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -4310,10 +4310,6 @@ fn draw_heat_census(
 const LAUNCHER_W: usize = FB_WIDTH;
 const LAUNCHER_H: usize = 520;
 const LAUNCH_MARGIN: usize = 8;
-/// The ROM identification table's Name column; Version and Revision
-/// split what remains of the pane.
-const ROM_INFO_NAME_W: usize = 200;
-const ROM_INFO_VERSION_W: usize = 92;
 const LAUNCH_MODEL_H: usize = 22;
 const LAUNCH_MODEL_GAP: usize = 4;
 /// Machines per row in the selector grid before it wraps; the grid rebalances
@@ -7699,32 +7695,82 @@ fn draw_launcher_row(
     // path row, headers first, then whatever the image on the row above
     // checksums to. The table stands whether or not an image is loaded.
     if matches!(r.kind, RowKind::RomInfoHeader | RowKind::RomInfoValue) {
-        let x = launcher_pane_x(rect) + 8;
-        let cols = [
-            (x, ROM_INFO_NAME_W),
-            (x + ROM_INFO_NAME_W, ROM_INFO_VERSION_W),
-            (x + ROM_INFO_NAME_W + ROM_INFO_VERSION_W, ROM_INFO_VERSION_W),
-        ];
-        let cells: [String; 3] = if r.kind == RowKind::RomInfoHeader {
-            [
-                "Name".to_string(),
-                "Version".to_string(),
-                "Revision".to_string(),
-            ]
-        } else {
-            let (name, version, revision) = state.rom_note_cells(r.field);
-            [name, version, revision]
+        // The host-disk table's style exactly -- dark fill, bordered box,
+        // headings over a rule -- minus the clickability, plus a divider
+        // between the columns. Its right edge lines up with the Clear
+        // button above it, and every cell reads from the left.
+        let (_, clear) = launcher_path_rects(rect, row_y);
+        let table = Rect {
+            x: launcher_pane_x(rect) + 8,
+            y: row_y,
+            w: (clear.x + clear.w).saturating_sub(launcher_pane_x(rect) + 8),
+            h: 2 * LAUNCH_ROW_H - 4,
         };
-        for ((cx, cw), cell) in cols.iter().zip(cells.iter()) {
-            draw_panel_text(
+        let col_w = table.w / 3;
+        let cell_at = |cell: &str, col: usize| {
+            (
+                table.x + col * col_w + 6,
+                truncate_to_width(cell, col_w.saturating_sub(12)),
+            )
+        };
+        if r.kind == RowKind::RomInfoHeader {
+            // The box spans this row and the value row below.
+            fill_rect(frame, scale_rect(table, scale), BUTTON_EDGE_DARK, scale);
+            fill_rect(
                 frame,
-                *cx,
-                row_y + 4,
-                &truncate_to_width(cell, cw.saturating_sub(8)),
-                PANEL_TEXT_DIM,
-                1,
+                scale_rect(
+                    Rect {
+                        x: table.x + 1,
+                        y: table.y + 1,
+                        w: table.w.saturating_sub(2),
+                        h: table.h.saturating_sub(2),
+                    },
+                    scale,
+                ),
+                ENTRY_BG,
                 scale,
             );
+            for (col, title) in ["Name", "Version", "Revision"].iter().enumerate() {
+                let (cx, text) = cell_at(title, col);
+                draw_panel_text(frame, cx, table.y + 5, &text, PANEL_TEXT_DIM, 1, scale);
+            }
+            // The rule under the headings, and a divider between columns.
+            fill_rect(
+                frame,
+                scale_rect(
+                    Rect {
+                        x: table.x + 2,
+                        y: table.y + LAUNCH_ROW_H - 4,
+                        w: table.w.saturating_sub(4),
+                        h: 1,
+                    },
+                    scale,
+                ),
+                BUTTON_EDGE_DARK,
+                scale,
+            );
+            for col in 1..3 {
+                fill_rect(
+                    frame,
+                    scale_rect(
+                        Rect {
+                            x: table.x + col * col_w,
+                            y: table.y + 2,
+                            w: 1,
+                            h: table.h.saturating_sub(4),
+                        },
+                        scale,
+                    ),
+                    BUTTON_EDGE_DARK,
+                    scale,
+                );
+            }
+            return;
+        }
+        let (name, version, revision) = state.rom_note_cells(r.field);
+        for (col, cell) in [name, version, revision].iter().enumerate() {
+            let (cx, text) = cell_at(cell, col);
+            draw_panel_text(frame, cx, row_y + 2, &text, PANEL_TEXT_DIM, 1, scale);
         }
         return;
     }

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -37,6 +37,9 @@ const BUTTON_TEXT_DISABLED: u32 = rgba(120, 120, 112);
 /// DDF fetch-bound verticals on the Frame Analyzer heatmap.
 const DDF_LINE: u32 = rgba(80, 200, 220);
 const ENTRY_BG: u32 = rgba(8, 10, 8);
+/// The ROM identification table's internal grid: fainter than the lit
+/// outline around it, so the cells divide without shouting.
+const ROM_TABLE_GRID: u32 = rgba(62, 64, 60);
 /// The mark inside a ticked box.
 const TICK_GREEN: u32 = rgba(72, 214, 96);
 
@@ -7700,14 +7703,16 @@ fn draw_launcher_row(
         // between the columns. Its right edge lines up with the Clear
         // button above it, and every cell reads from the left.
         let (browse, _) = launcher_path_rects(rect, row_y);
-        // Left edge on the section heading's own x, right edge on the
-        // Browse button's left, so the table sits squarely in the column
-        // the rows above it use.
+        // Left edge on the indented row labels ("  Kickstart ROM"), right
+        // edge on the Browse button's left, and the bottom sits close
+        // under the value line rather than padding out the grid row.
         let table = Rect {
-            x: launcher_pane_x(rect),
+            x: launcher_pane_x(rect) + 2 * font::GLYPH_W,
             y: row_y,
-            w: browse.x.saturating_sub(launcher_pane_x(rect)),
-            h: 2 * LAUNCH_ROW_H - 4,
+            w: browse
+                .x
+                .saturating_sub(launcher_pane_x(rect) + 2 * font::GLYPH_W),
+            h: 2 * LAUNCH_ROW_H - 12,
         };
         let col_w = table.w / 3;
         let cell_at = |cell: &str, col: usize| {
@@ -7755,7 +7760,7 @@ fn draw_launcher_row(
                     },
                     scale,
                 ),
-                BUTTON_EDGE_LIGHT,
+                ROM_TABLE_GRID,
                 scale,
             );
             for col in 1..3 {
@@ -7770,7 +7775,7 @@ fn draw_launcher_row(
                         },
                         scale,
                     ),
-                    BUTTON_EDGE_LIGHT,
+                    ROM_TABLE_GRID,
                     scale,
                 );
             }
@@ -7779,7 +7784,7 @@ fn draw_launcher_row(
         let (name, version, revision) = state.rom_note_cells(r.field);
         for (col, cell) in [name, version, revision].iter().enumerate() {
             let (cx, text) = cell_at(cell, col);
-            draw_panel_text(frame, cx, row_y + 2, &text, PANEL_TEXT_DIM, 1, scale);
+            draw_panel_text(frame, cx, row_y + 2, &text, PANEL_TEXT, 1, scale);
         }
         return;
     }
@@ -10107,22 +10112,26 @@ mod tests {
         let scale = 1;
         let (w, h) = (texture_width(scale), texture_height(scale));
         // Pixels painted in the table colour on a given ROM-tab row: the
-        // header row is index 3 and the value row index 4 (under the
-        // section heading, the path row, and the spacer).
+        // header row is index 2 and the value row index 3 (under the
+        // section heading and the path row).
+        // The headers draw dimmed, the values in full text colour; both
+        // count as the table's ink.
         let row_pixels = |frame: &[u8], rect: Rect, row: usize| {
             let row_y = launcher_row_y(rect, row);
             let mut lit = 0;
             for y in row_y..row_y + LAUNCH_ROW_H {
                 for x in launcher_pane_x(rect)..rect.x + rect.w - LAUNCH_MARGIN {
                     let p = (y * w + x) * 4;
-                    if frame[p..p + 4] == PANEL_TEXT_DIM.to_le_bytes() {
+                    if frame[p..p + 4] == PANEL_TEXT_DIM.to_le_bytes()
+                        || frame[p..p + 4] == PANEL_TEXT.to_le_bytes()
+                    {
                         lit += 1;
                     }
                 }
             }
             lit
         };
-        let note_row_pixels = |frame: &[u8], rect: Rect| row_pixels(frame, rect, 4);
+        let note_row_pixels = |frame: &[u8], rect: Rect| row_pixels(frame, rect, 3);
         let panel_of = |state: LauncherState| Panel::Launcher(Box::new(state));
 
         let mut setup = launcher::MachineSetup::default();
@@ -10149,7 +10158,7 @@ mod tests {
             "an unidentified image must leave the value line empty"
         );
         assert!(
-            row_pixels(&blank_frame, rect, 3) > 0,
+            row_pixels(&blank_frame, rect, 2) > 0,
             "the table's column headers stand even over an empty slot"
         );
 

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -6097,7 +6097,9 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                             if browse.contains(pos) {
                                 return Some(UiControl::LauncherBoardBrowse { board, opt });
                             }
-                            if clear.contains(pos) {
+                            if !state.setup.zorro_boards()[board].value(opt).is_empty()
+                                && clear.contains(pos)
+                            {
                                 return Some(UiControl::LauncherBoardClear { board, opt });
                             }
                         }
@@ -6325,7 +6327,7 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                     if browse.contains(pos) {
                         return Some(UiControl::LauncherBrowse(r.field));
                     }
-                    if clear.contains(pos) {
+                    if launcher_clear_enabled(&state.setup, r.field) && clear.contains(pos) {
                         return Some(UiControl::LauncherClear(r.field));
                     }
                 }
@@ -6362,7 +6364,7 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                         if browse.contains(pos) {
                             return Some(UiControl::LauncherBrowse(r.field));
                         }
-                        if clear.contains(pos) {
+                        if launcher_clear_enabled(&state.setup, r.field) && clear.contains(pos) {
                             return Some(UiControl::LauncherClear(r.field));
                         }
                         // A support archive with nothing chosen can fetch
@@ -7804,13 +7806,19 @@ fn draw_launcher_row(
         ) {
             if greyed_as != Some(GreyedAs::Blank) {
                 // Centred across the stepper span, where the value the
-                // row cannot have would sit.
+                // row cannot have would sit -- but the reasons vary in
+                // length, and a long one truly centred starts left of its
+                // shorter neighbours, which reads as a ragged margin
+                // rather than a centred column. So no reason starts
+                // further left than the commonest one would.
                 let (prev, _, next) = launcher_cycle_rects(rect, row_y);
                 let span = (next.x + next.w).saturating_sub(prev.x);
+                let floor_w = "needs 68020+".chars().count() * font::GLYPH_W;
+                let min_x = prev.x + span.saturating_sub(floor_w) / 2;
                 let text_w = reason.chars().count() * font::GLYPH_W;
                 draw_panel_text(
                     frame,
-                    prev.x + span.saturating_sub(text_w) / 2,
+                    (prev.x + span.saturating_sub(text_w) / 2).max(min_x),
                     row_y + 8,
                     reason,
                     PANEL_TEXT_DIM,
@@ -8212,7 +8220,7 @@ fn draw_launcher_row(
                     frame,
                     clear,
                     "Clear",
-                    true,
+                    launcher_clear_enabled(setup, r.field),
                     hover == Some(UiControl::LauncherClear(r.field)),
                     scale,
                 );
@@ -8538,7 +8546,7 @@ fn draw_launcher_row(
                 frame,
                 clear,
                 "Clear",
-                true,
+                launcher_clear_enabled(setup, r.field),
                 hover == Some(UiControl::LauncherClear(r.field)),
                 scale,
             );
@@ -8722,7 +8730,7 @@ fn draw_launcher_board_option(
                 frame,
                 clear,
                 "Clear",
-                true,
+                !value.is_empty(),
                 hover == Some(UiControl::LauncherBoardClear { board, opt }),
                 scale,
             );
@@ -12983,6 +12991,62 @@ mod tests {
             // The base swaps them.
             assert_eq!(probe(false, LauncherField::PathsBase), (true, false));
             assert_eq!(probe(true, LauncherField::PathsBase), (false, true));
+        }
+
+        // A Clear with nothing behind it takes no clicks. The drive rows
+        // and the floppy rows draw their own buttons rather than going
+        // through the Path arm, so each stands trial here: empty, the
+        // button is greyed and dead; with an image chosen, it answers.
+        {
+            let probe = |set: bool, tab: LauncherTab, field: LauncherField, kind: RowKind| {
+                let mut setup = launcher::MachineSetup::default();
+                // A machine that has all the rows: the default model
+                // carries no IDE port, and a row that does not apply
+                // takes no clicks whatever its buttons say.
+                setup.select_model(Some(MachineModel::A1200));
+                if set {
+                    setup.set_path(field, std::path::PathBuf::from("/probe/disk.img"));
+                }
+                let idx = launcher::rows(tab, Default::default(), Default::default(), false, false)
+                    .iter()
+                    .filter(|r| !setup.row_hidden(r.field))
+                    .position(|r| r.field == field && r.kind == kind)
+                    .expect("the field has a visible row");
+                let mut state = LauncherState::new(setup);
+                state.tab = tab;
+                let panel = Panel::Launcher(Box::new(state));
+                let rect = panel_rect(&panel);
+                let nav = if tab.has_top_nav() {
+                    launcher_nav_block_h(tab)
+                } else {
+                    0
+                };
+                let row_y = launcher_row_y(rect, idx) + nav;
+                let (_, clear) = launcher_path_rects(rect, row_y);
+                let got = panel_control_at(
+                    &panel,
+                    (
+                        (clear.x + clear.w / 2) as i32,
+                        (clear.y + clear.h / 2) as i32,
+                    ),
+                );
+                got == Some(UiControl::LauncherClear(field))
+            };
+            for (tab, field, kind) in [
+                (
+                    LauncherTab::Floppy,
+                    LauncherField::Df0Image,
+                    RowKind::FloppyMedia,
+                ),
+                (
+                    LauncherTab::Storage,
+                    LauncherField::IdeMaster,
+                    RowKind::Drive,
+                ),
+            ] {
+                assert!(!probe(false, tab, field, kind), "{field:?} empty must grey");
+                assert!(probe(true, tab, field, kind), "{field:?} set must answer");
+            }
         }
 
         // The confirm over Reset default answers every click on the panel:

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -6138,10 +6138,7 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
             let row_y = launcher_row_y(rect, i) + row_offset;
             match r.kind {
                 // Non-interactive rows.
-                RowKind::SectionHeader
-                | RowKind::BootpriHeader
-                | RowKind::Note
-                | RowKind::RomInfo => {}
+                RowKind::SectionHeader | RowKind::BootpriHeader | RowKind::RomInfo => {}
                 RowKind::Text => {
                     if launcher_text_rect(rect, row_y, r.field).contains(pos) {
                         // The same widget serves two stores: a Create Image
@@ -7718,25 +7715,6 @@ fn draw_launcher_row(
         );
         return;
     }
-    // The ROM tab's identification line: what the image on the row above
-    // checksums to, greyed and indented under it. Nothing is drawn for an
-    // image no checksum names, or for an empty row.
-    if r.kind == RowKind::Note {
-        if let Some(note) = state.rom_note(r.field) {
-            let x = launcher_pane_x(rect) + 8;
-            let avail = (rect.x + rect.w).saturating_sub(x + LAUNCH_MARGIN);
-            draw_panel_text(
-                frame,
-                x,
-                row_y + 4,
-                &truncate_to_width(note, avail),
-                PANEL_TEXT_DIM,
-                1,
-                scale,
-            );
-        }
-        return;
-    }
     // The greyed column titles above the Boot Priority rows.
     if r.kind == RowKind::BootpriHeader {
         for (x, title) in [
@@ -7805,20 +7783,13 @@ fn draw_launcher_row(
             Some(GreyedAs::DimmedValue | GreyedAs::DimmedReason)
         ) {
             if greyed_as != Some(GreyedAs::Blank) {
-                // Centred across the stepper span, where the value the
-                // row cannot have would sit -- but the reasons vary in
-                // length, and a long one truly centred starts left of its
-                // shorter neighbours, which reads as a ragged margin
-                // rather than a centred column. So no reason starts
-                // further left than the commonest one would.
-                let (prev, _, next) = launcher_cycle_rects(rect, row_y);
-                let span = (next.x + next.w).saturating_sub(prev.x);
-                let floor_w = "needs 68020+".chars().count() * font::GLYPH_W;
-                let min_x = prev.x + span.saturating_sub(floor_w) / 2;
-                let text_w = reason.chars().count() * font::GLYPH_W;
+                // Where the value the row cannot have would sit: flush
+                // against the right edge of the stepper's left arrow, so
+                // every reason shares one margin whatever its length.
+                let (prev, _, _) = launcher_cycle_rects(rect, row_y);
                 draw_panel_text(
                     frame,
-                    (prev.x + span.saturating_sub(text_w) / 2).max(min_x),
+                    prev.x + prev.w,
                     row_y + 8,
                     reason,
                     PANEL_TEXT_DIM,
@@ -7831,7 +7802,7 @@ fn draw_launcher_row(
     }
     match r.kind {
         // Drawn above with an early return.
-        RowKind::SectionHeader | RowKind::BootpriHeader | RowKind::Note | RowKind::RomInfo => {}
+        RowKind::SectionHeader | RowKind::BootpriHeader | RowKind::RomInfo => {}
         RowKind::Text => {
             draw_launcher_value_box(
                 frame,
@@ -10037,20 +10008,18 @@ mod tests {
         );
     }
 
-    /// The ROM tab's identification line is drawn under its path row, in the
-    /// greyed note colour, and only once there is something to say: an image
-    /// no checksum names leaves the value line blank -- while the table's
-    /// column headers stand either way.
+    /// The ROM tab's identification lines sit under the path row: the
+    /// greyed Name/Version/Revision prefixes stand either way, and an
+    /// image no checksum names leaves the values after them blank.
     #[test]
     fn the_rom_tab_draws_its_identification_line_under_the_path_row() {
         use super::super::window::{texture_height, texture_width};
         let scale = 1;
         let (w, h) = (texture_width(scale), texture_height(scale));
-        // Pixels painted in the info-line ink on a given ROM-tab row:
-        // the Name line is index 2, under the section heading and the
-        // path row.
-        // The headers draw dimmed, the values in full text colour; both
-        // count as the table's ink.
+        // Pixels painted in the info-line ink on a given ROM-tab row
+        // (the Name line is index 2, under the section heading and the
+        // path row). The prefixes draw dimmed, the values in full text
+        // colour; both count.
         let row_pixels = |frame: &[u8], rect: Rect, row: usize| {
             let row_y = launcher_row_y(rect, row);
             let mut lit = 0;

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -7714,9 +7714,12 @@ fn draw_launcher_row(
             )
         };
         if r.kind == RowKind::RomInfoHeader {
-            // The box spans this row and the value row below.
-            fill_rect(frame, scale_rect(table, scale), BUTTON_EDGE_DARK, scale);
-            fill_rect(
+            // The box spans this row and the value row below, sunk into
+            // the panel exactly as the disk selector is: dark fill, the
+            // lit outline all the way round, then the inset bevel.
+            fill_rect(frame, scale_rect(table, scale), ENTRY_BG, scale);
+            draw_outline(frame, table, BUTTON_EDGE_LIGHT, scale);
+            draw_rect_bevel(
                 frame,
                 scale_rect(
                     Rect {
@@ -7727,6 +7730,7 @@ fn draw_launcher_row(
                     },
                     scale,
                 ),
+                BUTTON_EDGE_DARK,
                 ENTRY_BG,
                 scale,
             );
@@ -10092,8 +10096,8 @@ mod tests {
         let scale = 1;
         let (w, h) = (texture_width(scale), texture_height(scale));
         // Pixels painted in the table colour on a given ROM-tab row: the
-        // header row is index 2 and the value row index 3 (under the
-        // section heading and the Kickstart ROM path row).
+        // header row is index 3 and the value row index 4 (under the
+        // section heading, the path row, and the spacer).
         let row_pixels = |frame: &[u8], rect: Rect, row: usize| {
             let row_y = launcher_row_y(rect, row);
             let mut lit = 0;
@@ -10107,7 +10111,7 @@ mod tests {
             }
             lit
         };
-        let note_row_pixels = |frame: &[u8], rect: Rect| row_pixels(frame, rect, 3);
+        let note_row_pixels = |frame: &[u8], rect: Rect| row_pixels(frame, rect, 4);
         let panel_of = |state: LauncherState| Panel::Launcher(Box::new(state));
 
         let mut setup = launcher::MachineSetup::default();
@@ -10134,7 +10138,7 @@ mod tests {
             "an unidentified image must leave the value line empty"
         );
         assert!(
-            row_pixels(&blank_frame, rect, 2) > 0,
+            row_pixels(&blank_frame, rect, 3) > 0,
             "the table's column headers stand even over an empty slot"
         );
 

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -4310,6 +4310,10 @@ fn draw_heat_census(
 const LAUNCHER_W: usize = FB_WIDTH;
 const LAUNCHER_H: usize = 520;
 const LAUNCH_MARGIN: usize = 8;
+/// The ROM identification table's Name column; Version and Revision
+/// split what remains of the pane.
+const ROM_INFO_NAME_W: usize = 200;
+const ROM_INFO_VERSION_W: usize = 92;
 const LAUNCH_MODEL_H: usize = 22;
 const LAUNCH_MODEL_GAP: usize = 4;
 /// Machines per row in the selector grid before it wraps; the grid rebalances
@@ -5551,6 +5555,14 @@ fn launcher_path_inherits(setup: &launcher::MachineSetup, field: LauncherField) 
     if field == LauncherField::CsynthSoundfont {
         return setup.path(field).is_none();
     }
+    // The ROMs with bundled defaults read the same way: unset means the
+    // bundled image, dimmed as Copperline's answer.
+    if field == LauncherField::Rom {
+        return setup.path(field).is_none();
+    }
+    if field == LauncherField::ScsiRom {
+        return setup.scsi_controller_is_a4091() && setup.path(field).is_none();
+    }
     field.is_paths_field() && field != LauncherField::PathsBase && !setup.paths_is_set(field)
 }
 
@@ -6128,7 +6140,11 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
             let row_y = launcher_row_y(rect, i) + row_offset;
             match r.kind {
                 // Non-interactive rows.
-                RowKind::SectionHeader | RowKind::BootpriHeader | RowKind::Note => {}
+                RowKind::SectionHeader
+                | RowKind::BootpriHeader
+                | RowKind::Note
+                | RowKind::RomInfoHeader
+                | RowKind::RomInfoValue => {}
                 RowKind::Text => {
                     if launcher_text_rect(rect, row_y, r.field).contains(pos) {
                         // The same widget serves two stores: a Create Image
@@ -7679,6 +7695,39 @@ fn draw_launcher_row(
         );
         return;
     }
+    // The ROM tab's identification table: three greyed columns under the
+    // path row, headers first, then whatever the image on the row above
+    // checksums to. The table stands whether or not an image is loaded.
+    if matches!(r.kind, RowKind::RomInfoHeader | RowKind::RomInfoValue) {
+        let x = launcher_pane_x(rect) + 8;
+        let cols = [
+            (x, ROM_INFO_NAME_W),
+            (x + ROM_INFO_NAME_W, ROM_INFO_VERSION_W),
+            (x + ROM_INFO_NAME_W + ROM_INFO_VERSION_W, ROM_INFO_VERSION_W),
+        ];
+        let cells: [String; 3] = if r.kind == RowKind::RomInfoHeader {
+            [
+                "Name".to_string(),
+                "Version".to_string(),
+                "Revision".to_string(),
+            ]
+        } else {
+            let (name, version, revision) = state.rom_note_cells(r.field);
+            [name, version, revision]
+        };
+        for ((cx, cw), cell) in cols.iter().zip(cells.iter()) {
+            draw_panel_text(
+                frame,
+                *cx,
+                row_y + 4,
+                &truncate_to_width(cell, cw.saturating_sub(8)),
+                PANEL_TEXT_DIM,
+                1,
+                scale,
+            );
+        }
+        return;
+    }
     // The ROM tab's identification line: what the image on the row above
     // checksums to, greyed and indented under it. Nothing is drawn for an
     // image no checksum names, or for an empty row.
@@ -7716,7 +7765,21 @@ fn draw_launcher_row(
     } else {
         setup.disabled_reason(r.field)
     };
-    let label_color = if reason.is_none() && !launcher_path_inherits(setup, r.field) {
+    // The SoundFont row's label stays lit even while the value shows
+    // the bundled default -- the setting is present either way; only
+    // the value is Copperline's answer rather than the person's.
+    let label_keeps_colour = matches!(r.field, LauncherField::Rom | LauncherField::ScsiRom) || {
+        #[cfg(feature = "coppersynth")]
+        {
+            r.field == LauncherField::CsynthSoundfont
+        }
+        #[cfg(not(feature = "coppersynth"))]
+        {
+            false
+        }
+    };
+    let label_inherits = !label_keeps_colour && launcher_path_inherits(setup, r.field);
+    let label_color = if reason.is_none() && !label_inherits {
         PANEL_TEXT
     } else {
         PANEL_TEXT_DIM
@@ -7767,7 +7830,11 @@ fn draw_launcher_row(
     }
     match r.kind {
         // Drawn above with an early return.
-        RowKind::SectionHeader | RowKind::BootpriHeader | RowKind::Note => {}
+        RowKind::SectionHeader
+        | RowKind::BootpriHeader
+        | RowKind::Note
+        | RowKind::RomInfoHeader
+        | RowKind::RomInfoValue => {}
         RowKind::Text => {
             draw_launcher_value_box(
                 frame,
@@ -8274,6 +8341,18 @@ fn draw_launcher_row(
             let inherits = launcher_path_inherits(setup, r.field);
             let (value_color, text_x) = if inherits {
                 let text_w = text.chars().count() * font::GLYPH_W;
+                // The SoundFont default sits in line with the cycle
+                // value column, centred under the arrows of the rows
+                // around it rather than adrift in the wider path box.
+                #[cfg(feature = "coppersynth")]
+                if r.field == LauncherField::CsynthSoundfont {
+                    let (_, value_box, _) = launcher_cycle_rects(rect, row_y);
+                    let x = value_box.x + value_box.w.saturating_sub(text_w) / 2;
+                    (PANEL_TEXT_DIM, x)
+                } else {
+                    (PANEL_TEXT_DIM, value_x + avail.saturating_sub(text_w) / 2)
+                }
+                #[cfg(not(feature = "coppersynth"))]
                 (PANEL_TEXT_DIM, value_x + avail.saturating_sub(text_w) / 2)
             } else {
                 (PANEL_TEXT, value_x)
@@ -8997,14 +9076,20 @@ fn draw_launcher(
             scale,
         );
     }
-    // Action bar.
+    // Action bar. While the Save dialog is up, every position outside
+    // its three buttons answers as the Save control (a stray click puts
+    // the dialog away), so pointer-lighting the button under it would
+    // flash on every hover in the dialog -- the button stays unlit until
+    // the dialog is gone.
     for (control, button_rect) in launcher_action_rects(rect) {
+        let lit =
+            hover == Some(control) && !(control == UiControl::LauncherSave && state.save_dialog);
         draw_text_button(
             frame,
             button_rect,
             launcher_action_label(control),
             true,
-            hover == Some(control),
+            lit,
             scale,
         );
     }
@@ -9953,16 +10038,18 @@ mod tests {
 
     /// The ROM tab's identification line is drawn under its path row, in the
     /// greyed note colour, and only once there is something to say: an image
-    /// no checksum names leaves the line blank rather than an empty box.
+    /// no checksum names leaves the value line blank -- while the table's
+    /// column headers stand either way.
     #[test]
     fn the_rom_tab_draws_its_identification_line_under_the_path_row() {
         use super::super::window::{texture_height, texture_width};
         let scale = 1;
         let (w, h) = (texture_width(scale), texture_height(scale));
-        // Pixels painted in the note colour on the note row (row 1, under
-        // the Kickstart ROM path row).
-        let note_row_pixels = |frame: &[u8], rect: Rect| {
-            let row_y = launcher_row_y(rect, 1);
+        // Pixels painted in the table colour on a given ROM-tab row: the
+        // header row is index 2 and the value row index 3 (under the
+        // section heading and the Kickstart ROM path row).
+        let row_pixels = |frame: &[u8], rect: Rect, row: usize| {
+            let row_y = launcher_row_y(rect, row);
             let mut lit = 0;
             for y in row_y..row_y + LAUNCH_ROW_H {
                 for x in launcher_pane_x(rect)..rect.x + rect.w - LAUNCH_MARGIN {
@@ -9974,6 +10061,7 @@ mod tests {
             }
             lit
         };
+        let note_row_pixels = |frame: &[u8], rect: Rect| row_pixels(frame, rect, 3);
         let panel_of = |state: LauncherState| Panel::Launcher(Box::new(state));
 
         let mut setup = launcher::MachineSetup::default();
@@ -9997,7 +10085,11 @@ mod tests {
         assert_eq!(
             note_row_pixels(&blank_frame, rect),
             0,
-            "an unidentified image must leave the note line empty"
+            "an unidentified image must leave the value line empty"
+        );
+        assert!(
+            row_pixels(&blank_frame, rect, 2) > 0,
+            "the table's column headers stand even over an empty slot"
         );
 
         let mut frame = vec![0u8; w * h * 4];

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -7701,12 +7701,16 @@ fn draw_launcher_row(
             "Revision" => revision,
             _ => name,
         };
+        // The prefix in grey, the fact itself in full text colour.
+        let x = launcher_pane_x(rect) + 4 * font::GLYPH_W;
+        let prefix = format!("{}: ", r.label);
+        draw_panel_text(frame, x, row_y + 4, &prefix, PANEL_TEXT_DIM, 1, scale);
         draw_panel_text(
             frame,
-            launcher_pane_x(rect) + 4 * font::GLYPH_W,
+            x + prefix.chars().count() * font::GLYPH_W,
             row_y + 4,
-            &format!("{}: {}", r.label, value),
-            PANEL_TEXT_DIM,
+            &value,
+            PANEL_TEXT,
             1,
             scale,
         );

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -37,9 +37,6 @@ const BUTTON_TEXT_DISABLED: u32 = rgba(120, 120, 112);
 /// DDF fetch-bound verticals on the Frame Analyzer heatmap.
 const DDF_LINE: u32 = rgba(80, 200, 220);
 const ENTRY_BG: u32 = rgba(8, 10, 8);
-/// The ROM identification table's internal grid: fainter than the lit
-/// outline around it, so the cells divide without shouting.
-const ROM_TABLE_GRID: u32 = rgba(62, 64, 60);
 /// The mark inside a ticked box.
 const TICK_GREEN: u32 = rgba(72, 214, 96);
 
@@ -6142,8 +6139,7 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                 RowKind::SectionHeader
                 | RowKind::BootpriHeader
                 | RowKind::Note
-                | RowKind::RomInfoHeader
-                | RowKind::RomInfoValue => {}
+                | RowKind::RomInfo => {}
                 RowKind::Text => {
                     if launcher_text_rect(rect, row_y, r.field).contains(pos) {
                         // The same widget serves two stores: a Create Image
@@ -7694,98 +7690,26 @@ fn draw_launcher_row(
         );
         return;
     }
-    // The ROM tab's identification table: three greyed columns under the
-    // path row, headers first, then whatever the image on the row above
-    // checksums to. The table stands whether or not an image is loaded.
-    if matches!(r.kind, RowKind::RomInfoHeader | RowKind::RomInfoValue) {
-        // The host-disk table's style exactly -- dark fill, bordered box,
-        // headings over a rule -- minus the clickability, plus a divider
-        // between the columns. Its right edge lines up with the Clear
-        // button above it, and every cell reads from the left.
-        let (browse, _) = launcher_path_rects(rect, row_y);
-        // Left edge on the indented row labels ("  Kickstart ROM"), right
-        // edge on the Browse button's left, and the bottom sits close
-        // under the value line rather than padding out the grid row.
-        let table = Rect {
-            x: launcher_pane_x(rect) + 2 * font::GLYPH_W,
-            y: row_y,
-            w: browse
-                .x
-                .saturating_sub(launcher_pane_x(rect) + 2 * font::GLYPH_W),
-            h: 2 * LAUNCH_ROW_H - 12,
-        };
-        let col_w = table.w / 3;
-        let cell_at = |cell: &str, col: usize| {
-            (
-                table.x + col * col_w + 6,
-                truncate_to_width(cell, col_w.saturating_sub(12)),
-            )
-        };
-        if r.kind == RowKind::RomInfoHeader {
-            // The box spans this row and the value row below, sunk into
-            // the panel exactly as the disk selector is: dark fill, the
-            // lit outline all the way round, then the inset bevel.
-            fill_rect(frame, scale_rect(table, scale), ENTRY_BG, scale);
-            draw_outline(frame, table, BUTTON_EDGE_LIGHT, scale);
-            draw_rect_bevel(
-                frame,
-                scale_rect(
-                    Rect {
-                        x: table.x + 1,
-                        y: table.y + 1,
-                        w: table.w.saturating_sub(2),
-                        h: table.h.saturating_sub(2),
-                    },
-                    scale,
-                ),
-                BUTTON_EDGE_DARK,
-                ENTRY_BG,
-                scale,
-            );
-            for (col, title) in ["Name", "Version", "Revision"].iter().enumerate() {
-                let (cx, text) = cell_at(title, col);
-                draw_panel_text(frame, cx, table.y + 5, &text, PANEL_TEXT_DIM, 1, scale);
-            }
-            // The grid: the rule under the headings and the column
-            // dividers run edge to edge, meeting the border, so every
-            // cell reads as a closed box.
-            fill_rect(
-                frame,
-                scale_rect(
-                    Rect {
-                        x: table.x + 1,
-                        y: table.y + LAUNCH_ROW_H - 4,
-                        w: table.w.saturating_sub(2),
-                        h: 1,
-                    },
-                    scale,
-                ),
-                ROM_TABLE_GRID,
-                scale,
-            );
-            for col in 1..3 {
-                fill_rect(
-                    frame,
-                    scale_rect(
-                        Rect {
-                            x: table.x + col * col_w,
-                            y: table.y + 1,
-                            w: 1,
-                            h: table.h.saturating_sub(2),
-                        },
-                        scale,
-                    ),
-                    ROM_TABLE_GRID,
-                    scale,
-                );
-            }
-            return;
-        }
+    // The ROM tab's identification lines: one greyed fact per row --
+    // Name, Version, Revision -- indented two spaces under the indented
+    // path row, the value following its label. The prefix stands even
+    // when an unrecognised image leaves the value blank.
+    if r.kind == RowKind::RomInfo {
         let (name, version, revision) = state.rom_note_cells(r.field);
-        for (col, cell) in [name, version, revision].iter().enumerate() {
-            let (cx, text) = cell_at(cell, col);
-            draw_panel_text(frame, cx, row_y + 2, &text, PANEL_TEXT, 1, scale);
-        }
+        let value = match r.label {
+            "Version" => version,
+            "Revision" => revision,
+            _ => name,
+        };
+        draw_panel_text(
+            frame,
+            launcher_pane_x(rect) + 4 * font::GLYPH_W,
+            row_y + 4,
+            &format!("{}: {}", r.label, value),
+            PANEL_TEXT_DIM,
+            1,
+            scale,
+        );
         return;
     }
     // The ROM tab's identification line: what the image on the row above
@@ -7890,11 +7814,7 @@ fn draw_launcher_row(
     }
     match r.kind {
         // Drawn above with an early return.
-        RowKind::SectionHeader
-        | RowKind::BootpriHeader
-        | RowKind::Note
-        | RowKind::RomInfoHeader
-        | RowKind::RomInfoValue => {}
+        RowKind::SectionHeader | RowKind::BootpriHeader | RowKind::Note | RowKind::RomInfo => {}
         RowKind::Text => {
             draw_launcher_value_box(
                 frame,
@@ -10111,9 +10031,9 @@ mod tests {
         use super::super::window::{texture_height, texture_width};
         let scale = 1;
         let (w, h) = (texture_width(scale), texture_height(scale));
-        // Pixels painted in the table colour on a given ROM-tab row: the
-        // header row is index 2 and the value row index 3 (under the
-        // section heading and the path row).
+        // Pixels painted in the info-line ink on a given ROM-tab row:
+        // the Name line is index 2, under the section heading and the
+        // path row.
         // The headers draw dimmed, the values in full text colour; both
         // count as the table's ink.
         let row_pixels = |frame: &[u8], rect: Rect, row: usize| {
@@ -10131,7 +10051,7 @@ mod tests {
             }
             lit
         };
-        let note_row_pixels = |frame: &[u8], rect: Rect| row_pixels(frame, rect, 3);
+        let note_row_pixels = |frame: &[u8], rect: Rect| row_pixels(frame, rect, 2);
         let panel_of = |state: LauncherState| Panel::Launcher(Box::new(state));
 
         let mut setup = launcher::MachineSetup::default();
@@ -10152,14 +10072,10 @@ mod tests {
         };
         let rect = panel_rect(ui.panel.as_ref().unwrap());
         draw(&mut blank_frame, scale, &ui, None, None);
-        assert_eq!(
-            note_row_pixels(&blank_frame, rect),
-            0,
-            "an unidentified image must leave the value line empty"
-        );
+        let blank_ink = note_row_pixels(&blank_frame, rect);
         assert!(
-            row_pixels(&blank_frame, rect, 2) > 0,
-            "the table's column headers stand even over an empty slot"
+            blank_ink > 0,
+            "the Name: prefix stands even over an unrecognised image"
         );
 
         let mut frame = vec![0u8; w * h * 4];
@@ -10169,8 +10085,8 @@ mod tests {
         };
         draw(&mut frame, scale, &ui, None, None);
         assert!(
-            note_row_pixels(&frame, rect) > 0,
-            "the identification is drawn under the ROM path row"
+            note_row_pixels(&frame, rect) > blank_ink,
+            "the identification's value adds ink beyond the prefix"
         );
     }
 

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -3509,6 +3509,7 @@ impl ApplicationHandler for App {
                 self.last_display_cursor_pos = None;
                 self.volume_dragging = false;
                 self.analyzer_dragging = false;
+                self.menu_hover_arm = None;
                 let layout = bar_layout(&self.media_bar());
                 if bar_hover_changed(&layout, previous_cursor_pos, self.cursor_pos) {
                     self.request_redraw();
@@ -5927,6 +5928,8 @@ impl App {
         };
         let pos = (pos.0.max(0) as usize, pos.1.max(0) as usize);
         let Some((depth, row)) = ui::menu_hit(&self.ui.menu_rows, &self.ui.menu_nav, pos) else {
+            // Off every row: a submenu arming for its dwell stands down.
+            self.menu_hover_arm = None;
             return false;
         };
         // The pointer is resting on the row this level is already open to.
@@ -6391,10 +6394,22 @@ impl App {
                         }
                     }
                     Some(crate::csynth::PanelRequest::ResetSoundfont) => {
-                        // Confirmed at the fascia; the unit holds its
-                        // Initializing... screen while the bank swaps.
+                        // Confirmed at the fascia. The swap rebuilds the
+                        // whole unit around the built-in bank, so the
+                        // panel that asked -- holding the Initializing...
+                        // screen -- is gone with it; the fresh panel
+                        // opens on the same hold, serves its second, and
+                        // boots.
                         if let Some(sink) = self.emu.bus_mut().midi_serial_mut() {
                             sink.reset_csynth_soundfont();
+                        }
+                        if let Some(synth) = self
+                            .emu
+                            .bus_mut()
+                            .midi_serial_mut()
+                            .and_then(crate::midi::MidiSerialSink::csynth_mut)
+                        {
+                            synth.panel_begin_initializing();
                         }
                     }
                     None => {}

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -181,6 +181,8 @@ const MAX_TEXTURE_SCALE: usize = 2;
 /// the fit integer.
 const MAX_INTEGER_TEXTURE_SCALE: usize = 4;
 const STATUS_BAR_HEIGHT: usize = 44;
+/// How long the pointer rests on a menu category before it opens.
+const MENU_SUBMENU_DWELL: std::time::Duration = std::time::Duration::from_millis(500);
 /// Logical window height: the presentation canvas for the active pixel aspect,
 /// plus the status bar below it unless it is hidden (in which case the display
 /// scales to fill the whole window).
@@ -1260,6 +1262,9 @@ pub struct App {
     /// analyzer panes live in separate tool-window state so they can be
     /// open at the same time.
     ui: UiState,
+    /// A submenu the pointer is resting on, waiting out the dwell before
+    /// it opens: `(depth, row, since)`. Hovering elsewhere disarms it.
+    menu_hover_arm: Option<(usize, usize, Instant)>,
     /// Emulated-machine summary lines for the About window.
     about_machine_lines: Vec<String>,
     /// Raw config of the running (or last-applied) machine, so the "Machine
@@ -1988,6 +1993,7 @@ impl App {
             keymap: keymap::KeyMap::load(),
             autofire_hz,
             ui: UiState::default(),
+            menu_hover_arm: None,
             about_machine_lines,
             machine_config,
             paused_before_debugger: false,
@@ -4327,6 +4333,7 @@ impl ApplicationHandler for App {
         // Resample the performance overlay after the step so its revision
         // is current when the redraw decision below is taken.
         self.update_perf_overlay(running);
+        self.poll_menu_hover_arm();
         #[cfg(feature = "coppersynth")]
         {
             self.repeat_csynth_dial();
@@ -5933,21 +5940,72 @@ impl App {
             return false;
         }
         let mut path = self.menu_path_to(depth);
-        // A category opens as the pointer reaches it, so submenus are walked
-        // into rather than clicked into. The cursor stays off the level that
+        // A category opens as the pointer rests on it, so submenus are
+        // walked into rather than clicked into -- after a brief dwell, so
+        // a pointer passing through on its way somewhere else does not
+        // pull levels open behind it. The cursor stays off the level that
         // opens until the pointer is actually over one of its rows; the
         // category itself stays lit as the way back.
         let opens = self
             .menu_row_at(depth, row)
             .is_some_and(|r| r.enabled && r.is_submenu());
         let cursor = if opens {
+            let now = Instant::now();
+            match self.menu_hover_arm {
+                Some((d, r, since)) if (d, r) == (depth, row) => {
+                    if now.duration_since(since) < MENU_SUBMENU_DWELL {
+                        // Still waiting: light the row, open nothing yet.
+                        self.ui.menu_nav.open_path(path, Some(row));
+                        return true;
+                    }
+                    self.menu_hover_arm = None;
+                }
+                _ => {
+                    self.menu_hover_arm = Some((depth, row, now));
+                    self.ui.menu_nav.open_path(path, Some(row));
+                    self.request_redraw();
+                    return true;
+                }
+            }
             path.push(row);
             None
         } else {
+            self.menu_hover_arm = None;
             Some(row)
         };
         self.ui.menu_nav.open_path(path, cursor);
         true
+    }
+
+    /// Open an armed submenu whose dwell has elapsed while the pointer
+    /// rests still -- resting produces no cursor events, so the frame
+    /// poll asks.
+    fn poll_menu_hover_arm(&mut self) {
+        let Some((depth, row, since)) = self.menu_hover_arm else {
+            return;
+        };
+        if !self.ui.menu_open {
+            self.menu_hover_arm = None;
+            return;
+        }
+        if since.elapsed() < MENU_SUBMENU_DWELL {
+            self.request_redraw();
+            return;
+        }
+        // Only if the pointer is still on the armed row.
+        let still_there = self
+            .cursor_pos
+            .map(|p| (p.0.max(0) as usize, p.1.max(0) as usize))
+            .and_then(|pos| ui::menu_hit(&self.ui.menu_rows, &self.ui.menu_nav, pos))
+            == Some((depth, row));
+        self.menu_hover_arm = None;
+        if !still_there {
+            return;
+        }
+        let mut path = self.menu_path_to(depth);
+        path.push(row);
+        self.ui.menu_nav.open_path(path, None);
+        self.request_redraw();
     }
 
     /// The open path down to `depth`, for a pointer that has landed on a level
@@ -6359,7 +6417,7 @@ impl App {
                 };
                 if came_up {
                     self.show_osd(if reset_font {
-                        "Coppersynth: default soundfont"
+                        "Coppersynth: default SoundFont"
                     } else {
                         "Coppersynth: power on"
                     });
@@ -6381,8 +6439,8 @@ impl App {
     #[cfg(feature = "coppersynth")]
     fn load_csynth_soundfont(&mut self) {
         let picked = rfd::FileDialog::new()
-            .set_title("Choose a soundfont")
-            .add_filter("Soundfonts", &["sf2", "SF2", "zip", "ZIP"])
+            .set_title("Choose a SoundFont")
+            .add_filter("SoundFonts", &["sf2", "SF2", "zip", "ZIP"])
             .pick_file();
         let Some(path) = picked else {
             return;
@@ -6775,6 +6833,7 @@ impl App {
 
     /// Close the menu and forget where it was open to.
     fn close_menu(&mut self) {
+        self.menu_hover_arm = None;
         self.ui.menu_open = false;
         self.ui.menu_rows = Vec::new();
         self.ui.menu_nav.reset();
@@ -8726,7 +8785,7 @@ impl App {
             LauncherField::Cd32Nvram => dialog.add_filter("NVRAM images", &["bin", "nv", "sav"]),
             #[cfg(feature = "coppersynth")]
             LauncherField::CsynthSoundfont => {
-                dialog.add_filter("Soundfonts", &["sf2", "SF2", "zip", "ZIP"])
+                dialog.add_filter("SoundFonts", &["sf2", "SF2", "zip", "ZIP"])
             }
             // SCSI, IDE, and lide drive slots all take hard disks or CD
             // images (a cue/iso/chd attaches a CD-ROM drive at that slot,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6376,29 +6376,31 @@ impl App {
                     .midi_serial_mut()
                     .and_then(crate::midi::MidiSerialSink::csynth_mut)
                     .and_then(|synth| synth.panel_button(button));
-                if let Some(crate::csynth::PanelRequest::Mt32Mode(mode)) = request {
-                    // The engine already switched; mirror the choice into
-                    // the session's options so a power cycle keeps it.
-                    let value = match mode {
-                        crate::csynth::Mt32Mode::On => "on",
-                        crate::csynth::Mt32Mode::Off => "off",
-                        crate::csynth::Mt32Mode::Auto => "auto",
-                    };
-                    if let Some(sink) = self.emu.bus_mut().midi_serial_mut() {
-                        sink.set_csynth_mt32_mode(value);
+                match request {
+                    Some(crate::csynth::PanelRequest::Mt32Mode(mode)) => {
+                        // The engine already switched; mirror the choice
+                        // into the session's options so a power cycle
+                        // keeps it.
+                        let value = match mode {
+                            crate::csynth::Mt32Mode::On => "on",
+                            crate::csynth::Mt32Mode::Off => "off",
+                            crate::csynth::Mt32Mode::Auto => "auto",
+                        };
+                        if let Some(sink) = self.emu.bus_mut().midi_serial_mut() {
+                            sink.set_csynth_mt32_mode(value);
+                        }
                     }
+                    Some(crate::csynth::PanelRequest::ResetSoundfont) => {
+                        // Confirmed at the fascia; the unit holds its
+                        // Initializing... screen while the bank swaps.
+                        if let Some(sink) = self.emu.bus_mut().midi_serial_mut() {
+                            sink.reset_csynth_soundfont();
+                        }
+                    }
+                    None => {}
                 }
             }
             CsynthPress::PowerOn(held) => {
-                // Both INSTRUMENT halves held through the power-on put
-                // the default soundfont back before the unit comes up.
-                let reset_font =
-                    held == [crate::csynth::Button::Both(crate::csynth::Pair::Instrument)];
-                if reset_font {
-                    if let Some(sink) = self.emu.bus_mut().midi_serial_mut() {
-                        sink.reset_csynth_soundfont();
-                    }
-                }
                 self.set_csynth_powered(true);
                 let came_up = if let Some(synth) = self
                     .emu
@@ -6407,20 +6409,15 @@ impl App {
                     .and_then(crate::midi::MidiSerialSink::csynth_mut)
                 {
                     // What was held on the fascia through the power-on
-                    // reaches the unit the way it reads its own buttons.
-                    if !reset_font {
-                        synth.panel_power_on_held(&held);
-                    }
+                    // reaches the unit the way it reads its own buttons
+                    // -- the factory questions included.
+                    synth.panel_power_on_held(&held);
                     true
                 } else {
                     false
                 };
                 if came_up {
-                    self.show_osd(if reset_font {
-                        "Coppersynth: default SoundFont"
-                    } else {
-                        "Coppersynth: power on"
-                    });
+                    self.show_osd("Coppersynth: power on");
                 } else {
                     // Asked to switch on and it did not: say why.
                     self.report_csynth();

--- a/src/video/window/csynthpanel.rs
+++ b/src/video/window/csynthpanel.rs
@@ -1592,8 +1592,8 @@ mod tests {
             panel.press(CsynthControl::Mute, false, true),
             CsynthPress::Button(Button::Monitor)
         );
-        // Both INSTRUMENT halves latched through a power-on: the
-        // default-font combination arrives as the pair held whole.
+        // Both INSTRUMENT halves latched through a power-on arrive as
+        // the pair held whole.
         panel.press(
             CsynthControl::Arrow(Pair::Instrument, Dir::Left),
             false,
@@ -1627,7 +1627,8 @@ mod tests {
         };
         assert!(held.contains(&Button::Both(Pair::MidiCh)));
         assert!(held.contains(&Button::Both(Pair::Instrument)));
-        // ALL and MUTE latched through a power-on: the version screen's.
+        // ALL and MUTE latched through a power-on arrive as themselves
+        // (the unit ignores the set; the resolution must still carry it).
         panel.press(CsynthControl::All, false, false);
         panel.press(CsynthControl::Mute, false, false);
         assert_eq!(

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -1339,13 +1339,16 @@ pub(super) fn draw_pause_button(
         },
         texture_scale,
     );
-    draw_rect_bevel(
-        frame,
-        rect,
-        BUTTON_EDGE_LIGHT,
-        BUTTON_EDGE_DARK,
-        texture_scale,
-    );
+    // Paused, the moulding turns over -- the MT-32 panel's pressed
+    // effect: the light that caught its top and left falls onto the
+    // bottom and right instead, so the button reads as held down for
+    // as long as the machine is.
+    let (near, far) = if paused {
+        (BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT)
+    } else {
+        (BUTTON_EDGE_LIGHT, BUTTON_EDGE_DARK)
+    };
+    draw_rect_bevel(frame, rect, near, far, texture_scale);
     let cx = rect.x + rect.w / 2;
     let cy = rect.y + rect.h / 2;
     // Show the action the button performs: a play triangle while paused

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4077,7 +4077,10 @@ fn launcher_panel_edits_machine_setup() {
     // control dispatch the mouse uses.
     app.activate_ui_control(UiControl::LauncherModel(MachineModel::A1200));
     app.activate_ui_control(UiControl::LauncherTab(LauncherTab::Cpu));
-    app.activate_ui_control(UiControl::LauncherToggle(LauncherField::Fpu));
+    app.activate_ui_control(UiControl::LauncherCycle {
+        field: LauncherField::Fpu,
+        forward: true,
+    });
 
     let state = match &app.ui.panel {
         Some(Panel::Launcher(state)) => state,


### PR DESCRIPTION
Nothing earth shattering, just a full sweep of the Launcher for various consistency fixes / UI improvements.etc 

**Launcher**
- On/off rows use the `‹ Enabled/Disabled ›` stepper instead of On/Off boxes.
- Clear buttons grey out (and take no clicks) when there's nothing to clear, on every Browse/Clear pair; Clear matches Browse's width. The SoundFont button says Clear; the Paths page keeps Reset at matching width.
- ROM tab: Primary/Extended headings; the Kickstart row shows Name/Version/Revision from checksum identification, the bundled AROS read off the image itself.
- Memory: sizes first, then power-on fill; the fill-pattern row only exists while the fill is Fixed. "needs …" reasons on CPU/Memory align by the stepper's left arrow.
- I/O Ports: "Sound Card:" heading, board rows drop "board", SoundFont spelling, MT-32 Mode above Front Panel in the menu, `(bundled A4091 ROM)` on the A4091 ROM row.

**Window**
- Submenus open after a 0.5 s hover dwell.
- The Pause button draws pressed while emulation is paused.

**Coppersynth 0.9.1** (pin `253cf8cb`)
- Fixed the power on key combos so they match an SC-55 (e.g. MT-32 mode, reset, debug mode, demo mode)
- The fascia asks its own service questions at power-on: INSTRUMENT ◄ for MT-32 mode, INSTRUMENT ► for the factory SoundFont reset (confirmed on the glass; a new panel request carries the reset to the host, whose old both-INSTRUMENT interception retires).
- ALL mode shows `---` for MIDI CH instead of stepping the device ID.
- The LCD shows `---` for a part receiving no channel.

Docs corrected to match; flatpak manifest follows the pin; a regression test covers the greyed Clears.