### PR TITLE
Feature/coppersynth sc55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,8 +601,8 @@ dependencies = [
 
 [[package]]
 name = "coppersynth"
-version = "0.9.2"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=7e489dc295029e8f10b074d85d016cc0fc96d361#7e489dc295029e8f10b074d85d016cc0fc96d361"
+version = "0.10.0"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=823fb7cf50cf08fbac2b1cf9d5fc648240c95886#823fb7cf50cf08fbac2b1cf9d5fc648240c95886"
 dependencies = [
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "7e489dc295029e8f10b074d85d016cc0fc96d361", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "823fb7cf50cf08fbac2b1cf9d5fc648240c95886", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/docs/guide/coppersynth.md
+++ b/docs/guide/coppersynth.md
@@ -66,7 +66,7 @@ translates. The mode can be changed live from the menu (**Coppersynth →
 MT-32 Mode**) or at the front panel. When the loaded bank carries the GS
 CM-64/32L drum kit, MT-32 rhythm selects it automatically.
 
-## The front panel
+## The Front Panel
 
 ![The Coppersynth front panel](../images/ui-preview-csynth-panel-strip.png)
 
@@ -76,14 +76,17 @@ puts the module's fascia under the display: the backlit LCD with the part
 values, the sixteen-part level meters, and the sound's name -- a game's
 MT-32 instrument uploads via SysEx to show extra info. Buttons press with a
 left click; a right click latches a button down, which is how multi-button
-gestures are made: latch one half of a pair and click the other to view
-that setting across all parts, or latch **ALL** and click **MUTE** to
-monitor (solo) the shown part.
+gestures are made. The module remembers its settings across power cycles,
+like the real unit's battery does.
+
+These button combinations / settings mostly reference an actual SC-55, so you
+could also reference the official SC-55 MKII manual for more info on some of 
+these settings and parameters. 
 
 | Button | Function |
 |---|---|
 | **PART < >** | Selects a part |
-| **INSTRUMENT < >** | Changes the timbre/sound for the selected part |
+| **INSTRUMENT < >** | Changes the timbre/sound for the selected part (drum kits on a drum part) |
 | **LEVEL < >** | Volume ceiling |
 | **PAN < >** | Pans the part left or right |
 | **REVERB < >** | Reverb DSP level |
@@ -91,39 +94,40 @@ monitor (solo) the shown part.
 | **KEY SHIFT < >** | Transposes the part |
 | **ALL** | Lit, sets all of the above parameters for every part |
 | **MUTE** | Silences the shown part (all of them, with **ALL** lit) |
-| **MIDI CH < >** | Sets the MIDI channel (1-16) for the selected part |
+| **MIDI CH < >** | Sets the MIDI channel (1-16, Off) for the selected part; with **ALL** lit, the SysEx Device ID (1-32) |
 | **VOLUME** (knob) | The module's main output level, separate from anything MIDI sends |
 | **POWER** | Switches the module off and on |
 
 ### Button combinations (POWER ON)
 
 Coppersynth front panel has various features accessed with multi-button
-combinations. The table below will separate these into ones which are 
-accessed with the unit powered on.  
+combinations. The table below will separate these into ones which are
+accessed with the unit powered on.
 
 ```
 Hold = Right Click
-Press = Left Click 
+Press = Left Click
 ```
 
 | Combination | Reaches |
 |---|---|
-| Hold `ALL` + `MUTE` | Solo the selected PART. Press `MUTE` to disable solo |
-| Hold `MUTE`, Press `CHORUS` | Change the Chorus DSP type (8 total; Chorus, Celestial, Flanger, Short Delay). `MUTE` to cancel, `ALL` to apply
-| Hold `MUTE`, press `MIDI CH` | Change the SysEx Device ID. `MUTE` to cancel, `ALL` to apply
-| Hold `MUTE`, Press `INSTRUMENT` | Change the parts parameters e.g. Portamento, Vibrato, Envelope Generators.etc. `INSTRUMENT` < or > to cycle parameter, `LEVEL` < or > to change the value. `MUTE` to cancel, `ALL` to apply. These can also be controlled via standard MIDI CC commands. 
-| Hold both `LEVEL`,`REVERB`, `KEY SHIFT`, `INSTRUMENT`, `PAN`, `CHORUS` or `MIDI CH` buttons | Holding both of any of those buttons at the same time will show their value in the Midi "equaliser" section across all 16 parts. 
+| Hold `ALL` + `MUTE` (either order, hold or press) | Solo the selected PART -- the MUTE lamp blinks. Press `MUTE` to disable solo |
+| Hold `PART <` + `PART >` | The part settings menu, opening on Part Mode (Norm/Drum). `MUTE` steps forward through the settings (Bend Range, Vib. Rate, Cutoff Freq, Portamento and the rest), `ALL` steps back, `INSTRUMENT` < or > changes the value, `PART` < or > moves between parts. Press both `PART` buttons again to leave. These can also be controlled via standard MIDI CC/NRPN commands |
+| Hold `PART <` + `PART >` with `ALL` lit | The system menu: master tune, the Reverb and Chorus DSP types, the meter display styles, reception switches and Back Up. Same controls as above |
+| Hold `INSTRUMENT <` + `INSTRUMENT >` | Variation select: `INSTRUMENT` < or > walks the SoundFont's variation banks for the part's instrument. Press both again to leave |
+| Hold both `LEVEL`, `REVERB`, `KEY SHIFT`, `INSTRUMENT`, `PAN`, `CHORUS` or `MIDI CH` buttons | Holding both of any of those buttons at the same time will show their value in the Midi "equaliser" section across all 16 parts |
 
 ### Button combinations (POWER OFF)
 
-The following button combinations expect the unit to first be powered off. 
+The following button combinations expect the unit to first be powered off.
 
 | Combination | Reaches |
 |---|---|
 | Hold `INSTRUMENT <`, Press `POWER` | MT-32 Mode. `MUTE` disables, `ALL` enables |
-| Hold `INSTRUMENT >`, Press `POWER`  | Load the default SoundFont. `MUTE` cancels, `ALL` confirms  |
-| Hold `PART <` + `PART >`, Press `POWER` | Demo sequences. press `ALL` to play, `MUTE` to stop, `PART` buttons to skip song. 
-| Hold both `INSTRUMENT` + both `MIDI CH` | Show version info + credits, `MUTE` or `ALL` skips
+| Hold `INSTRUMENT >`, Press `POWER` | Init GS: returns every setting to the GS standard. `MUTE` cancels, `ALL` confirms |
+| Hold `INSTRUMENT <` + `INSTRUMENT >`, Press `POWER` | Init All: the factory preset, including the default SoundFont. `MUTE` cancels, `ALL` confirms |
+| Hold `PART <` + `PART >`, Press `POWER` | Demo sequences. Press `ALL` to play, `MUTE` to stop, `PART` buttons to skip song, `ALL` + `MUTE` to leave |
+| Hold both `INSTRUMENT` + both `MIDI CH` | Show version info + credits, `MUTE` or `ALL` skips |
 
 ## Building without it
 

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -2,8 +2,8 @@
     {
         "type": "git",
         "url": "https://github.com/copperlinehq/coppersynth",
-        "commit": "7e489dc295029e8f10b074d85d016cc0fc96d361",
-        "dest": "flatpak-cargo/git/coppersynth-7e489dc"
+        "commit": "823fb7cf50cf08fbac2b1cf9d5fc648240c95886",
+        "dest": "flatpak-cargo/git/coppersynth-823fb7c"
     },
     {
         "type": "git",
@@ -826,12 +826,12 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-7e489dc/.\" \"cargo/vendor/coppersynth\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-823fb7c/.\" \"cargo/vendor/coppersynth\""
         ]
     },
     {
         "type": "inline",
-        "contents": "[package]\nname = \"coppersynth\"\nversion = \"0.9.2\"\nauthors = [\"Lee Hobson\"]\nedition = \"2021\"\nlicense = \"MIT\"\ndescription = \"Copperline's General MIDI sound module: a Sound Canvas-flavoured SoundFont synth with an MT-32 translation layer and front panel model\"\nrepository = \"https://github.com/CopperlineHQ/Coppersynth\"\npublish = false\n\n[dependencies.zip]\nversion = \"8\"\ndefault-features = false\nfeatures = [\"deflate\"]\n\n[build-dependencies]\nzip = \"8\"\n",
+        "contents": "[package]\nname = \"coppersynth\"\nversion = \"0.10.0\"\nauthors = [\"Lee Hobson\"]\nedition = \"2021\"\nlicense = \"MIT\"\ndescription = \"Copperline's General MIDI sound module: a Sound Canvas-flavoured SoundFont synth with an MT-32 translation layer and front panel model\"\nrepository = \"https://github.com/CopperlineHQ/Coppersynth\"\npublish = false\n\n[dependencies.zip]\nversion = \"8\"\ndefault-features = false\nfeatures = [\"deflate\"]\n\n[build-dependencies]\nzip = \"8\"\n",
         "dest": "cargo/vendor/coppersynth",
         "dest-filename": "Cargo.toml"
     },
@@ -6989,7 +6989,7 @@
     },
     {
         "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"7e489dc295029e8f10b074d85d016cc0fc96d361\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"823fb7cf50cf08fbac2b1cf9d5fc648240c95886\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3739,6 +3739,10 @@ impl Bus {
     }
 
     pub fn reset_for_keyboard_reset(&mut self) {
+        // The serial sink hears about the reset first: an in-process
+        // synthesizer releases what the interrupted guest left
+        // sounding, exactly as if its line had dropped.
+        self.paula.serial.machine_reset();
         let video_standard = self.agnus.video_standard();
         let agnus_revision = self.agnus.revision();
         self.cia_a = Cia::new(Which::A);

--- a/src/csynth/mod.rs
+++ b/src/csynth/mod.rs
@@ -27,6 +27,22 @@ pub const SOUNDFONT_NAME: &str = "GeneralUser-GS.sf2";
 /// needs no file at all: Coppersynth embeds its own.
 pub const SOUNDFONT_ZIP_NAME: &str = "GeneralUser-GS.zip";
 
+/// Whether the unit's battery-backed memory is read and written this
+/// run. Off until a frontend asks for it, so only a real session ever
+/// touches the file: tests and library users get a unit that
+/// remembers nothing, which is also what `--factory` asks for.
+static PERSIST: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+pub fn set_persistence(on: bool) {
+    PERSIST.store(on, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// The battery-backed memory's file, with the machines' other
+/// batteries.
+fn state_path() -> Option<PathBuf> {
+    Some(crate::paths::coppersynth_nvram_file())
+}
+
 /// The `[serial] coppersynth_*` settings the device is fitted with.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CsynthOptions {
@@ -153,17 +169,55 @@ pub struct CsynthDevice {
     panel: FrontPanel,
 }
 
+impl Drop for CsynthDevice {
+    /// The power going off writes the battery-backed memory, exactly
+    /// once, wherever the unit is dropped -- an endpoint change, the
+    /// machine going down, or the window closing.
+    fn drop(&mut self) {
+        // The panel hears about the power first: a demo left running
+        // stands down to the GS basic setting before anything is
+        // remembered.
+        self.panel.power_off(&mut self.engine);
+        if !PERSIST.load(std::sync::atomic::Ordering::Relaxed) {
+            return;
+        }
+        let Some(path) = state_path() else {
+            return;
+        };
+        // The directory is Copperline's own and may not exist yet.
+        if let Err(e) = crate::paths::ensure_parent(&path)
+            .and_then(|()| std::fs::write(&path, self.engine.save_state()))
+        {
+            log::warn!("midi: writing {}: {e}", path.display());
+        }
+    }
+}
+
 impl CsynthDevice {
     /// Fit the synthesizer with the given options.
     pub fn open(options: &CsynthOptions) -> Result<Self> {
         let mode = options.mode()?;
         let soundfont = find_soundfont(options.soundfont.as_deref())?;
-        let engine = match &soundfont {
+        let mut engine = match &soundfont {
             Some(path) => open_engine(path, mode)?,
             // Nothing configured: the bank Coppersynth carries itself.
             None => coppersynth::engine::Engine::open_bundled(crate::audio::MIX_SAMPLE_RATE, mode)
                 .map_err(|e| anyhow!("{e}"))?,
         };
+        // The battery-backed memory: the engine sorts out what the
+        // bytes mean and what its Back Up switch allows.
+        if PERSIST.load(std::sync::atomic::Ordering::Relaxed) {
+            if let Some(path) = state_path() {
+                match std::fs::read(&path) {
+                    Ok(bytes) => engine.load_state(&bytes),
+                    // No file is an ordinary first run; anything else
+                    // means settings that were meant to come back have
+                    // not, and the user should hear about it.
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => log::warn!("midi: reading {}: {e}", path.display()),
+                }
+            }
+        }
         let (mended, dropped) = engine.bank_repairs();
         let source = soundfont
             .as_ref()
@@ -210,6 +264,13 @@ impl CsynthDevice {
         })
     }
 
+    /// The machine reset or the timeline jumped: the source
+    /// power-cycled under the synthesizer, so the line is dropped and
+    /// everything sounding is released.
+    pub fn line_dropped(&mut self) {
+        self.engine.midi_off_line();
+    }
+
     /// Take a byte off the serial line.
     pub fn write_byte(&mut self, b: u8) {
         if let Some((w, since_flush)) = &mut self.capture {
@@ -252,7 +313,7 @@ impl CsynthDevice {
     /// Buttons held through the power-on, read as the unit reads its
     /// fascia at start-up.
     pub fn panel_power_on_held(&mut self, held: &[Button]) {
-        self.panel.power_on_held(held);
+        self.panel.power_on_held(&mut self.engine, held);
     }
 
     /// Whether the fascia is inside an edit or confirm screen, for the

--- a/src/main.rs
+++ b/src/main.rs
@@ -2204,6 +2204,12 @@ fn main() -> Result<()> {
     if cli.list_sampler_inputs {
         return print_sampler_input_devices();
     }
+    // The synthesizer's battery-backed memory is the frontend's to
+    // ask for; `--factory` leaves the file alone in both directions,
+    // the same promise the flag makes about the saved default
+    // configuration.
+    #[cfg(feature = "coppersynth")]
+    copperline::csynth::set_persistence(!cli.factory);
     let (cfg, mut raw_cfg) = load_config(cli.config_path.as_deref(), &cli.overrides, cli.factory)?;
     if let Some(p) = &cli.rom_path {
         raw_cfg.rom = Some(p.to_string_lossy().into_owned());

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -992,6 +992,14 @@ impl SerialSink for MidiSerialSink {
         self.anchor = None;
         self.framer = MidiFramer::default();
 
+        // Coppersynth keeps its settings across the jump; only the
+        // sounding notes belong to the abandoned future, and they are
+        // released the way a dropped line releases them.
+        #[cfg(feature = "coppersynth")]
+        if let Some(synth) = &mut self.csynth {
+            synth.line_dropped();
+        }
+
         #[cfg(feature = "mt32")]
         {
             // mt32-rs does not expose a snapshot of its voices, memory,
@@ -1009,6 +1017,15 @@ impl SerialSink for MidiSerialSink {
                 );
                 self.attach_mt32();
             }
+        }
+    }
+
+    fn machine_reset(&mut self) {
+        // The guest power-cycled under the synthesizer: the line is
+        // dropped, and whatever it was holding lets go.
+        #[cfg(feature = "coppersynth")]
+        if let Some(synth) = &mut self.csynth {
+            synth.line_dropped();
         }
     }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -410,6 +410,12 @@ pub fn akiko_nvram_file() -> PathBuf {
     battery_ram("cd32-nvram.bin")
 }
 
+/// Coppersynth's battery-backed memory, kept with the machines' other
+/// batteries.
+pub fn coppersynth_nvram_file() -> PathBuf {
+    battery_ram("copperline.nvram")
+}
+
 // --- where a dialog opens ------------------------------------------------
 //
 // Not Copperline's to write, and not created: these only say where a file

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -117,6 +117,11 @@ pub trait SerialSink: Send {
     /// future that was just left behind.
     fn reset_after_timeline_jump(&mut self) {}
 
+    /// The machine reset under the sink: an in-process synthesizer
+    /// treats it as its line dropping and releases what it was
+    /// holding. Ordinary byte sinks have nothing to do.
+    fn machine_reset(&mut self) {}
+
     /// The MIDI sink, when this is one, for runtime device switching. `None`
     /// for every other sink.
     #[cfg(feature = "midi")]

--- a/src/video/about.rs
+++ b/src/video/about.rs
@@ -255,13 +255,13 @@ pub(in crate::video) fn draw(frame: &mut [u8], rect: Rect, view: &AboutView, sca
     if room < 16 {
         return;
     }
-    // One column in from the left so the water clears the panel's
-    // trim; being a whole column, the inset keeps the grid landing
-    // exactly on the unchanged right edge.
+    // A sliver in from the left so the water butts against the
+    // panel's trim without touching it; the grid anchors to the right
+    // edge, so that end stays exactly where it is.
     let strip = Rect {
-        x: rect.x + WAVE_COL,
+        x: rect.x + 2,
         y: base - room,
-        w: rect.w - WAVE_COL,
+        w: rect.w - 2,
         h: room,
     };
     draw_waves(frame, strip, elapsed as f32 / 1000.0, scale);
@@ -273,7 +273,9 @@ pub(in crate::video) fn draw(frame: &mut [u8], rect: Rect, view: &AboutView, sca
 /// wavelength.
 fn draw_waves(frame: &mut [u8], strip: Rect, t: f32, scale: usize) {
     let base = strip.y + strip.h;
-    let cols = strip.w / WAVE_COL;
+    // The columns anchor to the strip's right edge; whatever is left
+    // over on the left becomes a clipped first bar against the trim.
+    let cols = strip.w.div_ceil(WAVE_COL);
     for layer in &LAYERS {
         for c in 0..cols {
             let phase = t * layer.speed - c as f32 * layer.spacing;
@@ -285,7 +287,12 @@ fn draw_waves(frame: &mut [u8], strip: Rect, t: f32, scale: usize) {
             // lift is 0..=1 and height <= 1, so h stays within the strip
             // and the subtractions below cannot underflow.
             let h = (((strip.h as f32 - 6.0) * layer.height * lift) as usize + 6).min(strip.h);
-            draw_bar(frame, strip.x + c * WAVE_COL, base, h, lift, layer, scale);
+            let grid_x = (strip.x + strip.w).saturating_sub((cols - c) * WAVE_COL);
+            let x = grid_x.max(strip.x);
+            let w = (WAVE_COL - 1).saturating_sub(x - grid_x);
+            if w > 0 {
+                draw_bar(frame, x, w, base, h, lift, layer, scale);
+            }
         }
     }
 }
@@ -297,6 +304,7 @@ fn draw_waves(frame: &mut [u8], strip: Rect, t: f32, scale: usize) {
 fn draw_bar(
     frame: &mut [u8],
     x: usize,
+    w: usize,
     base: usize,
     h: usize,
     lift: f32,
@@ -317,7 +325,7 @@ fn draw_bar(
         let band = Rect {
             x,
             y: top,
-            w: WAVE_COL - 1,
+            w,
             h: bottom - top,
         };
         fill_rect(frame, scale_rect(band, scale), color, scale);
@@ -326,7 +334,7 @@ fn draw_bar(
         let fleck = Rect {
             x,
             y: base - h,
-            w: WAVE_COL - 1,
+            w,
             h: 2,
         };
         let l = (layer.depth * 235.0) as u32;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6708,14 +6708,6 @@ impl App {
         }
         let now_ms = self.csynth_panel_epoch.elapsed().as_millis() as u64;
         let blink_on = (now_ms / 300).is_multiple_of(2);
-        // A latched ALL or MUTE flashes its lens, so the blink phase is
-        // part of what is on screen and must break the redraw cache.
-        let round_latched = self.csynth_panel.down().iter().any(|c| {
-            matches!(
-                c,
-                csynthpanel::CsynthControl::All | csynthpanel::CsynthControl::Mute
-            )
-        });
         let Some(sink) = self.emu.bus_mut().midi_serial_mut() else {
             return;
         };
@@ -6723,11 +6715,13 @@ impl App {
             return;
         }
         let key = match sink.csynth_mut() {
-            Some(synth) => (
-                Some(synth.panel_screen(now_ms)),
-                true,
-                round_latched && blink_on,
-            ),
+            Some(synth) => {
+                let screen = synth.panel_screen(now_ms);
+                // The monitor's blinking MUTE lamp is on-screen state,
+                // so its phase must break the redraw cache.
+                let blinking = screen.mute_blink;
+                (Some(screen), true, blinking && blink_on)
+            }
             None => (None, false, false),
         };
         if self.csynth_panel_drawn.as_ref() == Some(&key) {
@@ -6773,7 +6767,6 @@ impl App {
             .zip(csynthpanel::shown_panel_rect(csynth_panel_top()))
             .and_then(|(pos, panel)| csynthpanel::hover_at(panel, pos));
         let down = self.csynth_panel.down();
-        let latched = self.csynth_panel.latched();
         let stored_volume = self.csynth_volume;
         let sink = self.emu.bus_mut().midi_serial_mut()?;
         if !sink.csynth_selected() {
@@ -6795,7 +6788,6 @@ impl App {
             blink_on: (now_ms / 300).is_multiple_of(2),
             volume,
             down,
-            latched,
             hover,
         })
     }

--- a/src/video/window/csynthpanel.rs
+++ b/src/video/window/csynthpanel.rs
@@ -40,7 +40,7 @@ const HOVER_LIFT: f32 = 16.0;
 /// The glass. A Sound Canvas is the MT-32's negative: a bright amber
 /// backlight with dark characters printed over it, and nothing at all
 /// when the light goes out.
-const GLASS_LIT: u32 = rgba(233, 158, 48);
+const GLASS_LIT: u32 = rgba(244, 137, 5);
 const GLASS_DARK: u32 = rgba(150, 160, 159);
 const INK: u32 = rgba(43, 22, 8);
 /// Captions printed on the glass sit lighter than the values written
@@ -115,16 +115,14 @@ pub struct CsynthPanelView {
     /// The glass, exactly as the engine's panel composed it.
     pub screen: Screen,
     pub powered: bool,
-    /// This half of the latch blink -- a latched ALL or MUTE flashes
-    /// its lens to say it is standing in.
+    /// This half of the blink phase, for the lamps the unit itself
+    /// blinks -- the monitor's MUTE among them.
     pub blink_on: bool,
     /// Where the VOLUME knob stands, 0..=1.
     pub volume: f32,
     /// Buttons standing in: latched down, or lit under a click.
     pub down: Vec<CsynthControl>,
-    /// The latched subset alone -- the lens blink keys on these, so an
-    /// ordinary click never blink-gates a lamp.
-    pub latched: Vec<CsynthControl>,
+    /// The button under the pointer, if any.
     pub hover: Option<CsynthControl>,
 }
 
@@ -145,6 +143,7 @@ pub fn dark_screen() -> Screen {
         bars: [0; 16],
         all_led: false,
         mute_led: false,
+        mute_blink: false,
         translating: false,
     }
 }
@@ -806,28 +805,22 @@ fn small_glyph(ch: char) -> [u8; 5] {
 
 /// ALL, MUTE and LOAD: the buttons are LEDs themselves -- a misted
 /// clear lens when off, the backlight's orange when their state is on.
+/// The lamps say only what the unit says: lit states, and the blinks
+/// the manual prescribes -- a latch is shown by the button sitting
+/// down, not by the lamp.
 fn draw_rounds(frame: &mut [u8], panel: Rect, view: &CsynthPanelView, scale: usize) {
-    // A latched ALL or MUTE flashes its lens to say it is standing in
-    // -- unless its lamp is already speaking (lit, or flashing with a
-    // question), which takes precedence.
-    let latch_blink = |control: CsynthControl, led: bool| -> bool {
-        if led {
-            return true;
-        }
-        view.latched.contains(&control) && view.blink_on
-    };
     for (control, label, slot, lit) in [
         (
             CsynthControl::All,
             "ALL",
             0,
-            view.powered && latch_blink(CsynthControl::All, view.screen.all_led),
+            view.powered && view.screen.all_led,
         ),
         (
             CsynthControl::Mute,
             "MUTE",
             1,
-            view.powered && latch_blink(CsynthControl::Mute, view.screen.mute_led),
+            view.powered && (view.screen.mute_led || (view.screen.mute_blink && view.blink_on)),
         ),
         (CsynthControl::Load, "LOAD", 2, false),
     ] {
@@ -1182,7 +1175,8 @@ impl CsynthPanel {
             .collect()
     }
 
-    /// The latches alone, for the lens blink.
+    /// The latches alone, for the tests' eyes.
+    #[cfg(test)]
     pub fn latched(&self) -> Vec<CsynthControl> {
         self.holding.clone()
     }
@@ -1219,14 +1213,20 @@ impl CsynthPanel {
         // Right-clicking latches a button down; that is how two-button
         // gestures are made with one pointer.
         if !left {
-            // ALL and MUTE never stand together: latching the second
-            // lets them both go.
+            // ALL and MUTE never stand latched together: the second
+            // round completes the gesture instead -- ALL and MUTE
+            // pressed at once, however the two clicks were made -- and
+            // both let go.
             let is_round = |c: CsynthControl| matches!(c, CsynthControl::All | CsynthControl::Mute);
             if is_round(control) && self.holding.iter().any(|&h| is_round(h) && h != control) {
-                // Only the rounds release each other; an arrow latched
+                // Only the rounds spend each other; an arrow latched
                 // alongside stays standing.
                 self.holding.retain(|&h| !is_round(h));
-                return CsynthPress::None;
+                return if powered {
+                    CsynthPress::Button(Button::Monitor)
+                } else {
+                    CsynthPress::None
+                };
             }
             self.latch(control);
             // A pair latched whole resolves at once when running.
@@ -1306,7 +1306,8 @@ impl CsynthPanel {
     }
 
     /// A gesture the latched set already names whole: both halves of a
-    /// pair, or ALL with MUTE.
+    /// pair. (ALL with MUTE fires from the latch handler itself, since
+    /// the rounds never stand latched together.)
     fn latched_gesture(&self) -> Option<Button> {
         let [a, b] = self.holding[..] else {
             return None;
@@ -1424,11 +1425,6 @@ fn resolve(control: CsynthControl, latched: &[CsynthControl]) -> Button {
             | (CsynthControl::Mute, CsynthControl::All) => {
                 return Button::Monitor;
             }
-            // MUTE latched under an arrow: the service edits (Device
-            // ID on the MIDI CH pair, Chorus Type on the CHORUS pair).
-            (CsynthControl::Mute, CsynthControl::Arrow(pair, dir)) => {
-                return Button::MuteArrow(pair, dir);
-            }
             _ => {}
         }
     }
@@ -1486,7 +1482,6 @@ mod tests {
                     blink_on: false,
                     volume: 0.8,
                     down: Vec::new(),
-                    latched: vec![],
                     hover: None,
                 },
             ),
@@ -1498,7 +1493,6 @@ mod tests {
                     blink_on: false,
                     volume: 0.8,
                     down: vec![CsynthControl::Arrow(Pair::Level, Dir::Right)],
-                    latched: vec![],
                     hover: Some(CsynthControl::Arrow(Pair::Pan, Dir::Left)),
                 },
             ),
@@ -1510,7 +1504,6 @@ mod tests {
                     blink_on: false,
                     volume: 0.8,
                     down: Vec::new(),
-                    latched: vec![],
                     hover: None,
                 },
             ),
@@ -1611,15 +1604,16 @@ mod tests {
             CsynthPress::Button(Button::Both(Pair::Level))
         );
         panel.release_press();
-        // Latch ALL, then latch MUTE: the rounds never stand together,
-        // the second latch lets them both go and no gesture fires.
+        // Latch ALL, then latch MUTE: the rounds never stand together
+        // -- the second latch is the gesture, ALL and MUTE at once,
+        // and both let go.
         assert_eq!(
             panel.press(CsynthControl::All, false, true),
             CsynthPress::None
         );
         assert_eq!(
             panel.press(CsynthControl::Mute, false, true),
-            CsynthPress::None
+            CsynthPress::Button(Button::Monitor)
         );
         assert!(panel.down().is_empty(), "both rounds released");
         // The solo: latch ALL, CLICK MUTE -- one Monitor press, the
@@ -1632,11 +1626,12 @@ mod tests {
         );
         panel.release_press();
         assert!(panel.down().is_empty(), "the gesture spends the latch");
-        // MUTE latched under an arrow resolves to the service edit.
+        // MUTE latched under an arrow is nothing special: the arrow
+        // means itself, as on the unit.
         panel.press(CsynthControl::Mute, false, true);
         assert_eq!(
             panel.press(CsynthControl::Arrow(Pair::Chorus, Dir::Right), true, true),
-            CsynthPress::Button(Button::MuteArrow(Pair::Chorus, Dir::Right))
+            CsynthPress::Button(Button::Arrow(Pair::Chorus, Dir::Right))
         );
         panel.release_press();
         // The rounds release each other; a bystander latch survives.


### PR DESCRIPTION
# Coppersynth 0.10.0: host glue, About wave trim, panel docs

 - Pins Coppersynth 0.10.0 (SC-55mkII fascia, DSP characters, battery-backed memory) with the absolute minimum host-side glue: 
 - the obsolete MUTE-latch gesture resolve goes, the second round latch completes the ALL+MUTE gesture, the MUTE lamp blinks only when the unit says so
 - battery lands as `copperline.nvram` beside the machines' other NVRAM (written once on drop, untouched under `--factory`), 
 - machine reset or timeline jump reaches the synth as its line dropping so stuck notes release. Everything else — menus, ranges, persistence semantics, improved DSP — lives in the crate.


- About page: the footer wave now butts flush against the panel's left trim; the right edge is unchanged
- Docs: the front panel chapter rewritten for the new button grammar