### PR TITLE
Feature/Coppersynth MIDI CC compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "coppersynth"
 version = "0.9.2"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=6db5f9d35671b5ac08bf8c6aca44864761915f3f#6db5f9d35671b5ac08bf8c6aca44864761915f3f"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=7e489dc295029e8f10b074d85d016cc0fc96d361#7e489dc295029e8f10b074d85d016cc0fc96d361"
 dependencies = [
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "coppersynth"
 version = "0.9.1"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=6802725790eaf1ba4d2b0e69ff5ab292b3d1f48c#6802725790eaf1ba4d2b0e69ff5ab292b3d1f48c"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=ddfb6d122af3d64e5fd9422a496381db824dab74#ddfb6d122af3d64e5fd9422a496381db824dab74"
 dependencies = [
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "coppersynth"
 version = "0.9.1"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=a273b6245835125f7728afe505fe3f32f7ec2063#a273b6245835125f7728afe505fe3f32f7ec2063"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=6802725790eaf1ba4d2b0e69ff5ab292b3d1f48c#6802725790eaf1ba4d2b0e69ff5ab292b3d1f48c"
 dependencies = [
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "coppersynth"
 version = "0.9.1"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=ddfb6d122af3d64e5fd9422a496381db824dab74#ddfb6d122af3d64e5fd9422a496381db824dab74"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=1c05350d37f321e975f486e751945117fa0d4c44#1c05350d37f321e975f486e751945117fa0d4c44"
 dependencies = [
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,8 +601,8 @@ dependencies = [
 
 [[package]]
 name = "coppersynth"
-version = "0.9.1"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=1c05350d37f321e975f486e751945117fa0d4c44#1c05350d37f321e975f486e751945117fa0d4c44"
+version = "0.9.2"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=6db5f9d35671b5ac08bf8c6aca44864761915f3f#6db5f9d35671b5ac08bf8c6aca44864761915f3f"
 dependencies = [
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "coppersynth"
 version = "0.9.1"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=c112ca84eb962ff482a52eb46113c3765092caa6#c112ca84eb962ff482a52eb46113c3765092caa6"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=a273b6245835125f7728afe505fe3f32f7ec2063#a273b6245835125f7728afe505fe3f32f7ec2063"
 dependencies = [
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "6802725790eaf1ba4d2b0e69ff5ab292b3d1f48c", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "ddfb6d122af3d64e5fd9422a496381db824dab74", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "6db5f9d35671b5ac08bf8c6aca44864761915f3f", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "7e489dc295029e8f10b074d85d016cc0fc96d361", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "1c05350d37f321e975f486e751945117fa0d4c44", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "6db5f9d35671b5ac08bf8c6aca44864761915f3f", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "ddfb6d122af3d64e5fd9422a496381db824dab74", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "1c05350d37f321e975f486e751945117fa0d4c44", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "c112ca84eb962ff482a52eb46113c3765092caa6", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "a273b6245835125f7728afe505fe3f32f7ec2063", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "a273b6245835125f7728afe505fe3f32f7ec2063", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "6802725790eaf1ba4d2b0e69ff5ab292b3d1f48c", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/docs/guide/coppersynth.md
+++ b/docs/guide/coppersynth.md
@@ -98,37 +98,17 @@ monitor (solo) the shown part.
 ### Button combinations
 
 Coppersynth front panel has various features accessed with multi-button
-combinations. The POWER combinations require the unit to first be powered
-off; the others work on a running unit.
+combinations. Other than "Solo", these all require the unit to first be powered off.
 
-**Right click to hold/latch.** A held ALL or MUTE flashes to say it is
-standing in; holding one while the other is held releases both.
+**Right click to hold/latch.**
 
 | Combination | Reaches |
 |---|---|
-| ALL (held) + MUTE | Solo the selected PART. MUTE again immediately un-soloes and lets ALL go; any other press keeps the solo and releases ALL |
-| MUTE + MIDI CH < or > | Device ID (1-32, default 17). MIDI CH buttons change it, ALL confirms, MUTE cancels |
-| MUTE + CHORUS < or > | Chorus Type (0-8: Off, Chorus 1-3, Celeste 1-2, Flanger, Feedback Chorus, Short Delay). CHORUS buttons change it and each sounds as selected, ALL confirms, MUTE cancels |
-| MUTE + INSTRUMENT < or > | Part parameters (portamento time and switch, sostenuto, soft, vibrato rate/depth/delay, cutoff, resonance, envelope attack/decay/release). INSTRUMENT buttons browse, LEVEL buttons set 0-127 sounding live, PART buttons change part, ALL keeps, MUTE restores |
+| ALL + MUTE | Solo the selected PART. Same combo to disable solo |
 | INSTRUMENT < + POWER | MT-32 Mode. MUTE disables, ALL enables |
 | INSTRUMENT > + POWER  | Load the default SoundFont. MUTE cancels, ALL confirms  |
 | PART < + PART > + POWER | Demo sequences. press ALL to play, MUTE to stop, PART buttons to skip song. 
 | Both INSTRUMENT buttons + both MIDI CH buttons | Show version info + credits
-
-## MIDI implementation
-
-Coppersynth receives the SC-55mkII's controller set: bank select
-(MSB, latched until the program change), modulation, portamento time
-and switch, data entry, volume, pan, expression, hold, sostenuto,
-soft, portamento control (glide without re-trigger), reverb and
-chorus sends, RPNs (bend range, fine and coarse tune), the GS NRPNs
-(vibrato rate/depth/delay, cutoff, resonance, envelope
-attack/decay/release, and the drum set's per-note pitch, level, pan
-and effect sends), all-sound-off, reset-all-controllers (to the
-unit's own default table), all-notes-off, and the channel mode
-messages (omni as all-notes-off, mono, poly). Channel and polyphonic
-pressure are received and offered to the bank's modulators, routed
-nowhere by default -- as on the hardware.
 
 ## Building without it
 

--- a/docs/guide/coppersynth.md
+++ b/docs/guide/coppersynth.md
@@ -101,11 +101,12 @@ Coppersynth front panel has various features accessed with multi-button
 combinations. The POWER combinations require the unit to first be powered
 off; the others work on a running unit.
 
-**Right click to hold/latch.**
+**Right click to hold/latch.** A held ALL or MUTE flashes to say it is
+standing in; holding one while the other is held releases both.
 
 | Combination | Reaches |
 |---|---|
-| ALL + MUTE | Solo the selected PART. Same combo to disable solo |
+| ALL (held) + MUTE | Solo the selected PART. MUTE again immediately un-soloes and lets ALL go; any other press keeps the solo and releases ALL |
 | MUTE + MIDI CH < or > | Device ID (1-32, default 17). MIDI CH buttons change it, ALL confirms, MUTE cancels |
 | MUTE + CHORUS < or > | Chorus Type (0-8: Off, Chorus 1-3, Celeste 1-2, Flanger, Feedback Chorus, Short Delay). CHORUS buttons change it and each sounds as selected, ALL confirms, MUTE cancels |
 | MUTE + INSTRUMENT < or > | Part parameters (portamento time and switch, sostenuto, soft, vibrato rate/depth/delay, cutoff, resonance, envelope attack/decay/release). INSTRUMENT buttons browse, LEVEL buttons set 0-127 sounding live, PART buttons change part, ALL keeps, MUTE restores |

--- a/docs/guide/coppersynth.md
+++ b/docs/guide/coppersynth.md
@@ -98,13 +98,16 @@ monitor (solo) the shown part.
 ### Button combinations
 
 Coppersynth front panel has various features accessed with multi-button
-combinations. Other than "Solo", these all require the unit to first be powered off.
+combinations. The POWER combinations require the unit to first be powered
+off; the others work on a running unit.
 
 **Right click to hold/latch.**
 
 | Combination | Reaches |
 |---|---|
 | ALL + MUTE | Solo the selected PART. Same combo to disable solo |
+| MUTE + MIDI CH < or > | Device ID (1-32, default 17). MIDI CH buttons change it, ALL confirms, MUTE cancels |
+| MUTE + CHORUS < or > | Chorus Type (0-8: Off, Chorus 1-3, Celeste 1-2, Flanger, Feedback Chorus, Short Delay). CHORUS buttons change it, ALL confirms, MUTE cancels |
 | INSTRUMENT < + POWER | MT-32 Mode. MUTE disables, ALL enables |
 | INSTRUMENT > + POWER  | Load the default SoundFont. MUTE cancels, ALL confirms  |
 | PART < + PART > + POWER | Demo sequences. press ALL to play, MUTE to stop, PART buttons to skip song. 

--- a/docs/guide/coppersynth.md
+++ b/docs/guide/coppersynth.md
@@ -107,11 +107,27 @@ off; the others work on a running unit.
 |---|---|
 | ALL + MUTE | Solo the selected PART. Same combo to disable solo |
 | MUTE + MIDI CH < or > | Device ID (1-32, default 17). MIDI CH buttons change it, ALL confirms, MUTE cancels |
-| MUTE + CHORUS < or > | Chorus Type (0-8: Off, Chorus 1-3, Celeste 1-2, Flanger, Feedback Chorus, Short Delay). CHORUS buttons change it, ALL confirms, MUTE cancels |
+| MUTE + CHORUS < or > | Chorus Type (0-8: Off, Chorus 1-3, Celeste 1-2, Flanger, Feedback Chorus, Short Delay). CHORUS buttons change it and each sounds as selected, ALL confirms, MUTE cancels |
+| MUTE + INSTRUMENT < or > | Part parameters (portamento time and switch, sostenuto, soft, vibrato rate/depth/delay, cutoff, resonance, envelope attack/decay/release). INSTRUMENT buttons browse, LEVEL buttons set 0-127 sounding live, PART buttons change part, ALL keeps, MUTE restores |
 | INSTRUMENT < + POWER | MT-32 Mode. MUTE disables, ALL enables |
 | INSTRUMENT > + POWER  | Load the default SoundFont. MUTE cancels, ALL confirms  |
 | PART < + PART > + POWER | Demo sequences. press ALL to play, MUTE to stop, PART buttons to skip song. 
 | Both INSTRUMENT buttons + both MIDI CH buttons | Show version info + credits
+
+## MIDI implementation
+
+Coppersynth receives the SC-55mkII's controller set: bank select
+(MSB, latched until the program change), modulation, portamento time
+and switch, data entry, volume, pan, expression, hold, sostenuto,
+soft, portamento control (glide without re-trigger), reverb and
+chorus sends, RPNs (bend range, fine and coarse tune), the GS NRPNs
+(vibrato rate/depth/delay, cutoff, resonance, envelope
+attack/decay/release, and the drum set's per-note pitch, level, pan
+and effect sends), all-sound-off, reset-all-controllers (to the
+unit's own default table), all-notes-off, and the channel mode
+messages (omni as all-notes-off, mono, poly). Channel and polyphonic
+pressure are received and offered to the bank's modulators, routed
+nowhere by default -- as on the hardware.
 
 ## Building without it
 

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -2,8 +2,8 @@
     {
         "type": "git",
         "url": "https://github.com/copperlinehq/coppersynth",
-        "commit": "6db5f9d35671b5ac08bf8c6aca44864761915f3f",
-        "dest": "flatpak-cargo/git/coppersynth-6db5f9d"
+        "commit": "7e489dc295029e8f10b074d85d016cc0fc96d361",
+        "dest": "flatpak-cargo/git/coppersynth-7e489dc"
     },
     {
         "type": "git",
@@ -826,7 +826,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-6db5f9d/.\" \"cargo/vendor/coppersynth\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-7e489dc/.\" \"cargo/vendor/coppersynth\""
         ]
     },
     {
@@ -6989,7 +6989,7 @@
     },
     {
         "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"6db5f9d35671b5ac08bf8c6aca44864761915f3f\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"7e489dc295029e8f10b074d85d016cc0fc96d361\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -2,8 +2,8 @@
     {
         "type": "git",
         "url": "https://github.com/copperlinehq/coppersynth",
-        "commit": "c112ca84eb962ff482a52eb46113c3765092caa6",
-        "dest": "flatpak-cargo/git/coppersynth-c112ca8"
+        "commit": "1c05350d37f321e975f486e751945117fa0d4c44",
+        "dest": "flatpak-cargo/git/coppersynth-1c05350"
     },
     {
         "type": "git",
@@ -826,7 +826,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-c112ca8/.\" \"cargo/vendor/coppersynth\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-1c05350/.\" \"cargo/vendor/coppersynth\""
         ]
     },
     {
@@ -6989,7 +6989,7 @@
     },
     {
         "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"c112ca84eb962ff482a52eb46113c3765092caa6\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"1c05350d37f321e975f486e751945117fa0d4c44\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -2,8 +2,8 @@
     {
         "type": "git",
         "url": "https://github.com/copperlinehq/coppersynth",
-        "commit": "1c05350d37f321e975f486e751945117fa0d4c44",
-        "dest": "flatpak-cargo/git/coppersynth-1c05350"
+        "commit": "6db5f9d35671b5ac08bf8c6aca44864761915f3f",
+        "dest": "flatpak-cargo/git/coppersynth-6db5f9d"
     },
     {
         "type": "git",
@@ -826,12 +826,12 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-1c05350/.\" \"cargo/vendor/coppersynth\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-6db5f9d/.\" \"cargo/vendor/coppersynth\""
         ]
     },
     {
         "type": "inline",
-        "contents": "[package]\nname = \"coppersynth\"\nversion = \"0.9.1\"\nauthors = [\"Lee Hobson\"]\nedition = \"2021\"\nlicense = \"MIT\"\ndescription = \"Copperline's General MIDI sound module: a Sound Canvas-flavoured SoundFont synth with an MT-32 translation layer and front panel model\"\nrepository = \"https://github.com/CopperlineHQ/Coppersynth\"\npublish = false\n\n[dependencies.zip]\nversion = \"8\"\ndefault-features = false\nfeatures = [\"deflate\"]\n\n[build-dependencies]\nzip = \"8\"\n",
+        "contents": "[package]\nname = \"coppersynth\"\nversion = \"0.9.2\"\nauthors = [\"Lee Hobson\"]\nedition = \"2021\"\nlicense = \"MIT\"\ndescription = \"Copperline's General MIDI sound module: a Sound Canvas-flavoured SoundFont synth with an MT-32 translation layer and front panel model\"\nrepository = \"https://github.com/CopperlineHQ/Coppersynth\"\npublish = false\n\n[dependencies.zip]\nversion = \"8\"\ndefault-features = false\nfeatures = [\"deflate\"]\n\n[build-dependencies]\nzip = \"8\"\n",
         "dest": "cargo/vendor/coppersynth",
         "dest-filename": "Cargo.toml"
     },
@@ -6989,7 +6989,7 @@
     },
     {
         "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"1c05350d37f321e975f486e751945117fa0d4c44\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"6db5f9d35671b5ac08bf8c6aca44864761915f3f\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/src/csynth/mod.rs
+++ b/src/csynth/mod.rs
@@ -255,6 +255,12 @@ impl CsynthDevice {
         self.panel.power_on_held(held);
     }
 
+    /// Whether the fascia is inside an edit or confirm screen, for the
+    /// window to hold its latching gestures back.
+    pub fn panel_in_edit(&self) -> bool {
+        self.panel.in_edit()
+    }
+
     /// Open this freshly attached panel on the Initializing... hold:
     /// the unit was rebuilt mid-reset, and the hold serves its second
     /// before the ordinary boot, as if the panel had survived.

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -853,7 +853,6 @@ fn serial_rows(s: &MenuState) -> Vec<MenuRow> {
         rows.push(MenuRow::submenu(
             CSYNTH_LABEL,
             vec![
-                MenuRow::submenu("MT-32 Mode", modes),
                 MenuRow::toggle("Front Panel", MenuAction::ToggleCsynthPanel, s.csynth_panel),
                 MenuRow::submenu(
                     "SoundFont",
@@ -864,6 +863,7 @@ fn serial_rows(s: &MenuState) -> Vec<MenuRow> {
                             .available(s.csynth_custom_font),
                     ],
                 ),
+                MenuRow::submenu("MT-32 Mode", modes),
             ],
         ));
     }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6747,6 +6747,7 @@ impl App {
             .zip(csynthpanel::shown_panel_rect(csynth_panel_top()))
             .and_then(|(pos, panel)| csynthpanel::hover_at(panel, pos));
         let down = self.csynth_panel.down();
+        let latched = self.csynth_panel.latched();
         let stored_volume = self.csynth_volume;
         let sink = self.emu.bus_mut().midi_serial_mut()?;
         if !sink.csynth_selected() {
@@ -6768,6 +6769,7 @@ impl App {
             blink_on: (now_ms / 300).is_multiple_of(2),
             volume,
             down,
+            latched,
             hover,
         })
     }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6442,6 +6442,19 @@ impl App {
             self.request_redraw();
             return;
         }
+        // While an edit or confirm screen owns the glass, latching
+        // gestures stand back -- a right-click means nothing there, and
+        // the flashing lamps keep their one meaning.
+        if !left
+            && self
+                .emu
+                .bus_mut()
+                .midi_serial_mut()
+                .and_then(crate::midi::MidiSerialSink::csynth_mut)
+                .is_some_and(|synth| synth.panel_in_edit())
+        {
+            return;
+        }
         let press = self.csynth_panel.press(control, left, powered);
         self.apply_csynth_press(press);
         self.request_redraw();

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6734,13 +6734,9 @@ impl App {
         let powered = sink.csynth().is_some();
         // Switched off, the fascia is still there: dark glass, and the
         // knob standing where the hand left it.
-        let (screen, monitoring, volume) = match sink.csynth_mut() {
-            Some(synth) => (
-                synth.panel_screen(now_ms),
-                synth.panel_monitoring(),
-                synth.panel_volume_value(),
-            ),
-            None => (csynthpanel::dark_screen(), false, stored_volume),
+        let (screen, volume) = match sink.csynth_mut() {
+            Some(synth) => (synth.panel_screen(now_ms), synth.panel_volume_value()),
+            None => (csynthpanel::dark_screen(), stored_volume),
         };
         if powered {
             self.csynth_volume = volume;
@@ -6748,7 +6744,6 @@ impl App {
         Some(csynthpanel::CsynthPanelView {
             screen,
             powered,
-            mute_blinks: monitoring,
             blink_on: (now_ms / 300).is_multiple_of(2),
             volume,
             down,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6669,6 +6669,14 @@ impl App {
         }
         let now_ms = self.csynth_panel_epoch.elapsed().as_millis() as u64;
         let blink_on = (now_ms / 300).is_multiple_of(2);
+        // A latched ALL or MUTE flashes its lens, so the blink phase is
+        // part of what is on screen and must break the redraw cache.
+        let round_latched = self.csynth_panel.down().iter().any(|c| {
+            matches!(
+                c,
+                csynthpanel::CsynthControl::All | csynthpanel::CsynthControl::Mute
+            )
+        });
         let Some(sink) = self.emu.bus_mut().midi_serial_mut() else {
             return;
         };
@@ -6679,7 +6687,7 @@ impl App {
             Some(synth) => (
                 Some(synth.panel_screen(now_ms)),
                 true,
-                synth.panel_monitoring() && blink_on,
+                round_latched && blink_on,
             ),
             None => (None, false, false),
         };

--- a/src/video/window/csynthpanel.rs
+++ b/src/video/window/csynthpanel.rs
@@ -1165,10 +1165,6 @@ pub struct CsynthPanel {
     holding: Vec<CsynthControl>,
     /// The button a plain click is lighting until the mouse comes up.
     flash: Option<CsynthControl>,
-    /// The solo gesture just fired and ALL still stands: an immediate
-    /// second MUTE un-soloes and lets ALL go; any other press lets ALL
-    /// go and leaves the solo standing.
-    solo_armed: bool,
     dial: Option<DialGrab>,
     hold: Option<ArrowHold>,
 }
@@ -1215,7 +1211,6 @@ impl CsynthPanel {
         // Right-clicking latches a button down; that is how two-button
         // gestures are made with one pointer.
         if !left {
-            self.solo_armed = false;
             // ALL and MUTE never stand together: latching the second
             // lets them both go.
             let is_round = |c: CsynthControl| matches!(c, CsynthControl::All | CsynthControl::Mute);
@@ -1245,30 +1240,7 @@ impl CsynthPanel {
             return CsynthPress::None;
         }
         self.flash = Some(control);
-        // The solo gesture's aftermath: with ALL still standing, an
-        // immediate second MUTE un-soloes and lets ALL go; anything
-        // else lets ALL go quietly and the press means itself alone.
-        if self.solo_armed {
-            self.solo_armed = false;
-            self.holding.clear();
-            if control == CsynthControl::Mute && powered {
-                return CsynthPress::Button(Button::Monitor);
-            }
-            let button = resolve(control, &[]);
-            return if powered {
-                CsynthPress::Button(button)
-            } else {
-                CsynthPress::None
-            };
-        }
         let latched = std::mem::take(&mut self.holding);
-        // ALL latched under a MUTE click is the solo: ALL keeps
-        // standing so a second MUTE can take it straight back.
-        if control == CsynthControl::Mute && latched == [CsynthControl::All] && powered {
-            self.holding = latched;
-            self.solo_armed = true;
-            return CsynthPress::Button(Button::Monitor);
-        }
         let button = resolve(control, &latched);
         if powered {
             // A plain arrow held down repeats, gathering speed.
@@ -1637,35 +1609,16 @@ mod tests {
             CsynthPress::None
         );
         assert!(panel.down().is_empty(), "both rounds released");
-        // The solo: latch ALL, CLICK MUTE. ALL keeps standing so an
-        // immediate second MUTE takes it straight back and lets go.
+        // The solo: latch ALL, CLICK MUTE -- one Monitor press, the
+        // latch spent. The unit itself stands a solo down on whatever
+        // press comes next.
         panel.press(CsynthControl::All, false, true);
         assert_eq!(
             panel.press(CsynthControl::Mute, true, true),
             CsynthPress::Button(Button::Monitor)
         );
         panel.release_press();
-        assert!(
-            panel.down().contains(&CsynthControl::All),
-            "ALL stands through the solo"
-        );
-        assert_eq!(
-            panel.press(CsynthControl::Mute, true, true),
-            CsynthPress::Button(Button::Monitor)
-        );
-        panel.release_press();
-        assert!(panel.down().is_empty(), "the second MUTE lets ALL go");
-        // Armed again, any other press lets ALL go quietly, means
-        // itself alone, and the solo stays standing.
-        panel.press(CsynthControl::All, false, true);
-        panel.press(CsynthControl::Mute, true, true);
-        panel.release_press();
-        assert_eq!(
-            panel.press(CsynthControl::Arrow(Pair::Part, Dir::Right), true, true),
-            CsynthPress::Button(Button::Arrow(Pair::Part, Dir::Right))
-        );
-        panel.release_press();
-        assert!(panel.down().is_empty(), "ALL released on the way out");
+        assert!(panel.down().is_empty(), "the gesture spends the latch");
         // Both INSTRUMENT halves latched through a power-on arrive as
         // the pair held whole.
         panel.press(

--- a/src/video/window/csynthpanel.rs
+++ b/src/video/window/csynthpanel.rs
@@ -122,6 +122,9 @@ pub struct CsynthPanelView {
     pub volume: f32,
     /// Buttons standing in: latched down, or lit under a click.
     pub down: Vec<CsynthControl>,
+    /// The latched subset alone -- the lens blink keys on these, so an
+    /// ordinary click never blink-gates a lamp.
+    pub latched: Vec<CsynthControl>,
     pub hover: Option<CsynthControl>,
 }
 
@@ -811,7 +814,7 @@ fn draw_rounds(frame: &mut [u8], panel: Rect, view: &CsynthPanelView, scale: usi
         if led {
             return true;
         }
-        view.down.contains(&control) && view.blink_on
+        view.latched.contains(&control) && view.blink_on
     };
     for (control, label, slot, lit) in [
         (
@@ -1179,6 +1182,11 @@ impl CsynthPanel {
             .collect()
     }
 
+    /// The latches alone, for the lens blink.
+    pub fn latched(&self) -> Vec<CsynthControl> {
+        self.holding.clone()
+    }
+
     /// A press on `control`. The window carries out what comes back.
     pub fn press(&mut self, control: CsynthControl, left: bool, powered: bool) -> CsynthPress {
         if control == CsynthControl::Dial {
@@ -1215,7 +1223,9 @@ impl CsynthPanel {
             // lets them both go.
             let is_round = |c: CsynthControl| matches!(c, CsynthControl::All | CsynthControl::Mute);
             if is_round(control) && self.holding.iter().any(|&h| is_round(h) && h != control) {
-                self.holding.clear();
+                // Only the rounds release each other; an arrow latched
+                // alongside stays standing.
+                self.holding.retain(|&h| !is_round(h));
                 return CsynthPress::None;
             }
             self.latch(control);
@@ -1476,6 +1486,7 @@ mod tests {
                     blink_on: false,
                     volume: 0.8,
                     down: Vec::new(),
+                    latched: vec![],
                     hover: None,
                 },
             ),
@@ -1487,6 +1498,7 @@ mod tests {
                     blink_on: false,
                     volume: 0.8,
                     down: vec![CsynthControl::Arrow(Pair::Level, Dir::Right)],
+                    latched: vec![],
                     hover: Some(CsynthControl::Arrow(Pair::Pan, Dir::Left)),
                 },
             ),
@@ -1498,6 +1510,7 @@ mod tests {
                     blink_on: false,
                     volume: 0.8,
                     down: Vec::new(),
+                    latched: vec![],
                     hover: None,
                 },
             ),
@@ -1619,6 +1632,23 @@ mod tests {
         );
         panel.release_press();
         assert!(panel.down().is_empty(), "the gesture spends the latch");
+        // MUTE latched under an arrow resolves to the service edit.
+        panel.press(CsynthControl::Mute, false, true);
+        assert_eq!(
+            panel.press(CsynthControl::Arrow(Pair::Chorus, Dir::Right), true, true),
+            CsynthPress::Button(Button::MuteArrow(Pair::Chorus, Dir::Right))
+        );
+        panel.release_press();
+        // The rounds release each other; a bystander latch survives.
+        panel.press(CsynthControl::Arrow(Pair::Level, Dir::Left), false, true);
+        panel.press(CsynthControl::All, false, true);
+        panel.press(CsynthControl::Mute, false, true);
+        assert_eq!(
+            panel.latched(),
+            vec![CsynthControl::Arrow(Pair::Level, Dir::Left)],
+            "only the rounds let go"
+        );
+        panel.press(CsynthControl::Arrow(Pair::Level, Dir::Left), false, true);
         // Both INSTRUMENT halves latched through a power-on arrive as
         // the pair held whole.
         panel.press(

--- a/src/video/window/csynthpanel.rs
+++ b/src/video/window/csynthpanel.rs
@@ -115,10 +115,8 @@ pub struct CsynthPanelView {
     /// The glass, exactly as the engine's panel composed it.
     pub screen: Screen,
     pub powered: bool,
-    /// Whether the MUTE lamp should be blinking rather than steady --
-    /// the monitor is on.
-    pub mute_blinks: bool,
-    /// This half of the blink, when it does.
+    /// This half of the latch blink -- a latched ALL or MUTE flashes
+    /// its lens to say it is standing in.
     pub blink_on: bool,
     /// Where the VOLUME knob stands, 0..=1.
     pub volume: f32,
@@ -806,19 +804,28 @@ fn small_glyph(ch: char) -> [u8; 5] {
 /// ALL, MUTE and LOAD: the buttons are LEDs themselves -- a misted
 /// clear lens when off, the backlight's orange when their state is on.
 fn draw_rounds(frame: &mut [u8], panel: Rect, view: &CsynthPanelView, scale: usize) {
-    let mute_lit = if view.mute_blinks {
-        view.blink_on
-    } else {
-        view.screen.mute_led
+    // A latched ALL or MUTE flashes its lens to say it is standing in
+    // -- unless its lamp is already speaking (lit, or flashing with a
+    // question), which takes precedence.
+    let latch_blink = |control: CsynthControl, led: bool| -> bool {
+        if led {
+            return true;
+        }
+        view.down.contains(&control) && view.blink_on
     };
     for (control, label, slot, lit) in [
         (
             CsynthControl::All,
             "ALL",
             0,
-            view.powered && view.screen.all_led,
+            view.powered && latch_blink(CsynthControl::All, view.screen.all_led),
         ),
-        (CsynthControl::Mute, "MUTE", 1, view.powered && mute_lit),
+        (
+            CsynthControl::Mute,
+            "MUTE",
+            1,
+            view.powered && latch_blink(CsynthControl::Mute, view.screen.mute_led),
+        ),
         (CsynthControl::Load, "LOAD", 2, false),
     ] {
         let rect = round_rect(panel, slot);
@@ -1158,6 +1165,10 @@ pub struct CsynthPanel {
     holding: Vec<CsynthControl>,
     /// The button a plain click is lighting until the mouse comes up.
     flash: Option<CsynthControl>,
+    /// The solo gesture just fired and ALL still stands: an immediate
+    /// second MUTE un-soloes and lets ALL go; any other press lets ALL
+    /// go and leaves the solo standing.
+    solo_armed: bool,
     dial: Option<DialGrab>,
     hold: Option<ArrowHold>,
 }
@@ -1204,6 +1215,14 @@ impl CsynthPanel {
         // Right-clicking latches a button down; that is how two-button
         // gestures are made with one pointer.
         if !left {
+            self.solo_armed = false;
+            // ALL and MUTE never stand together: latching the second
+            // lets them both go.
+            let is_round = |c: CsynthControl| matches!(c, CsynthControl::All | CsynthControl::Mute);
+            if is_round(control) && self.holding.iter().any(|&h| is_round(h) && h != control) {
+                self.holding.clear();
+                return CsynthPress::None;
+            }
             self.latch(control);
             // A pair latched whole resolves at once when running.
             if powered {
@@ -1226,7 +1245,30 @@ impl CsynthPanel {
             return CsynthPress::None;
         }
         self.flash = Some(control);
+        // The solo gesture's aftermath: with ALL still standing, an
+        // immediate second MUTE un-soloes and lets ALL go; anything
+        // else lets ALL go quietly and the press means itself alone.
+        if self.solo_armed {
+            self.solo_armed = false;
+            self.holding.clear();
+            if control == CsynthControl::Mute && powered {
+                return CsynthPress::Button(Button::Monitor);
+            }
+            let button = resolve(control, &[]);
+            return if powered {
+                CsynthPress::Button(button)
+            } else {
+                CsynthPress::None
+            };
+        }
         let latched = std::mem::take(&mut self.holding);
+        // ALL latched under a MUTE click is the solo: ALL keeps
+        // standing so a second MUTE can take it straight back.
+        if control == CsynthControl::Mute && latched == [CsynthControl::All] && powered {
+            self.holding = latched;
+            self.solo_armed = true;
+            return CsynthPress::Button(Button::Monitor);
+        }
         let button = resolve(control, &latched);
         if powered {
             // A plain arrow held down repeats, gathering speed.
@@ -1293,8 +1335,6 @@ impl CsynthPanel {
             {
                 Some(Button::Both(p1))
             }
-            (CsynthControl::All, CsynthControl::Mute)
-            | (CsynthControl::Mute, CsynthControl::All) => Some(Button::Monitor),
             _ => None,
         }
     }
@@ -1461,7 +1501,6 @@ mod tests {
                 CsynthPanelView {
                     screen: splash,
                     powered: true,
-                    mute_blinks: false,
                     blink_on: false,
                     volume: 0.8,
                     down: Vec::new(),
@@ -1473,7 +1512,6 @@ mod tests {
                 CsynthPanelView {
                     screen,
                     powered: true,
-                    mute_blinks: false,
                     blink_on: false,
                     volume: 0.8,
                     down: vec![CsynthControl::Arrow(Pair::Level, Dir::Right)],
@@ -1485,7 +1523,6 @@ mod tests {
                 CsynthPanelView {
                     screen: dark_screen(),
                     powered: false,
-                    mute_blinks: false,
                     blink_on: false,
                     volume: 0.8,
                     down: Vec::new(),
@@ -1588,15 +1625,47 @@ mod tests {
             panel.press(CsynthControl::Arrow(Pair::Level, Dir::Right), true, true),
             CsynthPress::Button(Button::Both(Pair::Level))
         );
-        // Latch ALL, then latch MUTE: the gesture resolves at once.
+        panel.release_press();
+        // Latch ALL, then latch MUTE: the rounds never stand together,
+        // the second latch lets them both go and no gesture fires.
         assert_eq!(
             panel.press(CsynthControl::All, false, true),
             CsynthPress::None
         );
         assert_eq!(
             panel.press(CsynthControl::Mute, false, true),
+            CsynthPress::None
+        );
+        assert!(panel.down().is_empty(), "both rounds released");
+        // The solo: latch ALL, CLICK MUTE. ALL keeps standing so an
+        // immediate second MUTE takes it straight back and lets go.
+        panel.press(CsynthControl::All, false, true);
+        assert_eq!(
+            panel.press(CsynthControl::Mute, true, true),
             CsynthPress::Button(Button::Monitor)
         );
+        panel.release_press();
+        assert!(
+            panel.down().contains(&CsynthControl::All),
+            "ALL stands through the solo"
+        );
+        assert_eq!(
+            panel.press(CsynthControl::Mute, true, true),
+            CsynthPress::Button(Button::Monitor)
+        );
+        panel.release_press();
+        assert!(panel.down().is_empty(), "the second MUTE lets ALL go");
+        // Armed again, any other press lets ALL go quietly, means
+        // itself alone, and the solo stays standing.
+        panel.press(CsynthControl::All, false, true);
+        panel.press(CsynthControl::Mute, true, true);
+        panel.release_press();
+        assert_eq!(
+            panel.press(CsynthControl::Arrow(Pair::Part, Dir::Right), true, true),
+            CsynthPress::Button(Button::Arrow(Pair::Part, Dir::Right))
+        );
+        panel.release_press();
+        assert!(panel.down().is_empty(), "ALL released on the way out");
         // Both INSTRUMENT halves latched through a power-on arrive as
         // the pair held whole.
         panel.press(
@@ -1632,13 +1701,14 @@ mod tests {
         };
         assert!(held.contains(&Button::Both(Pair::MidiCh)));
         assert!(held.contains(&Button::Both(Pair::Instrument)));
-        // ALL and MUTE latched through a power-on arrive as themselves
-        // (the unit ignores the set; the resolution must still carry it).
+        // ALL and MUTE cannot be latched together even switched off:
+        // the second latch releases both, and the power press carries
+        // nothing.
         panel.press(CsynthControl::All, false, false);
         panel.press(CsynthControl::Mute, false, false);
         assert_eq!(
             panel.press(CsynthControl::Power, true, false),
-            CsynthPress::PowerOn(vec![Button::All, Button::Mute])
+            CsynthPress::PowerOn(vec![])
         );
         // Switched on with nothing latched, the switch turns it off.
         assert_eq!(

--- a/src/video/window/csynthpanel.rs
+++ b/src/video/window/csynthpanel.rs
@@ -1402,6 +1402,11 @@ fn resolve(control: CsynthControl, latched: &[CsynthControl]) -> Button {
             | (CsynthControl::Mute, CsynthControl::All) => {
                 return Button::Monitor;
             }
+            // MUTE latched under an arrow: the service edits (Device
+            // ID on the MIDI CH pair, Chorus Type on the CHORUS pair).
+            (CsynthControl::Mute, CsynthControl::Arrow(pair, dir)) => {
+                return Button::MuteArrow(pair, dir);
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
Integrates Coppersynth's MIDI-compliance and fascia work (pin `6db5f9d3`, Coppersynth 0.9.2). 

The pointer side resolves MUTE-latched arrows into the new service edits, a latched ALL or MUTE flashes its lens (with the blink phase breaking the panel's redraw cache so it animates), the solo gesture spends its latch like any other press (0.9.2 stands a solo down on any press, with the PART arrows carrying it along instead), and latching gestures stand back while an edit screen owns the glass. 

The Coppersynth menu reads Front Panel, SoundFont, MT-32 Mode in that order. The flatpak manifest follows the pin. Guide updates for the new features arrive separately.
