### PR TITLE
debugger: per-source rows on the Audio tab

### DIFF
--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -96,16 +96,31 @@ Step frames (**Frame**) to watch the state machine advance -- the Running
 line is highlighted while a channel is actively streaming samples.
 
 Each channel row also has a **Mute** button on the left and an oscilloscope on
-the right; a fifth row at the bottom does the same for the **CD-DA** audio
-stream (CDTV, CD32, or a SCSI CD-ROM unit). The oscilloscope traces the
-channel's output level (the DAC sample scaled by AUDxVOL), so both the
-waveform and its loudness are visible; the CD scope traces the mixed CD stereo
-level, and when the machine's CD drive is a SCSI CD-ROM unit the row's status
-line reports its play operation (playing/paused/done, track, and MSF
-position). Clicking **Mute** silences that channel (or the CD stream) in the
-host output while leaving its trace drawn (greyed) so you can still see what
-it would play. Mutes are developer aids: they change only the audio you hear,
-never the emulated Paula state, and are not part of a save state.
+the right; shorter rows at the bottom do the same for every line-mixed audio
+source the machine has. The **CD-DA** row (CDTV, CD32, or a SCSI CD-ROM unit)
+is always present; the others appear only while their source is fitted:
+
+- **MIDI** -- the in-process synthesizer on the serial port (the emulated
+  MT-32, with its control-ROM version, or the Coppersynth General MIDI
+  synth), with a sounding/idle state and the trace's peak level. A host
+  MIDI endpoint has no row: it sounds on the host, outside the mixer.
+- **Toccata** -- the sound board's codec output (what an AHI driver plays
+  through it): playback state, the latched sample rate and format, and the
+  board FIFO's fill level.
+- **MHI** -- the MPEG audio decoder board: transport state
+  (stopped/playing/paused/out of data), the stream's native sample rate,
+  the descriptor queue depth, and the volume/pan/bass/mid/treble param
+  latches.
+
+The oscilloscope traces a channel's output level (the DAC sample scaled by
+AUDxVOL), so both the waveform and its loudness are visible; a source row's
+scope traces that source's mixed stereo level, and when the machine's CD
+drive is a SCSI CD-ROM unit the CD row's status line reports its play
+operation (playing/paused/done, track, and MSF position). Clicking **Mute**
+silences that channel or source in the host output while leaving its trace
+drawn (greyed) so you can still see what it would play. Mutes are developer
+aids: they change only the audio you hear, never the emulated machine state,
+and are not part of a save state.
 
 **Memory** is a hex/ASCII dump, 256 bytes per page. Type a hex address in
 the `$` box and press Enter to jump there; the `<` and `>` buttons page by

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -4177,6 +4177,25 @@ impl Bus {
             .and_then(crate::scsi::ScsiCdRom::playback_line)
     }
 
+    /// The Toccata sound board, when one is configured, for the debugger's
+    /// audio tab.
+    pub fn toccata_board(&self) -> Option<&crate::toccata::Toccata> {
+        self.devices.iter().find_map(|dev| match dev {
+            crate::zorro_device::BoardDevice::Toccata(board) => Some(board.as_ref()),
+            _ => None,
+        })
+    }
+
+    /// The MHI MPEG decoder board, when one is configured, for the
+    /// debugger's audio tab.
+    #[cfg(feature = "mhi")]
+    pub fn mhi_board(&self) -> Option<&crate::mhi::Mhi> {
+        self.devices.iter().find_map(|dev| match dev {
+            crate::zorro_device::BoardDevice::Mhi(board) => Some(board.as_ref()),
+            _ => None,
+        })
+    }
+
     /// Whether the machine has a hard-disk controller, which is what gives it
     /// an HDD LED: a Zorro board, or the A3000's motherboard SCSI.
     fn has_hard_disk_controller(&self) -> bool {

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -389,6 +389,12 @@ fn scope_push(ring: &mut std::collections::VecDeque<i8>, sample: i8) {
     }
 }
 
+/// Fold one line-mixed source's stereo frame down to the -128..127 mono
+/// level its debugger oscilloscope traces.
+fn scope_level(left: f32, right: f32) -> i8 {
+    (((left + right) * 0.5).clamp(-1.0, 1.0) * 127.0) as i8
+}
+
 fn null_serial_sink() -> Box<dyn SerialSink> {
     Box::new(crate::serial::NullSerialSink)
 }
@@ -506,22 +512,37 @@ pub struct Paula {
     // recordings stay full scale regardless of the volume slider) for
     // the window's video recorder to drain once per emulated frame.
     capture: Option<Vec<(f32, f32)>>,
-    // Developer mute switches (debugger audio tab). Muting a channel or the
-    // CD-DA stream silences its contribution to the host output only; the
+    // Developer mute switches (debugger audio tab). Muting a channel or a
+    // line-mixed source (CD-DA, the in-process MIDI synth, a Toccata board,
+    // an MHI board) silences its contribution to the host output only; the
     // Paula state machine, counters and interrupts keep running exactly as
     // before, so this is not emulated state and never touches a save state.
     #[serde(skip)]
     channel_muted: [bool; 4],
     #[serde(skip)]
     cd_muted: bool,
-    // Rolling per-channel and CD output-level scopes for the debugger's
-    // oscilloscope meters. Each holds the most recent AUDIO_SCOPE_LEN host
-    // output samples (output level = DAC sample * volume, -128..127). Purely
-    // a debug tap, so it is skipped by the save state.
+    #[serde(skip)]
+    synth_muted: bool,
+    #[serde(skip)]
+    toccata_muted: bool,
+    #[serde(skip)]
+    mhi_muted: bool,
+    // Rolling output-level scopes for the debugger's oscilloscope meters:
+    // one per Paula channel plus one per line-mixed source (CD-DA, the
+    // in-process MIDI synth, a Toccata board, an MHI board). Each holds the
+    // most recent AUDIO_SCOPE_LEN host output samples (output level = DAC
+    // sample * volume for a channel, mixed stereo level for a source,
+    // -128..127). Purely a debug tap, so it is skipped by the save state.
     #[serde(skip)]
     channel_scope: [std::collections::VecDeque<i8>; 4],
     #[serde(skip)]
     cd_scope: std::collections::VecDeque<i8>,
+    #[serde(skip)]
+    synth_scope: std::collections::VecDeque<i8>,
+    #[serde(skip)]
+    toccata_scope: std::collections::VecDeque<i8>,
+    #[serde(skip)]
+    mhi_scope: std::collections::VecDeque<i8>,
 }
 
 impl Paula {
@@ -575,10 +596,16 @@ impl Paula {
             capture: None,
             channel_muted: [false; 4],
             cd_muted: false,
+            synth_muted: false,
+            toccata_muted: false,
+            mhi_muted: false,
             channel_scope: std::array::from_fn(|_| {
                 std::collections::VecDeque::with_capacity(AUDIO_SCOPE_LEN + 1)
             }),
             cd_scope: std::collections::VecDeque::with_capacity(AUDIO_SCOPE_LEN + 1),
+            synth_scope: std::collections::VecDeque::with_capacity(AUDIO_SCOPE_LEN + 1),
+            toccata_scope: std::collections::VecDeque::with_capacity(AUDIO_SCOPE_LEN + 1),
+            mhi_scope: std::collections::VecDeque::with_capacity(AUDIO_SCOPE_LEN + 1),
         }
     }
 
