### PR TITLE
feature/fancy About page

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6350,14 +6350,45 @@ pub fn rom_identification(path: &Path) -> Option<String> {
     crate::romdb::describe_file(path).map(|id| id.label().to_string())
 }
 
-/// The `ROM:` line the About panel and the ROM-load OSD show: the file's
-/// name, with the identification beside it when the image is a known one.
+/// The identification the About page prefers: a known checksum's label,
+/// or for the bundled AROS the version and revision read off the image
+/// itself, the way the launcher's Kickstart row shows them. `None` for
+/// an image nothing can name -- the file name carries the line then.
+pub fn about_rom_identification(path: &Path) -> Option<String> {
+    let id = rom_identification(path)?;
+    if id != "bundled AROS" {
+        return Some(id);
+    }
+    match crate::romdb::rom_self_versions(path) {
+        Some((version, revision)) if !version.is_empty() => Some(if revision.is_empty() {
+            format!("AROS {version}")
+        } else {
+            format!("AROS {version} ({revision})")
+        }),
+        _ => Some(id),
+    }
+}
+
+/// The `ROM:` line the About panel and the ROM-load OSD show: the
+/// identification the configuration page shows when the image is a known
+/// one, the file's name when it is not.
 pub fn about_rom_line(name: &str, identification: Option<&str>) -> String {
     match identification {
-        Some(id) => format!("ROM: {name} ({id})"),
+        Some(id) => format!("ROM: {id}"),
         None => format!("ROM: {name}"),
     }
 }
