### PR TITLE
Gamepads work out of the box via the bundled controller database

### DIFF
--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -941,10 +941,10 @@ two explicit input modes, and the active one is always shown by the gamepad
 / keyboard icon in the status bar (next to the volume control), so a "my
 keys aren't working" surprise can be spotted and fixed at a glance:
 
-- **gamepad** (the default): use only a calibrated gamepad; every keyboard
-  key passes through to the Amiga. With no pad connected there is no
-  joystick input. This is the no-surprise mode for interactive AmigaOS
-  setup.
+- **gamepad** (the default): use only a recognised or
+  [calibrated](#gamepad-calibration) gamepad; every keyboard key passes
+  through to the Amiga. With no pad connected there is no joystick input.
+  This is the no-surprise mode for interactive AmigaOS setup.
 - **keyboard**: use the keyboard-joystick mapping so the joystick port
   works without a controller.
 
@@ -985,11 +985,21 @@ autofire_hz`.
 
 ## Gamepad calibration
 
-Pads are read through raw `gilrs` events with no controller database, so
-each controller is calibrated once: push each control when prompted. This
+Most pads work with no setup at all: a controller found in the bundled
+SDL_GameControllerDB (or identified by the platform driver) uses a fixed
+standard layout. The d-pad and left stick drive the directions; the south
+face button (A / Cross) is fire / CD32 red, east (B / Circle) is blue,
+west (X / Square) is green, north (Y / Triangle) is yellow, Start is
+play/pause, and the left and right shoulders or triggers are reverse and
+forward. Personal SDL mapping strings in the standard
+`SDL_GAMECONTROLLERCONFIG` environment variable are honoured too.
+
+Calibration is the per-pad override, and the only path for controllers
+the database does not cover: push each control when prompted. This
 records raw axis/button codes and directions, which makes any pad work
-regardless of database coverage and handles inverted or odd axis layouts
-automatically.
+regardless of database coverage -- including pads with broken database
+entries -- and handles inverted or odd axis layouts automatically. A
+saved calibration always wins over the database for its pad.
 
 ```{figure} ../images/ui-preview-calibration.png
 :alt: The gamepad calibration window
@@ -1015,11 +1025,17 @@ shows the hold in progress, and releasing early cancels it. It works
 whenever the pad is connected -- even while the keyboard or another
 device drives the joystick ports, and while the machine is paused or
 powered off. Skip the step to leave quitting to the keyboard shortcut.
+The default database layout never binds a Quit hotkey; only a
+calibration can arm one.
 
 Calibrations are saved per controller UUID in
 `~/.config/copperline/gamepads.toml` (`$XDG_CONFIG_HOME` respected;
 `%APPDATA%\copperline\` on Windows, or beside the executable in
-[portable mode](#quick-save-slots)).
+[portable mode](#quick-save-slots)). A calibration recorded by a
+Copperline version that predates the bundled controller database can
+resolve a stick direction reversed on a database-covered pad; the log
+suggests recalibrating when it loads such a file, and recalibrating
+once fixes it.
 
 ## Input mapping
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -62,7 +62,7 @@ src/
   midi/             # host MIDI serial bridge (CoreMIDI / ALSA / WinMM)
   audio.rs          # AudioSink trait + cpal/WAV/null outputs
   priority.rs       # opt-in realtime-like thread scheduling (pacer + audio)
-  gamepad.rs        # gilrs input + guided calibration
+  gamepad.rs        # gilrs input: database layout + calibration override
   screenshot.rs     # PNG export helpers
   recorder.rs       # video+audio capture (ZMBV/PCM AVI writer)
   inputrec.rs       # live-input recording to the scripted-input format

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -529,7 +529,11 @@ resolves through a fixed standard layout, overridden per-UUID by the
 calibration described in [](../guide/ui), which records raw event codes
 and is the only path for unrecognised pads. On CD32 machines the pad
 output is serialized through the CD32 pad protocol instead of the plain
-digital joystick lines.
+digital joystick lines, modelled after the pad's 4021 shift register:
+in load mode the register's output follows Blue continuously (which is
+how Blue doubles as the plain second button on POTxY), and while the
+register is clocking each shifted bit reflects only its own button
+line, a held Blue included.
 
 The window layer has one host-source policy for the emulated port-2
 joystick/CD32 pad: gamepad (the default) or keyboard. Keyboard mode

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -523,10 +523,13 @@ overflow, and ghost suppression on the real A500 key matrix (the seven
 qualifiers are on dedicated lines and never ghost). The protocol was
 cross-checked against real-hardware-validated replacement keyboard
 firmware. Mouse deltas
-feed the JOY0DAT quadrature counters. Gamepads are read through raw
-`gilrs` events against the per-UUID calibration described in
-[](../guide/ui); on CD32 machines the pad output is serialized through
-the CD32 pad protocol instead of the plain digital joystick lines.
+feed the JOY0DAT quadrature counters. Gamepads are read through `gilrs`
+with its bundled SDL controller database enabled: a recognised pad
+resolves through a fixed standard layout, overridden per-UUID by the
+calibration described in [](../guide/ui), which records raw event codes
+and is the only path for unrecognised pads. On CD32 machines the pad
+output is serialized through the CD32 pad protocol instead of the plain
+digital joystick lines.
 
 The window layer has one host-source policy for the emulated port-2
 joystick/CD32 pad: gamepad (the default) or keyboard. Keyboard mode

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -48,11 +48,16 @@ impl Bus {
                     let x_bit = (8 + 4 * port) as u16; // POT0X=8, POT1X=12
                     let y_bit = x_bit + 2; // POT0Y=10, POT1Y=14
                     if self.cd32_pad_serial_mode(port) {
-                        // The mode-select POTxX pin reads low (driven);
-                        // POTxY carries the serial bit, which a held Blue
-                        // button still grounds.
+                        // The mode-select POTxX pin reads low (driven).
+                        // POTxY carries the pad's 4021 shift-register
+                        // output: its last stage follows Blue only while
+                        // the register is in load mode (how Blue reads as
+                        // a plain second button, and the pre-clock bit-8
+                        // state), so once the register is clocking a held
+                        // Blue is just its own bit of the report and does
+                        // not ground the later bits.
                         v &= !(1 << x_bit);
-                        if self.cd32_pad_serial_bit(port) && !self.input.ports[port].button2 {
+                        if self.cd32_pad_serial_bit(port) {
                             v |= 1 << y_bit;
                         } else {
                             v &= !(1 << y_bit);

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -10075,6 +10075,46 @@ fn cd32_pad_serial_protocol_shifts_button_bits() {
 }
 
 #[test]
+fn cd32_pad_held_blue_does_not_ground_the_serial_report() {
+    use crate::chipset::cia::REG_DDRA;
+    let mut bus = empty_bus();
+    bus.input.set_port_device(1, PortDevice::Cd32Pad);
+    // Blue arrives as the port's second button; Yellow gives the report a
+    // later pressed bit of its own.
+    bus.input
+        .set_joystick(1, false, false, false, false, false, true);
+    bus.input
+        .set_cd32_buttons(1, false, false, false, false, true);
+
+    let ddra = (REG_DDRA as u64) << 8;
+    let pra = (REG_PRA as u64) << 8;
+    let _ = bus.cia_a_write(ddra, 1, 0x80);
+    let _ = bus.cia_a_write(pra, 1, 0x80);
+    bus.custom_write(0x034, 2, 0x2000); // POTGO: OUTRX, DATRX=0
+
+    // The pad's 4021 output follows Blue only in load mode: while the
+    // register is clocking, the held Blue reads low as its own bit and
+    // every later bit still reflects its own button line (active low).
+    let expected = [
+        false, // 8 Blue pressed
+        true,  // 7 Red released
+        false, // 6 Yellow pressed
+        true,  // 5 Green released
+        true,  // 4 FFW released
+        true,  // 3 RWD released
+        true,  // 2 Play released
+        true,  // 1 pad-present
+        false, // 0 zeros
+    ];
+    for (step, want) in expected.iter().enumerate() {
+        let potgor = bus.custom_read(0x016, 2) as u16;
+        assert_eq!(potgor & (1 << 14) != 0, *want, "serial bit at step {step}");
+        let _ = bus.cia_a_write(pra, 1, 0x00); // falling edge: shift
+        let _ = bus.cia_a_write(pra, 1, 0x80); // rising edge
+    }
+}
+
+#[test]
 fn cd32_pad_serial_protocol_on_port_1_uses_pot0x_fir0_and_pot0y() {
     use crate::chipset::cia::REG_DDRA;
     let mut bus = empty_bus();

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -342,6 +342,23 @@ impl RawGamepads {
                     log::info!("gamepad diag: {:?}", event.event);
                 }
             }
+            // Any disconnect resets the accumulated state: gilrs has
+            // already dropped the pad from its connected list, so the id
+            // cannot be compared against the driven pad below, and after a
+            // reset the surviving pad's state rebuilds from its next events.
+            if event.event == gilrs::EventType::Disconnected {
+                self.axes.clear();
+                self.buttons.clear();
+                self.mapped = MappedPadState::default();
+                continue;
+            }
+            // Accumulate state only for the pad this reader drives -- the
+            // first connected one, the same selection poll() and the
+            // calibration flow make -- so a bystander pad's drift or
+            // presses cannot leak into it.
+            if self.first_gamepad() != Some(event.id) {
+                continue;
+            }
             match event.event {
                 gilrs::EventType::AxisChanged(axis, value, code) => {
                     self.axes.insert(code.into_u32(), value);
@@ -349,32 +366,34 @@ impl RawGamepads {
                 }
                 gilrs::EventType::ButtonChanged(button, value, code) => {
                     if self.collapsed_dpad_half_axis(event.id, button, code) {
-                        self.reroute_collapsed_dpad(button, value, code);
+                        apply_collapsed_dpad(
+                            &mut self.axes,
+                            &mut self.buttons,
+                            &mut self.mapped,
+                            button,
+                            value,
+                            code.into_u32(),
+                        );
                     } else {
                         let pressed = value >= AXIS_ACTIVE_THRESHOLD;
                         self.buttons.insert(code.into_u32(), pressed);
                         self.mapped.set_button(button, pressed);
                     }
                 }
-                gilrs::EventType::ButtonPressed(button, code) => {
-                    // A collapsed half-axis d-pad also emits Pressed/Released
-                    // at gilrs's threshold crossings; the ButtonChanged value
-                    // stream carries the direction, so drop these.
-                    if !self.collapsed_dpad_half_axis(event.id, button, code) {
-                        self.buttons.insert(code.into_u32(), true);
-                        self.mapped.set_button(button, true);
-                    }
+                // A collapsed half-axis d-pad also emits Pressed/Released at
+                // gilrs's threshold crossings; the ButtonChanged value stream
+                // carries the direction, so the guards drop those here.
+                gilrs::EventType::ButtonPressed(button, code)
+                    if !self.collapsed_dpad_half_axis(event.id, button, code) =>
+                {
+                    self.buttons.insert(code.into_u32(), true);
+                    self.mapped.set_button(button, true);
                 }
-                gilrs::EventType::ButtonReleased(button, code) => {
-                    if !self.collapsed_dpad_half_axis(event.id, button, code) {
-                        self.buttons.insert(code.into_u32(), false);
-                        self.mapped.set_button(button, false);
-                    }
-                }
-                gilrs::EventType::Disconnected => {
-                    self.axes.clear();
-                    self.buttons.clear();
-                    self.mapped = MappedPadState::default();
+                gilrs::EventType::ButtonReleased(button, code)
+                    if !self.collapsed_dpad_half_axis(event.id, button, code) =>
+                {
+                    self.buttons.insert(code.into_u32(), false);
+                    self.mapped.set_button(button, false);
                 }
                 _ => {}
             }
@@ -416,27 +435,34 @@ impl RawGamepads {
         }
     }
 
-    /// Recover both directions from a collapsed half-axis d-pad event: the
-    /// 0..1 button value spans the full axis, so recentre it to -1..1 and
-    /// store it as the raw axis it really is (which is also what the
-    /// pre-database calibration format recorded for these pads). The named
-    /// state gets the same value on the matching d-pad axis, flipped
-    /// vertically because SDL entries put up at the negative end while the
-    /// named convention is up-positive.
-    fn reroute_collapsed_dpad(&mut self, button: gilrs::Button, value: f32, code: gilrs::ev::Code) {
-        let v = value * 2.0 - 1.0;
-        self.axes.insert(code.into_u32(), v);
-        self.buttons.remove(&code.into_u32());
-        use gilrs::Button as B;
-        match button {
-            B::DPadUp | B::DPadDown => self.mapped.dpad_y = -v,
-            B::DPadLeft | B::DPadRight => self.mapped.dpad_x = v,
-            _ => {}
-        }
-    }
-
     fn first_gamepad(&self) -> Option<gilrs::GamepadId> {
         self.gilrs.gamepads().next().map(|(id, _)| id)
+    }
+}
+
+/// Recover both directions from a collapsed half-axis d-pad event (see
+/// [`RawGamepads::collapsed_dpad_half_axis`]): the 0..1 button value spans
+/// the full axis, so recentre it to -1..1 and store it as the raw axis it
+/// really is (which is also what the pre-database calibration format
+/// recorded for these pads). The named state gets the same value on the
+/// matching d-pad axis, flipped vertically because SDL entries put up at
+/// the negative end while the named convention is up-positive.
+fn apply_collapsed_dpad(
+    axes: &mut BTreeMap<u32, f32>,
+    buttons: &mut BTreeMap<u32, bool>,
+    mapped: &mut MappedPadState,
+    button: gilrs::Button,
+    value: f32,
+    code: u32,
+) {
+    let v = value * 2.0 - 1.0;
+    axes.insert(code, v);
+    buttons.remove(&code);
+    use gilrs::Button as B;
+    match button {
+        B::DPadUp | B::DPadDown => mapped.dpad_y = -v,
+        B::DPadLeft | B::DPadRight => mapped.dpad_x = v,
+        _ => {}
     }
 }
 
@@ -1033,6 +1059,45 @@ mod tests {
         mapped.set_button(gilrs::Button::DPadRight, true);
         let s = mapped.resolve();
         assert!(s.down && s.right && !s.up && !s.left);
+    }
+
+    #[test]
+    fn collapsed_dpad_reroute_recentres_and_replaces_the_button() {
+        use gilrs::Button as B;
+        let mut axes = BTreeMap::new();
+        let mut buttons = BTreeMap::new();
+        let mut mapped = MappedPadState::default();
+        // A stale pressed entry from before the collapse was detected must
+        // not linger once the code is rerouted as an axis.
+        buttons.insert(7, true);
+
+        // Physical up: button value 0.0 is the SDL-negative axis end. Raw
+        // recentres to -1 (the shape legacy calibrations recorded); the
+        // named state flips to the up-positive convention.
+        apply_collapsed_dpad(&mut axes, &mut buttons, &mut mapped, B::DPadUp, 0.0, 7);
+        assert_eq!(axes.get(&7), Some(&-1.0));
+        assert!(!buttons.contains_key(&7));
+        assert_eq!(mapped.dpad_y, 1.0);
+        let s = mapped.resolve();
+        assert!(s.up && !s.down);
+
+        // Rest sits at mid-travel and recentres to exactly 0.
+        apply_collapsed_dpad(&mut axes, &mut buttons, &mut mapped, B::DPadUp, 0.5, 7);
+        assert_eq!(axes.get(&7), Some(&0.0));
+        assert_eq!(mapped.resolve(), JoystickState::default());
+
+        // Physical down arrives through the same surviving button name.
+        apply_collapsed_dpad(&mut axes, &mut buttons, &mut mapped, B::DPadUp, 1.0, 7);
+        assert_eq!(axes.get(&7), Some(&1.0));
+        assert_eq!(mapped.dpad_y, -1.0);
+        let s = mapped.resolve();
+        assert!(s.down && !s.up);
+
+        // Horizontal has no flip: the SDL-negative end is left.
+        apply_collapsed_dpad(&mut axes, &mut buttons, &mut mapped, B::DPadRight, 0.0, 8);
+        assert_eq!(axes.get(&8), Some(&-1.0));
+        assert_eq!(mapped.dpad_x, -1.0);
+        assert!(mapped.resolve().left && !mapped.resolve().right);
     }
 
     #[test]

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -1,15 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-//! Generic USB gamepad support via a one-time guided calibration.
+//! Generic USB gamepad support: bundled controller-database defaults with a
+//! one-time guided calibration as the per-pad override.
 //!
-//! gilrs is used with its SDL controller mappings DISABLED, so we read raw
-//! axis/button event codes. That works for any pad regardless of how well it
-//! is covered by SDL_GameControllerDB (many cheap "retro" pads have broken or
-//! missing entries). Calibration records which raw input drives each Amiga
-//! port-2 joystick direction and button, keyed by controller UUID and
-//! persisted to a config file. Because calibration records the actual input
-//! the user pushes for each direction, it needs no axis-sign or axis-order
-//! assumptions -- inversion and layout fall out automatically.
+//! gilrs is built with its bundled SDL_GameControllerDB mappings (and the
+//! SDL_GAMECONTROLLERCONFIG environment variable) enabled. A pad the
+//! database or the platform driver recognises works out of the box through
+//! a fixed standard layout: d-pad and left stick drive the directions,
+//! South is fire/CD32 red, East blue, West green, North yellow, Start
+//! play/pause, and the left/right shoulders and triggers are reverse and
+//! forward. The default layout binds no Quit hotkey.
+//!
+//! A saved calibration always wins over the database. That keeps unknown
+//! pads working and broken database entries fixable the same way (many
+//! cheap "retro" pads have broken or missing SDL_GameControllerDB entries):
+//! calibrate once, pushing each control when prompted. Calibration records
+//! which raw axis/button event code drives each Amiga port-2 joystick
+//! direction and button, keyed by controller UUID and persisted to a config
+//! file. Because it records the actual input the user pushes for each
+//! direction, it needs no axis-sign or axis-order assumptions -- inversion
+//! and layout fall out automatically.
 //!
 //! Besides the emulated controls, calibration can optionally bind one pad
 //! input as a host-side Quit hotkey. That binding never reaches the emulated
@@ -28,6 +38,13 @@ const AXIS_ACTIVE_THRESHOLD: f32 = 0.5;
 /// calibration, so a resting/drifting stick isn't mistaken for a deliberate
 /// push.
 const AXIS_CAPTURE_THRESHOLD: f32 = 0.6;
+
+/// Format tag written into newly recorded calibrations. Format 0 (absent in
+/// the file) predates the bundled SDL controller mappings being enabled;
+/// those mappings can flip the sign a database-covered pad reports for a
+/// named axis, so a format-0 calibration on such a pad may have reversed
+/// stick directions and earns a recalibration hint.
+const CALIBRATION_FORMAT: u32 = 1;
 
 /// One raw gamepad input bound to a joystick action.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -90,6 +107,10 @@ pub struct GamepadCalibration {
     // Host-side Quit hotkey (optional; never driven into the emulated port).
     #[serde(default)]
     quit: Option<RawInput>,
+    /// [`CALIBRATION_FORMAT`] at recording time; 0 for files written before
+    /// the bundled controller mappings were enabled.
+    #[serde(default)]
+    format: u32,
 }
 
 /// Resolved emulated port-2 joystick state.
@@ -196,51 +217,221 @@ fn uuid_hex(uuid: [u8; 16]) -> String {
 // gilrs I/O: a raw reader shared by the runtime and the calibration flow.
 // ---------------------------------------------------------------------------
 
-/// A gilrs instance with SDL controller mappings turned off, plus the current
-/// raw axis/button state accumulated from its events.
+/// Standard-layout state for a pad the controller database or platform
+/// driver recognises, accumulated from gilrs's named events. Only consulted
+/// when the pad has no saved calibration.
+#[derive(Clone, Copy, Debug, Default)]
+struct MappedPadState {
+    dpad_up: bool,
+    dpad_down: bool,
+    dpad_left: bool,
+    dpad_right: bool,
+    south: bool,
+    east: bool,
+    west: bool,
+    north: bool,
+    start: bool,
+    left_shoulder: bool,
+    right_shoulder: bool,
+    left_trigger: bool,
+    right_trigger: bool,
+    /// Left stick and d-pad axes in gilrs's convention: up and right are
+    /// positive. Hat-style d-pads arrive as axes on some platforms.
+    left_x: f32,
+    left_y: f32,
+    dpad_x: f32,
+    dpad_y: f32,
+}
+
+impl MappedPadState {
+    fn set_button(&mut self, button: gilrs::Button, pressed: bool) {
+        use gilrs::Button as B;
+        match button {
+            B::DPadUp => self.dpad_up = pressed,
+            B::DPadDown => self.dpad_down = pressed,
+            B::DPadLeft => self.dpad_left = pressed,
+            B::DPadRight => self.dpad_right = pressed,
+            B::South => self.south = pressed,
+            B::East => self.east = pressed,
+            B::West => self.west = pressed,
+            B::North => self.north = pressed,
+            B::Start => self.start = pressed,
+            B::LeftTrigger => self.left_shoulder = pressed,
+            B::RightTrigger => self.right_shoulder = pressed,
+            B::LeftTrigger2 => self.left_trigger = pressed,
+            B::RightTrigger2 => self.right_trigger = pressed,
+            _ => {}
+        }
+    }
+
+    fn set_axis(&mut self, axis: gilrs::Axis, value: f32) {
+        use gilrs::Axis as A;
+        match axis {
+            A::LeftStickX => self.left_x = value,
+            A::LeftStickY => self.left_y = value,
+            A::DPadX => self.dpad_x = value,
+            A::DPadY => self.dpad_y = value,
+            _ => {}
+        }
+    }
+
+    /// The fixed standard layout: d-pad and left stick drive the directions;
+    /// South = fire/red, East = blue, West = green, North = yellow, Start =
+    /// play/pause, left shoulder/trigger = reverse, right = forward.
+    fn resolve(&self) -> JoystickState {
+        let t = AXIS_ACTIVE_THRESHOLD;
+        JoystickState {
+            up: self.dpad_up || self.left_y >= t || self.dpad_y >= t,
+            down: self.dpad_down || self.left_y <= -t || self.dpad_y <= -t,
+            left: self.dpad_left || self.left_x <= -t || self.dpad_x <= -t,
+            right: self.dpad_right || self.left_x >= t || self.dpad_x >= t,
+            fire: self.south,
+            button2: self.east,
+            green: self.west,
+            yellow: self.north,
+            play: self.start,
+            rwd: self.left_shoulder || self.left_trigger,
+            ffw: self.right_shoulder || self.right_trigger,
+        }
+    }
+}
+
+/// A gilrs instance with the bundled SDL controller mappings enabled, plus
+/// the current input state accumulated from its events in two forms: raw
+/// axis/button codes (what calibration records and resolves against) and the
+/// named standard layout (the default for recognised, uncalibrated pads).
 struct RawGamepads {
     gilrs: gilrs::Gilrs,
     axes: BTreeMap<u32, f32>,
     buttons: BTreeMap<u32, bool>,
+    mapped: MappedPadState,
 }
 
 impl RawGamepads {
     fn new() -> Result<Self> {
         let gilrs = gilrs::GilrsBuilder::new()
-            .add_included_mappings(false)
-            .add_env_mappings(false)
+            .add_included_mappings(true)
+            .add_env_mappings(true)
             .build()
             .map_err(|e| anyhow!("gamepad init: {e}"))?;
         Ok(Self {
             gilrs,
             axes: BTreeMap::new(),
             buttons: BTreeMap::new(),
+            mapped: MappedPadState::default(),
         })
     }
 
-    /// Drain pending events into the raw axis/button state.
+    /// Drain pending events into the raw and named input state.
     fn pump(&mut self) {
         while let Some(event) = self.gilrs.next_event() {
+            // COPPERLINE_DIAG_GAMEPAD=1 logs every gilrs event as delivered
+            // (named control, post-mapping value, raw code) plus each pad's
+            // identity and mapping source on connect: the ground truth for
+            // diagnosing a wrong or broken controller-database entry.
+            if crate::envcfg::flag("COPPERLINE_DIAG_GAMEPAD") {
+                if event.event == gilrs::EventType::Connected {
+                    let pad = self.gilrs.gamepad(event.id);
+                    log::info!(
+                        "gamepad diag: connected \"{}\" uuid {} mapping source {:?}",
+                        pad.name(),
+                        uuid_hex(pad.uuid()),
+                        pad.mapping_source()
+                    );
+                } else {
+                    log::info!("gamepad diag: {:?}", event.event);
+                }
+            }
             match event.event {
-                gilrs::EventType::AxisChanged(_, value, code) => {
+                gilrs::EventType::AxisChanged(axis, value, code) => {
                     self.axes.insert(code.into_u32(), value);
+                    self.mapped.set_axis(axis, value);
                 }
-                gilrs::EventType::ButtonChanged(_, value, code) => {
-                    self.buttons
-                        .insert(code.into_u32(), value >= AXIS_ACTIVE_THRESHOLD);
+                gilrs::EventType::ButtonChanged(button, value, code) => {
+                    if self.collapsed_dpad_half_axis(event.id, button, code) {
+                        self.reroute_collapsed_dpad(button, value, code);
+                    } else {
+                        let pressed = value >= AXIS_ACTIVE_THRESHOLD;
+                        self.buttons.insert(code.into_u32(), pressed);
+                        self.mapped.set_button(button, pressed);
+                    }
                 }
-                gilrs::EventType::ButtonPressed(_, code) => {
-                    self.buttons.insert(code.into_u32(), true);
+                gilrs::EventType::ButtonPressed(button, code) => {
+                    // A collapsed half-axis d-pad also emits Pressed/Released
+                    // at gilrs's threshold crossings; the ButtonChanged value
+                    // stream carries the direction, so drop these.
+                    if !self.collapsed_dpad_half_axis(event.id, button, code) {
+                        self.buttons.insert(code.into_u32(), true);
+                        self.mapped.set_button(button, true);
+                    }
                 }
-                gilrs::EventType::ButtonReleased(_, code) => {
-                    self.buttons.insert(code.into_u32(), false);
+                gilrs::EventType::ButtonReleased(button, code) => {
+                    if !self.collapsed_dpad_half_axis(event.id, button, code) {
+                        self.buttons.insert(code.into_u32(), false);
+                        self.mapped.set_button(button, false);
+                    }
                 }
                 gilrs::EventType::Disconnected => {
                     self.axes.clear();
                     self.buttons.clear();
+                    self.mapped = MappedPadState::default();
                 }
                 _ => {}
             }
+        }
+    }
+
+    /// Whether this d-pad button event is really one half of an axis-mapped
+    /// d-pad that gilrs collapsed to a single button.
+    ///
+    /// gilrs's SDL-mapping parser drops the `+`/`-` qualifiers of half-axis
+    /// d-pad entries (`dpup:-a1,dpdown:+a1`, the common shape for cheap
+    /// stickless pads) and keys its table by the native axis code, so the
+    /// second binding for an axis overwrites the first: exactly one button
+    /// of the pair keeps a code, and every event for that axis arrives as
+    /// that one button with the full axis travel in its 0..1 value (0 = the
+    /// SDL-negative end = up/left on standard entries, 0.5 = rest). Left as
+    /// buttons, one direction per axis is lost and the other fires from the
+    /// wrong end, so [`Self::reroute_collapsed_dpad`] turns these events
+    /// back into a signed axis for both the raw and the named state.
+    fn collapsed_dpad_half_axis(
+        &self,
+        id: gilrs::GamepadId,
+        button: gilrs::Button,
+        code: gilrs::ev::Code,
+    ) -> bool {
+        use gilrs::Button as B;
+        let pair = match button {
+            B::DPadUp | B::DPadDown => (B::DPadUp, B::DPadDown),
+            B::DPadLeft | B::DPadRight => (B::DPadLeft, B::DPadRight),
+            _ => return false,
+        };
+        let pad = self.gilrs.gamepad(id);
+        if pad.mapping_source() != gilrs::MappingSource::SdlMappings {
+            return false;
+        }
+        match (pad.button_code(pair.0), pad.button_code(pair.1)) {
+            (Some(c), None) | (None, Some(c)) => c == code,
+            _ => false,
+        }
+    }
+
+    /// Recover both directions from a collapsed half-axis d-pad event: the
+    /// 0..1 button value spans the full axis, so recentre it to -1..1 and
+    /// store it as the raw axis it really is (which is also what the
+    /// pre-database calibration format recorded for these pads). The named
+    /// state gets the same value on the matching d-pad axis, flipped
+    /// vertically because SDL entries put up at the negative end while the
+    /// named convention is up-positive.
+    fn reroute_collapsed_dpad(&mut self, button: gilrs::Button, value: f32, code: gilrs::ev::Code) {
+        let v = value * 2.0 - 1.0;
+        self.axes.insert(code.into_u32(), v);
+        self.buttons.remove(&code.into_u32());
+        use gilrs::Button as B;
+        match button {
+            B::DPadUp | B::DPadDown => self.mapped.dpad_y = -v,
+            B::DPadLeft | B::DPadRight => self.mapped.dpad_x = v,
+            _ => {}
         }
     }
 
@@ -249,15 +440,17 @@ impl RawGamepads {
     }
 }
 
-/// Runtime reader: maps the first connected, calibrated pad to the emulated
-/// port-2 joystick. Held by the window and polled once per scheduler quantum.
+/// Runtime reader: maps the first connected pad to the emulated port-2
+/// joystick, through its saved calibration when one exists and through the
+/// standard layout when the controller database or platform driver knows the
+/// pad. Held by the window and polled once per scheduler quantum.
 pub struct GamepadReader {
     raw: Option<RawGamepads>,
     store: CalibrationStore,
     warned_uncalibrated: bool,
-    /// UUID of the pad whose calibration we last announced as in use, so we
-    /// log it once per pad (and again if a different pad is plugged in).
-    logged_calibrated: Option<String>,
+    /// UUID of the pad whose input source we last announced, so we log it
+    /// once per pad (and again if a different pad is plugged in).
+    logged_pad: Option<String>,
 }
 
 impl Default for GamepadReader {
@@ -279,7 +472,7 @@ impl GamepadReader {
             raw,
             store: CalibrationStore::load(),
             warned_uncalibrated: false,
-            logged_calibrated: None,
+            logged_pad: None,
         }
     }
 
@@ -311,7 +504,7 @@ impl GamepadReader {
         self.store.save()?;
         self.warned_uncalibrated = false;
         // Re-announce on the next poll now that a (new) calibration is live.
-        self.logged_calibrated = None;
+        self.logged_pad = None;
         Ok(())
     }
 
@@ -333,20 +526,50 @@ impl GamepadReader {
 
     /// Poll the gamepad and return its resolved state (emulated joystick
     /// lines plus the host-side Quit hotkey), or `None` when there is no
-    /// pad or no calibration for the connected one.
+    /// pad, or the connected one is neither calibrated nor known to the
+    /// controller database.
     pub fn poll(&mut self) -> Option<PadState> {
         let raw = self.raw.as_mut()?;
         raw.pump();
         let id = raw.first_gamepad()?;
         let pad = raw.gilrs.gamepad(id);
         let uuid = uuid_hex(pad.uuid());
+        let mapped = !matches!(pad.mapping_source(), gilrs::MappingSource::None);
         match self.store.get(&uuid) {
             Some(cal) => {
-                if self.logged_calibrated.as_deref() != Some(uuid.as_str()) {
-                    self.logged_calibrated = Some(uuid.clone());
+                if self.logged_pad.as_deref() != Some(uuid.as_str()) {
+                    self.logged_pad = Some(uuid.clone());
                     log::info!("using saved calibration for gamepad \"{}\"", pad.name());
+                    if cal.format < CALIBRATION_FORMAT
+                        && matches!(pad.mapping_source(), gilrs::MappingSource::SdlMappings)
+                    {
+                        // The bundled mappings can flip named-axis signs
+                        // relative to what an old-format calibration
+                        // recorded for this (database-covered) pad.
+                        log::warn!(
+                            "gamepad \"{}\" was calibrated before the bundled controller \
+                             mappings were enabled; recalibrate if a direction is reversed",
+                            pad.name()
+                        );
+                    }
                 }
                 Some(cal.resolve_pad(&raw.axes, &raw.buttons))
+            }
+            None if mapped => {
+                if self.logged_pad.as_deref() != Some(uuid.as_str()) {
+                    self.logged_pad = Some(uuid.clone());
+                    log::info!(
+                        "gamepad \"{}\" recognised by the controller database; using the \
+                         standard layout (calibrate to customise)",
+                        pad.name()
+                    );
+                }
+                // The default layout binds no Quit hotkey; only an explicit
+                // calibration may arm a host-side control.
+                Some(PadState {
+                    joystick: raw.mapped.resolve(),
+                    quit: false,
+                })
             }
             None => {
                 if !self.warned_uncalibrated {
@@ -570,6 +793,7 @@ impl CalibrationSession {
             rwd: b[9],
             ffw: b[10],
             quit: b[11],
+            format: CALIBRATION_FORMAT,
         }
     }
 }
@@ -643,6 +867,7 @@ pub fn run_calibration() -> Result<()> {
             "the Quit Copperline hotkey (or wait to skip)",
             false,
         )?,
+        format: CALIBRATION_FORMAT,
     };
 
     let mut store = CalibrationStore::load();
@@ -741,12 +966,7 @@ mod tests {
             right: axis(0x10030, true),
             fire: button(0x90001),
             button2: button(0x90002),
-            green: None,
-            yellow: None,
-            play: None,
-            rwd: None,
-            ffw: None,
-            quit: None,
+            ..Default::default()
         };
 
         let mut axes = BTreeMap::new();
@@ -767,6 +987,82 @@ mod tests {
         let s = cal.resolve(&axes, &buttons);
         assert!(s.right && !s.left && s.button2 && !s.fire);
         assert!(!s.up && !s.down);
+    }
+
+    #[test]
+    fn default_layout_maps_standard_controls_to_cd32_actions() {
+        // A database-covered pad with no calibration resolves through the
+        // fixed standard layout: face buttons onto the CD32 colours, Start
+        // onto play/pause, shoulders and triggers onto the transport keys.
+        let mut mapped = MappedPadState::default();
+        mapped.set_button(gilrs::Button::South, true);
+        mapped.set_button(gilrs::Button::Start, true);
+        mapped.set_button(gilrs::Button::LeftTrigger, true);
+        mapped.set_button(gilrs::Button::RightTrigger2, true);
+        mapped.set_button(gilrs::Button::DPadUp, true);
+        let s = mapped.resolve();
+        assert!(s.fire && s.play && s.rwd && s.ffw && s.up);
+        assert!(!s.button2 && !s.green && !s.yellow && !s.down);
+
+        mapped = MappedPadState::default();
+        mapped.set_button(gilrs::Button::East, true);
+        mapped.set_button(gilrs::Button::West, true);
+        mapped.set_button(gilrs::Button::North, true);
+        let s = mapped.resolve();
+        assert!(s.button2 && s.green && s.yellow);
+        assert!(!s.fire && !s.play && !s.rwd && !s.ffw);
+    }
+
+    #[test]
+    fn default_layout_directions_from_stick_dpad_buttons_and_hat_axes() {
+        // gilrs's named-axis convention is up/right positive; a deflection
+        // must pass the activity threshold, and d-pad buttons, hat-style
+        // d-pad axes, and the left stick all drive the same four lines.
+        let mut mapped = MappedPadState::default();
+        mapped.set_axis(gilrs::Axis::LeftStickY, 0.9);
+        mapped.set_axis(gilrs::Axis::LeftStickX, -0.9);
+        let s = mapped.resolve();
+        assert!(s.up && s.left && !s.down && !s.right);
+
+        mapped.set_axis(gilrs::Axis::LeftStickY, 0.3); // below threshold
+        mapped.set_axis(gilrs::Axis::LeftStickX, 0.0);
+        assert_eq!(mapped.resolve(), JoystickState::default());
+
+        mapped = MappedPadState::default();
+        mapped.set_axis(gilrs::Axis::DPadY, -1.0);
+        mapped.set_button(gilrs::Button::DPadRight, true);
+        let s = mapped.resolve();
+        assert!(s.down && s.right && !s.up && !s.left);
+    }
+
+    #[test]
+    fn calibration_format_tags_new_recordings_and_defaults_to_legacy() {
+        // Files written before the bundled mappings were enabled carry no
+        // format key and must load as format 0 (legacy); anything recorded
+        // now is stamped with the current format.
+        let legacy: CalibrationStore = toml::from_str(
+            "[gamepads.0123]\nup = { kind = \"axis\", code = 49, positive = false }\n",
+        )
+        .unwrap();
+        let cal = legacy.get("0123").unwrap();
+        assert_eq!(cal.format, 0);
+        assert_eq!(cal.up, axis(49, false));
+
+        let mut session = CalibrationSession::new();
+        let pad = Some(("Pad".to_string(), "abc123".to_string()));
+        let axes = BTreeMap::new();
+        let mut buttons = BTreeMap::new();
+        for step in 0..5 {
+            session.advance(pad.clone(), &axes, &buttons); // neutral
+            buttons.insert(0x9000 + step as u32, true);
+            session.advance(pad.clone(), &axes, &buttons);
+            buttons.clear();
+        }
+        while session.can_skip() {
+            session.skip_current();
+        }
+        assert!(session.done());
+        assert_eq!(session.to_calibration().format, CALIBRATION_FORMAT);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2132,13 +2132,13 @@ fn list_midi_endpoints() -> Result<()> {
 fn main() -> Result<()> {
     let mut log_builder =
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"));
-    // Copperline reads raw gamepad axis/button codes with gilrs's SDL
-    // controller mappings disabled (see gamepad.rs) and applies its own
-    // per-UUID calibration from gamepads.toml. gilrs's mapping subsystem is
-    // therefore unused, so its "No mapping found for UUID ...; default mapping
-    // will be used" warnings are misleading noise even when the pad works.
-    // Silence gilrs below error level unless the user has explicitly asked for
-    // its logs via RUST_LOG.
+    // Copperline resolves gamepads through gilrs's bundled SDL controller
+    // mappings, overridden per-UUID by calibrations from gamepads.toml (see
+    // gamepad.rs). For a pad the database misses, gilrs logs "No mapping
+    // found for UUID ...; default mapping will be used", but gamepad.rs
+    // already prints a clearer calibration prompt for that case. Silence
+    // gilrs below error level unless the user has explicitly asked for its
+    // logs via RUST_LOG.
     if std::env::var_os("RUST_LOG").is_none() {
         log_builder.filter_module("gilrs", log::LevelFilter::Error);
         // The Cranelift JIT backend logs every compiled trace's full IR


### PR DESCRIPTION
Gamepads recognised by the bundled SDL_GameControllerDB (or the platform
driver) now work with no setup at all, while the guided calibration stays
as the per-pad override and the only path for unknown pads.

## Database defaults, calibration override

- gilrs is built with its bundled controller database enabled (plus
  `SDL_GAMECONTROLLERCONFIG` for personal mapping strings), previously
  switched off so every pad required calibration.
- Recognised pads use a fixed standard layout: d-pad + left stick for
  directions, South = fire/CD32 red, East = blue, West = green,
  North = yellow, Start = play/pause, shoulders/triggers = reverse and
  forward. The default layout never binds the Quit hotkey.
- A saved per-UUID calibration always wins, so pads with broken database
  entries are fixed the same way as before: calibrate once. New
  recordings carry a format tag; loading a legacy calibration for a
  database-covered pad logs a one-time recalibration hint (the mappings
  normalise named-axis signs and can reverse a stick recorded by the
  mappings-off era).

## Collapsed half-axis d-pads

gilrs's SDL parser drops the `+`/`-` qualifiers of half-axis d-pad
entries (`dpup:-a1,dpdown:+a1` - the common shape for cheap stickless
retro pads) and keys its table by native axis code, so the second
binding overwrites the first: one direction per axis vanishes and the
other fires from the wrong end. The collapse is detected via the
`button_code` asymmetry of the pair and the event's 0..1 value is
rerouted back into the signed raw axis it really is, restoring both the
default layout and calibration for such pads (verified on a real Padix
"Retro Controller").

## CD32 pad: held Blue grounded the whole serial report

Found while testing the above in-game: the POTGOR read gated the CD32
pad's serial bit with Blue, so holding Blue pulled POTxY low for every
clocked bit and the game saw all seven buttons pressed (the report is
active low). The real pad's 4021 shift register follows Blue only in
load mode - while clocking, a held Blue is just bit 8 of the report.
Gate removed; regression test
`cd32_pad_held_blue_does_not_ground_the_serial_report` added.

## Also

- `COPPERLINE_DIAG_GAMEPAD=1` logs every gilrs event (named control,
  post-mapping value, raw code) and each pad's identity + mapping source
  on connect - how both bugs above were traced.
- Docs updated: `docs/guide/ui.md` gamepad chapter rewritten for the
  hybrid model, `docs/internals/peripherals.md`, architecture tree note.

Unit suite, clippy, and fmt are clean; the d-pad reroute and CD32 fix
were verified against a real pad on a CD32 profile.