@@ -633,6 +660,33 @@ impl Paula {
         self.cd_muted
     }
 
+    /// Developer mute for the in-process MIDI synth (MT-32/Coppersynth).
+    pub fn toggle_synth_muted(&mut self) {
+        self.synth_muted = !self.synth_muted;
+    }
+
+    pub fn synth_muted(&self) -> bool {
+        self.synth_muted
+    }
+
+    /// Developer mute for a Toccata board's line-mixed output.
+    pub fn toggle_toccata_muted(&mut self) {
+        self.toccata_muted = !self.toccata_muted;
+    }
+
+    pub fn toccata_muted(&self) -> bool {
+        self.toccata_muted
+    }
+
+    /// Developer mute for an MHI board's line-mixed output.
+    pub fn toggle_mhi_muted(&mut self) {
+        self.mhi_muted = !self.mhi_muted;
+    }
+
+    pub fn mhi_muted(&self) -> bool {
+        self.mhi_muted
+    }
+
     /// Snapshot of a channel's oscilloscope ring (oldest..newest output
     /// levels, up to AUDIO_SCOPE_LEN samples) for the debugger meter.
     pub fn audio_scope_samples(&self, ch_idx: usize) -> Vec<i8> {
@@ -645,6 +699,22 @@ impl Paula {
     /// Snapshot of the CD-DA oscilloscope ring (oldest..newest).
     pub fn cd_scope_samples(&self) -> Vec<i8> {
         self.cd_scope.iter().copied().collect()
+    }
+
+    /// Snapshot of the in-process MIDI synth's oscilloscope ring
+    /// (oldest..newest).
+    pub fn synth_scope_samples(&self) -> Vec<i8> {
+        self.synth_scope.iter().copied().collect()
+    }
+
+    /// Snapshot of the Toccata board's oscilloscope ring (oldest..newest).
+    pub fn toccata_scope_samples(&self) -> Vec<i8> {
+        self.toccata_scope.iter().copied().collect()
+    }
+
+    /// Snapshot of the MHI board's oscilloscope ring (oldest..newest).
+    pub fn mhi_scope_samples(&self) -> Vec<i8> {
+        self.mhi_scope.iter().copied().collect()
     }
 
     pub fn set_dma_addr_mask(&mut self, mask: u32) {
@@ -1906,8 +1976,7 @@ impl Paula {
         // Record the pre-mute CD level for the debugger scope, then apply
         // the developer CD mute so the trace still shows activity while the
         // stream is silenced in the mix.
-        let cd_level = (((cd_left + cd_right) * 0.5).clamp(-1.0, 1.0) * 127.0) as i8;
-        scope_push(&mut self.cd_scope, cd_level);
+        scope_push(&mut self.cd_scope, scope_level(cd_left, cd_right));
         if self.cd_muted {
             cd_left = 0.0;
             cd_right = 0.0;
@@ -1919,33 +1988,52 @@ impl Paula {
         self.audio.push_source("cdda", cd_left, cd_right);
         // A MIDI device emulated in-process (an MT-32) is line-mixed the same
         // way, so the Amiga's own voices keep playing under it exactly as
-        // they would beside a real one on the desk.
+        // they would beside a real one on the desk. Scope pre-mute, stem and
+        // mix post-mute, exactly like CD-DA above.
         let mut synth_left = 0.0f32;
         let mut synth_right = 0.0f32;
         if !self.synth_silent {
             match self.serial.next_audio_frame() {
                 Some((sl, sr)) => {
-                    left += sl;
-                    right += sr;
                     synth_left = sl;
                     synth_right = sr;
                 }
                 None => self.synth_silent = true,
             }
         }
+        scope_push(&mut self.synth_scope, scope_level(synth_left, synth_right));
+        if self.synth_muted {
+            synth_left = 0.0;
+            synth_right = 0.0;
+        }
+        left += synth_left;
+        right += synth_right;
         self.audio
             .push_source(self.serial.synth_source_name(), synth_left, synth_right);
         // A Toccata board resamples its own codec-rate output to the mixer
         // rate before pushing here (see `Toccata::tick`), so this is a
         // plain per-frame pop like CD-DA, not a rate conversion.
-        let (toccata_left, toccata_right) = self.toccata_audio.next_sample();
+        let (mut toccata_left, mut toccata_right) = self.toccata_audio.next_sample();
+        scope_push(
+            &mut self.toccata_scope,
+            scope_level(toccata_left, toccata_right),
+        );
+        if self.toccata_muted {
+            toccata_left = 0.0;
+            toccata_right = 0.0;
+        }
         left += toccata_left;
         right += toccata_right;
         self.audio
             .push_source("toccata", toccata_left, toccata_right);
         // Likewise, an MHI board resamples its own decoded-MPEG-rate output
         // to the mixer rate before pushing here (see `Mhi::advance_mixer`).
-        let (mhi_left, mhi_right) = self.mhi_audio.next_sample();
+        let (mut mhi_left, mut mhi_right) = self.mhi_audio.next_sample();
+        scope_push(&mut self.mhi_scope, scope_level(mhi_left, mhi_right));
+        if self.mhi_muted {
+            mhi_left = 0.0;
+            mhi_right = 0.0;
+        }
         left += mhi_left;
         right += mhi_right;
         self.audio.push_source("mhi", mhi_left, mhi_right);
@@ -2955,6 +3043,100 @@ mod tests {
             "muted CD must be silent"
         );
         assert!(paula.cd_scope_samples().iter().any(|&s| s != 0));
+    }
+
+    #[test]
+    fn toccata_and_mhi_mutes_zero_contribution_but_scopes_keep_tracing() {
+        let (mut paula, frames) = paula_with_collect_sink();
+        paula.set_led_filter_guest(false);
+        let ram = vec![0u8; 64];
+        // No Paula channel audio, so the sink output is board-only. The
+        // boards' rings carry already-resampled mixer-rate frames.
+        let dmacon = DMACON_DMAEN;
+        for _ in 0..1024 {
+            paula.toccata_audio_mut().push_frame(0.25, 0.25);
+            paula.mhi_audio_mut().push_frame(-0.125, -0.125);
+        }
+        paula.tick_audio(4000, dmacon, &ram);
+        assert!(
+            frames
+                .borrow()
+                .iter()
+                .any(|&(l, r)| l.abs() > 1e-3 || r.abs() > 1e-3),
+            "board audio should reach the sink"
+        );
+        assert!(paula.toccata_scope_samples().iter().any(|&s| s != 0));
+        assert!(paula.mhi_scope_samples().iter().any(|&s| s != 0));
+
+        // Muted: both boards fall silent in the mix, but the scopes still
+        // record the pre-mute levels.
+        frames.borrow_mut().clear();
+        paula.toggle_toccata_muted();
+        paula.toggle_mhi_muted();
+        assert!(paula.toccata_muted());
+        assert!(paula.mhi_muted());
+        for _ in 0..1024 {
+            paula.toccata_audio_mut().push_frame(0.25, 0.25);
+            paula.mhi_audio_mut().push_frame(-0.125, -0.125);
+        }
+        paula.tick_audio(4000, dmacon, &ram);
+        assert!(
+            frames
+                .borrow()
+                .iter()
+                .all(|&(l, r)| l.abs() < 1e-6 && r.abs() < 1e-6),
+            "muted boards must be silent"
+        );
+        assert!(paula.toccata_scope_samples().iter().any(|&s| s != 0));
+        assert!(paula.mhi_scope_samples().iter().any(|&s| s != 0));
+    }
+
+    /// A serial sink standing in for an in-process synth: every mixer pull
+    /// answers with a constant non-zero frame.
+    struct ToneSynthSerial;
+
+    impl SerialSink for ToneSynthSerial {
+        fn write_byte(&mut self, _b: u8, _at_cck: u64) {}
+        fn flush(&mut self) {}
+        fn next_audio_frame(&mut self) -> Option<(f32, f32)> {
+            Some((0.2, 0.2))
+        }
+    }
+
+    #[test]
+    fn synth_mute_zeroes_contribution_but_scope_keeps_tracing() {
+        let frames = Rc::new(RefCell::new(Vec::new()));
+        let audio = CollectSink {
+            frames: Rc::clone(&frames),
+        };
+        let mut paula = Paula::new(Box::new(ToneSynthSerial), Box::new(audio));
+        paula.set_led_filter_guest(false);
+        let ram = vec![0u8; 64];
+        let dmacon = DMACON_DMAEN;
+        paula.tick_audio(4000, dmacon, &ram);
+        assert!(
+            frames
+                .borrow()
+                .iter()
+                .any(|&(l, r)| l.abs() > 1e-3 || r.abs() > 1e-3),
+            "synth audio should reach the sink"
+        );
+        assert!(paula.synth_scope_samples().iter().any(|&s| s != 0));
+
+        // Muted: the synth is silent in the mix, but the scope still
+        // records the pre-mute level.
+        frames.borrow_mut().clear();
+        paula.toggle_synth_muted();
+        assert!(paula.synth_muted());
+        paula.tick_audio(4000, dmacon, &ram);
+        assert!(
+            frames
+                .borrow()
+                .iter()
+                .all(|&(l, r)| l.abs() < 1e-6 && r.abs() < 1e-6),
+            "muted synth must be silent"
+        );
+        assert!(paula.synth_scope_samples().iter().any(|&s| s != 0));
     }
 
     #[test]

--- a/src/mhi.rs
+++ b/src/mhi.rs
@@ -762,6 +762,21 @@ impl ToneFilterBank {
     }
 }
 
+/// Snapshot of the board's state for the debugger's Audio tab: transport
+/// state, the current stream's native rate, the descriptor queue depth, and
+/// the audible param latches (0-100 each, pan/tone centred at 50).
+#[derive(Debug, Clone, Copy)]
+pub struct MhiDebug {
+    pub state: &'static str,
+    pub native_rate: u32,
+    pub queued: u32,
+    pub volume: u16,
+    pub panning: u16,
+    pub bass: u16,
+    pub mid: u16,
+    pub treble: u16,
+}
+
 /// The MHI board: `ZorroDevice` glue and register-window decode around
 /// [`Decoder`], plus the same two-cadence split as `Toccata` -- a causal
 /// native-rate producer (`advance_native`) that paces decode and
@@ -868,6 +883,25 @@ impl Mhi {
     /// `QUEUE_COUNT`: descriptors enqueued but not yet fully played out.
     fn queue_count(&self) -> u32 {
         self.desc_lengths.len() as u32 + self.current_frame.as_ref().map_or(0, |f| f.completes)
+    }
+
+    /// Board-state snapshot for the debugger's Audio tab.
+    pub fn debug_status(&self) -> MhiDebug {
+        MhiDebug {
+            state: match self.status {
+                Status::Stopped => "stopped",
+                Status::Playing => "playing",
+                Status::Paused => "paused",
+                Status::OutOfData => "out of data",
+            },
+            native_rate: self.native_rate,
+            queued: self.queue_count(),
+            volume: self.params[0],
+            panning: self.params[1],
+            bass: self.params[2],
+            mid: self.params[3],
+            treble: self.params[4],
+        }
     }
 
     fn merge_half(old: u16, off: u32, size: usize, value: u32) -> u16 {

--- a/src/toccata.rs
+++ b/src/toccata.rs
@@ -103,6 +103,19 @@ pub struct Toccata {
     resamplers: HashMap<u32, Resampler>,
 }
 
+/// Snapshot of the board's codec state for the debugger's Audio tab: the
+/// playback state, the format and rate latched at the last codec start, and
+/// the board FIFO's fill level.
+#[derive(Debug, Clone, Copy)]
+pub struct ToccataDebug {
+    pub playing: bool,
+    pub rate_hz: u32,
+    pub channels: usize,
+    pub sixteen_bit: bool,
+    pub fifo_len: usize,
+    pub fifo_capacity: usize,
+}
+
 impl Toccata {
     pub fn new() -> Self {
         Self {
@@ -111,6 +124,19 @@ impl Toccata {
             decoded: VecDeque::new(),
             mixer_acc: 0,
             resamplers: HashMap::new(),
+        }
+    }
+
+    /// Codec-state snapshot for the debugger's Audio tab.
+    pub fn debug_status(&self) -> ToccataDebug {
+        let (channels, sixteen_bit) = self.ad1848.active_format();
+        ToccataDebug {
+            playing: self.ad1848.play_active(),
+            rate_hz: self.ad1848.sample_rate_hz(),
+            channels,
+            sixteen_bit,
+            fifo_len: self.ad1848.fifo_len(),
+            fifo_capacity: self.ad1848.fifo_capacity(),
         }
     }
 

--- a/src/toccata/ad1848.rs
+++ b/src/toccata/ad1848.rs
@@ -285,6 +285,22 @@ impl Ad1848 {
         (l * self.left_volume, r * self.right_volume)
     }
 
+    /// Bytes currently buffered in the playback FIFO, for the debugger.
+    pub fn fifo_len(&self) -> usize {
+        self.fifo.len()
+    }
+
+    /// The playback FIFO's capacity in bytes, for the debugger.
+    pub fn fifo_capacity(&self) -> usize {
+        FIFO_CAPACITY
+    }
+
+    /// The format latched at the last codec start, as (channels, 16-bit?),
+    /// for the debugger.
+    pub fn active_format(&self) -> (usize, bool) {
+        (self.active_channels, self.active_sixteen_bit)
+    }
+
     // -----------------------------------------------------------------
     // Board control/status (base+0x0000)
     // -----------------------------------------------------------------

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -50,14 +50,24 @@ const FS_VARIANTS: [crate::diskimage::Variant; 3] = [
 const ENTRY_TEXT: u32 = rgba(27, 220, 71);
 const SCRIM: u32 = rgba(0, 0, 0);
 const SCRIM_ALPHA: f32 = 0.45;
-// Audio-tab oscilloscope trace colours (Paula ch0..3 then CD-DA).
-const AUDIO_SCOPE_COLORS: [u32; 5] = [
+// Audio-tab oscilloscope trace colours for the four Paula channels.
+const AUDIO_SCOPE_COLORS: [u32; 4] = [
     rgba(120, 255, 150), // ch0 green
     rgba(96, 200, 255),  // ch1 cyan
     rgba(230, 130, 245), // ch2 magenta
     rgba(240, 214, 96),  // ch3 yellow
-    rgba(255, 170, 90),  // CD amber
 ];
+
+/// Trace colour for a line-mixed source row (CD-DA, MIDI synth, Toccata,
+/// MHI).
+fn audio_extra_color(kind: AudioExtraKind) -> u32 {
+    match kind {
+        AudioExtraKind::Cd => rgba(255, 170, 90),       // amber
+        AudioExtraKind::Synth => rgba(160, 160, 255),   // lavender
+        AudioExtraKind::Toccata => rgba(120, 235, 235), // teal
+        AudioExtraKind::Mhi => rgba(255, 130, 150),     // coral
+    }
+}
 const AUDIO_MUTE_FACE: u32 = rgba(96, 44, 44);
 
 // ---------------------------------------------------------------------------
@@ -740,7 +750,9 @@ pub enum UiControl {
     DebugWaveArm,
     /// Waveform tab: stop the capture, finishing the file.
     DebugWaveStop,
-    /// Audio tab: toggle mute for a channel (0..3 = Paula, 4 = CD audio).
+    /// Audio tab: toggle mute for a row (0..3 = Paula channels, 4.. = the
+    /// line-mixed source rows in `AudioScopeView::extras` order, CD-DA
+    /// first).
     DebugAudioMute(usize),
     /// Frame analyzer: run/pause the machine while keeping the pane open.
     AnalyzerRun,
@@ -1284,22 +1296,33 @@ fn copper_tab_button_rects(rect: Rect) -> [(UiControl, Rect); 2] {
     ]
 }
 
-// Audio tab layout: a header line, four Paula channel blocks, then a CD row.
-// Each block has a mute button on the left, text detail in the middle, and an
-// oscilloscope box on the right.
+// Audio tab layout: a header line, four Paula channel blocks, then one
+// shorter row per line-mixed source (CD-DA always, MIDI synth / Toccata /
+// MHI while fitted). Each block has a mute button on the left, text detail
+// in the middle, and an oscilloscope box on the right.
 const AUDIO_HEADER_H: usize = 16;
 const AUDIO_ROW_H: usize = 46;
-const AUDIO_CD_ROW_H: usize = 30;
+const AUDIO_EXTRA_ROW_H: usize = 30;
 const AUDIO_MUTE_W: usize = 54;
 const AUDIO_TEXT_X: usize = 70;
 const AUDIO_SCOPE_X: usize = 470;
+/// The most rows the tab can hold: four Paula channels plus every
+/// line-mixed source (CD-DA, MIDI synth, Toccata, MHI).
+const AUDIO_MAX_ROWS: usize = 8;
 
 /// Geometry of one Audio-tab row: (mute button rect, scope box rect). `idx`
-/// 0..3 are the Paula channels, 4 is the CD-DA row.
+/// 0..3 are the Paula channels; 4.. are the line-mixed source rows in the
+/// order `AudioScopeView::extras` presents them (CD-DA first).
 fn audio_row_geom(rect: Rect, idx: usize) -> (Rect, Rect) {
-    let top = debug_content_top(rect) + AUDIO_HEADER_H + idx.min(4) * AUDIO_ROW_H;
+    let top = debug_content_top(rect)
+        + AUDIO_HEADER_H
+        + if idx < 4 {
+            idx * AUDIO_ROW_H
+        } else {
+            4 * AUDIO_ROW_H + (idx - 4) * AUDIO_EXTRA_ROW_H
+        };
     let row_h = if idx >= 4 {
-        AUDIO_CD_ROW_H
+        AUDIO_EXTRA_ROW_H
     } else {
         AUDIO_ROW_H
     };
@@ -1318,8 +1341,11 @@ fn audio_row_geom(rect: Rect, idx: usize) -> (Rect, Rect) {
     (mute, scope)
 }
 
-/// The five Audio-tab mute buttons (four Paula channels then CD).
-fn audio_tab_button_rects(rect: Rect) -> [(UiControl, Rect); 5] {
+/// The Audio-tab mute buttons: four Paula channels, then every possible
+/// line-mixed source slot. A slot with no row drawn in it still hit-tests
+/// (the geometry cannot see which sources are fitted); the click dispatcher
+/// rebuilds the fitted-source list and ignores clicks past its end.
+fn audio_tab_button_rects(rect: Rect) -> [(UiControl, Rect); AUDIO_MAX_ROWS] {
     std::array::from_fn(|i| (UiControl::DebugAudioMute(i), audio_row_geom(rect, i).0))
 }
 
@@ -1630,14 +1656,34 @@ pub struct DebuggerView {
     pub audio: Option<AudioScopeView>,
 }
 
-/// Per-channel and CD audio state for the debugger Audio tab.
+/// Per-channel and line-mixed-source state for the debugger Audio tab.
 pub struct AudioScopeView {
     /// Header line (DMACON / AUDEN / ADKCON summary).
     pub header: String,
     /// The four Paula channels, in order.
     pub channels: Vec<AudioRowView>,
-    /// The CD-DA row.
-    pub cd: AudioRowView,
+    /// The line-mixed source rows drawn under the channels, in order:
+    /// CD-DA first (always present), then one row per fitted source
+    /// (MIDI synth, Toccata, MHI). Row `4 + i` of the tab is `extras[i]`,
+    /// and the mute-click dispatcher maps clicks back through the same
+    /// order.
+    pub extras: Vec<AudioExtraRow>,
+}
+
+/// Which line-mixed source an extra Audio-tab row shows; picks the row's
+/// trace colour and the mute's OSD label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioExtraKind {
+    Cd,
+    Synth,
+    Toccata,
+    Mhi,
+}
+
+/// One line-mixed source row of the Audio tab.
+pub struct AudioExtraRow {
+    pub kind: AudioExtraKind,
+    pub row: AudioRowView,
 }
 
 /// One row of the Audio tab: text detail, mute state, and a scope trace.
@@ -3009,8 +3055,9 @@ fn draw_video_tab(
     }
 }
 
-/// Draw the Audio tab: a header line, four Paula channel blocks and a CD row,
-/// each with a mute button, text detail, and an output oscilloscope.
+/// Draw the Audio tab: a header line, four Paula channel blocks, and one
+/// row per line-mixed source, each with a mute button, text detail, and an
+/// output oscilloscope.
 fn draw_audio_tab(
     frame: &mut [u8],
     rect: Rect,
@@ -3028,14 +3075,24 @@ fn draw_audio_tab(
         1,
         scale,
     );
-    for idx in 0..5 {
+    // Channels occupy rows 0..3 and the line-mixed sources rows 4.. --
+    // fixed slots, so the extras stay where the mute hit-test expects them
+    // even if a channel row were ever absent.
+    let rows = audio
+        .channels
+        .iter()
+        .enumerate()
+        .take(4)
+        .map(|(idx, row)| (idx, row, AUDIO_SCOPE_COLORS[idx.min(3)]))
+        .chain(
+            audio
+                .extras
+                .iter()
+                .enumerate()
+                .map(|(i, extra)| (4 + i, &extra.row, audio_extra_color(extra.kind))),
+        );
+    for (idx, row, color) in rows.filter(|(idx, ..)| *idx < AUDIO_MAX_ROWS) {
         let (mute_rect, scope_rect) = audio_row_geom(rect, idx);
-        let row = if idx < 4 {
-            audio.channels.get(idx)
-        } else {
-            Some(&audio.cd)
-        };
-        let Some(row) = row else { continue };
         let control = UiControl::DebugAudioMute(idx);
         draw_mute_button(frame, mute_rect, row.muted, hover == Some(control), scale);
         // Text detail lines to the right of the mute button.
@@ -3055,7 +3112,6 @@ fn draw_audio_tab(
                 scale,
             );
         }
-        let color = AUDIO_SCOPE_COLORS[idx.min(4)];
         draw_audio_scope(frame, scope_rect, &row.scope, color, row.muted, scale);
     }
 }
@@ -10832,6 +10888,16 @@ mod tests {
             ui_audio.control_at(cd_pos),
             Some(UiControl::DebugAudioMute(4))
         );
+        // The line-mixed source slots continue below the CD row (last slot
+        // = AUDIO_MAX_ROWS - 1); the click dispatcher decides whether a
+        // fitted source actually occupies one.
+        let (last_control, last_mute) = audio_tab_button_rects(rect)[AUDIO_MAX_ROWS - 1];
+        assert_eq!(last_control, UiControl::DebugAudioMute(AUDIO_MAX_ROWS - 1));
+        let last_pos = (last_mute.x as i32 + 2, last_mute.y as i32 + 2);
+        assert_eq!(
+            ui_audio.control_at(last_pos),
+            Some(UiControl::DebugAudioMute(AUDIO_MAX_ROWS - 1))
+        );
         // On another tab that position does not resolve to a mute.
         assert_eq!(ui.control_at(pos), Some(UiControl::PanelBody));
 
@@ -11645,8 +11711,10 @@ mod tests {
         assert!(crate::waveform::parse_wave_args("PC=C033C2 2F".split_whitespace()).is_ok());
         save(&frame, "debugger-waveform");
 
-        // Audio tab: the four Paula channels plus CD, with representative
-        // state, mute buttons (AUD2 shown muted), and synthetic scope traces.
+        // Audio tab: the four Paula channels plus every line-mixed source
+        // row (CD, MIDI synth, Toccata, MHI), with representative state,
+        // mute buttons (AUD2 and MHI shown muted), and synthetic scope
+        // traces.
         let mut frame = vec![0u8; w * h * 4];
         let wave = |amp: f32, cycles: f32| -> Vec<i8> {
             (0..220)
@@ -11698,18 +11766,56 @@ mod tests {
                 scope: wave(48.0, 9.0),
             },
         ];
-        let cd = AudioRowView {
-            text: vec![
-                DbgLine::hilit("CD-DA  playing"),
-                DbgLine::plain("  peak  72"),
-            ],
-            muted: false,
-            scope: wave(72.0, 4.0),
-        };
+        let extras = vec![
+            AudioExtraRow {
+                kind: AudioExtraKind::Cd,
+                row: AudioRowView {
+                    text: vec![
+                        DbgLine::hilit("CD-DA  playing"),
+                        DbgLine::plain("  peak  72"),
+                    ],
+                    muted: false,
+                    scope: wave(72.0, 4.0),
+                },
+            },
+            AudioExtraRow {
+                kind: AudioExtraKind::Synth,
+                row: AudioRowView {
+                    text: vec![
+                        DbgLine::hilit("MIDI  MT-32  sounding"),
+                        DbgLine::plain("  peak  58"),
+                    ],
+                    muted: false,
+                    scope: wave(58.0, 5.0),
+                },
+            },
+            AudioExtraRow {
+                kind: AudioExtraKind::Toccata,
+                row: AudioRowView {
+                    text: vec![
+                        DbgLine::hilit("Toccata  playing"),
+                        DbgLine::plain("  44100 Hz 16-bit stereo  FIFO  612/1024"),
+                    ],
+                    muted: false,
+                    scope: wave(84.0, 7.0),
+                },
+            },
+            AudioExtraRow {
+                kind: AudioExtraKind::Mhi,
+                row: AudioRowView {
+                    text: vec![
+                        DbgLine::hilit("MHI  playing  44100 Hz"),
+                        DbgLine::plain("  queue 3  vol 100  pan 50  B/M/T 50/50/50"),
+                    ],
+                    muted: true,
+                    scope: wave(66.0, 11.0),
+                },
+            },
+        ];
         let audio = AudioScopeView {
             header,
             channels,
-            cd,
+            extras,
         };
         let data = PanelViewData::Debugger(Box::new(DebuggerView {
             running: false,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -7563,13 +7563,40 @@ impl App {
             (ToolPanelKind::Debugger, UiControl::DebugWaveArm) => self.debugger_wave_arm(),
             (ToolPanelKind::Debugger, UiControl::DebugWaveStop) => self.debugger_wave_stop(),
             (ToolPanelKind::Debugger, UiControl::DebugAudioMute(idx)) => {
-                let paula = &mut self.emu.bus_mut().paula;
                 let (label, muted) = if idx < 4 {
+                    let paula = &mut self.emu.bus_mut().paula;
                     paula.toggle_channel_muted(idx);
                     (format!("AUD{idx}"), paula.channel_muted(idx))
                 } else {
-                    paula.toggle_cd_muted();
-                    ("CD audio".to_string(), paula.cd_muted())
+                    // Rows past the channels are the line-mixed sources, in
+                    // the same order `audio_extra_kinds` builds the tab's
+                    // rows. A click on a slot no fitted source occupies is
+                    // dead space, not a hidden toggle.
+                    let Some(kind) = Self::audio_extra_kinds(self.emu.bus())
+                        .get(idx - 4)
+                        .copied()
+                    else {
+                        return;
+                    };
+                    let paula = &mut self.emu.bus_mut().paula;
+                    match kind {
+                        ui::AudioExtraKind::Cd => {
+                            paula.toggle_cd_muted();
+                            ("CD audio".to_string(), paula.cd_muted())
+                        }
+                        ui::AudioExtraKind::Synth => {
+                            paula.toggle_synth_muted();
+                            ("MIDI synth".to_string(), paula.synth_muted())
+                        }
+                        ui::AudioExtraKind::Toccata => {
+                            paula.toggle_toccata_muted();
+                            ("Toccata".to_string(), paula.toccata_muted())
+                        }
+                        ui::AudioExtraKind::Mhi => {
+                            paula.toggle_mhi_muted();
+                            ("MHI".to_string(), paula.mhi_muted())
+                        }
+                    }
                 };
                 self.show_osd(format!(
                     "{label} {}",
@@ -11627,6 +11654,62 @@ impl App {
         })
     }
 
+    /// The Audio tab's line-mixed source rows for this machine, in draw
+    /// order: CD-DA always, then one row per fitted source. The view
+    /// builder and the mute-click dispatcher both use this list, so a
+    /// click on row `4 + i` always lands on the source drawn there.
+    fn audio_extra_kinds(bus: &crate::bus::Bus) -> Vec<ui::AudioExtraKind> {
+        let mut kinds = vec![ui::AudioExtraKind::Cd];
+        #[cfg(feature = "midi")]
+        if bus.midi_serial().is_some_and(Self::midi_synth_fitted) {
+            kinds.push(ui::AudioExtraKind::Synth);
+        }
+        if bus.toccata_board().is_some() {
+            kinds.push(ui::AudioExtraKind::Toccata);
+        }
+        #[cfg(feature = "mhi")]
+        if bus.mhi_board().is_some() {
+            kinds.push(ui::AudioExtraKind::Mhi);
+        }
+        kinds
+    }
+
+    /// Whether the serial port's MIDI sink has an in-process synth fitted
+    /// (an MT-32 or the Coppersynth) -- the condition for the Audio tab's
+    /// synth row. A host MIDI endpoint sounds on the host, so there is
+    /// nothing for the mixer (or the row's scope) to show.
+    #[cfg(feature = "midi")]
+    fn midi_synth_fitted(midi: &crate::midi::MidiSerialSink) -> bool {
+        #[cfg(feature = "mt32")]
+        if midi.mt32().is_some() {
+            return true;
+        }
+        #[cfg(feature = "coppersynth")]
+        if midi.csynth().is_some() {
+            return true;
+        }
+        let _ = midi;
+        false
+    }
+
+    /// The fitted in-process synth's display name for the Audio tab row.
+    #[cfg(feature = "midi")]
+    fn midi_synth_label(midi: &crate::midi::MidiSerialSink) -> String {
+        #[cfg(feature = "mt32")]
+        if midi.mt32().is_some() {
+            return match midi.mt32_version() {
+                Some(version) => format!("MT-32 ({version})"),
+                None => "MT-32".to_string(),
+            };
+        }
+        #[cfg(feature = "coppersynth")]
+        if midi.csynth().is_some() {
+            return crate::midi::MIDI_OUT_CSYNTH_LABEL.to_string();
+        }
+        let _ = midi;
+        "synth".to_string()
+    }
+
     /// Snapshot the machine into the debugger panel's formatted lines.
     /// Everything reads through side-effect-free peeks, so inspecting
     /// state never perturbs the emulation.
@@ -12008,39 +12091,135 @@ impl App {
                         scope: bus.paula.audio_scope_samples(ch),
                     });
                 }
-                let cd_scope = bus.paula.cd_scope_samples();
-                let cd_active = cd_scope.iter().any(|&s| s != 0);
-                let cd_peak = cd_scope
-                    .iter()
-                    .map(|&s| (s as i16).abs())
-                    .max()
-                    .unwrap_or(0);
-                // A SCSI CD-ROM drive reports its play operation (state,
-                // track, position); the CDTV/CD32 controllers stream
-                // without one, so their row keeps the scope-derived state.
-                let cd_status = bus
-                    .scsi_cd_playback_line()
-                    .unwrap_or_else(|| if cd_active { "playing" } else { "idle" }.to_string());
-                let cd = ui::AudioRowView {
-                    text: vec![
-                        ui::DbgLine::hilit(format!("CD-DA  {cd_status}")),
-                        ui::DbgLine::plain(format!("  peak {cd_peak:>3}")),
-                    ],
-                    muted: bus.paula.cd_muted(),
-                    scope: cd_scope,
-                };
+                // One row per line-mixed source, in the same order the
+                // mute-click dispatcher maps clicks back through.
+                let mut extras: Vec<ui::AudioExtraRow> = Vec::new();
+                for kind in Self::audio_extra_kinds(bus) {
+                    let row = match kind {
+                        ui::AudioExtraKind::Cd => {
+                            let cd_scope = bus.paula.cd_scope_samples();
+                            let cd_active = cd_scope.iter().any(|&s| s != 0);
+                            let cd_peak = cd_scope
+                                .iter()
+                                .map(|&s| (s as i16).abs())
+                                .max()
+                                .unwrap_or(0);
+                            // A SCSI CD-ROM drive reports its play operation
+                            // (state, track, position); the CDTV/CD32
+                            // controllers stream without one, so their row
+                            // keeps the scope-derived state.
+                            let cd_status = bus.scsi_cd_playback_line().unwrap_or_else(|| {
+                                if cd_active { "playing" } else { "idle" }.to_string()
+                            });
+                            ui::AudioRowView {
+                                text: vec![
+                                    ui::DbgLine::hilit(format!("CD-DA  {cd_status}")),
+                                    ui::DbgLine::plain(format!("  peak {cd_peak:>3}")),
+                                ],
+                                muted: bus.paula.cd_muted(),
+                                scope: cd_scope,
+                            }
+                        }
+                        ui::AudioExtraKind::Synth => {
+                            #[cfg(feature = "midi")]
+                            {
+                                let scope = bus.paula.synth_scope_samples();
+                                let sounding = scope.iter().any(|&s| s != 0);
+                                let peak =
+                                    scope.iter().map(|&s| (s as i16).abs()).max().unwrap_or(0);
+                                let label = bus
+                                    .midi_serial()
+                                    .map(Self::midi_synth_label)
+                                    .unwrap_or_else(|| "synth".to_string());
+                                let head = format!(
+                                    "MIDI  {label}  {}",
+                                    if sounding { "sounding" } else { "idle" }
+                                );
+                                ui::AudioRowView {
+                                    text: vec![
+                                        if sounding {
+                                            ui::DbgLine::hilit(head)
+                                        } else {
+                                            ui::DbgLine::plain(head)
+                                        },
+                                        ui::DbgLine::plain(format!("  peak {peak:>3}")),
+                                    ],
+                                    muted: bus.paula.synth_muted(),
+                                    scope,
+                                }
+                            }
+                            #[cfg(not(feature = "midi"))]
+                            unreachable!("synth row is only offered with the midi feature")
+                        }
+                        ui::AudioExtraKind::Toccata => {
+                            let Some(board) = bus.toccata_board() else {
+                                continue;
+                            };
+                            let d = board.debug_status();
+                            let head =
+                                format!("Toccata  {}", if d.playing { "playing" } else { "idle" });
+                            ui::AudioRowView {
+                                text: vec![
+                                    if d.playing {
+                                        ui::DbgLine::hilit(head)
+                                    } else {
+                                        ui::DbgLine::plain(head)
+                                    },
+                                    ui::DbgLine::plain(format!(
+                                        "  {} Hz {} {}  FIFO {:>4}/{}",
+                                        d.rate_hz,
+                                        if d.sixteen_bit { "16-bit" } else { "8-bit" },
+                                        if d.channels == 2 { "stereo" } else { "mono" },
+                                        d.fifo_len,
+                                        d.fifo_capacity,
+                                    )),
+                                ],
+                                muted: bus.paula.toccata_muted(),
+                                scope: bus.paula.toccata_scope_samples(),
+                            }
+                        }
+                        ui::AudioExtraKind::Mhi => {
+                            #[cfg(feature = "mhi")]
+                            {
+                                let Some(board) = bus.mhi_board() else {
+                                    continue;
+                                };
+                                let d = board.debug_status();
+                                let head = format!("MHI  {}  {} Hz", d.state, d.native_rate);
+                                ui::AudioRowView {
+                                    text: vec![
+                                        if d.state == "playing" {
+                                            ui::DbgLine::hilit(head)
+                                        } else {
+                                            ui::DbgLine::plain(head)
+                                        },
+                                        ui::DbgLine::plain(format!(
+                                            "  queue {}  vol {}  pan {}  B/M/T {}/{}/{}",
+                                            d.queued, d.volume, d.panning, d.bass, d.mid, d.treble,
+                                        )),
+                                    ],
+                                    muted: bus.paula.mhi_muted(),
+                                    scope: bus.paula.mhi_scope_samples(),
+                                }
+                            }
+                            #[cfg(not(feature = "mhi"))]
+                            unreachable!("MHI row is only offered with the mhi feature")
+                        }
+                    };
+                    extras.push(ui::AudioExtraRow { kind, row });
+                }
                 // Mirror the text into `lines` for the headless/text fallback
                 // and the non-empty-view invariant; the tab itself is drawn
                 // graphically from the structured view.
                 lines.push(ui::DbgLine::hilit(header.clone()));
-                for row in channels.iter().chain(std::iter::once(&cd)) {
+                for row in channels.iter().chain(extras.iter().map(|extra| &extra.row)) {
                     lines.push(ui::DbgLine::plain(""));
                     lines.extend(row.text.iter().cloned());
                 }
                 audio = Some(ui::AudioScopeView {
                     header,
                     channels,
-                    cd,
+                    extras,
                 });
             }
             ui::DebugTab::Memory => {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4687,13 +4687,9 @@ fn audio_tab_lists_and_mutes_fitted_board_rows() {
     // Fit a Toccata and (feature permitting) an MHI board; the Audio tab
     // grows one row per board, in CD -> Toccata -> MHI order, and the
     // mute clicks map through the same order.
-    let mut devices = vec![crate::zorro_device::BoardDevice::Toccata(Box::new(
-        crate::toccata::Toccata::new(),
-    ))];
+    let mut devices = vec![crate::zorro_device::BoardDevice::Toccata(Box::default())];
     #[cfg(feature = "mhi")]
-    devices.push(crate::zorro_device::BoardDevice::Mhi(Box::new(
-        crate::mhi::Mhi::new(),
-    )));
+    devices.push(crate::zorro_device::BoardDevice::Mhi(Box::default()));
     app.emu.bus_mut().attach_devices(devices);
     app.open_debugger();
     if let Some(panel) = app.debugger_panel.as_mut() {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4582,12 +4582,16 @@ fn debugger_views_reflect_machine_state() {
                 assert!(view.lines.iter().any(|l| l.text.starts_with("AUD0")));
                 assert!(view.lines.iter().any(|l| l.text.starts_with("AUD3")));
                 // The structured view drives the graphical layout: four
-                // Paula channels plus a CD row.
+                // Paula channels plus the line-mixed source rows. The
+                // test machine has no synth, Toccata, or MHI fitted, so
+                // CD-DA is the only extra row.
                 let audio = view.audio.as_ref().expect("audio scope view");
                 assert!(audio.header.starts_with("DMACON"));
                 assert_eq!(audio.channels.len(), 4);
                 assert!(audio.channels[0].text[0].text.starts_with("AUD0"));
-                assert!(audio.cd.text[0].text.contains("CD-DA"));
+                assert_eq!(audio.extras.len(), 1);
+                assert_eq!(audio.extras[0].kind, super::ui::AudioExtraKind::Cd);
+                assert!(audio.extras[0].row.text[0].text.contains("CD-DA"));
             }
             super::ui::DebugTab::Memory => {
                 // The hex dump shows the NOP sled at the PC's ROM page.
@@ -4665,10 +4669,61 @@ fn audio_tab_mute_buttons_toggle_paula_mutes() {
     assert!(app.emu.bus().paula.channel_muted(1));
     app.activate_ui_control(super::ui::UiControl::DebugAudioMute(1));
     assert!(!app.emu.bus().paula.channel_muted(1));
-    // Index 4 is the CD-DA mute.
+    // Index 4 is the CD-DA mute (the first line-mixed source row).
     assert!(!app.emu.bus().paula.cd_muted());
     app.activate_ui_control(super::ui::UiControl::DebugAudioMute(4));
     assert!(app.emu.bus().paula.cd_muted());
+    // With no synth, Toccata, or MHI fitted there is no row 5: the click
+    // lands on dead space and toggles nothing.
+    app.activate_ui_control(super::ui::UiControl::DebugAudioMute(5));
+    assert!(!app.emu.bus().paula.synth_muted());
+    assert!(!app.emu.bus().paula.toccata_muted());
+    assert!(!app.emu.bus().paula.mhi_muted());
+}
+
+#[test]
+fn audio_tab_lists_and_mutes_fitted_board_rows() {
+    let mut app = test_app();
+    // Fit a Toccata and (feature permitting) an MHI board; the Audio tab
+    // grows one row per board, in CD -> Toccata -> MHI order, and the
+    // mute clicks map through the same order.
+    let mut devices = vec![crate::zorro_device::BoardDevice::Toccata(Box::new(
+        crate::toccata::Toccata::new(),
+    ))];
+    #[cfg(feature = "mhi")]
+    devices.push(crate::zorro_device::BoardDevice::Mhi(Box::new(
+        crate::mhi::Mhi::new(),
+    )));
+    app.emu.bus_mut().attach_devices(devices);
+    app.open_debugger();
+    if let Some(panel) = app.debugger_panel.as_mut() {
+        panel.tab = super::ui::DebugTab::Audio;
+    }
+    if let Some(panel) = app.debugger_panel.as_ref() {
+        let view = app.build_debugger_view(panel);
+        let audio = view.audio.as_ref().expect("audio scope view");
+        assert_eq!(audio.extras[0].kind, super::ui::AudioExtraKind::Cd);
+        assert_eq!(audio.extras[1].kind, super::ui::AudioExtraKind::Toccata);
+        assert!(audio.extras[1].row.text[0].text.contains("Toccata"));
+        assert!(audio.extras[1].row.text[1].text.contains("FIFO"));
+        #[cfg(feature = "mhi")]
+        {
+            assert_eq!(audio.extras[2].kind, super::ui::AudioExtraKind::Mhi);
+            assert!(audio.extras[2].row.text[0].text.contains("MHI"));
+            assert!(audio.extras[2].row.text[0].text.contains("stopped"));
+        }
+    }
+    // Row 5 is the Toccata row here.
+    assert!(!app.emu.bus().paula.toccata_muted());
+    app.activate_ui_control(super::ui::UiControl::DebugAudioMute(5));
+    assert!(app.emu.bus().paula.toccata_muted());
+    assert!(!app.emu.bus().paula.cd_muted());
+    #[cfg(feature = "mhi")]
+    {
+        assert!(!app.emu.bus().paula.mhi_muted());
+        app.activate_ui_control(super::ui::UiControl::DebugAudioMute(6));
+        assert!(app.emu.bus().paula.mhi_muted());
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The debugger's Audio tab now shows one row per line-mixed audio source under the four Paula channels, each with a status line, a developer **Mute** button, and an output oscilloscope:

- **CD-DA** - unchanged, always present.
- **MIDI** - the in-process synth on the serial port, shown only while one is fitted. Names the device (emulated MT-32 with its control-ROM version, or the Coppersynth) plus a sounding/idle state and the trace's peak level. A host MIDI endpoint gets no row: it sounds on the host, outside the mixer.
- **Toccata** - what an AHI driver plays through the board: playback state, the latched sample rate and format, and the board FIFO's fill level.
- **MHI** - transport state (stopped/playing/paused/out of data), the stream's native sample rate, descriptor queue depth, and the volume/pan/bass/mid/treble param latches.

## Implementation

- Paula taps each source's pre-mute stereo level into a scope ring in `push_mixed_frame` and gates its mix/stem contribution behind a new developer mute - the same pattern as the existing CD-DA row. Taps and mutes are `serde(skip)` debug state, so save states are unaffected and there is no `STATE_VERSION` bump.
- `Toccata::debug_status()` / `Mhi::debug_status()` snapshot board state through side-effect-free peeks; `Bus::toccata_board()` / `mhi_board()` find the fitted boards.
- The extra rows pack dynamically under the channels. The view builder and the mute-click dispatcher share one fitted-source list (`audio_extra_kinds`), so a click on row 4+i always lands on the source drawn there; clicks on unoccupied slots are ignored rather than toggling hidden state.
- `docs/debugger/window.md`'s Audio-tab section documents the new rows.

## Testing

- New Paula unit tests: mute gates zero each source's mix contribution while its pre-mute scope keeps tracing (Toccata + MHI rings, and a stub serial synth).
- New window test fits real Toccata/MHI boards, checks the view's row list and drives the row-5/row-6 mutes through the full click-dispatch path; the no-boards case checks the dead-slot click is ignored.
- Extended the ui hit-test coverage to the new slots and the `COPPERLINE_UI_PREVIEW` fixture to render all four source rows; layout verified against the rendered preview (all 8 rows fit the panel).
- `cargo test` (2728 passed), `cargo clippy`, `cargo fmt --check` all clean; feature permutations without `mhi` and without `mt32`/`coppersynth` compile.