+
+/// The `Extended ROM:` line, shown only when one is fitted: the same
+/// shape as the boot ROM's line.
+pub fn about_ext_rom_line(name: &str, identification: Option<&str>) -> String {
+    format!("Extended {}", about_rom_line(name, identification))
+}
+
+/// The About machine line of the configuration screen, where no
+/// machine is fitted yet. The About page recognises it and centres it
+/// as an invitation rather than bulleting it as a fact.
+pub const ABOUT_PLACEHOLDER_LINE: &str = "Configure a machine, press Run!";
 
 /// Emulated-machine summary lines for the About window.
 pub fn about_machine_lines(cfg: &Config) -> Vec<String> {
@@ -6392,8 +6423,16 @@ pub fn about_machine_lines(cfg: &Config) -> Vec<String> {
         // says which Kickstart it actually is.
         lines.push(about_rom_line(
             &name.to_string_lossy(),
-            rom_identification(&cfg.rom_path).as_deref(),
+            about_rom_identification(&cfg.rom_path).as_deref(),
         ));
+    }
+    if let Some(ext) = cfg.extended_rom_path.as_deref() {
+        if let Some(name) = ext.file_name() {
+            lines.push(about_ext_rom_line(
+                &name.to_string_lossy(),
+                about_rom_identification(ext).as_deref(),
+            ));
+        }
     }
     let drives = cfg
         .floppy_connected
@@ -11281,12 +11320,23 @@ mod tests {
         fs::write(&unknown, vec![0xA5u8; 4096]).unwrap();
         assert_eq!(rom_identification(&unknown), None);
         cfg.rom_path = unknown.clone();
+        // An unknown extended ROM gets a line of its own, named the same
+        // way; without one fitted no such line appears.
+        cfg.extended_rom_path = Some(unknown.clone());
         let name = unknown.file_name().unwrap().to_string_lossy().into_owned();
         let lines = about_machine_lines(&cfg);
         assert!(
             lines.iter().any(|l| *l == format!("ROM: {name}")),
             "{lines:?}"
         );
+        assert!(
+            lines.iter().any(|l| *l == format!("Extended ROM: {name}")),
+            "{lines:?}"
+        );
+        cfg.extended_rom_path = None;
+        assert!(!about_machine_lines(&cfg)
+            .iter()
+            .any(|l| l.starts_with("Extended ROM: ")),);
         let _ = fs::remove_file(&unknown);
 
         // A directory, a missing file and an over-large one are all just
@@ -11298,17 +11348,44 @@ mod tests {
         assert_eq!(rom_identification(&huge), None);
         let _ = fs::remove_file(&huge);
 
-        // A recognised image: the About line carries the version beside the
-        // file name. The bytes of a real Kickstart are not in the tree, so
-        // the composition is exercised through the same helper the panel
+        // A recognised image: the About line shows the identification
+        // alone, an unrecognised one falls back to the file name. The
+        // bytes of a real Kickstart are not in the tree, so the
+        // composition is exercised through the same helper the panel
         // uses, fed the label of a real table entry.
         let entry = crate::romdb::identify_crc(0x1483A091, 512 * 1024).expect("KS 3.1 A1200");
         assert_eq!(entry.label, "Kickstart 3.1 (40.68) A1200");
         assert_eq!(
             about_rom_line("kick40068.A1200", Some(entry.label)),
-            "ROM: kick40068.A1200 (Kickstart 3.1 (40.68) A1200)"
+            "ROM: Kickstart 3.1 (40.68) A1200"
         );
         assert_eq!(about_rom_line("mystery.rom", None), "ROM: mystery.rom");
+
+        // The bundled AROS names its own numbers: a fake image wearing
+        // the AROS file name, a version header at offset 12 and a $VER
+        // cookie in the body, resolves to the composed line the launcher's
+        // Kickstart row shows; stripped of both it stays "bundled AROS".
+        // The identification keys on the exact AROS file name, so it
+        // sits inside a unique directory rather than being uniquified.
+        let dir = temp_path("aros-dir");
+        fs::create_dir_all(&dir).unwrap();
+        let aros = dir.join(crate::romsearch::AROS_MAIN_FILE);
+        let mut data = vec![0u8; 32];
+        data[12..14].copy_from_slice(&46u16.to_be_bytes());
+        data[14..16].copy_from_slice(&7u16.to_be_bytes());
+        data.extend_from_slice(b"$VER: AROS ROM 46.0.7 (1.1.2024)\n");
+        fs::write(&aros, &data).unwrap();
+        assert_eq!(
+            about_rom_identification(&aros).as_deref(),
+            Some("AROS 46.7 (46.0.7)")
+        );
+        fs::write(&aros, b"").unwrap();
+        assert_eq!(
+            about_rom_identification(&aros).as_deref(),
+            Some("bundled AROS")
+        );
+        let _ = fs::remove_file(&aros);
+        let _ = fs::remove_dir(&dir);
     }
 
     fn temp_adf() -> Result<PathBuf> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2649,7 +2649,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         // belongs to the machine, and run_machine installs the real setting
         // when one is started.
         config::MouseCapture::default(),
-        vec!["Configure a machine, then press Run.".to_string()],
+        vec![config::ABOUT_PLACEHOLDER_LINE.to_string()],
         raw_cfg,
         audio_output_enabled,
         // The placeholder runs no sampler; run_machine attaches it on Run.

--- a/src/video/about.rs
+++ b/src/video/about.rs
@@ -1,0 +1,335 @@
+//! The About panel: what it says, and how it makes its entrance.
+//!
+//! Everything plays off one clock -- milliseconds since the panel
+//! opened -- so the entrance is a pure function of time and draws
+//! nothing, allocates nothing and runs nothing while the panel is
+//! closed.
+//!
+//! Everything editable sits at the top of the file: the names in
+//! [`CONTRIBUTORS`] and [`PATREON_SPONSORS`] (add a name, the page
+//! re-times and re-wraps itself), the pacing constants, and the wave
+//! sheets in [`LAYERS`]. Nothing below them needs touching for a
+//! content change.
+
+use super::font;
+use super::ui::{
+    draw_panel_text, wrap_text, PANEL_TEXT, PANEL_TEXT_DIM, PANEL_TEXT_HILIGHT, TITLE_H,
+};
+use super::window::{fill_rect, rgba, scale_rect, texture_height, texture_width, Rect};
+
+/// Contributors and Patreon sponsors credited on the page. Keep both
+/// in step with CREDITS.md and the website's Community section.
+const CONTRIBUTORS: &[&str] = &[
+    "Bernie Innocenti",
+    "Lee Hobson",
+    "jbl007",
+    "Simon Dick",
+    "Nicolas Ramz",
+    "Ben Letchford",
+    "Volker Schwaberow",
+    "Matt Harlum",
+];
+const PATREON_SPONSORS: &[&str] = &["Lee Hobson"];
+
+/// One title letter every so often: ten letters make the
+/// near-three-second assembly.
+const TITLE_LETTER_MS: u64 = 280;
+/// The breath between the lines that follow.
+const LINE_MS: u64 = 90;
+/// The breath between credited names.
+const NAME_MS: u64 = 150;
+/// The wave strip: its height in pixels -- shared by both pages, and
+/// sized so the running page's fuller text always leaves it room --
+/// and the width of one column.
+const WAVE_H: usize = 64;
+const WAVE_COL: usize = 8;
+
+/// One sheet of water: its motion, its share of the stage, and the
+/// colours it climbs between.
+struct Layer {
+    /// Phase advance per second; higher rolls faster.
+    speed: f32,
+    /// Phase step per column; higher packs the crests tighter.
+    spacing: f32,
+    /// Fraction of the strip this sheet's crests may reach.
+    height: f32,
+    /// Brightness multiplier; below 1.0 pushes the sheet back.
+    depth: f32,
+    /// Trough and crest colours the gradient climbs between.
+    dark: (f32, f32, f32),
+    bright: (f32, f32, f32),
+}
+
+/// The sheets, back to front: silver mist, deep copper, molten copper.
+const LAYERS: [Layer; 3] = [
+    Layer {
+        speed: 2.6,
+        spacing: 0.22,
+        height: 0.85,
+        depth: 0.45,
+        dark: (40.0, 44.0, 52.0),
+        bright: (205.0, 210.0, 220.0),
+    },
+    Layer {
+        speed: 3.8,
+        spacing: 0.3,
+        height: 0.65,
+        depth: 0.6,
+        dark: (60.0, 28.0, 14.0),
+        bright: (230.0, 140.0, 70.0),
+    },
+    Layer {
+        speed: 5.4,
+        spacing: 0.35,
+        height: 1.0,
+        depth: 1.0,
+        dark: (70.0, 32.0, 16.0),
+        bright: (255.0, 186.0, 100.0),
+    },
+];
+
+pub struct AboutView {
+    /// Emulated-machine summary lines (built once at startup, refreshed
+    /// on a ROM swap -- never per frame).
+    pub machine_lines: Vec<String>,
+    /// Milliseconds since the panel opened, driving the entrance.
+    pub elapsed_ms: u64,
+    /// Whether the machine lines are real facts (bulleted) rather
+    /// than the configuration screen's centred invitation. Power state
+    /// does not matter: a stopped machine keeps its reference card.
+    pub machine_fitted: bool,
+}
+
+/// The entrance timetable: each element's turn comes in drawing
+/// order, one call per element, so the layout is the schedule and
+/// inserting a line never needs it rebalanced.
+struct Timetable {
+    elapsed: u64,
+    gate: u64,
+}
+
+impl Timetable {
+    /// This element's turn: past due means drawn.
+    fn due(&mut self, step: u64) -> bool {
+        self.gate += step;
+        self.elapsed >= self.gate
+    }
+
+    /// How many of a list have arrived, one every `each_ms` once the
+    /// list's own turn (after `step`) has come.
+    fn arrivals(&mut self, step: u64, each_ms: u64, count: usize) -> usize {
+        let start = self.gate + step;
+        self.gate = start + each_ms * count as u64;
+        if self.elapsed < start {
+            return 0;
+        }
+        (((self.elapsed - start) / each_ms) as usize + 1).min(count)
+    }
+}
+
+pub(in crate::video) fn draw(frame: &mut [u8], rect: Rect, view: &AboutView, scale: usize) {
+    let elapsed = view.elapsed_ms;
+    let cx = |text: &str, px: usize| rect.x + rect.w.saturating_sub(text.len() * 8 * px) / 2;
+
+    // The title assembles itself like luggage on a belt: each letter
+    // slides in from the right edge and rides to its slot, the C
+    // settling first and the far 'e' arriving last, while the lines
+    // below print alongside on their own beat. (ASCII, so the byte
+    // slice per glyph is sound.)
+    let title = "Copperline";
+    let glyph_w = 8 * 3;
+    let x0 = cx(title, 3);
+    let mut y = rect.y + TITLE_H + 14;
+    let settled = (elapsed / TITLE_LETTER_MS) as usize;
+    for i in 0..title.len() {
+        let slot = x0 + i * glyph_w;
+        let glyph = &title[i..i + 1];
+        if i < settled {
+            draw_panel_text(frame, slot, y, glyph, PANEL_TEXT_HILIGHT, 3, scale);
+        } else if i == settled {
+            // In flight: the slot is always left of the entry point, so
+            // the ride is a plain lerp toward it.
+            let progress = (elapsed % TITLE_LETTER_MS) as f32 / TITLE_LETTER_MS as f32;
+            let from = (rect.x + rect.w - glyph_w - 8) as f32;
+            let x = from + (slot as f32 - from) * progress;
+            draw_panel_text(frame, x as usize, y, glyph, PANEL_TEXT_HILIGHT, 3, scale);
+        }
+    }
+    y += 30;
+
+    let mut clock = Timetable { elapsed, gate: 0 };
+
+    let version = concat!("version ", env!("COPPERLINE_DISPLAY_VERSION"));
+    if clock.due(LINE_MS) {
+        draw_panel_text(frame, cx(version, 1), y, version, PANEL_TEXT_DIM, 1, scale);
+    }
+    y += 14;
+    let tagline = "A cycle-stepped Amiga emulator";
+    if clock.due(LINE_MS) {
+        draw_panel_text(frame, cx(tagline, 2), y, tagline, PANEL_TEXT, 2, scale);
+    }
+    y += 22;
+    let author = "by Andrew \"LinuxJedi\" Hutchings";
+    if clock.due(LINE_MS) {
+        draw_panel_text(frame, cx(author, 1), y, author, PANEL_TEXT_DIM, 1, scale);
+    }
+    y += 24;
+
+    // Machine info sits between the small print and the headline: one
+    // and a half glyphs. That size only exists in raw pixels, so this
+    // block draws through the font directly; rounding up keeps a 1x
+    // window at full headline size.
+    let px = (3 * scale).div_ceil(2);
+    let char_w = (8 * px).div_ceil(scale);
+    let (tw, th) = (texture_width(scale), texture_height(scale));
+    if view.machine_fitted {
+        // The reference card: each fact behind a hanging bullet, wrapped
+        // continuations sitting square under the text.
+        let width = (rect.w.saturating_sub(48) / char_w).saturating_sub(2);
+        for line in &view.machine_lines {
+            for (i, part) in wrap_text(line, width, width).into_iter().enumerate() {
+                let (x, text) = if i == 0 {
+                    (rect.x + 24, format!("> {part}"))
+                } else {
+                    (rect.x + 24 + 2 * char_w, part)
+                };
+                if clock.due(LINE_MS) {
+                    font::draw_text(frame, tw, th, x * scale, y * scale, &text, PANEL_TEXT, px);
+                }
+                y += char_w + 3;
+            }
+        }
+    } else {
+        // The idle page's invitation: centred, no bullet.
+        for line in &view.machine_lines {
+            if clock.due(LINE_MS) {
+                let x = rect.x + rect.w.saturating_sub(line.len() * char_w) / 2;
+                font::draw_text(frame, tw, th, x * scale, y * scale, line, PANEL_TEXT, px);
+            }
+            y += char_w + 3;
+        }
+    }
+    y += 10;
+
+    for line in [
+        "m68k CPU core (MIT)",
+        "font8x8 by Daniel Hepper / Marcel Sondaar",
+        "winit + pixels + cpal + gilrs",
+    ] {
+        if clock.due(LINE_MS) {
+            let line = format!("* {line}");
+            draw_panel_text(frame, rect.x + 24 + 16, y, &line, PANEL_TEXT_DIM, 1, scale);
+        }
+        y += 12;
+    }
+    y += 10;
+
+    // Each label takes a line of its own; the names arrive one by one
+    // beneath it, indented. Wrapping re-flows as each name lands, which
+    // is the point -- the line grows in front of you.
+    let max_small = rect.w.saturating_sub(48 + 16) / 8;
+    for (label, names) in [
+        ("Contributors", CONTRIBUTORS),
+        ("Patreon sponsors", PATREON_SPONSORS),
+    ] {
+        if clock.due(LINE_MS) {
+            let line = format!("{label}:");
+            draw_panel_text(frame, rect.x + 24, y, &line, PANEL_TEXT, 1, scale);
+        }
+        y += 12;
+        let arrived = clock.arrivals(NAME_MS, NAME_MS, names.len());
+        for part in wrap_text(&names[..arrived].join(", "), max_small, max_small) {
+            draw_panel_text(frame, rect.x + 24 + 16, y, &part, PANEL_TEXT, 1, scale);
+            y += 12;
+        }
+        // A breath of space between the groups.
+        y += 6;
+    }
+
+    // The floor show, playing from the moment the panel opens across
+    // the panel's whole width, and kept below the text -- whatever room
+    // is left under the last line is its stage, so growing the credits
+    // can shrink the water but never flood the words.
+    let base = rect.y + rect.h - 8;
+    let room = base.saturating_sub(y + 6).min(WAVE_H);
+    if room < 16 {
+        return;
+    }
+    // One column in from the left so the water clears the panel's
+    // trim; being a whole column, the inset keeps the grid landing
+    // exactly on the unchanged right edge.
+    let strip = Rect {
+        x: rect.x + WAVE_COL,
+        y: base - room,
+        w: rect.w - WAVE_COL,
+        h: room,
+    };
+    draw_waves(frame, strip, elapsed as f32 / 1000.0, scale);
+}
+
+/// The floor show: the wave sheets of [`LAYERS`] in parallax, drawing
+/// themselves in from the left, each column joining as its sheet's
+/// front reaches it and swelling up from nothing over its first
+/// wavelength.
+fn draw_waves(frame: &mut [u8], strip: Rect, t: f32, scale: usize) {
+    let base = strip.y + strip.h;
+    let cols = strip.w / WAVE_COL;
+    for layer in &LAYERS {
+        for c in 0..cols {
+            let phase = t * layer.speed - c as f32 * layer.spacing;
+            if phase <= 0.0 {
+                continue;
+            }
+            let swell = (phase / std::f32::consts::TAU).min(1.0);
+            let lift = swell * (1.0 + phase.sin()) * 0.5;
+            // lift is 0..=1 and height <= 1, so h stays within the strip
+            // and the subtractions below cannot underflow.
+            let h = (((strip.h as f32 - 6.0) * layer.height * lift) as usize + 6).min(strip.h);
+            draw_bar(frame, strip.x + c * WAVE_COL, base, h, lift, layer, scale);
+        }
+    }
+}
+
+/// One bar of one sheet: a vertical gradient from the layer's dark
+/// waterline up to its bright crest, scaled by how high the bar
+/// stands (`lift`) so the swell glows as it rises, with a fleck of
+/// white light on the tallest.
+fn draw_bar(
+    frame: &mut [u8],
+    x: usize,
+    base: usize,
+    h: usize,
+    lift: f32,
+    layer: &Layer,
+    scale: usize,
+) {
+    let bands = (h / 5).max(1);
+    for b in 0..bands {
+        let top = base - h + b * h / bands;
+        let bottom = base - h + (b + 1) * h / bands;
+        let glow = lift * (1.0 - (b as f32 + 0.5) / bands as f32);
+        let chan = |dark: f32, bright: f32| (layer.depth * (dark + (bright - dark) * glow)) as u32;
+        let color = rgba(
+            chan(layer.dark.0, layer.bright.0),
+            chan(layer.dark.1, layer.bright.1),
+            chan(layer.dark.2, layer.bright.2),
+        );
+        let band = Rect {
+            x,
+            y: top,
+            w: WAVE_COL - 1,
+            h: bottom - top,
+        };
+        fill_rect(frame, scale_rect(band, scale), color, scale);
+    }
+    if lift > 0.85 && h > 8 {
+        let fleck = Rect {
+            x,
+            y: base - h,
+            w: WAVE_COL - 1,
+            h: 2,
+        };
+        let l = (layer.depth * 235.0) as u32;
+        fill_rect(frame, scale_rect(fleck, scale), rgba(l, l, l + 8), scale);
+    }
+}

--- a/src/video/mod.rs
+++ b/src/video/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#[cfg(feature = "frontend")]
+pub mod about;
 pub mod beam;
 pub mod bitplane;
 pub mod deinterlace;

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -28,9 +28,9 @@ const MENU_HILIGHT_TEXT: u32 = rgba(255, 255, 255);
 const PANEL_BG: u32 = rgba(30, 32, 36);
 const PANEL_TITLE_BG: u32 = rgba(0, 85, 170);
 const PANEL_TITLE_TEXT: u32 = rgba(255, 255, 255);
-const PANEL_TEXT: u32 = rgba(214, 216, 208);
-const PANEL_TEXT_DIM: u32 = rgba(136, 138, 130);
-const PANEL_TEXT_HILIGHT: u32 = rgba(120, 255, 150);
+pub(in crate::video) const PANEL_TEXT: u32 = rgba(214, 216, 208);
+pub(in crate::video) const PANEL_TEXT_DIM: u32 = rgba(136, 138, 130);
+pub(in crate::video) const PANEL_TEXT_HILIGHT: u32 = rgba(120, 255, 150);
 const PANEL_TEXT_ACCENT: u32 = rgba(255, 184, 80);
 const BUTTON_TEXT: u32 = rgba(220, 222, 214);
 const BUTTON_TEXT_DISABLED: u32 = rgba(120, 120, 112);
@@ -968,7 +968,7 @@ pub enum UiControl {
 
 fn panel_dims(panel: &Panel) -> (usize, usize) {
     match panel {
-        Panel::About => (560, 380),
+        Panel::About => (560, 450),
         Panel::Shortcuts => (600, shortcuts_panel_height()),
         Panel::Calibration(_) => (620, 372),
         Panel::InputMap(_) => (INPUT_MAP_W, input_map_panel_height()),
@@ -1025,7 +1025,7 @@ fn panel_rect(panel: &Panel) -> Rect {
     }
 }
 
-const TITLE_H: usize = 22;
+pub(in crate::video) const TITLE_H: usize = 22;
 
 fn close_button_rect(rect: Rect) -> Rect {
     Rect {
@@ -1550,11 +1550,6 @@ pub const MEM_PAGE_BYTES: u32 = 256;
 // View data built by window.rs each redraw
 // ---------------------------------------------------------------------------
 
-pub struct AboutView {
-    /// Emulated-machine summary lines (built once at startup).
-    pub machine_lines: Vec<String>,
-}
-
 pub struct CalRow {
     pub label: &'static str,
     pub binding: String,
@@ -1851,7 +1846,7 @@ pub struct FrameAnalyzerView {
 }
 
 pub enum PanelViewData {
-    About(AboutView),
+    About(super::about::AboutView),
     Shortcuts,
     Calibration(CalibrationView),
     Debugger(Box<DebuggerView>),
@@ -1862,7 +1857,7 @@ pub enum PanelViewData {
 // Drawing
 // ---------------------------------------------------------------------------
 
-fn draw_panel_text(
+pub(in crate::video) fn draw_panel_text(
     frame: &mut [u8],
     x: usize,
     y: usize,
@@ -2011,7 +2006,11 @@ fn draw_close_gadget(frame: &mut [u8], rect: Rect, close_hover: bool, scale: usi
 /// Word-wrap `text` so no panel line is cropped: the first line holds up to
 /// `first_width` characters, continuations up to `rest_width` (they are drawn
 /// indented). Words longer than a whole line are hard-split.
-fn wrap_text(text: &str, first_width: usize, rest_width: usize) -> Vec<String> {
+pub(in crate::video) fn wrap_text(
+    text: &str,
+    first_width: usize,
+    rest_width: usize,
+) -> Vec<String> {
     let mut lines: Vec<String> = Vec::new();
     let mut cur = String::new();
     for word in text.split_whitespace() {
@@ -2043,73 +2042,6 @@ fn wrap_text(text: &str, first_width: usize, rest_width: usize) -> Vec<String> {
         lines.push(cur);
     }
     lines
-}
-
-/// Contributors and Patreon sponsors credited in the About panel. Keep
-/// both in step with CREDITS.md and the website's Community section.
-const CONTRIBUTORS: &[&str] = &[
-    "Bernie Innocenti",
-    "Lee Hobson",
-    "jbl007",
-    "Simon Dick",
-    "Nicolas Ramz",
-    "Ben Letchford",
-    "Volker Schwaberow",
-    "Matt Harlum",
-];
-const PATREON_SPONSORS: &[&str] = &["Lee Hobson"];
-
-fn draw_about(frame: &mut [u8], rect: Rect, view: &AboutView, scale: usize) {
-    let cx = |text: &str, px: usize| rect.x + rect.w.saturating_sub(text.len() * 8 * px) / 2;
-    let title = "Copperline";
-    let mut y = rect.y + TITLE_H + 14;
-    draw_panel_text(frame, cx(title, 3), y, title, PANEL_TEXT_HILIGHT, 3, scale);
-    y += 30;
-    let version = concat!("version ", env!("COPPERLINE_DISPLAY_VERSION"));
-    draw_panel_text(frame, cx(version, 1), y, version, PANEL_TEXT_DIM, 1, scale);
-    y += 14;
-    let tagline = "A cycle-stepped Amiga emulator";
-    draw_panel_text(frame, cx(tagline, 2), y, tagline, PANEL_TEXT, 2, scale);
-    y += 22;
-    let author = "by Andrew \"LinuxJedi\" Hutchings";
-    draw_panel_text(frame, cx(author, 1), y, author, PANEL_TEXT_DIM, 1, scale);
-    y += 24;
-    let max_chars = rect.w.saturating_sub(48) / 16;
-    for line in &view.machine_lines {
-        for (i, part) in wrap_text(line, max_chars, max_chars.saturating_sub(1))
-            .iter()
-            .enumerate()
-        {
-            // Continuation lines are indented by one glyph cell.
-            let x = rect.x + 24 + if i == 0 { 0 } else { 16 };
-            draw_panel_text(frame, x, y, part, PANEL_TEXT, 2, scale);
-            y += 18;
-        }
-    }
-    y += 10;
-    for line in [
-        "m68k CPU core (MIT)",
-        "font8x8 by Daniel Hepper / Marcel Sondaar",
-        "winit + pixels + cpal + gilrs",
-    ] {
-        draw_panel_text(frame, rect.x + 24, y, line, PANEL_TEXT_DIM, 1, scale);
-        y += 12;
-    }
-    y += 10;
-    let max_small = rect.w.saturating_sub(48) / 8;
-    let contributors = format!("Contributors: {}", CONTRIBUTORS.join(", "));
-    let sponsors = format!("Patreon sponsors: {}", PATREON_SPONSORS.join(", "));
-    for line in [&contributors, &sponsors] {
-        for (i, part) in wrap_text(line, max_small, max_small.saturating_sub(1))
-            .iter()
-            .enumerate()
-        {
-            // Continuation lines are indented by one glyph cell.
-            let x = rect.x + 24 + if i == 0 { 0 } else { 8 };
-            draw_panel_text(frame, x, y, part, PANEL_TEXT, 1, scale);
-            y += 12;
-        }
-    }
 }
 
 fn draw_drop_chooser(
@@ -9401,7 +9333,7 @@ pub fn draw_panel_layer(
     let rect = panel_rect(panel);
     match (panel, data) {
         (Panel::About, Some(PanelViewData::About(view))) => {
-            draw_about(frame, rect, view, texture_scale)
+            super::about::draw(frame, rect, view, texture_scale)
         }
         (Panel::Shortcuts, _) => draw_shortcuts(frame, rect, texture_scale),
         (Panel::Calibration(session), Some(PanelViewData::Calibration(view))) => {
@@ -11515,7 +11447,7 @@ mod tests {
             menu_nav: menu::MenuNav::default(),
             panel: Some(Panel::About),
         };
-        let data = PanelViewData::About(AboutView {
+        let data = PanelViewData::About(crate::video::about::AboutView {
             machine_lines: vec![
                 "Machine: A1200".to_string(),
                 "CPU: M68EC020 @ 14 MHz".to_string(),
@@ -11524,10 +11456,61 @@ mod tests {
                 "ROM: system v3.1 a1200 release image path rom".to_string(),
                 "Floppy drives: 1".to_string(),
             ],
+            // Deep into the entrance so the snapshot shows the settled page.
+            elapsed_ms: 60_000,
+            machine_fitted: true,
         });
         draw(&mut frame, scale, &ui, None, Some(&data));
         assert!(panel_has_title_bar(&frame, ui.panel.as_ref().unwrap()));
         save(&frame, "about");
+
+        // Mid-entrance: the title half printed, the wave half drawn in.
+        // The entrance is a pure function of elapsed time, so comparing
+        // against the just-opened page makes deterministic assertions:
+        // by mid-entrance the title's first slot has its settled letter
+        // and wave columns stand on the left, while the strip's right
+        // edge is still untouched -- the reveal front has not reached it.
+        let about_at = |elapsed_ms: u64| {
+            let mut frame = vec![0u8; w * h * 4];
+            let data = PanelViewData::About(crate::video::about::AboutView {
+                machine_lines: vec![crate::config::ABOUT_PLACEHOLDER_LINE.to_string()],
+                elapsed_ms,
+                machine_fitted: false,
+            });
+            draw(&mut frame, scale, &ui, None, Some(&data));
+            frame
+        };
+        let opened = about_at(0);
+        let mid = about_at(2_500);
+        let region_differs = |a: &[u8], b: &[u8], x0: usize, x1: usize, y0: usize, y1: usize| {
+            (y0..y1).any(|y| {
+                a[(y * w + x0) * 4..(y * w + x1) * 4] != b[(y * w + x0) * 4..(y * w + x1) * 4]
+            })
+        };
+        let rect = panel_rect(&Panel::About);
+        let title_y = rect.y + TITLE_H + 14;
+        let slot0 = rect.x + (rect.w - 240) / 2;
+        assert!(
+            region_differs(&mid, &opened, slot0, slot0 + 24, title_y, title_y + 24),
+            "title's first letter should have settled by mid-entrance"
+        );
+        let base = rect.y + rect.h - 8;
+        assert!(
+            region_differs(&mid, &opened, rect.x, rect.x + rect.w / 4, base - 8, base),
+            "wave columns should have arrived on the left by mid-entrance"
+        );
+        assert!(
+            !region_differs(
+                &mid,
+                &opened,
+                rect.x + rect.w - 24,
+                rect.x + rect.w,
+                base - 60,
+                base
+            ),
+            "the reveal front should not have reached the right edge yet"
+        );
+        save(&mid, "about-opening");
 
         let mut frame = vec![0u8; w * h * 4];
         let ui = UiState {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1280,6 +1280,10 @@ pub struct App {
     /// A submenu the pointer is resting on, waiting out the dwell before
     /// it opens: `(depth, row, since)`. Hovering elsewhere disarms it.
     menu_hover_arm: Option<(usize, usize, Instant)>,
+    /// When the About panel opened, driving its entrance animation, and
+    /// when its animation last asked for a frame.
+    about_opened_at: Instant,
+    about_redraw_at: Instant,
     /// Emulated-machine summary lines for the About window.
     about_machine_lines: Vec<String>,
     /// Raw config of the running (or last-applied) machine, so the "Machine
@@ -2011,6 +2015,8 @@ impl App {
             autofire_hz,
             ui: UiState::default(),
             menu_hover_arm: None,
+            about_opened_at: Instant::now(),
+            about_redraw_at: Instant::now(),
             about_machine_lines,
             machine_config,
             paused_before_debugger: false,
@@ -4280,6 +4286,9 @@ impl ApplicationHandler for App {
         // A held scroll arrow has no event of its own to wake on: the button
         // went down once and the repeats are this loop's own doing.
         let scrolling = self.scroll_hold.is_some();
+        // The About panel animates on the clock, so it too must keep the
+        // loop awake while it is up.
+        let about_open = matches!(self.ui.panel, Some(Panel::About));
         event_loop.set_control_flow(
             if running
                 || osd_active
@@ -4287,6 +4296,7 @@ impl ApplicationHandler for App {
                 || writing_image
                 || scrolling
                 || typing
+                || about_open
                 || pad_quit_watch
             {
                 ControlFlow::Poll
@@ -4303,6 +4313,11 @@ impl ApplicationHandler for App {
         if pad_quit_watch && !running && !writing_image {
             // Poll the pad at a human rate rather than spinning a core;
             // plenty of granularity inside the quit hotkey's 1.5 s hold.
+            std::thread::sleep(std::time::Duration::from_millis(16));
+        }
+        if about_open && !running && !writing_image {
+            // The About animation likewise paces itself when the machine
+            // is off: a human-rate tick, not a spinning core.
             std::thread::sleep(std::time::Duration::from_millis(16));
         }
         if osd_active && !running {
@@ -4416,6 +4431,14 @@ impl ApplicationHandler for App {
         // is current when the redraw decision below is taken.
         self.update_perf_overlay(running);
         self.poll_menu_hover_arm();
+        // The About panel's entrance and wave play on the clock; keep
+        // the frames coming while it is up.
+        if matches!(self.ui.panel, Some(Panel::About))
+            && self.about_redraw_at.elapsed() >= std::time::Duration::from_millis(40)
+        {
+            self.about_redraw_at = std::time::Instant::now();
+            self.request_redraw();
+        }
         #[cfg(feature = "coppersynth")]
         {
             self.repeat_csynth_dial();
@@ -5739,7 +5762,10 @@ impl App {
                 self.ui.panel = Some(Panel::Calibration(crate::gamepad::CalibrationSession::new()));
             }
             A::OpenShortcuts => self.ui.panel = Some(Panel::Shortcuts),
-            A::OpenAbout => self.ui.panel = Some(Panel::About),
+            A::OpenAbout => {
+                self.about_opened_at = std::time::Instant::now();
+                self.ui.panel = Some(Panel::About);
+            }
             A::LoadRom => self.load_rom_from_dialog(),
 
             A::SetAudioOutput(choice) => {
@@ -10711,7 +10737,14 @@ impl App {
             match result {
                 Ok(identified) => {
                     let name = display_file_name(&main_path);
-                    let rom_line = crate::config::about_rom_line(&name, identified);
+                    // The in-memory identification sees through a Cloanto
+                    // wrapper; the path-based one names an AROS image's
+                    // version and revision. Prefer the former, fall back
+                    // to the latter.
+                    let line_id = identified
+                        .map(str::to_string)
+                        .or_else(|| crate::config::about_rom_identification(&main_path));
+                    let rom_line = crate::config::about_rom_line(&name, line_id.as_deref());
                     match identified {
                         Some(id) => info!("boot ROM loaded: {} ({id})", main_path.display()),
                         None => info!("boot ROM loaded: {}", main_path.display()),
@@ -10727,6 +10760,35 @@ impl App {
                     {
                         Some(line) => *line = rom_line,
                         None => self.about_machine_lines.push(rom_line),
+                    }
+                    // The extended ROM line follows the same swap: updated,
+                    // added after the boot ROM's line, or dropped to match
+                    // what is now fitted.
+                    let ext_line = ext_path.as_deref().map(|p| {
+                        crate::config::about_ext_rom_line(
+                            &display_file_name(p),
+                            crate::config::about_rom_identification(p).as_deref(),
+                        )
+                    });
+                    let at = self
+                        .about_machine_lines
+                        .iter()
+                        .position(|l| l.starts_with("Extended ROM: "));
+                    match (at, ext_line) {
+                        (Some(i), Some(line)) => self.about_machine_lines[i] = line,
+                        (Some(i), None) => {
+                            self.about_machine_lines.remove(i);
+                        }
+                        (None, Some(line)) => {
+                            let after_rom = self
+                                .about_machine_lines
+                                .iter()
+                                .position(|l| l.starts_with("ROM: "))
+                                .map(|i| i + 1)
+                                .unwrap_or(self.about_machine_lines.len());
+                            self.about_machine_lines.insert(after_rom, line);
+                        }
+                        (None, None) => {}
                     }
                     self.powered_on = true;
                     self.cpu_halted = false;
@@ -11606,8 +11668,11 @@ impl App {
     /// Build the per-redraw view data for the open panel, if any.
     fn build_panel_view_data(&self) -> Option<ui::PanelViewData> {
         match self.ui.panel.as_ref()? {
-            Panel::About => Some(ui::PanelViewData::About(ui::AboutView {
+            Panel::About => Some(ui::PanelViewData::About(crate::video::about::AboutView {
                 machine_lines: self.about_machine_lines.clone(),
+                elapsed_ms: self.about_opened_at.elapsed().as_millis() as u64,
+                machine_fitted: self.about_machine_lines.first().map(String::as_str)
+                    != Some(crate::config::ABOUT_PLACEHOLDER_LINE),
             })),
             Panel::Shortcuts => Some(ui::PanelViewData::Shortcuts),
             // Self-contained: the panel's own state is everything it draws.


### PR DESCRIPTION
# About page overhaul

https://github.com/user-attachments/assets/951a73f6-0bcf-4302-a5b8-52b7a052b5ad

The About panel moves into its own `src/video/about.rs` and animates from one clock: the title letters slide in from the right to their slots (C first), the lines below print alongside on their own beat, contributor and sponsor names arrive one by one, and a three-layer copper/silver wave draws itself in across the foot of the panel, always kept below the text. Names, pacing and wave colours are plain tables at the top of the file; the page costs nothing while closed.

The decision to move into a separate "about.rs" was so the animation logic isn't cluttering the actual important stuff, plus makes it simpler to edit the credits/sponsors moving forwards. 

- Machine info at a mid text size behind `>` bullets with square-wrapped continuations; centred "Configure a machine, press Run!" when no machine is configured; library credits as an indented `*` list
- ROM line shows the identification alone — including the bundled AROS's version and revision read off the image, as the launcher shows them — falling back to the file name for unknown images
- Machine info includes an `Extended ROM:` line when one is fitted, identified the same way as the boot ROM and kept in step with the ROM swap dialog
- Event loop stays awake at a paced rate while the About panel is open, so the animation still runs even with the machine off if you open About...