### PR TITLE
Feature/UI keyboard and gamepad navigation

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -671,11 +671,9 @@ floppy_sounds_volume = 100
 # device, as on a real Amiga:
 #   "mouse"    quadrature mouse (three buttons)
 #   "gamepad-mouse"
-#              the same mouse, moved by a gamepad as well as by the host's
-#              own: the pad's d-pad and left stick move the pointer and its
-#              two buttons click. Port 1 only, and while it is chosen that
-#              pad drives no joystick port -- whichever port it would have
-#              driven falls to the keyboard until the port is changed back
+#              a mouse a gamepad moves as well as the host's own (d-pad and
+#              left stick move the pointer, its two buttons click). Port 1
+#              only; while it is chosen the pad drives no joystick port
 #   "joystick" digital switch joystick (fire + second button)
 #   "cd32"     CD32 joypad (adds the serial button protocol)
 #   "analogue" analogue paddles / proportional stick on the POT pins,

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -670,6 +670,12 @@ floppy_sounds_volume = 100
 # Controller device plugged into each game port. Either port accepts any
 # device, as on a real Amiga:
 #   "mouse"    quadrature mouse (three buttons)
+#   "gamepad-mouse"
+#              the same mouse, moved by a gamepad as well as by the host's
+#              own: the pad's d-pad and left stick move the pointer and its
+#              two buttons click. Port 1 only, and while it is chosen that
+#              pad drives no joystick port -- whichever port it would have
+#              driven falls to the keyboard until the port is changed back
 #   "joystick" digital switch joystick (fire + second button)
 #   "cd32"     CD32 joypad (adds the serial button protocol)
 #   "analogue" analogue paddles / proportional stick on the POT pins,

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -392,8 +392,9 @@ relative motion there.
 
 Controller ports: `input.get_ports` -> `{"port1": "mouse", "port2":
 "joystick"}`; `input.set_port {port, device:
-"mouse"|"joystick"|"cd32"|"analogue"|"none"}` hot-plugs a device, as if
-swapping the physical plug (the old device's held lines release; the
+"mouse"|"gamepad-mouse"|"joystick"|"cd32"|"analogue"|"none"}` hot-plugs a
+device, as if swapping the physical plug (`"gamepad-mouse"` is port 1
+only, and is refused elsewhere) (the old device's held lines release; the
 change is applied live, mid-run included, and is not journaled for
 reverse replay):
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -95,6 +95,12 @@ A controller drives all of this with its d-pad, fire and second button.
 Its [Menu button](#gamepad-calibration) is the way in from a running
 machine.
 
+The debugger, frame analyzer and console windows are deliberately not
+walked -- they are worked with the keyboard and mouse -- but `Esc`
+closes the focused one, and the pad's second button (or its Menu
+button) closes the top one, so a window opened from the menu can be put
+away again the same way.
+
 ## Status bar
 
 The status bar (44 pixels below the display) holds, left to right (it can
@@ -1100,6 +1106,12 @@ described under Keyboard and controller navigation above. While the menu
 or a panel is open, the pad stops driving the emulated port, just as the
 keyboard does. On the default database layout Select/Back and the guide
 button carry it; a calibration can put it anywhere (or skip it).
+
+Once every step is captured the bindings can be tested by pressing
+them, and *holding* any one of them for about a second hands the
+panel's own Save and Cancel buttons to the pad, which then walks them
+with the very controls it has just been taught. Without that, finishing
+a calibration needs the mouse.
 
 Calibrations are saved per controller UUID in
 `~/.config/copperline/gamepads.toml` (`$XDG_CONFIG_HOME` respected;

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -59,47 +59,42 @@ Everything the mouse can reach in the launcher, the menu, the status bar
 and the overlay panels can be reached with the arrow keys or a
 controller.
 
-The arrows move the focus, which lights the control it stands on in blue
-and breathes while it is there. Return (or the pad's fire button) works
-whatever is lit; the pad's second button steps back out, closing a
-setting, then the surface. Left and right move along the row the focus is
-on, up and down to the nearest control above or below; at the edge of a
-surface the focus stays where it is.
+The arrows move the focus, which lights the control it is on. Return (or
+the pad's fire button) works it; `Esc` (or the pad's second button) steps
+back out -- out of an open setting, then the page, then the surface.
+Left and right move along the row, up and down to the row above or below;
+at the edge of a surface the focus stays where it is. Controls that
+cannot be pressed are skipped.
 
-| Control | Focus | Return / fire |
-|---|---|---|
-| Buttons, tabs, the close gadget | Lights blue | Presses it |
-| Tick boxes and cover art | Green edge | Ticks it |
-| Text boxes | Light blue | Opens it for typing, with the caret |
-| `< value >` settings | Lights both arrows, value stays green | Opens it: the value turns white and left/right change it. Return again closes it |
-| Volume slider | Lights the knob | Opens it: left and right move it |
+| Control | Return / fire |
+|---|---|
+| Buttons, tabs, the close gadget | Presses it |
+| Tick boxes and cover art | Ticks it |
+| Text boxes | Opens it for typing |
+| `< value >` settings | Opens it; left and right change the value, Return closes it |
+| Volume slider | Opens it; left and right move it |
 
 Lists -- the games, the favourites, the host's disks -- are walked with
-up and down, which move the list's own selection and scroll it. Left
-leaves a list, right steps across to the tick beside a row and then on
-out of the list. Buttons that cannot be pressed are skipped.
+up and down, which move the list's own selection and scroll it. Right
+steps to the tick beside a row and then out of the list; left leaves it.
 
 Stepping down off the foot of a surface reaches the status bar, and up
-returns. Stepping left out of a settings page returns to the category
-button that opened it, and stepping right from one opens its page.
-Walking off the bottom of the menu closes it and leaves the focus on the
-menu button. Escape (or the second button) backs out: out of an open
-setting, then out of the page, then out of the surface.
+returns. Left out of a settings page returns to the category button that
+opened it, and right opens that button's page. Walking off the bottom of
+the menu closes it and leaves the focus on the menu button.
 
-Clicking anything puts the focus out and leaves it where the pointer
+Clicking anything puts the focus away and leaves it where the pointer
 pressed, so going back to the keyboard resumes from there. While the
-focus is showing, the pointer highlights nothing; moving the mouse puts
-the focus away again.
+focus is shown the pointer highlights nothing; moving the mouse puts it
+away again.
 
 A controller drives all of this with its d-pad, fire and second button.
 Its [Menu button](#gamepad-calibration) is the way in from a running
 machine.
 
-The debugger, frame analyzer and console windows are deliberately not
-walked -- they are worked with the keyboard and mouse -- but `Esc`
-closes the focused one, and the pad's second button (or its Menu
-button) closes the top one, so a window opened from the menu can be put
-away again the same way.
+The debugger, frame analyzer and console windows are not navigated this
+way, but `Esc` closes the focused one and the pad's second button closes
+the top one.
 
 ## Status bar
 
@@ -989,19 +984,14 @@ buttons, on either port. An `analogue` device presents pot resistances on
 the POTxX/POTxY pins; no live host device maps to it yet -- drive it with
 `--pot-after` scripting or the control protocol's `input.analogue`.
 
-A `gamepad-mouse` device is the same quadrature mouse the machine always
-sees, moved by a gamepad as well as by the host's own mouse -- one mouse
-with two hands on it, not two mice. The pad's d-pad moves the pointer,
-gathering speed while a direction is held; its left stick moves it
-proportionally where the pad has one, so a slight deflection creeps and a
-full one crosses the screen. Fire is the left button and the second
-button is the right, and the
-[mouse sensitivity](configuration.md#mouse-sensitivity) setting scales it
-along with the host mouse. It is offered on port 1 alone, which is where
-a mouse belongs. While it is chosen that pad drives no joystick port --
-one pad cannot be both -- and whichever port it would have driven falls
-to the keyboard until the device is changed back; the joystick input mode
-itself is untouched, so switching away restores it.
+A `gamepad-mouse` device is a mouse a gamepad moves as well as the host's
+own; the machine still sees one mouse. The d-pad moves the pointer,
+gathering speed while a direction is held, and the left stick moves it
+proportionally where the pad has one. Fire is the left button, the second
+button the right, and `mouse_sensitivity` scales both hands alike. It is
+offered on port 1 only. While it is chosen the pad drives no joystick
+port -- whichever port it would have driven falls to the keyboard until
+the device is changed back.
 
 Copperline can also emulate the joystick from the host keyboard. There are
 two explicit input modes, and the active one is always shown by the gamepad
@@ -1082,11 +1072,10 @@ live test of the finished bindings and a Save button that makes them live
 immediately -- or from the terminal with `copperline --calibrate-gamepad`.
 The steps are the four directions, fire (CD32 red), button 2 (CD32 blue),
 the optional CD32 green/yellow/play/rewind/forward buttons, an optional
-**Open menu** button, and an optional **Quit Copperline** hotkey. Push
-the control to bind it -- the binding is taken when it comes back up, so
-a control already down when a step begins cannot bleed into it -- or
-hold any control for about a second to skip a step the pad has no
-control for. The four directions and fire cannot be skipped.
+**Open menu** button, and an optional **Quit Copperline** hotkey. Push a
+control to bind it, or hold any control for about a second to skip a step
+the pad has no control for; the four directions and fire cannot be
+skipped.
 
 The Quit hotkey is a host-side control: it never reaches the emulated
 machine, so any spare pad button (Select, Start, a shoulder button) can
@@ -1101,19 +1090,16 @@ calibration can arm one.
 
 The Menu button is the other host-side control: a press opens the pop-up
 menu (or closes an open overlay panel), and from there the pad walks
-whatever is up -- the menu, the status bar, the machine configuration
-and the panels beyond it. Its directions, fire and second button mean
-what the arrow keys, `Return` and `Esc` mean, so the walk is the one
-described under Keyboard and controller navigation above. While the menu
-or a panel is open, the pad stops driving the emulated port, just as the
-keyboard does. On the default database layout Select/Back and the guide
-button carry it; a calibration can put it anywhere (or skip it).
+whatever is up, as described under
+[Keyboard and controller navigation](#keyboard-and-controller-navigation)
+above. While the menu or a panel is open the pad stops driving the
+emulated port, just as the keyboard does. On the default database layout
+Select/Back and the guide button carry it; a calibration can put it
+anywhere (or skip it).
 
-Once every step is captured the bindings can be tested by pushing them,
-and holding any one of them hands the panel's own Save and Cancel
-buttons to the pad, which then walks them with the very controls it has
-just been taught. Without that, finishing a calibration needs the
-mouse.
+Once every step is captured, pushing a control tests its binding and
+holding one hands the panel's Save and Cancel buttons to the pad, so a
+calibration can be finished without the mouse.
 
 Calibrations are saved per controller UUID in
 `~/.config/copperline/gamepads.toml` (`$XDG_CONFIG_HOME` respected;

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -935,7 +935,8 @@ either direction.
 
 An Amiga has two game ports, and either accepts any controller. Copperline
 models that: each port carries a device -- `mouse`, `joystick`, `cd32` pad,
-`analogue` paddles, or `none` -- set with `[input] port1`/`port2` in the
+`analogue` paddles, or `none`, and port 1 additionally `gamepad-mouse` --
+set with `[input] port1`/`port2` in the
 config (or `--port1`/`--port2`, or the launcher's *Input* tab). The default
 is the stock wiring, a mouse in port 1 and a joystick in port 2 (a CD32 pad
 on the CD32 profile). The runtime menu's **Port 1 Device** / **Port 2
@@ -981,6 +982,20 @@ protocol instead, including the red/blue/green/yellow and transport
 buttons, on either port. An `analogue` device presents pot resistances on
 the POTxX/POTxY pins; no live host device maps to it yet -- drive it with
 `--pot-after` scripting or the control protocol's `input.analogue`.
+
+A `gamepad-mouse` device is the same quadrature mouse the machine always
+sees, moved by a gamepad as well as by the host's own mouse -- one mouse
+with two hands on it, not two mice. The pad's d-pad moves the pointer,
+gathering speed while a direction is held; its left stick moves it
+proportionally where the pad has one, so a slight deflection creeps and a
+full one crosses the screen. Fire is the left button and the second
+button is the right, and the
+[mouse sensitivity](configuration.md#mouse-sensitivity) setting scales it
+along with the host mouse. It is offered on port 1 alone, which is where
+a mouse belongs. While it is chosen that pad drives no joystick port --
+one pad cannot be both -- and whichever port it would have driven falls
+to the keyboard until the device is changed back; the joystick input mode
+itself is untouched, so switching away restores it.
 
 Copperline can also emulate the joystick from the host keyboard. There are
 two explicit input modes, and the active one is always shown by the gamepad

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -1082,9 +1082,11 @@ live test of the finished bindings and a Save button that makes them live
 immediately -- or from the terminal with `copperline --calibrate-gamepad`.
 The steps are the four directions, fire (CD32 red), button 2 (CD32 blue),
 the optional CD32 green/yellow/play/rewind/forward buttons, an optional
-**Open menu** button, and an optional **Quit Copperline** hotkey; every
-step waits for the pad to return to neutral before sampling, so a held
-control cannot bleed into the next binding.
+**Open menu** button, and an optional **Quit Copperline** hotkey. Push
+the control to bind it -- the binding is taken when it comes back up, so
+a control already down when a step begins cannot bleed into it -- or
+hold any control for about a second to skip a step the pad has no
+control for. The four directions and fire cannot be skipped.
 
 The Quit hotkey is a host-side control: it never reaches the emulated
 machine, so any spare pad button (Select, Start, a shoulder button) can
@@ -1107,11 +1109,11 @@ or a panel is open, the pad stops driving the emulated port, just as the
 keyboard does. On the default database layout Select/Back and the guide
 button carry it; a calibration can put it anywhere (or skip it).
 
-Once every step is captured the bindings can be tested by pressing
-them, and *holding* any one of them for about a second hands the
-panel's own Save and Cancel buttons to the pad, which then walks them
-with the very controls it has just been taught. Without that, finishing
-a calibration needs the mouse.
+Once every step is captured the bindings can be tested by pushing them,
+and holding any one of them hands the panel's own Save and Cancel
+buttons to the pad, which then walks them with the very controls it has
+just been taught. Without that, finishing a calibration needs the
+mouse.
 
 Calibrations are saved per controller UUID in
 `~/.config/copperline/gamepads.toml` (`$XDG_CONFIG_HOME` respected;

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -53,6 +53,48 @@ the keyboard hardware directly behaves. `Ctrl+Amiga+Amiga` runs the
 authentic reset protocol (reset warning, then KCLK held low), so the
 reboot lands a fraction of a second after the chord, as on real hardware.
 
+## Keyboard and controller navigation
+
+Everything the mouse can reach in the launcher, the menu, the status bar
+and the overlay panels can be reached with the arrow keys or a
+controller.
+
+The arrows move the focus, which lights the control it stands on in blue
+and breathes while it is there. Return (or the pad's fire button) works
+whatever is lit; the pad's second button steps back out, closing a
+setting, then the surface. Left and right move along the row the focus is
+on, up and down to the nearest control above or below; at the edge of a
+surface the focus stays where it is.
+
+| Control | Focus | Return / fire |
+|---|---|---|
+| Buttons, tabs, the close gadget | Lights blue | Presses it |
+| Tick boxes and cover art | Green edge | Ticks it |
+| Text boxes | Light blue | Opens it for typing, with the caret |
+| `< value >` settings | Lights both arrows, value stays green | Opens it: the value turns white and left/right change it. Return again closes it |
+| Volume slider | Lights the knob | Opens it: left and right move it |
+
+Lists -- the games, the favourites, the host's disks -- are walked with
+up and down, which move the list's own selection and scroll it. Left
+leaves a list, right steps across to the tick beside a row and then on
+out of the list. Buttons that cannot be pressed are skipped.
+
+Stepping down off the foot of a surface reaches the status bar, and up
+returns. Stepping left out of a settings page returns to the category
+button that opened it, and stepping right from one opens its page.
+Walking off the bottom of the menu closes it and leaves the focus on the
+menu button. Escape (or the second button) backs out: out of an open
+setting, then out of the page, then out of the surface.
+
+Clicking anything puts the focus out and leaves it where the pointer
+pressed, so going back to the keyboard resumes from there. While the
+focus is showing, the pointer highlights nothing; moving the mouse puts
+the focus away again.
+
+A controller drives all of this with its d-pad, fire and second button.
+Its [Menu button](#gamepad-calibration) is the way in from a running
+machine.
+
 ## Status bar
 
 The status bar (44 pixels below the display) holds, left to right (it can
@@ -1035,14 +1077,14 @@ The default database layout never binds a Quit hotkey; only a
 calibration can arm one.
 
 The Menu button is the other host-side control: a press opens the pop-up
-menu (or closes an open overlay panel), and while the menu is up the pad
-walks it -- the d-pad steps rows (hold to repeat), right opens a
-category, left backs out of one, fire activates the row, and the second
-button backs out a level at a time, closing the menu from the top: the
-same walk the arrow keys and `Esc` do. While the menu or a panel is
-open, the pad stops driving the emulated port, just as the keyboard
-does. On the default database layout Select/Back and the guide button
-carry it; a calibration can put it anywhere (or skip it).
+menu (or closes an open overlay panel), and from there the pad walks
+whatever is up -- the menu, the status bar, the machine configuration
+and the panels beyond it. Its directions, fire and second button mean
+what the arrow keys, `Return` and `Esc` mean, so the walk is the one
+described under Keyboard and controller navigation above. While the menu
+or a panel is open, the pad stops driving the emulated port, just as the
+keyboard does. On the default database layout Select/Back and the guide
+button carry it; a calibration can put it anywhere (or skip it).
 
 Calibrations are saved per controller UUID in
 `~/.config/copperline/gamepads.toml` (`$XDG_CONFIG_HOME` respected;

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2009,6 +2009,9 @@ pub enum PortDevice {
     /// Analogue paddles / proportional stick: positions present resistances
     /// on POTxX/POTxY; the two buttons ground the LEFT/RIGHT lines.
     Analogue,
+    /// Empty port: nothing drives the pins. Reads like an idle mouse (the
+    /// JOYxDAT counters hold, the pot pins float).
+    None,
     /// A quadrature mouse, driven by a gamepad as well as by the host's
     /// own mouse. Electrically this *is* [`PortDevice::Mouse`] -- the
     /// machine is given one mouse with two hands on it, not two mice --
@@ -2016,10 +2019,11 @@ pub enum PortDevice {
     /// pad's d-pad and left stick move the pointer and its two buttons
     /// click, and no joystick port hears from that pad while it does.
     /// Offered on port 1 alone, which is the port a mouse belongs in.
+    ///
+    /// Last on purpose: a save state encodes a variant by its position,
+    /// so a state written before this existed must still read an empty
+    /// port as empty. The pickers order themselves.
     GamepadMouse,
-    /// Empty port: nothing drives the pins. Reads like an idle mouse (the
-    /// JOYxDAT counters hold, the pot pins float).
-    None,
 }
 
 impl PortDevice {

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2009,6 +2009,14 @@ pub enum PortDevice {
     /// Analogue paddles / proportional stick: positions present resistances
     /// on POTxX/POTxY; the two buttons ground the LEFT/RIGHT lines.
     Analogue,
+    /// A quadrature mouse, driven by a gamepad as well as by the host's
+    /// own mouse. Electrically this *is* [`PortDevice::Mouse`] -- the
+    /// machine is given one mouse with two hands on it, not two mice --
+    /// and it differs only in where the host looks for movement: the
+    /// pad's d-pad and left stick move the pointer and its two buttons
+    /// click, and no joystick port hears from that pad while it does.
+    /// Offered on port 1 alone, which is the port a mouse belongs in.
+    GamepadMouse,
     /// Empty port: nothing drives the pins. Reads like an idle mouse (the
     /// JOYxDAT counters hold, the pot pins float).
     None,
@@ -2022,8 +2030,16 @@ impl PortDevice {
             PortDevice::Joystick => "joystick",
             PortDevice::Cd32Pad => "cd32",
             PortDevice::Analogue => "analogue",
+            PortDevice::GamepadMouse => "gamepad-mouse",
             PortDevice::None => "none",
         }
+    }
+
+    /// Whether this port presents a quadrature mouse to the machine.
+    /// True of both mouse devices: they differ in what moves them on the
+    /// host, not in anything the Amiga can tell apart.
+    pub fn is_mouse(self) -> bool {
+        matches!(self, PortDevice::Mouse | PortDevice::GamepadMouse)
     }
 
     /// What a picker shows the user, as against the config name [`label`]
@@ -2034,8 +2050,9 @@ impl PortDevice {
         match self {
             PortDevice::Mouse => "Mouse",
             PortDevice::Joystick => "Joystick",
-            PortDevice::Cd32Pad => "CD32 pad",
+            PortDevice::Cd32Pad => "CD32 Pad",
             PortDevice::Analogue => "Analogue",
+            PortDevice::GamepadMouse => "Gamepad Mouse",
             PortDevice::None => "None",
         }
     }
@@ -2047,6 +2064,7 @@ impl PortDevice {
             "joystick" | "joy" => Some(PortDevice::Joystick),
             "cd32" | "cd32pad" | "pad" => Some(PortDevice::Cd32Pad),
             "analogue" | "analog" | "paddle" => Some(PortDevice::Analogue),
+            "gamepad-mouse" | "gamepad_mouse" | "padmouse" => Some(PortDevice::GamepadMouse),
             "none" | "off" => Some(PortDevice::None),
             _ => None,
         }
@@ -2128,7 +2146,9 @@ impl ControllerPort {
     /// The JOYxDAT word this port's device presents.
     pub fn joydat(&self) -> u16 {
         match self.device {
-            PortDevice::Mouse | PortDevice::None => mouse_joydat(self.counter_x, self.counter_y),
+            PortDevice::Mouse | PortDevice::GamepadMouse | PortDevice::None => {
+                mouse_joydat(self.counter_x, self.counter_y)
+            }
             PortDevice::Joystick | PortDevice::Cd32Pad => {
                 digital_joydat(self.up, self.down, self.left, self.right)
             }
@@ -2315,7 +2335,7 @@ impl InputState {
         button2: bool,
     ) {
         let idx = Self::port_index(port);
-        if matches!(self.ports[idx].device, PortDevice::Mouse | PortDevice::None) {
+        if self.ports[idx].device.is_mouse() || self.ports[idx].device == PortDevice::None {
             self.set_port_device(port, PortDevice::Joystick);
         }
         let p = &mut self.ports[idx];

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -671,7 +671,10 @@ where
             }
             "--port1" => {
                 overrides.port1 = Some(args.next().ok_or_else(|| {
-                    anyhow!("--port1 requires a device (mouse/joystick/cd32/analogue/none)")
+                    anyhow!(
+                        "--port1 requires a device \
+                         (mouse/gamepad-mouse/joystick/cd32/analogue/none)"
+                    )
                 })?);
             }
             "--port2" => {

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -1250,12 +1250,21 @@ pub(crate) fn parse_menu_scale(s: &str) -> Result<MenuScale> {
 }
 
 pub(crate) fn parse_port_device(s: &str, key: &str) -> Result<PortDevice> {
-    PortDevice::parse(s).ok_or_else(|| {
+    let device = PortDevice::parse(s).ok_or_else(|| {
         anyhow!(
-            "[input] {key} must be \"mouse\", \"joystick\", \"cd32\", \
-             \"analogue\", or \"none\", got {s:?}"
+            "[input] {key} must be \"mouse\", \"gamepad-mouse\", \"joystick\", \
+             \"cd32\", \"analogue\", or \"none\", got {s:?}"
         )
-    })
+    })?;
+    // A mouse belongs in port 1, and a gamepad driving one is still a
+    // mouse: Workbench and nearly every game read the pointer there, so
+    // port 2 is told plainly rather than left to behave oddly.
+    if device == PortDevice::GamepadMouse && key != "port1" {
+        bail!(
+            "[input] {key} cannot be \"gamepad-mouse\": only port 1 takes a mouse a gamepad drives"
+        );
+    }
+    Ok(device)
 }
 
 /// Display label for a mouse sensitivity value: the neutral midpoint shows as

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -948,13 +948,20 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             let device = p.str_req("device")?;
             let device = crate::bus::PortDevice::parse(&device).ok_or_else(|| {
                 CtlError::invalid_params(format!(
-                    "device must be mouse|joystick|cd32|analogue|none, got {device}"
+                    "device must be mouse|gamepad-mouse|joystick|cd32|analogue|none, got {device}"
                 ))
             })?;
-            host(HostOp::SetPortDevice {
-                port: parse_port_req(&p)?,
-                device,
-            })
+            let port = parse_port_req(&p)?;
+            // A mouse belongs in port 1, and a gamepad driving one is
+            // still a mouse. The launcher and the config both say so;
+            // saying it here too keeps the wire from being the one way
+            // into a wiring the GUI cannot show.
+            if device == crate::bus::PortDevice::GamepadMouse && port != 0 {
+                return Err(CtlError::invalid_params(
+                    "gamepad-mouse is port 1 only".to_string(),
+                ));
+            }
+            host(HostOp::SetPortDevice { port, device })
         }
         "input.get_ports" => core(CoreOp::InputPortsGet),
         "media.floppy.insert" => host(HostOp::FloppyInsert {

--- a/src/gamelib/library.rs
+++ b/src/gamelib/library.rs
@@ -127,6 +127,25 @@ impl Library {
 
     /// Whether this list already covers `folder`, so a redraw need not
     /// read the directory again.
+    /// A library of made-up entries, for tests that need a list of a
+    /// given length without a folder of archives behind it.
+    #[cfg(test)]
+    pub(crate) fn of_titles(titles: impl IntoIterator<Item = String>) -> Library {
+        Library {
+            folder: None,
+            entries: titles
+                .into_iter()
+                .map(|title| Entry {
+                    path: PathBuf::from(&title),
+                    relative: title.clone(),
+                    file_name: title,
+                    game: None,
+                    duplicated: false,
+                })
+                .collect(),
+        }
+    }
+
     pub fn covers(&self, folder: &Path) -> bool {
         self.folder.as_deref() == Some(folder)
     }

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -1163,17 +1163,17 @@ mod tests {
         let axes = BTreeMap::new();
         let mut buttons = BTreeMap::new();
         // Something the pad reports as down from the start.
-        buttons.insert(0x900_01, true);
+        buttons.insert(0x90001, true);
         session.advance(pad.clone(), &axes, &buttons);
         session.advance(pad.clone(), &axes, &buttons);
         assert_eq!(session.current_step(), Some(0), "nothing was pressed");
 
         // A press: down, then up. Nothing is captured until it comes up,
         // since until then it could still turn out to be a hold.
-        buttons.insert(0x900_02, true);
+        buttons.insert(0x90002, true);
         session.advance(pad.clone(), &axes, &buttons);
         assert_eq!(session.current_step(), Some(0), "still down");
-        buttons.insert(0x900_02, false);
+        buttons.insert(0x90002, false);
         session.advance(pad.clone(), &axes, &buttons);
         assert_eq!(session.current_step(), Some(1), "captured on release");
         assert_eq!(session.binding_text(0), "button 90002");
@@ -1195,15 +1195,15 @@ mod tests {
 
         // Up is required: holding it through the hold captures nothing,
         // and it is the release that binds it.
-        buttons.insert(0x900_01, true);
+        buttons.insert(0x90001, true);
         session.advance(pad.clone(), &axes, &buttons);
-        session.pending = Some((RawInput::Button { code: 0x900_01 }, held_long_enough()));
+        session.pending = Some((RawInput::Button { code: 0x90001 }, held_long_enough()));
         session.advance(pad.clone(), &axes, &buttons);
         assert_eq!(session.current_step(), Some(0), "a required step stands");
 
         // Walk to the first step that may be skipped, then hold.
-        while session.can_skip() == false && !session.done() {
-            let code = 0x900_10 + session.step as u32;
+        while !session.can_skip() && !session.done() {
+            let code = 0x90010 + session.step as u32;
             buttons.insert(code, true);
             session.advance(pad.clone(), &axes, &buttons);
             buttons.insert(code, false);
@@ -1211,9 +1211,9 @@ mod tests {
         }
         let at = session.step;
         assert!(session.can_skip(), "there is a step to skip");
-        buttons.insert(0x900_20, true);
+        buttons.insert(0x90020, true);
         session.advance(pad.clone(), &axes, &buttons);
-        session.pending = Some((RawInput::Button { code: 0x900_20 }, held_long_enough()));
+        session.pending = Some((RawInput::Button { code: 0x90020 }, held_long_enough()));
         session.advance(pad.clone(), &axes, &buttons);
         assert_eq!(session.current_step(), Some(at + 1), "the step was skipped");
         assert_eq!(session.binding_text(at), "skipped");
@@ -1227,10 +1227,10 @@ mod tests {
         let mut session = CalibrationSession::finished_for_test();
         let axes = BTreeMap::new();
         let mut buttons = BTreeMap::new();
-        buttons.insert(0x900_01, true);
+        buttons.insert(0x90001, true);
         session.advance(pad.clone(), &axes, &buttons);
         assert!(!session.handed_over(), "a press is how a binding is tried");
-        session.pending = Some((RawInput::Button { code: 0x900_01 }, held_long_enough()));
+        session.pending = Some((RawInput::Button { code: 0x90001 }, held_long_enough()));
         session.advance(pad.clone(), &axes, &buttons);
         assert!(session.handed_over(), "and a hold asks for the buttons");
     }

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -155,6 +155,12 @@ pub struct PadState {
     pub stick: (f32, f32),
 }
 
+/// How long a control must be held for the hold to mean something: a
+/// step skipped while capturing, and the panel's own buttons once
+/// everything is captured. Long enough that pressing a control to
+/// capture or to try it never trips it.
+const CAL_HOLD: std::time::Duration = std::time::Duration::from_millis(700);
+
 impl GamepadCalibration {
     fn resolve_pad(&self, axes: &BTreeMap<u32, f32>, buttons: &BTreeMap<u32, bool>) -> PadState {
         PadState {
@@ -671,21 +677,22 @@ const CAL_STEPS: [(&str, bool); 13] = [
     ("Quit Copperline", false),
 ];
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CalPhase {
-    /// Wait for every control to return to rest before sampling, so a
-    /// held input from the previous step is not recaptured.
-    WaitNeutral,
-    Capture,
-}
-
 /// A guided calibration in progress: which step is being prompted, what
 /// has been captured so far, and the connected pad's identity. Fed raw
 /// gamepad state by [`GamepadReader::calibration_tick`].
 pub struct CalibrationSession {
     bindings: [Option<RawInput>; CAL_STEPS.len()],
     step: usize,
-    phase: CalPhase,
+    /// Every control active on the last tick. A press is a control that
+    /// was not active and now is, so a control already down when a step
+    /// begins -- one held over from the step before, or one a pad
+    /// reports as down at rest -- never presses, and can never be
+    /// captured by a step that is not asking for it.
+    active: Vec<RawInput>,
+    /// The press being waited on, and when it began. Released before the
+    /// hold, it is the step's binding; still down at the hold, the step
+    /// is skipped -- not every pad has every control.
+    pending: Option<(RawInput, std::time::Instant)>,
     /// The last pad seen, kept across disconnects so a finished session
     /// can still be saved if the pad is unplugged at the end.
     pad: Option<(String, String)>,
@@ -694,6 +701,10 @@ pub struct CalibrationSession {
     /// Once every step is captured, the names of the bindings currently
     /// being pressed, so the user can test the calibration before saving.
     live_test: String,
+    /// Once every step is captured, whether a hold has asked for the
+    /// panel's own buttons: the testing is finished, and the pad walks
+    /// Save and Cancel with the bindings it has just been taught.
+    handed_over: bool,
     /// The pad as the bindings just captured see it, kept while those
     /// bindings are being tested. Holding one long enough hands the
     /// panel's own buttons to the pad, which walks them with exactly the
@@ -707,8 +718,10 @@ impl CalibrationSession {
         Self {
             bindings: [None; CAL_STEPS.len()],
             live_pad: PadState::default(),
+            handed_over: false,
+            active: Vec::new(),
+            pending: None,
             step: 0,
-            phase: CalPhase::WaitNeutral,
             pad: None,
             connected: false,
             backend_missing: false,
@@ -759,6 +772,12 @@ impl CalibrationSession {
         self.live_pad
     }
 
+    /// Whether a hold has asked for the panel's own buttons, the
+    /// testing being finished.
+    pub fn handed_over(&self) -> bool {
+        self.handed_over
+    }
+
     /// A session with every step captured, for tests of what the panel
     /// does once there is nothing left to capture.
     #[cfg(test)]
@@ -769,10 +788,11 @@ impl CalibrationSession {
         session
     }
 
-    /// Pretend the named bindings are being held, for the same tests.
+    /// Pretend a hold has asked for the panel's buttons, for the same
+    /// tests.
     #[cfg(test)]
-    pub(crate) fn hold_for_test(&mut self, held: &str) {
-        self.live_test = held.to_string();
+    pub(crate) fn hand_over_for_test(&mut self) {
+        self.handed_over = true;
     }
 
     /// Whether the current prompt may be skipped (optional CD32 extras).
@@ -795,12 +815,15 @@ impl CalibrationSession {
         }
     }
 
-    /// Skip the current (optional) step.
+    /// Skip the current (optional) step. The Skip button's way of doing
+    /// what holding a control does.
     pub fn skip_current(&mut self) {
         if self.can_skip() {
             self.bindings[self.step] = None;
             self.step += 1;
-            self.phase = CalPhase::WaitNeutral;
+            // Whatever is down stays down as far as the next step is
+            // concerned: it never pressed, so it cannot be captured.
+            self.pending = None;
         }
     }
 
@@ -827,16 +850,25 @@ impl CalibrationSession {
             }
         }
         if changed {
-            // A (re)connected pad may still report a stale deflection;
-            // require neutral before sampling for the current prompt.
-            self.phase = CalPhase::WaitNeutral;
+            // A (re)connected pad may still report a stale deflection.
+            // Forgetting what was active makes everything it reports
+            // look like it was already down, so nothing is captured
+            // until something is pressed afresh.
+            self.active = active_inputs(axes, buttons);
+            self.pending = None;
         }
         if !self.connected {
             return changed;
         }
+        let now = active_inputs(axes, buttons);
+        // What was pressed this tick: active now, and not before.
+        let pressed = now.iter().copied().find(|i| !self.active.contains(i));
+        let held = |input: &RawInput| now.contains(input);
         if self.done() {
             // Live test: show which captured bindings are active right now
-            // so the calibration can be verified before saving.
+            // so the calibration can be verified before saving. A press
+            // is how a binding is tried, so it is a hold that says the
+            // testing is finished and asks for the panel's buttons.
             let labels: Vec<&str> = self
                 .bindings
                 .iter()
@@ -850,25 +882,71 @@ impl CalibrationSession {
                 changed = true;
             }
             self.live_pad = self.to_calibration().resolve_pad(axes, buttons);
+            changed |= self.watch_hold(pressed, &held, |session| {
+                session.handed_over = true;
+            });
+            self.active = now;
             return changed;
         }
-        match self.phase {
-            CalPhase::WaitNeutral => {
-                if raw_state_neutral(axes, buttons) {
-                    self.phase = CalPhase::Capture;
-                    // The phase flip itself is invisible; no redraw needed.
-                }
+        // A press captures the control it was made with; holding it says
+        // the pad has not got that control, and skips the step. Which of
+        // the two it was is only known when the button comes back up, so
+        // nothing is captured until it does.
+        let skippable = !CAL_STEPS[self.step].1;
+        changed |= self.watch_hold(pressed, &held, move |session| {
+            if skippable {
+                session.bindings[session.step] = None;
+                session.step += 1;
             }
-            CalPhase::Capture => {
-                if let Some(input) = strongest_input_from(axes, buttons) {
-                    self.bindings[self.step] = Some(input);
-                    self.step += 1;
-                    self.phase = CalPhase::WaitNeutral;
-                    changed = true;
+        });
+        self.active = now;
+        changed
+    }
+
+    /// Follow one press through to what it turns out to be.
+    ///
+    /// A press is remembered rather than acted on: released before the
+    /// hold it is a press, and `on_press` has it; still down at the hold
+    /// it is a hold, and `on_hold` runs instead. Either way the press is
+    /// spent, so a control kept down after it does nothing more.
+    fn watch_hold(
+        &mut self,
+        pressed: Option<RawInput>,
+        held: &dyn Fn(&RawInput) -> bool,
+        on_hold: impl FnOnce(&mut Self),
+    ) -> bool {
+        match self.pending {
+            None => {
+                if let Some(input) = pressed {
+                    self.pending = Some((input, std::time::Instant::now()));
+                }
+                false
+            }
+            Some((input, since)) => {
+                if !held(&input) {
+                    self.pending = None;
+                    self.on_press(input);
+                    true
+                } else if since.elapsed() >= CAL_HOLD {
+                    self.pending = None;
+                    on_hold(self);
+                    true
+                } else {
+                    false
                 }
             }
         }
-        changed
+    }
+
+    /// A control pressed and released: the binding for the step being
+    /// captured, and nothing at all once every step is captured -- there
+    /// a press is how a binding is tried.
+    fn on_press(&mut self, input: RawInput) {
+        if self.done() {
+            return;
+        }
+        self.bindings[self.step] = Some(input);
+        self.step += 1;
     }
 
     /// The captured bindings as a persistable calibration.
@@ -897,6 +975,31 @@ impl Default for CalibrationSession {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Every control the pad has active right now: each pressed button, and
+/// each axis deflected past the capture threshold, in the direction it
+/// is deflected.
+///
+/// Calibration works from this rather than from "the strongest one",
+/// because what a step wants is the control that was *pressed* -- and a
+/// pad reporting something as down at rest, which several do, would
+/// otherwise be captured by every step in turn.
+fn active_inputs(axes: &BTreeMap<u32, f32>, buttons: &BTreeMap<u32, bool>) -> Vec<RawInput> {
+    let mut active: Vec<RawInput> = buttons
+        .iter()
+        .filter(|(_, &pressed)| pressed)
+        .map(|(&code, _)| RawInput::Button { code })
+        .collect();
+    active.extend(
+        axes.iter()
+            .filter(|(_, v)| v.abs() >= AXIS_CAPTURE_THRESHOLD)
+            .map(|(&code, &v)| RawInput::Axis {
+                code,
+                positive: v > 0.0,
+            }),
+    );
+    active
 }
 
 /// The most strongly deflected axis or any pressed button, if past the
@@ -1049,6 +1152,95 @@ mod tests {
         Some(RawInput::Button { code })
     }
 
+    /// A press captures the control it was made with, and a control
+    /// already down when a step begins is not a press: several pads
+    /// report something as held at rest, and every step in turn was
+    /// capturing it.
+    #[test]
+    fn a_step_captures_the_control_that_was_pressed() {
+        let pad = Some(("Pad".to_string(), "uuid".to_string()));
+        let mut session = CalibrationSession::new();
+        let axes = BTreeMap::new();
+        let mut buttons = BTreeMap::new();
+        // Something the pad reports as down from the start.
+        buttons.insert(0x900_01, true);
+        session.advance(pad.clone(), &axes, &buttons);
+        session.advance(pad.clone(), &axes, &buttons);
+        assert_eq!(session.current_step(), Some(0), "nothing was pressed");
+
+        // A press: down, then up. Nothing is captured until it comes up,
+        // since until then it could still turn out to be a hold.
+        buttons.insert(0x900_02, true);
+        session.advance(pad.clone(), &axes, &buttons);
+        assert_eq!(session.current_step(), Some(0), "still down");
+        buttons.insert(0x900_02, false);
+        session.advance(pad.clone(), &axes, &buttons);
+        assert_eq!(session.current_step(), Some(1), "captured on release");
+        assert_eq!(session.binding_text(0), "button 90002");
+
+        // The control that was down all along still is, and still has
+        // not pressed: the next step is untouched by it.
+        session.advance(pad.clone(), &axes, &buttons);
+        assert_eq!(session.current_step(), Some(1));
+    }
+
+    /// Holding a control skips the step, for a pad that lacks it -- but
+    /// only where the step may be skipped at all.
+    #[test]
+    fn holding_a_control_skips_the_step_it_can_skip() {
+        let pad = Some(("Pad".to_string(), "uuid".to_string()));
+        let mut session = CalibrationSession::new();
+        let axes = BTreeMap::new();
+        let mut buttons = BTreeMap::new();
+
+        // Up is required: holding it through the hold captures nothing,
+        // and it is the release that binds it.
+        buttons.insert(0x900_01, true);
+        session.advance(pad.clone(), &axes, &buttons);
+        session.pending = Some((RawInput::Button { code: 0x900_01 }, held_long_enough()));
+        session.advance(pad.clone(), &axes, &buttons);
+        assert_eq!(session.current_step(), Some(0), "a required step stands");
+
+        // Walk to the first step that may be skipped, then hold.
+        while session.can_skip() == false && !session.done() {
+            let code = 0x900_10 + session.step as u32;
+            buttons.insert(code, true);
+            session.advance(pad.clone(), &axes, &buttons);
+            buttons.insert(code, false);
+            session.advance(pad.clone(), &axes, &buttons);
+        }
+        let at = session.step;
+        assert!(session.can_skip(), "there is a step to skip");
+        buttons.insert(0x900_20, true);
+        session.advance(pad.clone(), &axes, &buttons);
+        session.pending = Some((RawInput::Button { code: 0x900_20 }, held_long_enough()));
+        session.advance(pad.clone(), &axes, &buttons);
+        assert_eq!(session.current_step(), Some(at + 1), "the step was skipped");
+        assert_eq!(session.binding_text(at), "skipped");
+    }
+
+    /// Once every step is captured, a press tries a binding and a hold
+    /// asks for the panel's own buttons.
+    #[test]
+    fn a_hold_at_the_end_asks_for_the_panels_buttons() {
+        let pad = Some(("Pad".to_string(), "uuid".to_string()));
+        let mut session = CalibrationSession::finished_for_test();
+        let axes = BTreeMap::new();
+        let mut buttons = BTreeMap::new();
+        buttons.insert(0x900_01, true);
+        session.advance(pad.clone(), &axes, &buttons);
+        assert!(!session.handed_over(), "a press is how a binding is tried");
+        session.pending = Some((RawInput::Button { code: 0x900_01 }, held_long_enough()));
+        session.advance(pad.clone(), &axes, &buttons);
+        assert!(session.handed_over(), "and a hold asks for the buttons");
+    }
+
+    /// A moment far enough in the past that a press begun then has
+    /// become a hold.
+    fn held_long_enough() -> std::time::Instant {
+        std::time::Instant::now() - CAL_HOLD
+    }
+
     #[test]
     fn resolve_reads_calibrated_axes_and_buttons_with_recorded_signs() {
         // Up/down share one axis with opposite signs (a typical retro pad
@@ -1187,11 +1379,16 @@ mod tests {
         let pad = Some(("Pad".to_string(), "abc123".to_string()));
         let axes = BTreeMap::new();
         let mut buttons = BTreeMap::new();
+        // The pad arrives first: what it reports as it connects was not
+        // pressed by anyone, so nothing is captured from it.
+        session.advance(pad.clone(), &axes, &buttons);
         for step in 0..5 {
-            session.advance(pad.clone(), &axes, &buttons); // neutral
+            // Down, then up: a control is captured by being pressed,
+            // which is only known once it comes back up.
             buttons.insert(0x9000 + step as u32, true);
             session.advance(pad.clone(), &axes, &buttons);
             buttons.clear();
+            session.advance(pad.clone(), &axes, &buttons);
         }
         while session.can_skip() {
             session.skip_current();
@@ -1229,20 +1426,22 @@ mod tests {
         assert!(session.advance(pad.clone(), &axes, &buttons));
         assert_eq!(session.current_step(), Some(0));
 
-        // Neutral first, then a deflected axis captures step 0 (Up).
-        assert!(!session.advance(pad.clone(), &axes, &buttons));
+        // A deflected axis, pressed and released, captures step 0 (Up).
+        // Nothing is captured while it is down: until it comes up it
+        // could still turn out to be a hold.
         axes.insert(0x31, -0.9);
+        assert!(!session.advance(pad.clone(), &axes, &buttons));
+        assert_eq!(session.current_step(), Some(0));
+        axes.clear();
         assert!(session.advance(pad.clone(), &axes, &buttons));
         assert_eq!(session.current_step(), Some(1));
         assert_eq!(session.binding_text(0), "axis 31-");
 
-        // Still held: the same input must not capture step 1 until the
-        // controls return to neutral.
-        assert!(!session.advance(pad.clone(), &axes, &buttons));
-        assert_eq!(session.current_step(), Some(1));
-        axes.clear();
-        assert!(!session.advance(pad.clone(), &axes, &buttons));
+        // The other way on the same axis is a different control, and it
+        // binds step 1 the same way.
         axes.insert(0x31, 0.9);
+        assert!(!session.advance(pad.clone(), &axes, &buttons));
+        axes.clear();
         assert!(session.advance(pad.clone(), &axes, &buttons));
         assert_eq!(session.binding_text(1), "axis 31+");
 
@@ -1252,8 +1451,9 @@ mod tests {
             assert_eq!(session.current_step(), Some(expected_step));
             axes.clear();
             buttons.clear();
-            session.advance(pad.clone(), &axes, &buttons);
             buttons.insert(0x9000 + expected_step as u32, true);
+            session.advance(pad.clone(), &axes, &buttons);
+            buttons.clear();
             assert!(session.advance(pad.clone(), &axes, &buttons));
         }
         assert_eq!(session.binding_text(4), "button 9004");
@@ -1313,10 +1513,12 @@ mod tests {
         // Capture the required steps, then skip the CD32 extras to land
         // on the final (optional) Quit step.
         for step in 0..5 {
-            session.advance(pad.clone(), &axes, &buttons); // neutral
+            // Down, then up: a control is captured by being pressed,
+            // which is only known once it comes back up.
             buttons.insert(0x9000 + step as u32, true);
             session.advance(pad.clone(), &axes, &buttons);
             buttons.clear();
+            session.advance(pad.clone(), &axes, &buttons);
         }
         while session.can_skip() && session.current_step() != Some(CAL_STEPS.len() - 1) {
             session.skip_current();
@@ -1324,13 +1526,15 @@ mod tests {
         assert_eq!(session.current_step(), Some(CAL_STEPS.len() - 1));
         assert!(session.can_skip());
 
-        session.advance(pad.clone(), &axes, &buttons); // neutral
         buttons.insert(0x900FF, true);
+        session.advance(pad.clone(), &axes, &buttons);
+        buttons.clear();
         assert!(session.advance(pad.clone(), &axes, &buttons));
         assert!(session.done());
         assert_eq!(session.to_calibration().quit, button(0x900FF));
 
         // The post-capture live test reports the held quit binding by name.
+        buttons.insert(0x900FF, true);
         assert!(session.advance(pad, &axes, &buttons));
         assert_eq!(session.live_test(), "Quit Copperline");
     }
@@ -1353,14 +1557,16 @@ mod tests {
         assert!(!session.advance(None, &axes, &buttons));
         assert_eq!(session.current_step(), Some(0));
 
-        // On reconnect the stale deflection must not capture; the session
-        // requires neutral first, then captures a fresh push.
+        // On reconnect the stale deflection must not capture: it was
+        // already there, so nobody pressed it. A fresh push does.
         assert!(session.advance(pad.clone(), &axes, &buttons));
         assert!(!session.advance(pad.clone(), &axes, &buttons));
         assert_eq!(session.current_step(), Some(0));
         axes.clear();
         session.advance(pad.clone(), &axes, &buttons);
         axes.insert(0x30, 1.0);
+        assert!(!session.advance(pad.clone(), &axes, &buttons));
+        axes.clear();
         assert!(session.advance(pad.clone(), &axes, &buttons));
         assert_eq!(session.current_step(), Some(1));
     }

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -884,6 +884,7 @@ impl CalibrationSession {
             self.live_pad = self.to_calibration().resolve_pad(axes, buttons);
             changed |= self.watch_hold(pressed, &held, |session| {
                 session.handed_over = true;
+                true
             });
             self.active = now;
             return changed;
@@ -894,10 +895,12 @@ impl CalibrationSession {
         // nothing is captured until it does.
         let skippable = !CAL_STEPS[self.step].1;
         changed |= self.watch_hold(pressed, &held, move |session| {
-            if skippable {
-                session.bindings[session.step] = None;
-                session.step += 1;
+            if !skippable {
+                return false;
             }
+            session.bindings[session.step] = None;
+            session.step += 1;
+            true
         });
         self.active = now;
         changed
@@ -906,14 +909,19 @@ impl CalibrationSession {
     /// Follow one press through to what it turns out to be.
     ///
     /// A press is remembered rather than acted on: released before the
-    /// hold it is a press, and `on_press` has it; still down at the hold
-    /// it is a hold, and `on_hold` runs instead. Either way the press is
-    /// spent, so a control kept down after it does nothing more.
+    /// hold it is a press, and it binds the step; still down at the
+    /// hold, `on_hold` has it instead and the press is spent, so a
+    /// control kept down after that does nothing more.
+    ///
+    /// `on_hold` says whether it took the hold. Where it did not -- a
+    /// step that cannot be skipped -- the press stays pending, so
+    /// holding one of the four directions and letting go still binds it
+    /// rather than quietly coming to nothing.
     fn watch_hold(
         &mut self,
         pressed: Option<RawInput>,
         held: &dyn Fn(&RawInput) -> bool,
-        on_hold: impl FnOnce(&mut Self),
+        on_hold: impl FnOnce(&mut Self) -> bool,
     ) -> bool {
         match self.pending {
             None => {
@@ -927,9 +935,8 @@ impl CalibrationSession {
                     self.pending = None;
                     self.on_press(input);
                     true
-                } else if since.elapsed() >= CAL_HOLD {
+                } else if since.elapsed() >= CAL_HOLD && on_hold(self) {
                     self.pending = None;
-                    on_hold(self);
                     true
                 } else {
                     false
@@ -1193,13 +1200,18 @@ mod tests {
         let axes = BTreeMap::new();
         let mut buttons = BTreeMap::new();
 
-        // Up is required: holding it through the hold captures nothing,
-        // and it is the release that binds it.
+        // Up is required: holding it through the hold skips nothing, and
+        // the press is still there to bind it when the control comes up.
         buttons.insert(0x90001, true);
         session.advance(pad.clone(), &axes, &buttons);
         session.pending = Some((RawInput::Button { code: 0x90001 }, held_long_enough()));
         session.advance(pad.clone(), &axes, &buttons);
         assert_eq!(session.current_step(), Some(0), "a required step stands");
+        buttons.insert(0x90001, false);
+        session.advance(pad.clone(), &axes, &buttons);
+        assert_eq!(session.current_step(), Some(1), "and the release binds it");
+        assert_eq!(session.binding_text(0), "button 90001");
+        buttons.remove(&0x90001);
 
         // Walk to the first step that may be skipped, then hold.
         while !session.can_skip() && !session.done() {

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -694,12 +694,19 @@ pub struct CalibrationSession {
     /// Once every step is captured, the names of the bindings currently
     /// being pressed, so the user can test the calibration before saving.
     live_test: String,
+    /// The pad as the bindings just captured see it, kept while those
+    /// bindings are being tested. Holding one long enough hands the
+    /// panel's own buttons to the pad, which walks them with exactly the
+    /// controls it has just been taught -- so reaching Save proves the
+    /// calibration works rather than asking for a mouse to finish.
+    live_pad: PadState,
 }
 
 impl CalibrationSession {
     pub fn new() -> Self {
         Self {
             bindings: [None; CAL_STEPS.len()],
+            live_pad: PadState::default(),
             step: 0,
             phase: CalPhase::WaitNeutral,
             pad: None,
@@ -744,6 +751,28 @@ impl CalibrationSession {
     /// the session is done; used to test before saving).
     pub fn live_test(&self) -> &str {
         &self.live_test
+    }
+
+    /// The pad as the bindings under test see it. Meaningless before the
+    /// last step is captured, since there is nothing to resolve against.
+    pub fn live_pad(&self) -> PadState {
+        self.live_pad
+    }
+
+    /// A session with every step captured, for tests of what the panel
+    /// does once there is nothing left to capture.
+    #[cfg(test)]
+    pub(crate) fn finished_for_test() -> Self {
+        let mut session = Self::new();
+        session.step = CAL_STEPS.len();
+        session.connected = true;
+        session
+    }
+
+    /// Pretend the named bindings are being held, for the same tests.
+    #[cfg(test)]
+    pub(crate) fn hold_for_test(&mut self, held: &str) {
+        self.live_test = held.to_string();
     }
 
     /// Whether the current prompt may be skipped (optional CD32 extras).
@@ -820,6 +849,7 @@ impl CalibrationSession {
                 self.live_test = live_test;
                 changed = true;
             }
+            self.live_pad = self.to_calibration().resolve_pad(axes, buttons);
             return changed;
         }
         match self.phase {

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -136,7 +136,7 @@ pub struct JoystickState {
 
 /// One poll of a calibrated pad: the emulated joystick lines plus the
 /// host-side controls, which never reach the emulated port.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct PadState {
     pub joystick: JoystickState,
     /// The calibrated Quit hotkey is currently held. Host-side only: the
@@ -145,6 +145,14 @@ pub struct PadState {
     /// The Menu button is currently held. Host-side only: a press opens
     /// (or closes) the pop-up menu, and the pad walks it while it is up.
     pub menu: bool,
+    /// The left stick, each axis in [-1, 1], right and up positive.
+    ///
+    /// The joystick lines above are what a digital port can hear, so
+    /// they are all a calibration records; this is the deflection behind
+    /// them, which only a pad the controller database knows can report.
+    /// Gamepad Mouse spends it on how fast the pointer moves, where a
+    /// switch could only say whether it moves at all.
+    pub stick: (f32, f32),
 }
 
 impl GamepadCalibration {
@@ -153,6 +161,10 @@ impl GamepadCalibration {
             joystick: self.resolve(axes, buttons),
             quit: self.quit.is_some_and(|i| i.active(axes, buttons)),
             menu: self.menu.is_some_and(|i| i.active(axes, buttons)),
+            // A calibration binds raw inputs one at a time and has no
+            // notion of an axis pair, so a calibrated pad reports no
+            // deflection and its d-pad moves the pointer instead.
+            stick: (0.0, 0.0),
         }
     }
 
@@ -619,6 +631,7 @@ impl GamepadReader {
                     joystick: raw.mapped.resolve(),
                     quit: false,
                     menu: raw.mapped.select || raw.mapped.mode,
+                    stick: (raw.mapped.left_x, raw.mapped.left_y),
                 })
             }
             None => {

--- a/src/inputrec.rs
+++ b/src/inputrec.rs
@@ -246,7 +246,7 @@ impl InputRecorder {
                 self.close_port_holds(port, secs);
             }
             match cur.device {
-                PortDevice::Mouse => {
+                PortDevice::Mouse | PortDevice::GamepadMouse => {
                     let dx = cur.counter_x.wrapping_sub(old.counter_x) as i8;
                     let dy = cur.counter_y.wrapping_sub(old.counter_y) as i8;
                     if dx != 0 || dy != 0 {

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -205,7 +205,10 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //  60: Akiko's `command_active` widened from u8 to u32: it now counts the
 //      drive microcontroller's command turnaround in emulated CCKs
 //      (CMD_EXEC_DELAY_CCK) instead of counting register accesses.
-pub const STATE_VERSION: u32 = 60;
+//  61: PortDevice gained the GamepadMouse variant (a mouse a gamepad can
+//      move as well as the host's own, `[input] port1`), appended at the
+//      end of the enum.
+pub const STATE_VERSION: u32 = 61;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -779,6 +779,16 @@ const fn row(field: LauncherField, label: &'static str, kind: RowKind) -> Row {
     Row { field, label, kind }
 }
 
+/// Whether a field is one of the boot-priority steppers, whose range
+/// runs to hundreds and so wants the held ramp rather than the steady
+/// pace the shorter lists take.
+pub fn field_is_bootpri(field: LauncherField) -> bool {
+    BOOTPRI_ROWS
+        .iter()
+        .chain(LIDE_ROWS.iter())
+        .any(|r| r.field == field && r.kind == RowKind::Bootpri)
+}
+
 /// A non-interactive section heading row (see [`RowKind::SectionHeader`]).
 const fn section_header(label: &'static str) -> Row {
     Row {
@@ -5364,6 +5374,23 @@ impl MachineSetup {
     }
 
     /// The disks the Host Disk table is showing.
+    /// Fill the host-disk list with made-up rows, for tests that need
+    /// the page's list without the host having any disks to scan.
+    #[cfg(test)]
+    pub(crate) fn fake_host_disks(&mut self, rows: usize) {
+        self.host_disks = (0..rows)
+            .map(|i| HostDiskRow {
+                id: format!("disk{i}"),
+                fingerprint: None,
+                volume: format!("Volume {i}"),
+                size: "1.0 GB".to_string(),
+                mounted: Vec::new(),
+                writable: false,
+                attach: None,
+            })
+            .collect();
+    }
+
     pub fn host_disks(&self) -> &[HostDiskRow] {
         &self.host_disks
     }

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1883,6 +1883,17 @@ const PORT_DEVICES: [PortDevice; 5] = [
     PortDevice::Analogue,
     PortDevice::None,
 ];
+// Port 1 offers one more: a mouse a gamepad can move as well as the
+// hand on the desk. Only port 1, because only port 1 is where a mouse
+// belongs -- Workbench and nearly every game read it there.
+const PORT1_DEVICES: [PortDevice; 6] = [
+    PortDevice::Mouse,
+    PortDevice::GamepadMouse,
+    PortDevice::Joystick,
+    PortDevice::Cd32Pad,
+    PortDevice::Analogue,
+    PortDevice::None,
+];
 // `None` = no SCSI board fitted; the two boards are mutually exclusive here even
 // though the engine could run both, so a config round-trips through this picker.
 const SCSI_CONTROLLERS: [Option<ScsiController>; 4] = [
@@ -3611,7 +3622,7 @@ impl MachineSetup {
             }
             // Neither mouse row does anything unless a port holds a mouse.
             F::MouseSensitivity | F::MouseCapture => {
-                reason(self.port_devices.contains(&PortDevice::Mouse), "No mouse")
+                reason(self.port_devices.iter().any(|d| d.is_mouse()), "No mouse")
             }
             _ => None,
         }
@@ -4040,21 +4051,25 @@ impl MachineSetup {
         let routing =
             crate::video::window::host_routing_for(self.port_devices, self.joystick_input_mode);
         std::array::from_fn(|port| {
-            let source = if routing.mouse == Some(port) {
+            let source = if routing.gamepad_mouse == Some(port) {
+                "the host mouse and the gamepad".to_string()
+            } else if routing.mouse == Some(port) {
                 "the host mouse".to_string()
             } else if routing.gamepad == Some(port) && routing.keyboard2 == Some(port) {
                 "the gamepad (numpad keys without a pad)".to_string()
             } else if routing.gamepad == Some(port) {
                 "the gamepad".to_string()
             } else if routing.keyboard == Some(port) {
-                if self.port_devices[port] == PortDevice::Mouse {
+                if self.port_devices[port].is_mouse() {
                     "cursor keys as a mouse (fire keys = buttons)".to_string()
                 } else {
                     "cursor keys (Ctrl/RAlt = fire, LAlt = button 2)".to_string()
                 }
             } else {
                 match self.port_devices[port] {
-                    PortDevice::Mouse => "nothing (flip Joystick input to keyboard)".to_string(),
+                    PortDevice::Mouse | PortDevice::GamepadMouse => {
+                        "nothing (flip Joystick input to keyboard)".to_string()
+                    }
                     PortDevice::Joystick | PortDevice::Cd32Pad => {
                         "nothing (keyboard passes through to the Amiga)".to_string()
                     }
@@ -4647,7 +4662,7 @@ impl MachineSetup {
                 self.mouse_capture = cycle_slice(&MOUSE_CAPTURES, self.mouse_capture, forward)
             }
             F::Port1Device => {
-                self.port_devices[0] = cycle_slice(&PORT_DEVICES, self.port_devices[0], forward)
+                self.port_devices[0] = cycle_slice(&PORT1_DEVICES, self.port_devices[0], forward)
             }
             F::Port2Device => {
                 self.port_devices[1] = cycle_slice(&PORT_DEVICES, self.port_devices[1], forward)

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -4246,8 +4246,13 @@ fn port_devices_round_trip_through_raw_against_the_profile_baseline() {
     assert!(raw.input.port1.is_none());
     assert!(raw.input.port2.is_none());
 
-    // Non-default devices are written and read back.
-    s.cycle(LauncherField::Port1Device, true); // Mouse -> Joystick
+    // Non-default devices are written and read back. Port 1 offers the
+    // gamepad-driven mouse between Mouse and Joystick; port 2 does not
+    // offer it at all, a mouse belonging in port 1.
+    s.cycle(LauncherField::Port1Device, true); // Mouse -> Gamepad Mouse
+    assert_eq!(s.port_devices[0], PortDevice::GamepadMouse);
+    assert_eq!(s.to_raw().input.port1.as_deref(), Some("gamepad-mouse"));
+    s.cycle(LauncherField::Port1Device, true); // -> Joystick
     s.cycle(LauncherField::Port2Device, true); // Joystick -> Cd32Pad
     let raw = s.to_raw();
     assert_eq!(raw.input.port1.as_deref(), Some("joystick"));

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -807,8 +807,11 @@ fn player_video_rows(s: &MenuState) -> Vec<MenuRow> {
 }
 
 fn input_rows(s: &MenuState) -> Vec<MenuRow> {
-    const DEVICES: [PortDevice; 5] = [
+    const DEVICES: [PortDevice; 6] = [
         PortDevice::Mouse,
+        // A mouse a gamepad can move as well as the hand on the desk,
+        // offered on port 1 alone: that is where a mouse belongs.
+        PortDevice::GamepadMouse,
         PortDevice::Joystick,
         PortDevice::Cd32Pad,
         PortDevice::Analogue,
@@ -817,6 +820,7 @@ fn input_rows(s: &MenuState) -> Vec<MenuRow> {
     let port = |n: usize| -> Vec<MenuRow> {
         DEVICES
             .iter()
+            .filter(|d| n == 0 || **d != PortDevice::GamepadMouse)
             .map(|d| {
                 MenuRow::choice(
                     d.menu_label(),

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -334,11 +334,23 @@ impl MenuNav {
     /// Step the cursor, skipping rows that cannot be picked and wrapping at
     /// both ends. Starting with no cursor, down lands on the first row and up
     /// on the last, so a menu just opened answers either key sensibly.
+    /// Step the cursor, wrapping round the level.
     pub fn step(&mut self, root: &[MenuRow], forward: bool) {
+        self.walk(root, forward, true);
+    }
+
+    /// Step the cursor without wrapping: at the end of the level it
+    /// stays where it is and says so, which is how the caller knows the
+    /// walk has run out of menu and belongs somewhere else.
+    pub fn step_within(&mut self, root: &[MenuRow], forward: bool) -> bool {
+        self.walk(root, forward, false)
+    }
+
+    fn walk(&mut self, root: &[MenuRow], forward: bool, wrap: bool) -> bool {
         let rows = self.current(root);
         if rows.is_empty() {
             self.cursor = None;
-            return;
+            return false;
         }
         let n = rows.len();
         let start = match self.cursor {
@@ -352,18 +364,23 @@ impl MenuNav {
             }
         };
         for hop in 1..=n {
-            let i = if forward {
-                (start + hop) % n
+            let (i, wrapped) = if forward {
+                (start + hop, start + hop >= n)
             } else {
-                (start + n - hop % n) % n
+                ((start + n - hop % n) % n, hop > start)
             };
+            let i = i % n;
+            if wrapped && !wrap {
+                return false;
+            }
             if rows[i].enabled {
                 self.cursor = Some(i);
-                return;
+                return true;
             }
         }
         // Nothing on this level can be picked; leave the cursor alone rather
         // than parking it on a row that would refuse.
+        false
     }
 
     /// Open the submenu under the cursor. Returns false when there is none,

--- a/src/video/mod.rs
+++ b/src/video/mod.rs
@@ -10,6 +10,8 @@ pub mod font;
 pub mod launcher;
 #[cfg(feature = "frontend")]
 pub mod menu;
+#[cfg(feature = "frontend")]
+pub mod nav;
 pub mod present_common;
 #[cfg(feature = "frontend")]
 pub mod ui;

--- a/src/video/nav.rs
+++ b/src/video/nav.rs
@@ -946,6 +946,32 @@ mod tests {
         );
     }
 
+    /// A panel with nothing on it but its close gadget still offers that:
+    /// a surface the focus cannot enter is a surface Escape is the only
+    /// way out of.
+    #[test]
+    fn every_panel_offers_its_close_gadget() {
+        use crate::video::menu::MenuNav;
+        use crate::video::ui::{Panel, UiState};
+        for panel in [Panel::About, Panel::Shortcuts] {
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: MenuNav::default(),
+                panel: Some(panel),
+            };
+            let items = map(
+                &ui,
+                crate::video::window::texture_width(1),
+                crate::video::window::texture_height(1),
+            );
+            assert!(
+                find(&items, NavTarget::Ui(UiControl::PanelClose)).is_some(),
+                "the close gadget is a place to stand"
+            );
+        }
+    }
+
     /// A page's map, printed, for working out why a step goes where it
     /// does.
     #[test]

--- a/src/video/nav.rs
+++ b/src/video/nav.rs
@@ -605,6 +605,14 @@ impl Nav {
         self.open = false;
     }
 
+    /// Put the marker away but remember where it was: the pointer has
+    /// moved, so the hand on the mouse is the one in charge, and going
+    /// back to the keyboard resumes from here.
+    pub(in crate::video) fn hide(&mut self) {
+        self.showing = false;
+        self.open = false;
+    }
+
     pub(in crate::video) fn clear(&mut self) {
         *self = Self::default();
     }

--- a/src/video/nav.rs
+++ b/src/video/nav.rs
@@ -1,0 +1,1291 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Driving the interface without a pointer.
+//!
+//! The map of what can be reached is not written down anywhere: it is
+//! read off the same hit-testing the mouse uses, by asking it what sits
+//! at each point of a coarse grid and collecting what answers. That way
+//! there is one description of where things are -- the one the pointer
+//! already trusts -- and a control cannot appear under the mouse but be
+//! unreachable from the keyboard, which is exactly how such maps rot.
+//!
+//! What the focus means is deliberately small. A control is either
+//! *focused* -- which the surfaces show by lighting it, the way they
+//! light what the pointer is over -- or *open*, which only a stepper
+//! can be: its arrows light and left and right change its value
+//! instead of moving on. How any of that is drawn is the surfaces'
+//! own business; this module only says where the focus is.
+
+use super::ui::{UiControl, UiState};
+use super::window::statusbar::BarControl;
+use super::window::Rect;
+
+/// Somewhere the focus can stand. The interface's surfaces and the
+/// status bar are one space to walk: the bar sits under the panels on
+/// the screen, so stepping down off the bottom of one reaches it, and
+/// stepping back up returns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::video) enum NavTarget {
+    Ui(UiControl),
+    Bar(BarControl),
+}
+
+/// How far apart the probes sit when reading the map. Fine enough to
+/// find the smallest control the interface draws (a scroll arrow is
+/// nine pixels across), coarse enough that a whole screen is a few
+/// thousand questions rather than a million.
+const PROBE_STEP: usize = 3;
+
+/// One place the focus can stand: a control, and the box it occupies.
+/// A stepper's box takes in both its arrows and the value between
+/// them, because the focus stands on the setting rather than on one
+/// end of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::video) struct NavItem {
+    pub(in crate::video) target: NavTarget,
+    pub(in crate::video) rect: Rect,
+}
+
+/// Everything reachable on the surface as it stands, in reading order.
+///
+/// The two halves of a stepper answer as one place to stand: the focus
+/// belongs to the setting, and its arrows are what opening it lights.
+pub(in crate::video) fn map(ui: &UiState, width: usize, height: usize) -> Vec<NavItem> {
+    // Sampled raw first: a stepper's two arrows are two controls here,
+    // and only afterwards become the one place the focus stands.
+    let mut raw: Vec<(UiControl, Vec<Rect>)> = Vec::new();
+    let mut y = 0;
+    while y < height {
+        let mut x = 0;
+        while x < width {
+            if let Some(control) = ui.control_at((x as i32, y as i32)) {
+                if reachable(control) && crate::video::ui::control_live(ui, control) {
+                    add_sample(&mut raw, control, x, y);
+                }
+            }
+            x += PROBE_STEP;
+        }
+        y += PROBE_STEP;
+    }
+    let mut items: Vec<NavItem> = Vec::new();
+    for (control, rect) in largest(raw) {
+        let key = focus_key(NavTarget::Ui(control));
+        match items.iter_mut().find(|i| focus_key(i.target) == key) {
+            Some(item) => {
+                // The second arrow of a stepper: the box grows to hold
+                // both of them and the value they sit either side of.
+                let (left, right) = if rect.x < item.rect.x {
+                    (rect, item.rect)
+                } else {
+                    (item.rect, rect)
+                };
+                item.rect = Rect {
+                    x: left.x,
+                    y: left.y.min(right.y),
+                    w: (right.x + right.w) - left.x,
+                    h: left.h.max(right.h),
+                };
+            }
+            None => items.push(NavItem {
+                target: NavTarget::Ui(control),
+                rect,
+            }),
+        }
+    }
+    // Reading order, for a surface with no geometry worth speaking of.
+    items.sort_by_key(|i| (i.rect.y, i.rect.x));
+    items
+}
+
+/// Take a probe into the clusters of the control it found.
+///
+/// One control can answer for two places at once -- a page reached
+/// both from the category column and from the row of sibling pages
+/// above the settings -- and a box drawn round both of them would span
+/// the width of the window, which is neither where the control is nor
+/// anywhere the focus should think it is. So each control keeps its
+/// separate clusters, and the largest of them is where it lives.
+fn add_sample(clusters: &mut Vec<(UiControl, Vec<Rect>)>, control: UiControl, x: usize, y: usize) {
+    let entry = match clusters.iter_mut().find(|(c, _)| *c == control) {
+        Some(entry) => entry,
+        None => {
+            clusters.push((control, Vec::new()));
+            clusters.last_mut().expect("just pushed")
+        }
+    };
+    // Near an existing cluster means part of it: probes are a step
+    // apart, so anything within a step of the box belongs to it.
+    let reach = PROBE_STEP;
+    match entry.1.iter_mut().find(|r| {
+        x + reach >= r.x && x <= r.x + r.w + reach && y + reach >= r.y && y <= r.y + r.h + reach
+    }) {
+        Some(rect) => *rect = union(*rect, x, y),
+        None => entry.1.push(Rect { x, y, w: 1, h: 1 }),
+    }
+}
+
+/// Where each control lives, when it answers for more than one place:
+/// its largest cluster, which is the control itself rather than some
+/// sliver of it.
+fn largest(clusters: Vec<(UiControl, Vec<Rect>)>) -> Vec<(UiControl, Rect)> {
+    clusters
+        .into_iter()
+        .filter_map(|(control, rects)| {
+            rects
+                .into_iter()
+                .max_by_key(|r| r.w * r.h)
+                .map(|rect| (control, rect))
+        })
+        .collect()
+}
+
+/// The status bar's own controls, sampled the same way. The bar keeps
+/// its hit-testing to itself, so the caller hands in the way to ask.
+pub(in crate::video) fn bar_map(
+    bar: Rect,
+    control_at: impl Fn((i32, i32)) -> Option<BarControl>,
+    volume: Rect,
+) -> Vec<NavItem> {
+    let mut items: Vec<NavItem> = Vec::new();
+    let mut y = bar.y;
+    while y < bar.y + bar.h {
+        let mut x = bar.x;
+        while x < bar.x + bar.w {
+            if let Some(control) = control_at((x as i32, y as i32)) {
+                let target = NavTarget::Bar(control);
+                match items.iter_mut().find(|i| i.target == target) {
+                    Some(item) => item.rect = union(item.rect, x, y),
+                    None => items.push(NavItem {
+                        target,
+                        rect: Rect { x, y, w: 1, h: 1 },
+                    }),
+                }
+            }
+            x += PROBE_STEP;
+        }
+        y += PROBE_STEP;
+    }
+    // The volume is a slider rather than a button: its whole travel is
+    // what the focus stands on, and what the line goes under.
+    if let Some(item) = items
+        .iter_mut()
+        .find(|i| i.target == NavTarget::Bar(BarControl::Volume))
+    {
+        item.rect = volume;
+    }
+    items.sort_by_key(|i| (i.rect.y, i.rect.x));
+    items
+}
+
+/// Whether the focus has any business standing on a control. The body
+/// of a panel answers for every point it does not otherwise use -- it
+/// is how a click is kept from falling through to the machine -- and
+/// the focus must not take that for a control, or the line would be
+/// drawn around the whole window and pressing it would do nothing.
+fn reachable(control: UiControl) -> bool {
+    !matches!(
+        control,
+        UiControl::PanelBody
+            | UiControl::MenuRow { .. }
+            // A list's scroll arrows are the pointer's way of doing what
+            // up and down already do from a row of it, and they sit at
+            // the far right of the box: standing on one puts the marker
+            // nowhere the eye is. Coming up out of the buttons under a
+            // list found the arrow rather than the list, and coming down
+            // into one found the arrow above the first row -- which,
+            // greyed at the top of its list, cannot light at all.
+            | UiControl::LauncherHostDiskScroll(_)
+    ) && !library_scroll(control)
+}
+
+/// The game page's own scroll arrows, where that page is built at all.
+#[cfg(feature = "game-library")]
+fn library_scroll(control: UiControl) -> bool {
+    matches!(
+        control,
+        UiControl::LauncherLibraryScroll(_) | UiControl::LauncherLibraryFavouriteScroll(_)
+    )
+}
+
+#[cfg(not(feature = "game-library"))]
+fn library_scroll(_control: UiControl) -> bool {
+    false
+}
+
+/// The one place a control stands for, for anything that needs to name
+/// the focus rather than move it.
+pub(in crate::video) fn normalise(target: NavTarget) -> NavTarget {
+    focus_key(target)
+}
+
+/// What the focus treats as one place. A stepper's two arrows share a
+/// key: the focus lands on the setting, not on one of its ends.
+fn focus_key(target: NavTarget) -> NavTarget {
+    match target {
+        NavTarget::Ui(UiControl::LauncherCycle { field, .. }) => {
+            NavTarget::Ui(UiControl::LauncherCycle {
+                field,
+                forward: false,
+            })
+        }
+        other => other,
+    }
+}
+
+/// Grow a box to take in another probe. The box holds the probes and
+/// nothing more: growing it by the step between them would have it
+/// overlap the rows either side, and then neither is beyond the other
+/// and the walk stops dead.
+fn union(rect: Rect, x: usize, y: usize) -> Rect {
+    let x0 = rect.x.min(x);
+    let y0 = rect.y.min(y);
+    let x1 = (rect.x + rect.w).max(x + 1);
+    let y1 = (rect.y + rect.h).max(y + 1);
+    Rect {
+        x: x0,
+        y: y0,
+        w: x1 - x0,
+        h: y1 - y0,
+    }
+}
+
+/// Which way the focus is being asked to go.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::video) enum Dir {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+impl Dir {
+    /// Whether this direction runs across the screen. An open stepper
+    /// spends these on its value rather than on moving the focus.
+    pub(in crate::video) fn horizontal(self) -> bool {
+        matches!(self, Dir::Left | Dir::Right)
+    }
+
+    /// Whether this direction runs down the screen.
+    fn vertical(self) -> bool {
+        !self.horizontal()
+    }
+}
+
+/// Whether a control belongs to the page beside the category column,
+/// rather than to the column itself, the profiles above it or the
+/// buttons and bar below.
+pub(in crate::video) fn in_page(target: NavTarget) -> bool {
+    matches!(band(target), Band::Pages | Band::Settings)
+}
+
+/// The control the focus should move to, or `None` if there is nothing
+/// that way.
+///
+/// The browsers' own heuristic for this (Blink's, by way of the WICG's
+/// spatial-navigation work) scores every candidate beyond the focused
+/// box on a blend of distances and overlap. It was tried here and it
+/// is wrong for this interface, because this interface is not a page:
+/// its rows and columns are laid out on a grid the eye can see, and a
+/// score that trades alignment off against nearness will, sooner or
+/// later, cross the window to find something marginally closer. What
+/// works is stricter and simpler -- see the walk below.
+pub(in crate::video) fn step(
+    items: &[NavItem],
+    from: Option<NavTarget>,
+    dir: Dir,
+) -> Option<NavTarget> {
+    let Some(from) = from.and_then(|c| find(items, c)) else {
+        // Nowhere yet: the first place in reading order takes it.
+        return items.first().map(|i| i.target);
+    };
+    // Sideways stays in the row the focus is on: left and right mean
+    // along this row, so a button on another row is not a candidate
+    // however near it looks -- which is what stops a step right from
+    // the foot of a page landing in the status bar.
+    //
+    // Up and down go to the next row, and to whatever in that row is
+    // nearest across the screen. Judging them by distance alone reads
+    // wrongly on a page where the rows are not all the same shape: the
+    // eye sees rows, and expects the one under this one, not whichever
+    // control happens to be closest as the crow flies.
+    //
+    // Nothing that way means nothing happens. The focus stays where it
+    // is at the edges of a surface rather than warping to the far
+    // corner, which is what "as far as you can go" should mean.
+    // Within the band the focus is in first; only when that band has
+    // run out does the walk leave it, which is how the settings reach
+    // the buttons under them and those reach the status bar.
+    let here = band(from.target);
+    for same_band in [true, false] {
+        let mut best: Option<(i64, i64, NavTarget)> = None;
+        for item in items {
+            if focus_key(item.target) == focus_key(from.target) {
+                continue;
+            }
+            let there = band(item.target);
+            if same_band && there != here {
+                continue;
+            }
+            // Leaving a band vertically stays on its side of the
+            // window: down from the row of sibling pages carries on
+            // into that page's settings rather than stepping across
+            // into the category column, and up from the first setting
+            // climbs to the profiles rather than to the category
+            // button beside it.
+            if dir.vertical()
+                && side(here) != Side::Both
+                && side(there) != Side::Both
+                && side(there) != side(here)
+            {
+                continue;
+            }
+            if !beyond(from.rect, item.rect, dir) {
+                continue;
+            }
+            if dir.horizontal() && !shares_row(from.rect, item.rect) {
+                continue;
+            }
+            let (along, across) = spans(from.rect, item.rect, dir);
+            // The row it is in comes first, and where it sits in that
+            // row second: an item a few pixels further down is in the
+            // same row as one directly below, not in a nearer one.
+            let rank = (along + ROW_SLACK / 2) / ROW_SLACK;
+            if best
+                .as_ref()
+                .is_none_or(|(r, a, _)| (rank, across) < (*r, *a))
+            {
+                best = Some((rank, across, item.target));
+            }
+        }
+        if let Some((_, _, target)) = best {
+            return Some(foot_landing(items, from.target, dir, target));
+        }
+    }
+    None
+}
+
+/// Where a walk that comes down onto the row of buttons at the foot
+/// lands.
+///
+/// Each track ends on its own end of that row: the category column on
+/// the first button, the page beside it on the last. Nearest-across
+/// lands wherever the page's bottom setting happens to sit over, which
+/// is Defaults from one page and Run from the next, and reads as
+/// random -- the row is one thing, not four things under four columns.
+fn foot_landing(items: &[NavItem], from: NavTarget, dir: Dir, target: NavTarget) -> NavTarget {
+    if dir != Dir::Down || band(from) == Band::Foot || band(target) != Band::Foot {
+        return target;
+    }
+    let feet = items.iter().filter(|item| band(item.target) == Band::Foot);
+    let end = if side(band(from)) == Side::Column {
+        feet.min_by_key(|item| item.rect.x)
+    } else {
+        feet.max_by_key(|item| item.rect.x)
+    };
+    end.map_or(target, |item| item.target)
+}
+
+/// How far apart two rows have to be before they are different rows.
+/// Rows of controls are rarely aligned to the pixel, and a page mixes
+/// tall boxes with short ones.
+const ROW_SLACK: i64 = 14;
+
+/// The gaps between two boxes, along the direction and across it.
+fn spans(from: Rect, to: Rect, dir: Dir) -> (i64, i64) {
+    let dx = gap(from.x, from.w, to.x, to.w);
+    let dy = gap(from.y, from.h, to.y, to.h);
+    if dir.horizontal() {
+        (dx, dy)
+    } else {
+        (dy, dx)
+    }
+}
+
+/// The band of the screen a control belongs to. The configuration
+/// screen is built of them: a row of machine profiles, a row of
+/// sibling pages, a column of categories, the settings themselves, the
+/// buttons along the foot, and the status bar under everything.
+///
+/// Up and down keep to the band they start in wherever they can. Two
+/// bands can interleave down the screen -- the category column and the
+/// settings beside it are the obvious pair -- and a walk down one of
+/// them that hopped into the other whenever its rows happened to fall
+/// between would be unusable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Band {
+    Close,
+    Profiles,
+    Pages,
+    Column,
+    Settings,
+    Foot,
+    Bar,
+}
+
+/// Which of the two tracks running down the window a band belongs to.
+///
+/// The category column on the left and the page beside it interleave
+/// all the way down, so a walk down one that fell into the other
+/// whenever a row happened to line up would be unusable. Bands that
+/// span the whole width -- the profiles above, the status bar below --
+/// belong to both, and are where a track ends.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Side {
+    Column,
+    Page,
+    Both,
+}
+
+fn side(band: Band) -> Side {
+    match band {
+        Band::Column => Side::Column,
+        Band::Pages | Band::Settings => Side::Page,
+        // The buttons along the foot run under both tracks -- Load sits
+        // beneath the column, Run beneath the page -- so each track ends
+        // on whichever of them it comes down onto.
+        Band::Close | Band::Profiles | Band::Foot | Band::Bar => Side::Both,
+    }
+}
+
+fn band(target: NavTarget) -> Band {
+    match target {
+        NavTarget::Bar(_) => Band::Bar,
+        // The close gadget belongs to the window's corner, not to the
+        // settings it sits over: left in with them, a walk up the
+        // settings would find it above everything and stop there.
+        NavTarget::Ui(UiControl::PanelClose) => Band::Close,
+        NavTarget::Ui(UiControl::LauncherModel(_)) => Band::Profiles,
+        NavTarget::Ui(UiControl::LauncherNavTab(_)) => Band::Pages,
+        NavTarget::Ui(UiControl::LauncherTab(_)) => Band::Column,
+        NavTarget::Ui(
+            UiControl::LauncherLoad
+            | UiControl::LauncherSave
+            | UiControl::LauncherSaveAs
+            | UiControl::LauncherDefaults
+            | UiControl::LauncherRun,
+        ) => Band::Foot,
+        NavTarget::Ui(_) => Band::Settings,
+    }
+}
+
+/// Whether two boxes share any of the same rows of the screen.
+fn shares_row(a: Rect, b: Rect) -> bool {
+    a.y < b.y + b.h && b.y < a.y + a.h
+}
+
+/// Whether a candidate lies beyond the focused control's edge in the
+/// direction asked for.
+fn beyond(from: Rect, to: Rect, dir: Dir) -> bool {
+    // A probe's worth of slack: boxes read off a grid are a pixel or
+    // two out, and two rows that touch should still be beyond one
+    // another.
+    let slack = PROBE_STEP;
+    match dir {
+        Dir::Up => to.y + to.h <= from.y + slack,
+        Dir::Down => to.y + slack >= from.y + from.h,
+        Dir::Left => to.x + to.w <= from.x + slack,
+        Dir::Right => to.x + slack >= from.x + from.w,
+    }
+}
+
+/// How far apart two boxes are along one axis: nothing if they overlap
+/// on it, and the gap between their nearest edges otherwise.
+fn gap(a0: usize, a_len: usize, b0: usize, b_len: usize) -> i64 {
+    let (a1, b1) = ((a0 + a_len) as i64, (b0 + b_len) as i64);
+    let (a0, b0) = (a0 as i64, b0 as i64);
+    if b0 >= a1 {
+        b0 - a1
+    } else if a0 >= b1 {
+        a0 - b1
+    } else {
+        0
+    }
+}
+
+/// The item a control stands for, matching a stepper by its setting.
+pub(in crate::video) fn find(items: &[NavItem], target: NavTarget) -> Option<NavItem> {
+    let key = focus_key(target);
+    items.iter().copied().find(|i| focus_key(i.target) == key)
+}
+
+/// Whether a control is a stepper -- the one kind that opens for
+/// editing rather than simply being pressed.
+pub(in crate::video) fn is_stepper(target: NavTarget) -> bool {
+    matches!(
+        target,
+        NavTarget::Ui(UiControl::LauncherCycle { .. }) | NavTarget::Bar(BarControl::Volume)
+    )
+}
+
+/// The stepper's own arrow for a direction, for the press an open
+/// setting turns into.
+pub(in crate::video) fn stepper_arrow(target: NavTarget, dir: Dir) -> Option<NavTarget> {
+    match target {
+        NavTarget::Ui(UiControl::LauncherCycle { field, .. }) => {
+            Some(NavTarget::Ui(UiControl::LauncherCycle {
+                field,
+                forward: dir == Dir::Right,
+            }))
+        }
+        _ => None,
+    }
+}
+
+/// Where the focus stands, and how it is being shown.
+#[derive(Debug, Default, Clone)]
+pub(in crate::video) struct Nav {
+    /// The control the focus is on. Kept across a mouse click so
+    /// coming back to the keyboard resumes where the hand left off.
+    focus: Option<NavTarget>,
+    /// Whether the focus is being shown. Set by a key or a pad, cleared
+    /// by the pointer: a line under a control means the keyboard is
+    /// driving, and the moment the mouse is used it is not.
+    showing: bool,
+    /// A stepper standing open: its arrows are lit, and left and right
+    /// change the value instead of moving on.
+    open: bool,
+}
+
+impl Nav {
+    /// The control the focus is on, whether or not it is being shown.
+    pub(in crate::video) fn focus(&self) -> Option<NavTarget> {
+        self.focus
+    }
+
+    /// The control the focus is on while it is being shown -- what the
+    /// surfaces light. `None` while the pointer is driving.
+    pub(in crate::video) fn shown(&self) -> Option<NavTarget> {
+        self.showing.then_some(self.focus).flatten()
+    }
+
+    /// Whether the focused stepper stands open.
+    pub(in crate::video) fn open(&self) -> bool {
+        self.open && self.focus.is_some_and(is_stepper)
+    }
+
+    pub(in crate::video) fn showing(&self) -> bool {
+        self.showing
+    }
+
+    /// Put the focus somewhere and show it.
+    pub(in crate::video) fn show(&mut self, target: Option<NavTarget>) {
+        self.focus = target;
+        self.showing = true;
+        self.open = false;
+    }
+
+    /// Remember where the pointer last pressed, so the keyboard picks
+    /// up from there rather than from the top of the page.
+    pub(in crate::video) fn follow_pointer(&mut self, target: NavTarget) {
+        self.focus = Some(target);
+        self.showing = false;
+        self.open = false;
+    }
+
+    /// Open or close the focused stepper.
+    pub(in crate::video) fn toggle_open(&mut self) {
+        if self.focus.is_some_and(is_stepper) {
+            self.open = !self.open;
+        }
+    }
+
+    pub(in crate::video) fn close(&mut self) {
+        self.open = false;
+    }
+
+    /// Forget everything: the surface underneath has gone.
+    /// Put the focus somewhere without saying whether it is shown.
+    ///
+    /// A surface that has just opened has a place to start from, and
+    /// whichever hand opened it keeps the marker as it was: opening the
+    /// launcher from the menu carries the keyboard's marker straight
+    /// onto the page, opening it with the mouse leaves it unmarked.
+    pub(in crate::video) fn park(&mut self, target: Option<NavTarget>) {
+        self.focus = target;
+        self.open = false;
+    }
+
+    pub(in crate::video) fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    /// Keep the focus honest when the page changes under it: a control
+    /// that is no longer there hands the focus to the first thing that
+    /// is.
+    pub(in crate::video) fn settle(&mut self, items: &[NavItem], home: Option<NavTarget>) {
+        // Somewhere it cannot be -- the page changed under it -- or
+        // nowhere at all, which is where a surface that has just opened
+        // starts.
+        if !self.focus.is_some_and(|t| find(items, t).is_some()) {
+            // Home if the surface offers one -- the page the eye starts
+            // on -- and otherwise the first place in reading order.
+            self.focus = home
+                .filter(|t| find(items, *t).is_some())
+                .or_else(|| items.first().map(|i| i.target));
+            self.open = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    /// One page's map, as the window sees it.
+    fn page(tab: crate::video::launcher::LauncherTab) -> Vec<NavItem> {
+        page_of(tab, |_| {})
+    }
+
+    /// The same, with the page's own contents put there first: a page
+    /// that is mostly list has none of the things a walk across it must
+    /// find until something is in the list.
+    fn page_of(
+        tab: crate::video::launcher::LauncherTab,
+        fill: impl FnOnce(&mut crate::video::launcher::LauncherState),
+    ) -> Vec<NavItem> {
+        use crate::video::launcher::{LauncherState, MachineSetup};
+        use crate::video::menu::MenuNav;
+        use crate::video::ui::Panel;
+        let mut state = LauncherState::new(MachineSetup::default());
+        state.tab = tab;
+        fill(&mut state);
+        let ui = UiState {
+            menu_open: false,
+            menu_rows: Vec::new(),
+            menu_nav: MenuNav::default(),
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        map(
+            &ui,
+            crate::video::window::texture_width(1),
+            crate::video::window::texture_height(1),
+        )
+    }
+
+    /// Every page offers the focus somewhere to go when it steps right
+    /// out of the category column, and the rows across the top of a
+    /// page lead back up to the machine profiles rather than to the
+    /// corner of the window.
+    #[test]
+    fn every_page_can_be_entered_and_left() {
+        use crate::config::MachineModel;
+        use crate::video::launcher::{LauncherState, LauncherTab, MachineSetup};
+        use crate::video::menu::MenuNav;
+        use crate::video::ui::Panel;
+
+        for tab in [
+            LauncherTab::System,
+            LauncherTab::Cpu,
+            LauncherTab::Memory,
+            LauncherTab::Rom,
+            LauncherTab::Floppy,
+            LauncherTab::Storage,
+            LauncherTab::Input,
+            LauncherTab::IoPorts,
+            LauncherTab::Zorro,
+            LauncherTab::WhdloadLibrary,
+            LauncherTab::AvAudio,
+        ] {
+            let mut state = LauncherState::new(MachineSetup::default());
+            state.tab = tab;
+            let ui = UiState {
+                menu_open: false,
+                menu_rows: Vec::new(),
+                menu_nav: MenuNav::default(),
+                panel: Some(Panel::Launcher(Box::new(state))),
+            };
+            let items = map(
+                &ui,
+                crate::video::window::texture_width(1),
+                crate::video::window::texture_height(1),
+            );
+            // Something to enter: either a row of sibling pages, or a
+            // setting of its own. The window picks between them; the map
+            // has to offer at least one.
+            let column = find(&items, NavTarget::Ui(UiControl::LauncherTab(tab)))
+                .unwrap_or_else(|| panic!("{tab:?} has no category button"));
+            let right_of_column = column.rect.x + column.rect.w;
+            assert!(
+                items.iter().any(|item| {
+                    item.rect.x >= right_of_column
+                        && matches!(band(item.target), Band::Pages | Band::Settings)
+                }),
+                "{tab:?} offers the focus nothing to the right of its button"
+            );
+            // And a page with sibling pages climbs from them to the
+            // profiles above, not to the close gadget in the corner.
+            if let Some(pages) = items
+                .iter()
+                .find(|item| band(item.target) == Band::Pages)
+                .map(|item| item.target)
+            {
+                assert!(
+                    matches!(
+                        step(&items, Some(pages), Dir::Up),
+                        Some(NavTarget::Ui(UiControl::LauncherModel(_)))
+                    ),
+                    "{tab:?} does not climb from its sibling pages to the profiles"
+                );
+            }
+            // Above the top row of profiles there is only the corner of
+            // the window: climbing must never drop back into the page.
+            assert!(
+                matches!(
+                    step(
+                        &items,
+                        Some(NavTarget::Ui(UiControl::LauncherModel(MachineModel::A1000))),
+                        Dir::Up
+                    ),
+                    None | Some(NavTarget::Ui(UiControl::PanelClose))
+                ),
+                "{tab:?} climbs off the top row back into the page"
+            );
+        }
+    }
+
+    /// The buttons along the foot end both tracks: the category column
+    /// comes down onto them, and so does the page beside it.
+    #[test]
+    fn the_foot_ends_both_tracks() {
+        use crate::video::launcher::LauncherTab;
+        let items = page(LauncherTab::Rom);
+        assert_eq!(
+            step(
+                &items,
+                Some(NavTarget::Ui(UiControl::LauncherTab(LauncherTab::AvAudio))),
+                Dir::Down
+            ),
+            Some(NavTarget::Ui(UiControl::LauncherLoad)),
+            "the last category comes down onto the button under it"
+        );
+        // And the page's own track ends there too, rather than stepping
+        // sideways into the column on its way down.
+        assert_eq!(
+            step(
+                &items,
+                Some(NavTarget::Ui(UiControl::LauncherBrowse(
+                    crate::video::launcher::LauncherField::ExtendedRom
+                ))),
+                Dir::Down
+            ),
+            Some(NavTarget::Ui(UiControl::LauncherRun)),
+            "the last setting comes down onto the buttons, not the column"
+        );
+        // Climbing off the first setting of a page with no row of
+        // sibling pages goes to the profiles above, not across into the
+        // category button beside it.
+        assert!(
+            matches!(
+                step(
+                    &items,
+                    Some(NavTarget::Ui(UiControl::LauncherBrowse(
+                        crate::video::launcher::LauncherField::Rom
+                    ))),
+                    Dir::Up
+                ),
+                Some(NavTarget::Ui(UiControl::LauncherModel(_)))
+            ),
+            "the first setting climbs to the machines above it"
+        );
+    }
+
+    /// A row of choices is walked both ways. Coming back left through
+    /// one used to leave the page at the first step, because leaving it
+    /// was tried before staying on it.
+    #[test]
+    fn a_row_of_choices_walks_both_ways() {
+        use crate::video::launcher::{FsFamily, LauncherField, LauncherTab};
+        let items = page(LauncherTab::CreateFloppy);
+        let family = |family| {
+            NavTarget::Ui(UiControl::LauncherFsFamily {
+                field: LauncherField::NewFloppyFs,
+                family,
+            })
+        };
+        assert_eq!(
+            step(&items, Some(family(FsFamily::Ffs)), Dir::Left),
+            Some(family(FsFamily::Ofs)),
+            "left goes back through the choices"
+        );
+        assert_eq!(
+            step(&items, Some(family(FsFamily::Ofs)), Dir::Left),
+            Some(family(FsFamily::Unformatted)),
+            "and keeps going"
+        );
+        // Only then has the row run out. What is left of it is the
+        // category column, which the window turns into the button that
+        // opened the page.
+        assert!(
+            !step(&items, Some(family(FsFamily::Unformatted)), Dir::Left).is_some_and(in_page),
+            "the first choice in the row leaves the page"
+        );
+    }
+
+    /// The game page is a list with a strip of letters over it and a
+    /// second list under the buttons, and every walk across it has been
+    /// got wrong at least once.
+    #[test]
+    fn the_game_page_is_a_list_to_walk() {
+        use crate::video::launcher::LauncherTab;
+        let items = page_of(LauncherTab::WhdloadLibrary, |state| {
+            state.library.games =
+                crate::gamelib::Library::of_titles((0..40).map(|i| format!("Game {i:03}")));
+            for i in 0..3 {
+                let title = format!("Game {i:03}");
+                state.library.db.toggle_favourite(&title, &title);
+            }
+        });
+        let go = |from: UiControl, dir: Dir| step(&items, Some(NavTarget::Ui(from)), dir);
+        let at = |control: UiControl| Some(NavTarget::Ui(control));
+        use UiControl::{
+            LauncherLibraryFavourite as Tick, LauncherLibraryFavouritePick as Starred,
+            LauncherLibraryJump as Letter, LauncherLibraryPick as Game,
+            LauncherLibraryRefresh as Refresh,
+        };
+
+        // The letters are a strip: along it either way, and no further
+        // than its ends.
+        assert_eq!(go(Letter(0), Dir::Right), at(Letter(1)));
+        assert_eq!(go(Letter(1), Dir::Left), at(Letter(0)));
+        assert_eq!(go(Letter(27), Dir::Right), None, "Z is the end of it");
+        assert!(
+            !go(Letter(0), Dir::Left).is_some_and(in_page),
+            "and left off the first leaves the page, for the button that opened it"
+        );
+        // Above them is the row of sibling pages; below them, the list.
+        assert_eq!(
+            go(Letter(0), Dir::Up),
+            at(UiControl::LauncherNavTab(LauncherTab::WhdloadLibrary))
+        );
+        assert_eq!(go(Letter(0), Dir::Down), at(Game(0)));
+
+        // A row's tick is drawn inside the row's own box, so neither
+        // is beyond the other and the geometry has nothing to offer
+        // across a list. The window names those steps itself.
+        assert_eq!(go(Game(0), Dir::Right), None);
+        assert_ne!(
+            go(Tick(0), Dir::Left),
+            at(Game(0)),
+            "the geometry cannot find a row from the tick drawn inside it"
+        );
+
+        // Under the list are its buttons, and under those the
+        // favourites, which is the only way down to them.
+        assert_eq!(go(Refresh, Dir::Down), at(Starred(0)));
+        assert!(
+            matches!(go(Refresh, Dir::Up), Some(NavTarget::Ui(Game(_)))),
+            "up off the buttons comes back to the list, got {:?}",
+            go(Refresh, Dir::Up)
+        );
+    }
+
+    /// The Back button on a sub-page leads down into the page, and
+    /// where the page has nothing to lead into, past the buttons that
+    /// cannot be pressed to the one that can.
+    #[test]
+    fn a_sub_page_is_entered_from_its_back_button() {
+        use crate::video::launcher::LauncherTab;
+        let back = Some(NavTarget::Ui(UiControl::LauncherNavTab(
+            LauncherTab::Storage,
+        )));
+        let full = page_of(LauncherTab::HostDisk, |state| {
+            state.setup.fake_host_disks(4);
+        });
+        assert_eq!(
+            step(&full, back, Dir::Down),
+            Some(NavTarget::Ui(UiControl::LauncherHostDiskSelect(0))),
+            "down off Back is the first disk in the list"
+        );
+        assert_eq!(
+            step(
+                &full,
+                Some(NavTarget::Ui(UiControl::LauncherHostDiskSelect(3))),
+                Dir::Down
+            ),
+            Some(NavTarget::Ui(UiControl::LauncherHostDiskRefresh)),
+            "and the last row comes down onto the button that can be pressed"
+        );
+        // A list long enough to scroll grows a pair of arrows in the
+        // corner of its box, above the first row and below the last.
+        // They are the pointer's, and greyed at the end of the list they
+        // cannot light: down off Back found one and the marker vanished.
+        let long = page_of(LauncherTab::HostDisk, |state| {
+            state.setup.fake_host_disks(20);
+        });
+        assert_eq!(
+            step(&long, back, Dir::Down),
+            Some(NavTarget::Ui(UiControl::LauncherHostDiskSelect(0))),
+            "down off Back is the first disk, not the scroll arrow over it"
+        );
+        // Across a row: the attach column only once the disk is ticked,
+        // then its two ticks. The Enable tick is a place of its own so
+        // the focus can stand on the box it ticks.
+        assert_eq!(
+            step(
+                &full,
+                Some(NavTarget::Ui(UiControl::LauncherHostDiskSelect(0))),
+                Dir::Right
+            ),
+            Some(NavTarget::Ui(UiControl::LauncherHostDiskWritable(0))),
+            "an unticked disk has no attach cell to stand on"
+        );
+        assert_eq!(
+            step(
+                &full,
+                Some(NavTarget::Ui(UiControl::LauncherHostDiskWritable(0))),
+                Dir::Right
+            ),
+            Some(NavTarget::Ui(UiControl::LauncherHostDiskEnable(0))),
+        );
+        // With nothing to mount, Mount and Unmount are dead: the focus
+        // steps over them to Refresh, which only ever looks.
+        let empty = page(LauncherTab::HostDisk);
+        assert_eq!(
+            step(&empty, back, Dir::Down),
+            Some(NavTarget::Ui(UiControl::LauncherHostDiskRefresh)),
+            "an empty list drops past the dead buttons"
+        );
+    }
+
+    /// A page's map, printed, for working out why a step goes where it
+    /// does.
+    #[test]
+    #[ignore = "a tool for reading a page, not a check"]
+    fn dump_page() {
+        use crate::video::launcher::LauncherTab;
+        for tab in [LauncherTab::BootPriority] {
+            println!("=== {tab:?}");
+            for i in page_of(tab, |_| {}) {
+                println!(
+                    "{:>4},{:>4} {:>4}x{:<4} {:?}",
+                    i.rect.x, i.rect.y, i.rect.w, i.rect.h, i.target
+                );
+            }
+        }
+    }
+
+    /// The bar's own controls reach the map: the focus can walk down
+    /// off the foot of a surface onto them.
+    #[test]
+    fn the_bar_is_in_the_map() {
+        use crate::video::window::statusbar::{bar_layout, control_at, status_bar_rect, MediaBar};
+        // The bar as it stands with a bare machine: no drives, no CD.
+        let layout = bar_layout(&MediaBar {
+            drives: Default::default(),
+            cd: None,
+        });
+        let bar = status_bar_rect();
+        println!("bar rect {:?}", (bar.x, bar.y, bar.w, bar.h));
+        let items = bar_map(
+            bar,
+            |pos| control_at(pos, &layout),
+            crate::video::window::statusbar::volume_control_hit_rect(),
+        );
+        for i in &items {
+            println!(
+                "{:>4},{:>4} {:>4}x{:<4} {:?}",
+                i.rect.x, i.rect.y, i.rect.w, i.rect.h, i.target
+            );
+        }
+        assert!(!items.is_empty(), "the bar has controls to stand on");
+
+        // And the focus can walk down onto them from the foot of a
+        // surface, which is the only way to reach the bar without a
+        // pointer.
+        use crate::video::launcher::{LauncherState, LauncherTab, MachineSetup};
+        use crate::video::menu::MenuNav;
+        use crate::video::ui::Panel;
+        let mut state = LauncherState::new(MachineSetup::default());
+        state.tab = LauncherTab::IoPorts;
+        let ui = UiState {
+            menu_open: false,
+            menu_rows: Vec::new(),
+            menu_nav: MenuNav::default(),
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        let mut all = map(
+            &ui,
+            crate::video::window::texture_width(1),
+            crate::video::window::texture_height(1),
+        );
+        all.extend(items);
+        let down = step(&all, Some(NavTarget::Ui(UiControl::LauncherRun)), Dir::Down);
+        assert!(
+            matches!(down, Some(NavTarget::Bar(_))),
+            "down off the last button reaches the bar, got {down:?}"
+        );
+        // And back up again.
+        let up = step(&all, down, Dir::Up);
+        assert!(
+            matches!(up, Some(NavTarget::Ui(_))),
+            "and up returns to the surface, got {up:?}"
+        );
+    }
+
+    /// The walk across a real page, against the real map. Directions mean
+    /// what the eye means by them: down from a machine profile lands on
+    /// the box directly below it, sideways along the row of sibling
+    /// pages stays in that row, and the buttons along the foot reach
+    /// each other rather than climbing into the settings above.
+    #[test]
+    fn the_walk_follows_the_eye() {
+        use crate::config::MachineModel;
+        use crate::video::launcher::{LauncherState, LauncherTab, MachineSetup};
+        use crate::video::menu::MenuNav;
+        use crate::video::ui::Panel;
+
+        let mut state = LauncherState::new(MachineSetup::default());
+        state.tab = LauncherTab::IoPorts;
+        let ui = UiState {
+            menu_open: false,
+            menu_rows: Vec::new(),
+            menu_nav: MenuNav::default(),
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        let items = map(
+            &ui,
+            crate::video::window::texture_width(1),
+            crate::video::window::texture_height(1),
+        );
+        let go = |from: UiControl, dir: Dir| step(&items, Some(NavTarget::Ui(from)), dir);
+        let at = |control: UiControl| Some(NavTarget::Ui(control));
+
+        assert_eq!(
+            go(UiControl::LauncherModel(MachineModel::A3000), Dir::Down),
+            at(UiControl::LauncherNavTab(LauncherTab::IoPorts)),
+            "down lands on what is directly below"
+        );
+        assert_eq!(
+            go(
+                UiControl::LauncherNavTab(LauncherTab::IoParallel),
+                Dir::Left
+            ),
+            at(UiControl::LauncherNavTab(LauncherTab::IoPorts)),
+            "left takes the page beside it, not the profile above"
+        );
+        assert_eq!(
+            go(UiControl::LauncherSave, Dir::Right),
+            at(UiControl::LauncherDefaults),
+            "right along the foot reaches the buttons to the right of it"
+        );
+        assert_eq!(
+            go(UiControl::LauncherDefaults, Dir::Left),
+            at(UiControl::LauncherSave),
+        );
+        assert_eq!(
+            go(UiControl::LauncherTab(LauncherTab::Cpu), Dir::Down),
+            at(UiControl::LauncherTab(LauncherTab::Memory)),
+            "the category column is a column"
+        );
+        // Down goes to the row below, and to what in that row is
+        // nearest across the screen -- not to whatever is closest as
+        // the crow flies.
+        assert_eq!(
+            go(UiControl::LauncherLoad, Dir::Right),
+            at(UiControl::LauncherSave),
+        );
+        assert_eq!(
+            go(UiControl::LauncherRun, Dir::Left),
+            at(UiControl::LauncherDefaults),
+            "left walks back along the foot of the page"
+        );
+
+        // A page whose settings do not line up under one another: down
+        // still takes the next setting rather than diving to the
+        // buttons along the foot, which happen to line up exactly.
+        let mut state = LauncherState::new(MachineSetup::default());
+        state.tab = LauncherTab::Floppy;
+        let ui = UiState {
+            menu_open: false,
+            menu_rows: Vec::new(),
+            menu_nav: MenuNav::default(),
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        let floppy = map(
+            &ui,
+            crate::video::window::texture_width(1),
+            crate::video::window::texture_height(1),
+        );
+        let down = step(
+            &floppy,
+            Some(NavTarget::Ui(UiControl::LauncherBrowse(
+                crate::video::launcher::LauncherField::Df0Image,
+            ))),
+            Dir::Down,
+        );
+        assert!(
+            !matches!(down, Some(NavTarget::Ui(UiControl::LauncherDefaults))),
+            "down from Browse takes the settings under it, not the foot of the page"
+        );
+        // The row under the drive-speed stepper is the one holding the
+        // Browse button, so that is where down goes -- there is no
+        // other way to reach it.
+        assert_eq!(
+            step(
+                &floppy,
+                Some(NavTarget::Ui(UiControl::LauncherCycle {
+                    field: crate::video::launcher::LauncherField::FloppySpeed,
+                    forward: false,
+                })),
+                Dir::Down,
+            ),
+            Some(NavTarget::Ui(UiControl::LauncherBrowse(
+                crate::video::launcher::LauncherField::Df0Image
+            ))),
+            "down takes the row below, whatever is in it"
+        );
+        // And the row of sibling pages can always climb back to the
+        // machine profiles above it.
+        let mut state = LauncherState::new(MachineSetup::default());
+        state.tab = LauncherTab::WhdloadLibrary;
+        let ui = UiState {
+            menu_open: false,
+            menu_rows: Vec::new(),
+            menu_nav: MenuNav::default(),
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        let whdload = map(
+            &ui,
+            crate::video::window::texture_width(1),
+            crate::video::window::texture_height(1),
+        );
+        assert_eq!(
+            step(
+                &whdload,
+                Some(NavTarget::Ui(UiControl::LauncherNavTab(
+                    LauncherTab::WhdloadLibrary
+                ))),
+                Dir::Up
+            ),
+            at(UiControl::LauncherModel(MachineModel::A3000)),
+            "up from the sibling row reaches the profile above it"
+        );
+    }
+
+    use crate::video::launcher::LauncherField;
+
+    fn item(control: UiControl, x: usize, y: usize, w: usize, h: usize) -> NavItem {
+        NavItem {
+            target: NavTarget::Ui(control),
+            rect: Rect { x, y, w, h },
+        }
+    }
+
+    fn ui(control: UiControl) -> NavTarget {
+        NavTarget::Ui(control)
+    }
+
+    /// A walk down a column of settings stays in its column, even when
+    /// something in the next column sits closer as the crow flies.
+    #[test]
+    fn a_walk_down_a_column_stays_in_it() {
+        let tab = UiControl::LauncherTab(crate::video::launcher::LauncherTab::System);
+        let rows: Vec<NavItem> = vec![
+            item(
+                UiControl::LauncherToggle(LauncherField::FloppyVolume),
+                200,
+                100,
+                90,
+                12,
+            ),
+            item(
+                UiControl::LauncherToggle(LauncherField::MouseSensitivity),
+                200,
+                130,
+                90,
+                12,
+            ),
+            // Nearer in a straight line, but off to one side -- and
+            // sharing the row, as a category button beside a setting
+            // does.
+            item(tab, 120, 100, 40, 12),
+        ];
+        let from = rows[0].target;
+        assert_eq!(
+            step(&rows, Some(from), Dir::Down),
+            Some(rows[1].target),
+            "down takes the row below, not the nearer neighbour beside it"
+        );
+        assert_eq!(
+            step(&rows, Some(from), Dir::Left),
+            Some(ui(tab)),
+            "and left crosses to it"
+        );
+        assert_eq!(step(&rows, Some(from), Dir::Up), None, "nothing above");
+    }
+
+    /// A stepper's two arrows are one place to stand: the focus belongs
+    /// to the setting, and its ends are what opening it works.
+    #[test]
+    fn a_steppers_arrows_are_one_place() {
+        let back = UiControl::LauncherCycle {
+            field: LauncherField::FloppyVolume,
+            forward: false,
+        };
+        let forward = UiControl::LauncherCycle {
+            field: LauncherField::FloppyVolume,
+            forward: true,
+        };
+        let rows = vec![
+            item(back, 200, 100, 12, 12),
+            item(forward, 260, 100, 12, 12),
+        ];
+        assert!(
+            find(&rows, ui(forward)).is_some_and(|i| i.target == ui(back)),
+            "either end finds the same place"
+        );
+        assert_eq!(
+            step(&rows, Some(ui(back)), Dir::Right),
+            None,
+            "and right does not walk from one end of it to the other"
+        );
+        assert_eq!(stepper_arrow(ui(back), Dir::Right), Some(ui(forward)));
+        assert_eq!(stepper_arrow(ui(back), Dir::Left), Some(ui(back)));
+        assert!(is_stepper(ui(back)) && !is_stepper(ui(UiControl::PanelClose)));
+    }
+
+    /// The body of a panel is not somewhere the focus can stand. It
+    /// answers for every point the panel does not otherwise use, so
+    /// taking it for a control drew the line around the whole window
+    /// and left nothing to press.
+    #[test]
+    fn the_panel_body_is_not_a_place_to_stand() {
+        let ui = UiState {
+            menu_open: false,
+            menu_rows: Vec::new(),
+            menu_nav: crate::video::menu::MenuNav::default(),
+            panel: Some(crate::video::ui::Panel::About),
+        };
+        let items = map(&ui, 720, 300);
+        assert!(
+            items
+                .iter()
+                .any(|i| i.target == NavTarget::Ui(UiControl::PanelClose)),
+            "the close gadget is reachable"
+        );
+        assert!(
+            !items
+                .iter()
+                .any(|i| i.target == NavTarget::Ui(UiControl::PanelBody)),
+            "and the body it sits on is not"
+        );
+    }
+
+    /// The focus survives a page it still exists on, and moves home when
+    /// it does not.
+    #[test]
+    fn the_focus_settles_when_the_page_changes() {
+        let close = UiControl::PanelClose;
+        let body = UiControl::PanelBody;
+        let mut nav = Nav::default();
+        nav.show(Some(ui(close)));
+        assert_eq!(nav.shown(), Some(ui(close)));
+        nav.settle(&[item(close, 0, 0, 8, 8)], None);
+        assert_eq!(nav.focus(), Some(ui(close)), "still there, still focused");
+        nav.settle(&[item(body, 0, 0, 8, 8)], None);
+        assert_eq!(nav.focus(), Some(ui(body)), "gone: the focus goes home");
+        // The pointer puts the line out but remembers the place.
+        nav.follow_pointer(ui(close));
+        assert_eq!(nav.shown(), None);
+        assert_eq!(nav.focus(), Some(ui(close)));
+    }
+}

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -11,8 +11,8 @@
 use super::launcher::{self, EditTarget, LauncherField, LauncherState, LauncherTab, RowKind};
 use super::menu;
 use super::window::{
-    draw_rect_bevel, fill_rect, fill_rect_blend, rgba, scale_rect, texture_height, texture_width,
-    Rect, BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT, BUTTON_FACE, BUTTON_FACE_HOVER,
+    draw_rect_bevel, fill_rect, fill_rect_blend, rgba, scale_rect, texture_width, Rect,
+    BUTTON_EDGE_DARK, BUTTON_EDGE_LIGHT, BUTTON_FACE, BUTTON_FACE_HOVER,
 };
 use super::{font, present_height, FB_WIDTH, HOST_SHORTCUT_MODIFIER_LABEL};
 use crate::config::MachineModel;
@@ -48,7 +48,11 @@ const FS_VARIANTS: [crate::diskimage::Variant; 3] = [
     crate::diskimage::Variant::LongName,
 ];
 const ENTRY_TEXT: u32 = rgba(27, 220, 71);
-const SCRIM: u32 = rgba(0, 0, 0);
+/// The veil an overlay draws over what it covers: enough to throw the
+/// overlay forward and to say the machine is not listening, while
+/// leaving what is behind readable. One tint for the menu and every
+/// dialog alike -- two of them differing was a step you could see.
+const SCRIM: u32 = rgba(8, 9, 11);
 const SCRIM_ALPHA: f32 = 0.45;
 // Audio-tab oscilloscope trace colours for the four Paula channels.
 const AUDIO_SCOPE_COLORS: [u32; 4] = [
@@ -789,6 +793,11 @@ pub enum UiControl {
     LauncherModel(MachineModel),
     /// Configuration screen: switch the category tab.
     LauncherTab(LauncherTab),
+    /// The same page, reached from the row of sibling pages above the
+    /// settings rather than from the category column. It is a button
+    /// of its own -- somewhere else on the screen, lighting on its own
+    /// -- even though pressing it goes where the category button goes.
+    LauncherNavTab(LauncherTab),
     /// Configuration screen: step a cycle/stepper field one value.
     LauncherCycle {
         field: LauncherField,
@@ -903,6 +912,10 @@ pub enum UiControl {
     /// Give a real disk back to the host, from the drive row holding it.
     LauncherHostDiskUnmount(LauncherField),
     /// Move the disk list's window up or down one row.
+    /// The Enable tick at the end of a host-disk row: the same answer
+    /// as picking the row, given its own place so the focus can stand
+    /// on the box it ticks rather than on the whole row.
+    LauncherHostDiskEnable(usize),
     LauncherHostDiskScroll(isize),
     /// Look at the host's storage again.
     LauncherHostDiskRefresh,
@@ -1883,11 +1896,11 @@ fn draw_text_button(
     rect: Rect,
     label: &str,
     enabled: bool,
-    hover: bool,
+    hover: f32,
     texture_scale: usize,
 ) {
-    let face = if hover && enabled {
-        BUTTON_FACE_HOVER
+    let face = if enabled {
+        light_face(BUTTON_FACE, BUTTON_FACE_HOVER, hover)
     } else {
         BUTTON_FACE
     };
@@ -1936,13 +1949,13 @@ fn draw_panel_chrome(frame: &mut [u8], panel: &Panel, hover: Option<UiControl>, 
         frame,
         rect,
         panel_title(panel),
-        hover == Some(UiControl::PanelClose),
+        lit(hover, UiControl::PanelClose),
         scale,
     );
 }
 
 /// A panel's blue title bar, with its name and its close gadget.
-fn draw_title_bar(frame: &mut [u8], rect: Rect, title: &str, close_hover: bool, scale: usize) {
+fn draw_title_bar(frame: &mut [u8], rect: Rect, title: &str, close_hover: f32, scale: usize) {
     let bar = Rect {
         x: rect.x + 1,
         y: rect.y + 1,
@@ -1963,13 +1976,11 @@ fn draw_title_bar(frame: &mut [u8], rect: Rect, title: &str, close_hover: bool, 
 }
 
 /// The close gadget: a classic square with an inner square.
-fn draw_close_gadget(frame: &mut [u8], rect: Rect, close_hover: bool, scale: usize) {
+fn draw_close_gadget(frame: &mut [u8], rect: Rect, close_hover: f32, scale: usize) {
     let close = close_button_rect(rect);
-    let face = if close_hover {
-        BUTTON_FACE_HOVER
-    } else {
-        PANEL_TITLE_BG
-    };
+    // The gadget already wears the interface's blue, so the focus lifts
+    // it to the paler one rather than painting it the colour it is.
+    let face = light_face_to(PANEL_TITLE_BG, BUTTON_FACE_HOVER, NAV_FACE_ON, close_hover);
     let close_scaled = scale_rect(
         Rect {
             x: close.x + 1,
@@ -2001,6 +2012,159 @@ fn draw_close_gadget(frame: &mut [u8], rect: Rect, close_hover: bool, scale: usi
         h: 4,
     };
     fill_rect(frame, scale_rect(hole, scale), face, scale);
+}
+
+// Where the focus stands while a surface is being drawn, and how far
+// through its breath it is.
+//
+// The focus lights a control the way the pointer lights one -- there
+// is no second language to learn -- but in the interface's own blue
+// rather than the pointer's grey, and breathing rather than steady,
+// so the two hands never say the same thing. Drawing is one pass on
+// one thread, so the surface reads where the focus is from here
+// rather than every drawing function in the file carrying it through.
+thread_local! {
+    static NAV_LIGHT: std::cell::Cell<(Option<UiControl>, f32)> =
+        const { std::cell::Cell::new((None, 0.0)) };
+    /// Whether that control stands open for changing.
+    static NAV_OPEN: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Say where the focus is, and how far through its breath, for the
+/// drawing about to happen.
+pub(in crate::video) fn set_nav_light(target: Option<UiControl>, mix: f32, open: bool) {
+    NAV_LIGHT.with(|light| light.set((target, mix.clamp(0.0, 1.0))));
+    NAV_OPEN.with(|flag| flag.set(open));
+}
+
+/// How lit a control is: all the way under the pointer, and as far as
+/// the breath has come when the focus is standing on it.
+fn lit(hover: Option<UiControl>, control: UiControl) -> f32 {
+    // Negative says the focus has it rather than the pointer: the two
+    // light the same control differently, and one number carries both
+    // how far through the breath it is and whose it is. The focus is
+    // asked first, so a control the mouse happens to be resting on
+    // still breathes when the keyboard walks onto it.
+    let focused = nav_lit(control);
+    if focused != 0.0 {
+        return -focused;
+    }
+    // And while the marker is up at all, the keyboard is in charge: the
+    // pointer lights nothing, or a hand left resting on the mouse marks
+    // a second control wherever it happens to sit. Moving the mouse
+    // puts the marker away, and the pointer has it back.
+    if nav_showing() {
+        return 0.0;
+    }
+    if hover == Some(control) {
+        1.0
+    } else {
+        0.0
+    }
+}
+
+/// Whether the focus is being shown at all, whatever it is standing on.
+fn nav_showing() -> bool {
+    NAV_LIGHT.with(|light| light.get().0.is_some())
+}
+
+/// The face a control wears, given how lit it is: the pointer's grey,
+/// or the focus's blue. The status bar draws its own buttons and uses
+/// this too, so the two surfaces cannot drift apart.
+pub(in crate::video) fn light_face(resting: u32, hovered: u32, light: f32) -> u32 {
+    light_face_to(resting, hovered, NAV_FACE, light)
+}
+
+/// The same, saying which blue the focus lifts a control toward.
+pub(in crate::video) fn light_face_to(resting: u32, hovered: u32, focused: u32, light: f32) -> u32 {
+    if light < 0.0 {
+        mix_colour(resting, focused, -light)
+    } else {
+        mix_colour(resting, hovered, light)
+    }
+}
+
+/// The face the focus lights a control with: the blue the interface
+/// already wears for a chosen page. The two hands say different
+/// things, so the focus takes the blue and the pointer keeps its grey.
+pub(in crate::video) const NAV_FACE: u32 = PANEL_TITLE_BG;
+/// A control already wearing that blue lifts toward this instead --
+/// the same colour again would say nothing about where the focus is.
+pub(in crate::video) const NAV_FACE_ON: u32 = rgba(120, 176, 236);
+
+/// How lit the focus alone has a control -- the pointer does not count.
+/// The value a stepper is about to change reads this: it should say
+/// which setting the focus is on, not which arrow the mouse is over.
+fn nav_lit(control: UiControl) -> f32 {
+    NAV_LIGHT.with(|light| {
+        let (target, mix) = light.get();
+        if target == Some(control) {
+            mix
+        } else {
+            0.0
+        }
+    })
+}
+
+/// What a tick box's outline says: green under the pointer, the
+/// focus's blue while it stands there, and nothing at all otherwise.
+/// A tick box is a box: filling its middle would read as a tick.
+/// The fill a row of a list takes while it is under the pointer or the
+/// focus, over `resting`.
+///
+/// A list is the one place the two hands would otherwise look alike: a
+/// whole row filled grey reads as a selection rather than as a marker,
+/// and the row that really is selected is already filled. So the
+/// keyboard keeps its blue here as everywhere else.
+#[cfg(feature = "game-library")]
+fn row_light(resting: u32, light: f32) -> Option<u32> {
+    (light != 0.0).then(|| light_face(resting, BUTTON_FACE_HOVER, light))
+}
+
+fn tick_outline(light: f32) -> Option<u32> {
+    if light == 0.0 {
+        return None;
+    }
+    Some(if light < 0.0 {
+        // Green, breathing up out of the box's own edge. A tick box is
+        // the one control small enough that the marker has to be its
+        // outline, and an outline in the focus's blue over a green tick
+        // read as a second state of the box rather than as a marker.
+        mix_colour(BUTTON_EDGE_LIGHT, PANEL_TEXT_HILIGHT, -light)
+    } else {
+        PANEL_TEXT_HILIGHT
+    })
+}
+
+/// How lit one end of a stepper is: the pointer's own light if it is
+/// over that end, and otherwise the focus's, which both ends share.
+fn stepper_light(hover: Option<UiControl>, end: UiControl, stepper: f32) -> f32 {
+    if hover == Some(end) {
+        1.0
+    } else {
+        -stepper
+    }
+}
+
+/// Whether the setting the focus is on stands open for changing.
+fn nav_open() -> bool {
+    NAV_OPEN.with(std::cell::Cell::get)
+}
+
+/// A colour part of the way to another.
+pub(in crate::video) fn mix_colour(from: u32, to: u32, t: f32) -> u32 {
+    if t <= 0.0 {
+        return from;
+    }
+    if t >= 1.0 {
+        return to;
+    }
+    let channel = |shift: u32| {
+        let a = ((from >> shift) & 0xFF) as f32;
+        let b = ((to >> shift) & 0xFF) as f32;
+        ((a + (b - a) * t) as u32) << shift
+    };
+    channel(0) | channel(8) | channel(16) | (from & 0xFF00_0000)
 }
 
 /// Word-wrap `text` so no panel line is cropped: the first line holds up to
@@ -2083,14 +2247,7 @@ fn draw_drop_chooser(
                 .collect();
             label.push_str("..");
         }
-        draw_text_button(
-            frame,
-            button_rect,
-            &label,
-            true,
-            hover == Some(control),
-            scale,
-        );
+        draw_text_button(frame, button_rect, &label, true, lit(hover, control), scale);
     }
     let hint = format!("1-{} selects - Esc cancels", state.drives.len());
     draw_panel_text(
@@ -2340,7 +2497,7 @@ fn draw_input_map(
                     *button_rect,
                     label,
                     set == panel.mapping,
-                    hover == Some(*control),
+                    lit(hover, *control),
                     false,
                     scale,
                 );
@@ -2353,7 +2510,7 @@ fn draw_input_map(
                     *button_rect,
                     label,
                     true,
-                    hover == Some(*control),
+                    lit(hover, *control),
                     scale,
                 );
             }
@@ -2364,7 +2521,7 @@ fn draw_input_map(
                     *button_rect,
                     "Clear",
                     bound,
-                    hover == Some(*control),
+                    lit(hover, *control),
                     scale,
                 );
             }
@@ -2373,7 +2530,7 @@ fn draw_input_map(
                 *button_rect,
                 "Defaults",
                 true,
-                hover == Some(*control),
+                lit(hover, *control),
                 scale,
             ),
             UiControl::RemapSave => draw_text_button(
@@ -2381,7 +2538,7 @@ fn draw_input_map(
                 *button_rect,
                 "Save",
                 true,
-                hover == Some(*control),
+                lit(hover, *control),
                 scale,
             ),
             _ => {}
@@ -2492,7 +2649,7 @@ fn draw_calibration(
             button_rect,
             label,
             cal_button_enabled(control, session),
-            hover == Some(control),
+            lit(hover, control),
             scale,
         );
     }
@@ -2521,13 +2678,11 @@ fn draw_debugger(
     for (index, tab) in DEBUG_TABS.iter().enumerate() {
         let tab_rect = debug_tab_rect(rect, index);
         let selected = panel.tab == *tab;
-        let hovered = hover == Some(UiControl::DebugTab(*tab));
+        let hovered = lit(hover, UiControl::DebugTab(*tab));
         let face = if selected {
-            ENTRY_BG
-        } else if hovered {
-            BUTTON_FACE_HOVER
+            light_face_to(ENTRY_BG, ENTRY_BG, NAV_FACE_ON, hovered)
         } else {
-            BUTTON_FACE
+            light_face(BUTTON_FACE, BUTTON_FACE_HOVER, hovered)
         };
         let scaled = scale_rect(tab_rect, scale);
         fill_rect(frame, scaled, face, scale);
@@ -2567,7 +2722,7 @@ fn draw_debugger(
                 button_rect,
                 label,
                 enabled,
-                hover == Some(control),
+                lit(hover, control),
                 scale,
             );
         }
@@ -2588,7 +2743,7 @@ fn draw_debugger(
                 button_rect,
                 label,
                 enabled,
-                hover == Some(control),
+                lit(hover, control),
                 scale,
             );
         }
@@ -2606,7 +2761,7 @@ fn draw_debugger(
                 button_rect,
                 label,
                 enabled,
-                hover == Some(control),
+                lit(hover, control),
                 scale,
             );
         }
@@ -2625,7 +2780,7 @@ fn draw_debugger(
                 button_rect,
                 label,
                 enabled,
-                hover == Some(control),
+                lit(hover, control),
                 scale,
             );
         }
@@ -2740,7 +2895,7 @@ fn draw_debugger(
                     button_rect,
                     label,
                     enabled,
-                    hover == Some(control),
+                    lit(hover, control),
                     scale,
                 );
             }
@@ -2925,7 +3080,7 @@ fn draw_video_tab(
             button_rect,
             &label,
             shown,
-            hover == Some(control),
+            lit(hover, control),
             scale,
         );
     }
@@ -3026,7 +3181,7 @@ fn draw_audio_tab(
     for (idx, row, color) in rows.filter(|(idx, ..)| *idx < AUDIO_MAX_ROWS) {
         let (mute_rect, scope_rect) = audio_row_geom(rect, idx);
         let control = UiControl::DebugAudioMute(idx);
-        draw_mute_button(frame, mute_rect, row.muted, hover == Some(control), scale);
+        draw_mute_button(frame, mute_rect, row.muted, lit(hover, control), scale);
         // Text detail lines to the right of the mute button.
         for (line, dbg) in row.text.iter().enumerate() {
             let color = if dbg.highlight {
@@ -3049,13 +3204,11 @@ fn draw_audio_tab(
 }
 
 /// A single mute toggle button: red-tinted face and "Muted" label when active.
-fn draw_mute_button(frame: &mut [u8], rect: Rect, muted: bool, hover: bool, scale: usize) {
+fn draw_mute_button(frame: &mut [u8], rect: Rect, muted: bool, hover: f32, scale: usize) {
     let face = if muted {
         AUDIO_MUTE_FACE
-    } else if hover {
-        BUTTON_FACE_HOVER
     } else {
-        BUTTON_FACE
+        light_face(BUTTON_FACE, BUTTON_FACE_HOVER, hover)
     };
     let scaled = scale_rect(rect, scale);
     fill_rect(frame, scaled, face, scale);
@@ -3683,7 +3836,7 @@ fn draw_analyzer_checkboxes(
             control_rect,
             label,
             checked,
-            hover == Some(control),
+            lit(hover, control),
             scale,
         );
     }
@@ -3695,7 +3848,7 @@ fn draw_analyzer_checkbox(
     control: Rect,
     label: &str,
     checked: bool,
-    hover: bool,
+    hover: f32,
     scale: usize,
 ) {
     let box_rect = Rect {
@@ -3707,7 +3860,7 @@ fn draw_analyzer_checkbox(
     fill_rect(
         frame,
         scale_rect(box_rect, scale),
-        if hover { BUTTON_FACE_HOVER } else { ENTRY_BG },
+        light_face(ENTRY_BG, BUTTON_FACE_HOVER, hover),
         scale,
     );
     draw_outline(frame, box_rect, BUTTON_EDGE_LIGHT, scale);
@@ -3732,7 +3885,7 @@ fn draw_analyzer_checkbox(
         box_rect.x + 18,
         control.y + (control.h - 8) / 2,
         label,
-        if hover { BUTTON_TEXT } else { PANEL_TEXT },
+        light_face(PANEL_TEXT, BUTTON_TEXT, hover),
         1,
         scale,
     );
@@ -3773,14 +3926,7 @@ fn draw_frame_analyzer(
             UiControl::AnalyzerFrame => "Frame",
             _ => "To slot",
         };
-        draw_text_button(
-            frame,
-            button_rect,
-            label,
-            true,
-            hover == Some(control),
-            scale,
-        );
+        draw_text_button(frame, button_rect, label, true, lit(hover, control), scale);
     }
     if panel.tab == AnalyzerTab::Beam {
         draw_analyzer_checkboxes(frame, rect, panel, hover, scale);
@@ -3798,13 +3944,11 @@ fn draw_analyzer_tabs(
     for (index, tab) in ANALYZER_TABS.iter().enumerate() {
         let tab_rect = analyzer_tab_rect(rect, index);
         let active = selected == *tab;
-        let hovered = hover == Some(UiControl::AnalyzerTab(*tab));
+        let hovered = lit(hover, UiControl::AnalyzerTab(*tab));
         let face = if active {
-            ENTRY_BG
-        } else if hovered {
-            BUTTON_FACE_HOVER
+            light_face_to(ENTRY_BG, ENTRY_BG, NAV_FACE_ON, hovered)
         } else {
-            BUTTON_FACE
+            light_face(BUTTON_FACE, BUTTON_FACE_HOVER, hovered)
         };
         let scaled = scale_rect(tab_rect, scale);
         fill_rect(frame, scaled, face, scale);
@@ -4204,7 +4348,7 @@ fn draw_analyzer_presets(
             button,
             &preset.label,
             true,
-            active || hover == Some(control),
+            lit(hover, control).max(f32::from(u8::from(active))),
             scale,
         );
     }
@@ -4571,6 +4715,53 @@ fn indefinite_article(size: &str) -> &'static str {
     }
 }
 
+/// Which control a free-text value box is. The same widget serves two
+/// stores -- a Create Image word and a serial address on the machine --
+/// so both the hit-test and the drawing ask here rather than each
+/// keeping its own copy of the rule.
+fn value_box_control(field: LauncherField) -> UiControl {
+    if field == LauncherField::RamPattern {
+        UiControl::LauncherRamPatternEdit
+    } else if LauncherState::is_serial_addr(field) {
+        UiControl::LauncherSerialAddrEdit(field)
+    } else {
+        UiControl::LauncherNewImageEdit(field)
+    }
+}
+
+/// Light a text box the focus is standing on.
+///
+/// A box takes the same blue as every other control, so walking onto
+/// one looks like walking onto anything else. Opening it to type hands
+/// the box back its own colours: what to watch then is the caret
+/// blinking in the value, and a lit box behind it would fight that.
+/// Only the focus lights these -- the pointer has never coloured them,
+/// and a box that changed under the mouse would read as a button.
+fn light_edit_box(
+    frame: &mut [u8],
+    box_rect: Rect,
+    control: UiControl,
+    editing: bool,
+    scale: usize,
+) {
+    let light = lit(None, control);
+    if light == 0.0 || editing {
+        return;
+    }
+    let inner = Rect {
+        x: box_rect.x + 1,
+        y: box_rect.y + 1,
+        w: box_rect.w.saturating_sub(2),
+        h: box_rect.h.saturating_sub(2),
+    };
+    fill_rect(
+        frame,
+        scale_rect(inner, scale),
+        light_face(PANEL_BG, NAV_FACE, light),
+        scale,
+    );
+}
+
 /// Draw a free-text/number value box: what the setting holds, or what is
 /// being typed into it, with a caret while it has the focus. Used by the
 /// Create Image pages and by the Serial section's TCP address boxes, so it
@@ -4589,6 +4780,13 @@ fn draw_launcher_value_box(
         scale_rect(box_rect, scale),
         BUTTON_EDGE_DARK,
         BUTTON_EDGE_LIGHT,
+        scale,
+    );
+    light_edit_box(
+        frame,
+        box_rect,
+        value_box_control(field),
+        state.typing_in_value_box(field),
         scale,
     );
     let avail = box_rect.w.saturating_sub(8);
@@ -4659,21 +4857,23 @@ fn draw_launcher_tick_choice(
     label: &str,
     set: bool,
     disabled: bool,
-    hot: bool,
+    hot: f32,
     scale: usize,
 ) {
     let colour = if disabled { PANEL_TEXT_DIM } else { TICK_GREEN };
     draw_tick_box(frame, at.x, at.y, set, colour, scale);
-    if hot && !disabled {
-        draw_outline(
-            frame,
-            Rect {
-                w: LAUNCH_TICK_BOX,
-                ..at
-            },
-            PANEL_TEXT_HILIGHT,
-            scale,
-        );
+    if !disabled {
+        if let Some(edge) = tick_outline(hot) {
+            draw_outline(
+                frame,
+                Rect {
+                    w: LAUNCH_TICK_BOX,
+                    ..at
+                },
+                edge,
+                scale,
+            );
+        }
     }
     draw_panel_text(
         frame,
@@ -5144,26 +5344,23 @@ fn draw_az_button(
     rect: Rect,
     label: &str,
     live: bool,
-    hovered: bool,
+    hovered: f32,
     scale: usize,
 ) {
     let scaled = scale_rect(rect, scale);
     fill_rect(
         frame,
         scaled,
-        if hovered {
-            MENU_HILIGHT_BG
-        } else {
-            BUTTON_FACE
-        },
+        light_face(BUTTON_FACE, MENU_HILIGHT_BG, hovered),
         scale,
     );
     draw_rect_bevel(frame, scaled, BUTTON_EDGE_LIGHT, BUTTON_EDGE_DARK, scale);
-    let colour = match (live, hovered) {
-        (_, true) => MENU_HILIGHT_TEXT,
-        (true, false) => BUTTON_TEXT,
-        (false, false) => BUTTON_TEXT_DISABLED,
+    let resting = if live {
+        BUTTON_TEXT
+    } else {
+        BUTTON_TEXT_DISABLED
     };
+    let colour = light_face(resting, MENU_HILIGHT_TEXT, hovered);
     let text_w = label.chars().count() * font::GLYPH_W;
     let x = rect.x + rect.w.saturating_sub(text_w) / 2;
     let y = rect.y + rect.h.saturating_sub(font::GLYPH_H) / 2;
@@ -5303,16 +5500,16 @@ fn draw_scroll_arrow(
     arrow: Rect,
     up: bool,
     live: bool,
-    hovered: bool,
+    hovered: f32,
     scale: usize,
 ) {
     let scaled = scale_rect(arrow, scale);
     fill_rect(frame, scaled, BUTTON_FACE, scale);
     draw_rect_bevel(frame, scaled, BUTTON_EDGE_LIGHT, BUTTON_EDGE_DARK, scale);
-    let colour = match (live, hovered) {
-        (false, _) => BUTTON_TEXT_DISABLED,
-        (true, true) => PANEL_TEXT_HILIGHT,
-        (true, false) => BUTTON_TEXT,
+    let colour = if live {
+        light_face(BUTTON_TEXT, PANEL_TEXT_HILIGHT, hovered)
+    } else {
+        BUTTON_TEXT_DISABLED
     };
     // Three rows is enough to read as an arrow at this size. Widening
     // downwards is an up arrow (narrow tip at the top); widening upwards is
@@ -5365,8 +5562,106 @@ fn host_disk_writable_cell(rect: Rect, index: usize) -> Rect {
     }
 }
 
+/// The Enable cell: the last column, and the rest of the row with it.
+fn host_disk_enable_cell(rect: Rect, index: usize) -> Rect {
+    let row = host_disk_row_rect(rect, index);
+    Rect {
+        x: row.x + HOST_DISK_COL_TICK,
+        y: row.y,
+        w: row.w.saturating_sub(HOST_DISK_COL_TICK),
+        h: row.h,
+    }
+}
+
 /// The buttons under the table, left to right: the two acts on the ticked
 /// disks first, then Refresh, which only looks.
+/// The setting a control belongs to, where it belongs to one.
+///
+/// A greyed row greys everything on it -- its arrows, its box, its
+/// Browse -- so this is how the focus knows to step over the lot
+/// rather than standing on a control that cannot light or answer.
+fn control_field(control: UiControl) -> Option<LauncherField> {
+    Some(match control {
+        UiControl::LauncherCycle { field, .. }
+        | UiControl::LauncherFsFamily { field, .. }
+        | UiControl::LauncherFsVariant { field, .. }
+        | UiControl::LauncherToggle(field)
+        | UiControl::LauncherBrowse(field)
+        | UiControl::LauncherClear(field)
+        | UiControl::LauncherDriveNameEdit(field)
+        | UiControl::LauncherDriveFilesystemToggle(field)
+        | UiControl::LauncherNewImageEdit(field)
+        | UiControl::LauncherSerialAddrEdit(field)
+        | UiControl::LauncherNewImageCreate(field)
+        | UiControl::LauncherDriveBootpriEdit(field)
+        | UiControl::LauncherDriveBootToggle(field) => field,
+        #[cfg(feature = "game-library")]
+        UiControl::LauncherWhdloadDownload(field) => field,
+        _ => return None,
+    })
+}
+
+/// Whether a control can be worked at all.
+///
+/// The drawing greys what cannot be answered and, having greyed it,
+/// refuses it any light: a marker standing on one is a marker that has
+/// disappeared, which reads as the arrow key having done nothing. So
+/// the focus is not offered them. The pointer still is -- clicking a
+/// dead button has always been harmless, and taking the hit away would
+/// change what the mouse does.
+pub(in crate::video) fn control_live(ui: &UiState, control: UiControl) -> bool {
+    let Some(Panel::Launcher(state)) = ui.panel.as_ref() else {
+        return true;
+    };
+    if let UiControl::LauncherHostDiskAttach(at) = control {
+        // Blank until the disk is ticked, and a blank cell is nothing
+        // to stand on: ticking is what gives a disk a place to go.
+        return state
+            .setup
+            .host_disks()
+            .get(at)
+            .is_some_and(|disk| state.setup.host_disk_is_selected(&disk.id));
+    }
+    // A dialog answers for the whole panel while it is up, and what it
+    // answers with everywhere else is "put me away". That is a click
+    // anywhere, not a place on the screen, so it is nowhere for the
+    // marker to stand -- and standing on it, covering the panel, there
+    // was nothing beyond it to step to.
+    if state.save_dialog && control == UiControl::LauncherSave {
+        return false;
+    }
+    if state.confirm_reset && control == UiControl::LauncherCancelReset {
+        return false;
+    }
+    let Some(field) = control_field(control) else {
+        return true;
+    };
+    // A workshop row greys on its own terms -- there is no machine
+    // setting behind it to explain itself -- so it is asked directly,
+    // as the drawing asks it.
+    if LauncherState::is_workshop(field) {
+        return state.workshop_applies(field);
+    }
+    state.setup.disabled_reason(field).is_none()
+}
+
+/// Whether one of the buttons under the host-disk list can be pressed.
+///
+/// Mount needs a disk to mount; Unmount a ticked disk the machine
+/// actually has; Refresh only ever looks, so it stays live. Asked by
+/// the hit-test as well as the drawing, so a dead button is no more a
+/// place for the focus to stand than it is a thing to click.
+fn host_disk_button_live(setup: &launcher::MachineSetup, control: UiControl) -> bool {
+    match control {
+        UiControl::LauncherHostDiskMount => !setup.host_disks_selected().is_empty(),
+        UiControl::LauncherHostDiskUnmountSelected => setup
+            .host_disks_selected()
+            .iter()
+            .any(|id| setup.host_disk_is_attached(id)),
+        _ => true,
+    }
+}
+
 fn host_disk_button_rects(rect: Rect) -> [(UiControl, Rect); 3] {
     let table = host_disk_table_rect(rect);
     let y = table.y + table.h + 10;
@@ -5799,7 +6094,7 @@ fn draw_launcher_confirm(
         frame,
         dialog,
         "Reset default",
-        hover == Some(UiControl::LauncherDialogClose),
+        lit(hover, UiControl::LauncherDialogClose),
         scale,
     );
     // The title bar has already said which default, and the buttons say
@@ -5820,7 +6115,7 @@ fn draw_launcher_confirm(
         yes,
         "Yes",
         true,
-        hover == Some(UiControl::LauncherConfirmReset),
+        lit(hover, UiControl::LauncherConfirmReset),
         scale,
     );
     draw_text_button(
@@ -5828,7 +6123,7 @@ fn draw_launcher_confirm(
         cancel,
         "Cancel",
         true,
-        hover == Some(UiControl::LauncherCancelReset),
+        lit(hover, UiControl::LauncherCancelReset),
         scale,
     );
 }
@@ -5848,7 +6143,7 @@ fn launcher_action_label(control: UiControl) -> &'static str {
 
 /// What the Save dialog offers, left to right. The one that deletes
 /// something sits furthest from where the pointer comes in.
-const SAVE_ACTIONS: [UiControl; 3] = [
+pub(in crate::video) const SAVE_ACTIONS: [UiControl; 3] = [
     UiControl::LauncherSaveAs,
     UiControl::LauncherSaveDefault,
     UiControl::LauncherResetDefault,
@@ -5949,7 +6244,7 @@ fn draw_launcher_save_dialog(
         frame,
         dialog,
         "Save configuration...",
-        hover == Some(UiControl::LauncherDialogClose),
+        lit(hover, UiControl::LauncherDialogClose),
         scale,
     );
     for (control, item) in launcher_save_dialog_rects(rect) {
@@ -5958,7 +6253,7 @@ fn draw_launcher_save_dialog(
             item,
             launcher_action_label(control),
             true,
-            hover == Some(control),
+            lit(hover, control),
             scale,
         );
     }
@@ -6131,13 +6426,7 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                     if launcher_text_rect(rect, row_y, r.field).contains(pos) {
                         // The same widget serves two stores: a Create Image
                         // word, and a serial address on the machine.
-                        return Some(if r.field == LauncherField::RamPattern {
-                            UiControl::LauncherRamPatternEdit
-                        } else if LauncherState::is_serial_addr(r.field) {
-                            UiControl::LauncherSerialAddrEdit(r.field)
-                        } else {
-                            UiControl::LauncherNewImageEdit(r.field)
-                        });
+                        return Some(value_box_control(r.field));
                     }
                 }
                 RowKind::Size => {
@@ -6474,13 +6763,16 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                 if host_disk_writable_cell(rect, slot).contains(pos) {
                     return Some(UiControl::LauncherHostDiskWritable(i));
                 }
+                if host_disk_enable_cell(rect, slot).contains(pos) {
+                    return Some(UiControl::LauncherHostDiskEnable(i));
+                }
                 if host_disk_row_rect(rect, slot).contains(pos) {
                     return Some(UiControl::LauncherHostDiskSelect(i));
                 }
             }
         }
         for (control, button) in host_disk_button_rects(rect) {
-            if button.contains(pos) {
+            if button.contains(pos) && host_disk_button_live(&state.setup, control) {
                 return Some(control);
             }
         }
@@ -6491,13 +6783,13 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
     let mut slot = 0;
     if let Some(parent) = state.tab.parent_tab() {
         if launcher_back_button_rect(rect).contains(pos) {
-            return Some(UiControl::LauncherTab(parent));
+            return Some(UiControl::LauncherNavTab(parent));
         }
         slot = 1;
     }
     for (i, &(_, target)) in state.tab.nav_options().iter().enumerate() {
         if launcher_nav_button_rect(rect, slot + i).contains(pos) {
-            return Some(UiControl::LauncherTab(target));
+            return Some(UiControl::LauncherNavTab(target));
         }
     }
     for (control, button_rect) in launcher_action_rects(rect) {
@@ -6547,7 +6839,11 @@ fn draw_library_page(
             .enumerate()
         {
             let live = present.get(bucket).copied().unwrap_or(false);
-            let hovered = live && hover == Some(UiControl::LauncherLibraryJump(bucket));
+            let hovered = if live {
+                lit(hover, UiControl::LauncherLibraryJump(bucket))
+            } else {
+                0.0
+            };
             draw_az_button(frame, at, launcher::az_label(bucket), live, hovered, scale);
         }
     }
@@ -6621,8 +6917,10 @@ fn draw_library_page(
             && state.library.scroll + drawn == state.library.selected;
         if chosen {
             fill_rect(frame, scale_rect(row, scale), MENU_HILIGHT_BG, scale);
-        } else if hover == Some(UiControl::LauncherLibraryPick(drawn)) {
-            fill_rect(frame, scale_rect(row, scale), BUTTON_FACE_HOVER, scale);
+        } else if let Some(face) =
+            row_light(ENTRY_BG, lit(hover, UiControl::LauncherLibraryPick(drawn)))
+        {
+            fill_rect(frame, scale_rect(row, scale), face, scale);
         }
         let colour = if chosen {
             MENU_HILIGHT_TEXT
@@ -6652,8 +6950,8 @@ fn draw_library_page(
             TICK_GREEN,
             scale,
         );
-        if hover == Some(UiControl::LauncherLibraryFavourite(drawn)) {
-            draw_outline(frame, tick, PANEL_TEXT_HILIGHT, scale);
+        if let Some(edge) = tick_outline(lit(hover, UiControl::LauncherLibraryFavourite(drawn))) {
+            draw_outline(frame, tick, edge, scale);
         }
     }
 
@@ -6665,7 +6963,7 @@ fn draw_library_page(
                 true => state.library.scroll > 0,
                 false => state.library.scroll + visible < entries.len(),
             };
-            draw_scroll_arrow(frame, at, up, live, hover == Some(control), scale);
+            draw_scroll_arrow(frame, at, up, live, lit(hover, control), scale);
         }
     }
 
@@ -6704,8 +7002,11 @@ fn draw_library_page(
             && state.library.favourite_scroll + drawn == state.library.favourite_selected;
         if chosen {
             fill_rect(frame, scale_rect(row, scale), MENU_HILIGHT_BG, scale);
-        } else if hover == Some(UiControl::LauncherLibraryFavouritePick(drawn)) {
-            fill_rect(frame, scale_rect(row, scale), BUTTON_FACE_HOVER, scale);
+        } else if let Some(face) = row_light(
+            ENTRY_BG,
+            lit(hover, UiControl::LauncherLibraryFavouritePick(drawn)),
+        ) {
+            fill_rect(frame, scale_rect(row, scale), face, scale);
         }
         // One no longer in the library is dimmed: still listed, still
         // removable, but there is nothing to launch.
@@ -6729,8 +7030,10 @@ fn draw_library_page(
         );
         let tick = library_remove_box(rect, whdload_entry, drawn);
         draw_tick_box(frame, tick.x, tick.y, false, TICK_GREEN, scale);
-        if hover == Some(UiControl::LauncherLibraryFavouriteRemove(drawn)) {
-            draw_outline(frame, tick, PANEL_TEXT_HILIGHT, scale);
+        if let Some(edge) =
+            tick_outline(lit(hover, UiControl::LauncherLibraryFavouriteRemove(drawn)))
+        {
+            draw_outline(frame, tick, edge, scale);
         }
     }
 
@@ -6742,7 +7045,7 @@ fn draw_library_page(
                 true => state.library.favourite_scroll > 0,
                 false => state.library.favourite_scroll + favourite_rows < starred,
             };
-            draw_scroll_arrow(frame, at, up, live, hover == Some(control), scale);
+            draw_scroll_arrow(frame, at, up, live, lit(hover, control), scale);
         }
     }
 
@@ -6775,7 +7078,7 @@ fn draw_library_page(
             buttons[at],
             label,
             enabled,
-            hover == Some(control),
+            lit(hover, control),
             scale,
         );
     }
@@ -7196,11 +7499,16 @@ fn draw_host_disk_page(
         // A disk the machine has keeps the highlight whether or not it is
         // ticked right now: in a long list, what is in use should be
         // findable at a glance.
-        if ticked
-            || setup.host_disk_is_attached(&disk.id)
-            || hover == Some(UiControl::LauncherHostDiskSelect(i))
-        {
-            fill_rect(frame, scale_rect(row, scale), BUTTON_FACE, scale);
+        let light = lit(hover, UiControl::LauncherHostDiskSelect(i));
+        if ticked || setup.host_disk_is_attached(&disk.id) || light != 0.0 {
+            // The pointer's own highlight here is the same face a disk
+            // in use keeps, so only the focus changes the colour.
+            fill_rect(
+                frame,
+                scale_rect(row, scale),
+                light_face(BUTTON_FACE, BUTTON_FACE, light),
+                scale,
+            );
         }
         let text_y = row.y + (HOST_DISK_ROW_H - font::GLYPH_H) / 2;
         // A disk the host has mounted is not dimmed: mounting takes it from
@@ -7230,22 +7538,53 @@ fn draw_host_disk_page(
         // to this disk, and is it going to the machine at all. Writing is on
         // by default -- a disk given to a machine is normally meant to be
         // used -- so unticking R/W is what protects it.
-        draw_tick_box(
-            frame,
-            row.x + HOST_DISK_COL_WRITABLE + 6,
-            row.y + 2,
-            disk.writable,
-            PANEL_TEXT,
-            scale,
-        );
-        draw_tick_box(
-            frame,
-            row.x + HOST_DISK_COL_TICK + 12,
-            row.y + 2,
-            ticked,
-            PANEL_TEXT_HILIGHT,
-            scale,
-        );
+        for (x, set, colour, control) in [
+            (
+                HOST_DISK_COL_WRITABLE + 6,
+                disk.writable,
+                PANEL_TEXT,
+                UiControl::LauncherHostDiskWritable(i),
+            ),
+            (
+                HOST_DISK_COL_TICK + 12,
+                ticked,
+                PANEL_TEXT_HILIGHT,
+                UiControl::LauncherHostDiskEnable(i),
+            ),
+        ] {
+            let at = Rect {
+                x: row.x + x,
+                y: row.y + 2,
+                w: TICK_BOX,
+                h: TICK_BOX,
+            };
+            draw_tick_box(frame, at.x, at.y, set, colour, scale);
+            if let Some(edge) = tick_outline(lit(hover, control)) {
+                draw_outline(frame, at, edge, scale);
+            }
+        }
+        // The attach column is blank until the disk is ticked, so the
+        // focus standing on it has nothing of its own to light: it
+        // takes the face a button under the pointer would.
+        let attach_light = lit(hover, UiControl::LauncherHostDiskAttach(i));
+        if attach_light != 0.0 {
+            let cell = host_disk_attach_cell(rect, slot);
+            fill_rect(
+                frame,
+                scale_rect(cell, scale),
+                light_face(BUTTON_FACE, BUTTON_FACE_HOVER, attach_light),
+                scale,
+            );
+            draw_panel_text(
+                frame,
+                cell.x,
+                text_y,
+                &disk.attach.map(|a| a.label()).unwrap_or_default(),
+                PANEL_TEXT,
+                1,
+                scale,
+            );
+        }
     }
 
     // Arrows only when there is somewhere to go, and each greys at its end
@@ -7258,7 +7597,7 @@ fn draw_host_disk_page(
             } else {
                 scroll + HOST_DISK_VISIBLE_ROWS < disks.len()
             };
-            draw_scroll_arrow(frame, arrow, up, live, hover == Some(control), scale);
+            draw_scroll_arrow(frame, arrow, up, live, lit(hover, control), scale);
         }
     }
 
@@ -7268,22 +7607,13 @@ fn draw_host_disk_page(
             UiControl::LauncherHostDiskUnmountSelected => "Unmount",
             _ => "Refresh",
         };
-        // Mount needs a disk to mount; Unmount a ticked disk the machine
-        // actually has; Refresh only ever looks, so it stays live.
-        let enabled = match control {
-            UiControl::LauncherHostDiskMount => !setup.host_disks_selected().is_empty(),
-            UiControl::LauncherHostDiskUnmountSelected => setup
-                .host_disks_selected()
-                .iter()
-                .any(|id| setup.host_disk_is_attached(id)),
-            _ => true,
-        };
+        let enabled = host_disk_button_live(setup, control);
         draw_text_button(
             frame,
             button,
             label,
             enabled,
-            enabled && hover == Some(control),
+            if enabled { lit(hover, control) } else { 0.0 },
             scale,
         );
     }
@@ -7388,8 +7718,16 @@ fn draw_host_disk_page(
 
 /// A small square box, filled when set. The fill colour distinguishes what
 /// is being answered: one page can carry more than one kind of tick.
+/// A tick box is this square, wherever one is drawn.
+const TICK_BOX: usize = 10;
+
 fn draw_tick_box(frame: &mut [u8], x: usize, y: usize, set: bool, colour: u32, scale: usize) {
-    let outer = Rect { x, y, w: 10, h: 10 };
+    let outer = Rect {
+        x,
+        y,
+        w: TICK_BOX,
+        h: TICK_BOX,
+    };
     fill_rect(frame, scale_rect(outer, scale), ENTRY_BG, scale);
     draw_outline(frame, outer, BUTTON_EDGE_LIGHT, scale);
     if set {
@@ -7552,16 +7890,14 @@ fn draw_launcher_chip(
     rect: Rect,
     label: &str,
     active: bool,
-    hover: bool,
+    hover: f32,
     align_left: bool,
     scale: usize,
 ) {
     let face = if active {
-        PANEL_TITLE_BG
-    } else if hover {
-        BUTTON_FACE_HOVER
+        light_face_to(PANEL_TITLE_BG, PANEL_TITLE_BG, NAV_FACE_ON, hover)
     } else {
-        BUTTON_FACE
+        light_face(BUTTON_FACE, BUTTON_FACE_HOVER, hover)
     };
     let scaled = scale_rect(rect, scale);
     fill_rect(frame, scaled, face, scale);
@@ -7820,7 +8156,7 @@ fn draw_launcher_row(
                 unit.x,
                 unit.y + 6,
                 state.workshop.size_unit.label(),
-                if hover == Some(UiControl::LauncherNewImageUnit) {
+                if lit(hover, UiControl::LauncherNewImageUnit) != 0.0 {
                     PANEL_TEXT_HILIGHT
                 } else {
                     PANEL_TEXT
@@ -7852,11 +8188,13 @@ fn draw_launcher_row(
                     family.label(),
                     state.workshop_fs_family_set(r.field, family),
                     disabled,
-                    hover
-                        == Some(UiControl::LauncherFsFamily {
+                    lit(
+                        hover,
+                        UiControl::LauncherFsFamily {
                             field: r.field,
                             family,
-                        }),
+                        },
+                    ),
                     scale,
                 );
             }
@@ -7876,27 +8214,35 @@ fn draw_launcher_row(
                     variant.label(),
                     state.workshop_fs_variant_set(r.field, variant),
                     disabled || !state.workshop_fs_variant_enabled(r.field, variant),
-                    hover
-                        == Some(UiControl::LauncherFsVariant {
+                    lit(
+                        hover,
+                        UiControl::LauncherFsVariant {
                             field: r.field,
                             variant,
-                        }),
+                        },
+                    ),
                     scale,
                 );
             }
         }
         RowKind::Stepper => {
             let (prev, value, next) = launcher_geometry_stepper_rects(rect, row_y);
+            // Both ends light together, as on any other stepper.
+            let back = UiControl::LauncherCycle {
+                field: r.field,
+                forward: false,
+            };
+            let forward = UiControl::LauncherCycle {
+                field: r.field,
+                forward: true,
+            };
+            let stepper = nav_lit(back);
             draw_text_button(
                 frame,
                 prev,
                 "<",
                 !disabled,
-                hover
-                    == Some(UiControl::LauncherCycle {
-                        field: r.field,
-                        forward: false,
-                    }),
+                stepper_light(hover, back, stepper),
                 scale,
             );
             draw_text_button(
@@ -7904,11 +8250,7 @@ fn draw_launcher_row(
                 next,
                 ">",
                 !disabled,
-                hover
-                    == Some(UiControl::LauncherCycle {
-                        field: r.field,
-                        forward: true,
-                    }),
+                stepper_light(hover, forward, stepper),
                 scale,
             );
             draw_launcher_value_box(frame, value, state, r.field, disabled, true, scale);
@@ -7924,7 +8266,7 @@ fn draw_launcher_row(
                 auto,
                 "Auto",
                 !by_hand,
-                hover == Some(UiControl::LauncherGeometryAuto),
+                lit(hover, UiControl::LauncherGeometryAuto),
                 false,
                 scale,
             );
@@ -7933,7 +8275,7 @@ fn draw_launcher_row(
                 custom,
                 "Custom",
                 by_hand,
-                hover == Some(UiControl::LauncherGeometryCustom),
+                lit(hover, UiControl::LauncherGeometryCustom),
                 false,
                 scale,
             );
@@ -7943,7 +8285,7 @@ fn draw_launcher_row(
                     configure,
                     "Configure",
                     true,
-                    hover == Some(UiControl::LauncherTab(LauncherTab::CreateGeometry)),
+                    lit(hover, UiControl::LauncherTab(LauncherTab::CreateGeometry)),
                     scale,
                 );
             }
@@ -7955,7 +8297,7 @@ fn draw_launcher_row(
                 launcher_action_rect(rect, row_y),
                 &label,
                 !disabled,
-                hover == Some(UiControl::LauncherNewImageCreate(r.field)),
+                lit(hover, UiControl::LauncherNewImageCreate(r.field)),
                 scale,
             );
             // The geometry editor commits with Save, and fills itself in
@@ -7967,26 +8309,34 @@ fn draw_launcher_row(
                     launcher_action2_rect(rect, row_y),
                     &auto,
                     true,
-                    hover
-                        == Some(UiControl::LauncherNewImageCreate(
-                            LauncherField::NewGeomAuto,
-                        )),
+                    lit(
+                        hover,
+                        UiControl::LauncherNewImageCreate(LauncherField::NewGeomAuto),
+                    ),
                     scale,
                 );
             }
         }
         RowKind::Cycle => {
             let (prev, value, next) = launcher_cycle_rects(rect, row_y);
+            // Both ends light together: the focus is on the setting,
+            // and the setting is the pair of them. The pointer still
+            // lights only the one it is over.
+            let back = UiControl::LauncherCycle {
+                field: r.field,
+                forward: false,
+            };
+            let forward = UiControl::LauncherCycle {
+                field: r.field,
+                forward: true,
+            };
+            let stepper = nav_lit(back);
             draw_text_button(
                 frame,
                 prev,
                 "<",
                 !disabled,
-                hover
-                    == Some(UiControl::LauncherCycle {
-                        field: r.field,
-                        forward: false,
-                    }),
+                stepper_light(hover, back, stepper),
                 scale,
             );
             draw_text_button(
@@ -7994,11 +8344,7 @@ fn draw_launcher_row(
                 next,
                 ">",
                 !disabled,
-                hover
-                    == Some(UiControl::LauncherCycle {
-                        field: r.field,
-                        forward: true,
-                    }),
+                stepper_light(hover, forward, stepper),
                 scale,
             );
             // Clip a long value (e.g. a wordy MIDI device name) to the box so
@@ -8013,7 +8359,14 @@ fn draw_launcher_row(
             let color = if disabled {
                 PANEL_TEXT_DIM
             } else {
-                PANEL_TEXT_HILIGHT
+                // Green while the focus is merely on it; white once it
+                // stands open, which is the difference between choosing
+                // a setting and changing it.
+                if nav_open() && stepper != 0.0 {
+                    PANEL_TITLE_TEXT
+                } else {
+                    PANEL_TEXT_HILIGHT
+                }
             };
             draw_panel_text(frame, tx, value.y + 6, &text, color, 1, scale);
         }
@@ -8030,16 +8383,25 @@ fn draw_launcher_row(
             let disabled = disabled || setup.drive_boot_off(r.field);
             let (prev, value, next) = launcher_bootpri_rects(rect, row_y);
             if !no_drive {
+                // Both ends light together, as on any other stepper:
+                // the focus is on the setting, and the setting is the
+                // pair of them with its box between. The pointer still
+                // lights only the one it is over.
+                let back = UiControl::LauncherCycle {
+                    field: r.field,
+                    forward: false,
+                };
+                let forward = UiControl::LauncherCycle {
+                    field: r.field,
+                    forward: true,
+                };
+                let stepper = nav_lit(back);
                 draw_text_button(
                     frame,
                     prev,
                     "<",
                     !disabled,
-                    hover
-                        == Some(UiControl::LauncherCycle {
-                            field: r.field,
-                            forward: false,
-                        }),
+                    stepper_light(hover, back, stepper),
                     scale,
                 );
                 draw_text_button(
@@ -8047,11 +8409,7 @@ fn draw_launcher_row(
                     next,
                     ">",
                     !disabled,
-                    hover
-                        == Some(UiControl::LauncherCycle {
-                            field: r.field,
-                            forward: true,
-                        }),
+                    stepper_light(hover, forward, stepper),
                     scale,
                 );
                 draw_rect_bevel(
@@ -8063,6 +8421,13 @@ fn draw_launcher_row(
                 );
             }
             let editing = state.editing() == Some(EditTarget::DriveBootpri(r.field));
+            light_edit_box(
+                frame,
+                value,
+                UiControl::LauncherDriveBootpriEdit(r.field),
+                editing,
+                scale,
+            );
             let text = if let Some(reason) = reason.filter(|_| greyed_shows_reason) {
                 reason.to_string()
             } else {
@@ -8120,14 +8485,17 @@ fn draw_launcher_row(
                 scale,
             );
             let box_rect = launcher_bootable_box(cell);
-            let hovered = hover == Some(UiControl::LauncherDriveBootToggle(r.field));
-            fill_rect(
+            let hovered = lit(hover, UiControl::LauncherDriveBootToggle(r.field));
+            fill_rect(frame, scale_rect(box_rect, scale), ENTRY_BG, scale);
+            // Green on its edge, like every other tick box: this one is
+            // drawn by hand rather than by draw_tick_box, and lighting
+            // its whole face was the one box that did not match.
+            draw_outline(
                 frame,
-                scale_rect(box_rect, scale),
-                if hovered { BUTTON_FACE_HOVER } else { ENTRY_BG },
+                box_rect,
+                tick_outline(hovered).unwrap_or(BUTTON_EDGE_LIGHT),
                 scale,
             );
-            draw_outline(frame, box_rect, BUTTON_EDGE_LIGHT, scale);
             if !disabled {
                 fill_rect(
                     frame,
@@ -8160,7 +8528,7 @@ fn draw_launcher_row(
                     button,
                     "Configure",
                     true,
-                    hover == Some(UiControl::LauncherBridgeConfigure(bay)),
+                    lit(hover, UiControl::LauncherBridgeConfigure(bay)),
                     scale,
                 );
             } else {
@@ -8172,7 +8540,7 @@ fn draw_launcher_row(
                     browse,
                     "Browse",
                     true,
-                    hover == Some(UiControl::LauncherBrowse(r.field)),
+                    lit(hover, UiControl::LauncherBrowse(r.field)),
                     scale,
                 );
                 draw_text_button(
@@ -8180,7 +8548,7 @@ fn draw_launcher_row(
                     clear,
                     "Clear",
                     launcher_clear_enabled(setup, r.field),
-                    hover == Some(UiControl::LauncherClear(r.field)),
+                    lit(hover, UiControl::LauncherClear(r.field)),
                     scale,
                 );
             }
@@ -8190,16 +8558,19 @@ fn draw_launcher_row(
             let bay = launcher::MachineSetup::drive_protect_bay(r.field);
             #[cfg_attr(not(feature = "fluxbridge"), allow(unused_variables))]
             let (protect_cell, bridge_cell) = launcher_floppy_flag_rects(rect, row_y);
-            let mut tick = |cell: Rect, label: &str, on: bool, hot: bool| {
+            let mut tick = |cell: Rect, label: &str, on: bool, hot: f32| {
                 draw_panel_text(frame, cell.x, cell.y + 6, label, PANEL_TEXT, 1, scale);
                 let box_rect = launcher_flag_box(cell, label);
-                fill_rect(
+                // The box keeps its own face: a tick box says what it
+                // says with its outline, and a filled middle reads as
+                // a tick that is not there.
+                fill_rect(frame, scale_rect(box_rect, scale), ENTRY_BG, scale);
+                draw_outline(
                     frame,
-                    scale_rect(box_rect, scale),
-                    if hot { BUTTON_FACE_HOVER } else { ENTRY_BG },
+                    box_rect,
+                    tick_outline(hot).unwrap_or(BUTTON_EDGE_LIGHT),
                     scale,
                 );
-                draw_outline(frame, box_rect, BUTTON_EDGE_LIGHT, scale);
                 if on {
                     fill_rect(
                         frame,
@@ -8221,7 +8592,7 @@ fn draw_launcher_row(
                 protect_cell,
                 WRITE_PROTECT_LABEL,
                 setup.toggle_value(r.field),
-                hover == Some(UiControl::LauncherToggle(r.field)),
+                lit(hover, UiControl::LauncherToggle(r.field)),
             );
             // Only drawn where a physical drive can actually be attached; a
             // build without the feature leaves the write-protect box alone on
@@ -8232,7 +8603,7 @@ fn draw_launcher_row(
                     bridge_cell,
                     PHYSICAL_DRIVE_LABEL,
                     setup.drive_bridged(bay),
-                    hover == Some(UiControl::LauncherDriveBridgeToggle(bay)),
+                    lit(hover, UiControl::LauncherDriveBridgeToggle(bay)),
                 );
             }
         }
@@ -8241,7 +8612,7 @@ fn draw_launcher_row(
             // list of choices about one thing, and ticks read as a list.
             let button = launcher_toggle_rect(rect, row_y);
             let on = state.row_toggle(r.field);
-            let hot = hover == Some(UiControl::LauncherToggle(r.field));
+            let hot = lit(hover, UiControl::LauncherToggle(r.field));
             let box_rect = Rect {
                 x: button.x,
                 y: row_y + (LAUNCH_ROW_H - 10) / 2,
@@ -8258,8 +8629,10 @@ fn draw_launcher_row(
                 if disabled { PANEL_TEXT_DIM } else { TICK_GREEN },
                 scale,
             );
-            if hot && !disabled {
-                draw_outline(frame, box_rect, PANEL_TEXT_HILIGHT, scale);
+            if !disabled {
+                if let Some(edge) = tick_outline(hot) {
+                    draw_outline(frame, box_rect, edge, scale);
+                }
             }
         }
         RowKind::Toggle => {
@@ -8274,7 +8647,7 @@ fn draw_launcher_row(
                 button,
                 label,
                 true,
-                hover == Some(UiControl::LauncherToggle(r.field)),
+                lit(hover, UiControl::LauncherToggle(r.field)),
                 scale,
             );
         }
@@ -8327,7 +8700,7 @@ fn draw_launcher_row(
                     browse,
                     "Browse",
                     true,
-                    hover == Some(UiControl::LauncherBrowse(r.field)),
+                    lit(hover, UiControl::LauncherBrowse(r.field)),
                     scale,
                 );
             }
@@ -8345,7 +8718,7 @@ fn draw_launcher_row(
                     clear,
                     label,
                     enabled,
-                    hover == Some(UiControl::LauncherClear(r.field)),
+                    lit(hover, UiControl::LauncherClear(r.field)),
                     scale,
                 );
             }
@@ -8374,7 +8747,7 @@ fn draw_launcher_row(
                 button,
                 if signed_in { "Log out" } else { "Log in" },
                 true,
-                hover == Some(UiControl::LauncherOpenRetroLogin),
+                lit(hover, UiControl::LauncherOpenRetroLogin),
                 scale,
             );
         }
@@ -8407,7 +8780,7 @@ fn draw_launcher_row(
                     unmount,
                     "Unmount",
                     true,
-                    hover == Some(UiControl::LauncherHostDiskUnmount(r.field)),
+                    lit(hover, UiControl::LauncherHostDiskUnmount(r.field)),
                     scale,
                 );
                 return;
@@ -8448,6 +8821,13 @@ fn draw_launcher_row(
                     scale,
                 );
                 let editing = state.editing() == Some(EditTarget::DriveName(r.field));
+                light_edit_box(
+                    frame,
+                    name_box,
+                    UiControl::LauncherDriveNameEdit(r.field),
+                    editing,
+                    scale,
+                );
                 let (label, color) = if let Some(name) = setup.drive_name(r.field) {
                     (name.to_string(), PANEL_TEXT)
                 } else {
@@ -8489,7 +8869,7 @@ fn draw_launcher_row(
                     fs_box,
                     label,
                     true,
-                    hover == Some(UiControl::LauncherDriveFilesystemToggle(r.field)),
+                    lit(hover, UiControl::LauncherDriveFilesystemToggle(r.field)),
                     scale,
                 );
             }
@@ -8498,7 +8878,7 @@ fn draw_launcher_row(
                 browse,
                 "Browse",
                 true,
-                hover == Some(UiControl::LauncherBrowse(r.field)),
+                lit(hover, UiControl::LauncherBrowse(r.field)),
                 scale,
             );
             draw_text_button(
@@ -8506,7 +8886,7 @@ fn draw_launcher_row(
                 clear,
                 "Clear",
                 launcher_clear_enabled(setup, r.field),
-                hover == Some(UiControl::LauncherClear(r.field)),
+                lit(hover, UiControl::LauncherClear(r.field)),
                 scale,
             );
             // A support archive with nothing chosen offers to fetch its
@@ -8519,7 +8899,7 @@ fn draw_launcher_row(
                     launcher_download_rect(rect, row_y),
                     "Download",
                     true,
-                    hover == Some(UiControl::LauncherWhdloadDownload(r.field)),
+                    lit(hover, UiControl::LauncherWhdloadDownload(r.field)),
                     scale,
                 );
             }
@@ -8543,7 +8923,7 @@ fn draw_launcher_zorro(
         launcher_zorro_add_rect(rect),
         "Add board...",
         true,
-        hover == Some(UiControl::LauncherZorroAdd),
+        lit(hover, UiControl::LauncherZorroAdd),
         scale,
     );
     if setup.zorro_boards().is_empty() {
@@ -8570,7 +8950,7 @@ fn draw_launcher_zorro(
                     remove,
                     "Remove",
                     true,
-                    hover == Some(UiControl::LauncherZorroRemove(i)),
+                    lit(hover, UiControl::LauncherZorroRemove(i)),
                     scale,
                 );
             }
@@ -8613,7 +8993,7 @@ fn draw_launcher_board_option(
                 launcher_toggle_rect(rect, row_y),
                 if on { "On" } else { "Off" },
                 true,
-                hover == Some(UiControl::LauncherBoardToggle { board, opt }),
+                lit(hover, UiControl::LauncherBoardToggle { board, opt }),
                 scale,
             );
         }
@@ -8624,12 +9004,14 @@ fn draw_launcher_board_option(
                 prev,
                 "<",
                 true,
-                hover
-                    == Some(UiControl::LauncherBoardCycle {
+                lit(
+                    hover,
+                    UiControl::LauncherBoardCycle {
                         board,
                         opt,
                         forward: false,
-                    }),
+                    },
+                ),
                 scale,
             );
             let shown = truncate_to_width(&value, val.w.saturating_sub(8));
@@ -8647,12 +9029,14 @@ fn draw_launcher_board_option(
                 next,
                 ">",
                 true,
-                hover
-                    == Some(UiControl::LauncherBoardCycle {
+                lit(
+                    hover,
+                    UiControl::LauncherBoardCycle {
                         board,
                         opt,
                         forward: true,
-                    }),
+                    },
+                ),
                 scale,
             );
         }
@@ -8682,7 +9066,7 @@ fn draw_launcher_board_option(
                 browse,
                 "Browse",
                 true,
-                hover == Some(UiControl::LauncherBoardBrowse { board, opt }),
+                lit(hover, UiControl::LauncherBoardBrowse { board, opt }),
                 scale,
             );
             draw_text_button(
@@ -8690,7 +9074,7 @@ fn draw_launcher_board_option(
                 clear,
                 "Clear",
                 !value.is_empty(),
-                hover == Some(UiControl::LauncherBoardClear { board, opt }),
+                lit(hover, UiControl::LauncherBoardClear { board, opt }),
                 scale,
             );
         }
@@ -8702,6 +9086,13 @@ fn draw_launcher_board_option(
                 scale_rect(vbox, scale),
                 BUTTON_EDGE_DARK,
                 BUTTON_EDGE_LIGHT,
+                scale,
+            );
+            light_edit_box(
+                frame,
+                vbox,
+                UiControl::LauncherBoardEdit { board, opt },
+                editing,
                 scale,
             );
             if editing {
@@ -8746,7 +9137,7 @@ fn draw_launcher(
             launcher_model_rect(rect, i),
             launcher::model_label(model),
             selected_model == model,
-            hover == Some(UiControl::LauncherModel(model)),
+            lit(hover, UiControl::LauncherModel(model)),
             false,
             scale,
         );
@@ -8783,7 +9174,7 @@ fn draw_launcher(
             launcher_tab_rect(rect, i),
             tab.label(),
             state.tab.strip_tab() == tab,
-            hover == Some(UiControl::LauncherTab(tab)),
+            lit(hover, UiControl::LauncherTab(tab)),
             true,
             scale,
         );
@@ -8825,7 +9216,7 @@ fn draw_launcher(
             launcher_back_button_rect(rect),
             "< Back",
             true,
-            hover == Some(UiControl::LauncherTab(parent)),
+            lit(hover, UiControl::LauncherNavTab(parent)),
             scale,
         );
         slot = 1;
@@ -8836,7 +9227,7 @@ fn draw_launcher(
             launcher_nav_button_rect(rect, slot + i),
             label,
             target == state.tab,
-            hover == Some(UiControl::LauncherTab(target)),
+            lit(hover, UiControl::LauncherNavTab(target)),
             false,
             scale,
         );
@@ -9042,14 +9433,17 @@ fn draw_launcher(
     // flash on every hover in the dialog -- the button stays unlit until
     // the dialog is gone.
     for (control, button_rect) in launcher_action_rects(rect) {
-        let lit =
-            hover == Some(control) && !(control == UiControl::LauncherSave && state.save_dialog);
+        let light = if control == UiControl::LauncherSave && state.save_dialog {
+            0.0
+        } else {
+            lit(hover, control)
+        };
         draw_text_button(
             frame,
             button_rect,
             launcher_action_label(control),
             true,
-            lit,
+            light,
             scale,
         );
     }
@@ -9091,7 +9485,7 @@ fn draw_meta_dialog(
         frame,
         dialog,
         "Update metadata",
-        hover == Some(UiControl::MetaCancel),
+        lit(hover, UiControl::MetaCancel),
         scale,
     );
 
@@ -9140,8 +9534,11 @@ fn draw_meta_dialog(
         BUTTON_EDGE_LIGHT,
         scale,
     );
-    if hover == Some(UiControl::MetaArt) {
-        draw_outline(frame, art, PANEL_TEXT_HILIGHT, scale);
+    // The same green edge a tick box takes, breathing under the focus:
+    // the art is answered by choosing a picture, so it is a thing to
+    // press rather than a value to change.
+    if let Some(edge) = tick_outline(lit(hover, UiControl::MetaArt)) {
+        draw_outline(frame, art, edge, scale);
     }
 
     for field in launcher::MetaField::ALL {
@@ -9208,7 +9605,7 @@ fn draw_meta_dialog(
             meta_button_rects(rect)[at],
             label,
             true,
-            hover == Some(control),
+            lit(hover, control),
             scale,
         );
     }
@@ -9247,7 +9644,7 @@ fn draw_login_dialog(
         frame,
         dialog,
         "Log in to OpenRetro",
-        hover == Some(UiControl::LoginCancel),
+        lit(hover, UiControl::LoginCancel),
         scale,
     );
     for field in [LoginField::User, LoginField::Pass] {
@@ -9309,7 +9706,7 @@ fn draw_login_dialog(
         ok,
         "OK",
         !login.sending,
-        hover == Some(UiControl::LoginOk),
+        lit(hover, UiControl::LoginOk),
         scale,
     );
     draw_text_button(
@@ -9317,7 +9714,7 @@ fn draw_login_dialog(
         cancel,
         "Cancel",
         true,
-        hover == Some(UiControl::LoginCancel),
+        lit(hover, UiControl::LoginCancel),
         scale,
     );
 }
@@ -9381,11 +9778,13 @@ pub fn draw(
 // The pop-up menu
 // ---------------------------------------------------------------------------
 
-/// How much of the picture the open menu veils. Enough to throw the menu
-/// forward and to say the machine is not listening, while leaving what is
-/// behind readable.
-const MENU_VEIL: u32 = rgba(8, 9, 11);
-const MENU_VEIL_ALPHA: f32 = 0.45;
+/// The menu's own ground: the status bar's colour, since the menu is
+/// the bar's.
+const MENU_BG: u32 = super::window::STATUS_BG;
+
+/// The open menu wears the same veil as every other overlay.
+const MENU_VEIL: u32 = SCRIM;
+const MENU_VEIL_ALPHA: f32 = SCRIM_ALPHA;
 
 /// A tick, drawn rather than typed: the font stops at ASCII, and a mark built
 /// from the text scale grows with it.
@@ -9418,16 +9817,18 @@ fn draw_check(frame: &mut [u8], x: usize, y: usize, color: u32, px: usize, scale
 /// Draw the menu: a veil over everything behind, then one column per open
 /// level from the hamburger button upward.
 fn draw_menu(frame: &mut [u8], rows: &[menu::MenuRow], nav: &menu::MenuNav, scale: usize) {
-    // The veil goes over the whole presentation, panels included: the menu
-    // takes precedence over anything it is opened on top of. It is painted
-    // into the presentation texture, so it never reaches a recording.
+    // The veil goes over the display, panels included: the menu takes
+    // precedence over anything it is opened on top of. The status bar
+    // below is left alight -- it is still live while the menu is up,
+    // and a dialog does not dim it either. It is painted into the
+    // presentation texture, so it never reaches a recording.
     fill_rect_blend(
         frame,
         Rect {
             x: 0,
             y: 0,
             w: texture_width(scale),
-            h: texture_height(scale),
+            h: super::present_height() * scale,
         },
         MENU_VEIL,
         MENU_VEIL_ALPHA,
@@ -9447,7 +9848,9 @@ fn draw_menu(frame: &mut [u8], rows: &[menu::MenuRow], nav: &menu::MenuNav, scal
             w: column.w,
             h: column.h,
         };
-        fill_rect(frame, scale_rect(panel, scale), PANEL_BG, scale);
+        // The menu wears the status bar's own colour: it belongs to the
+        // bar it hangs from, not to the panels it opens over.
+        fill_rect(frame, scale_rect(panel, scale), MENU_BG, scale);
         draw_rect_bevel(
             frame,
             scale_rect(panel, scale),

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -2065,7 +2065,12 @@ fn lit(hover: Option<UiControl>, control: UiControl) -> f32 {
 
 /// Whether the focus is being shown at all, whatever it is standing on.
 fn nav_showing() -> bool {
-    NAV_LIGHT.with(|light| light.get().0.is_some())
+    nav_target().is_some()
+}
+
+/// What the focus is standing on, if it is being shown.
+fn nav_target() -> Option<UiControl> {
+    NAV_LIGHT.with(|light| light.get().0)
 }
 
 /// The face a control wears, given how lit it is: the pointer's grey,
@@ -6258,8 +6263,10 @@ fn draw_launcher_save_dialog(
         );
     }
     // Above the row, where a dialog's own words go, and never blank: with
-    // the pointer on none of the three it says what the dialog is for.
-    let help = save_dialog_help(hover.unwrap_or(UiControl::LauncherSaveAs));
+    // neither hand on any of the three it says what the dialog is for.
+    // The marker is asked first, as the lighting asks it -- what the
+    // keyboard is standing on is what the line should be about.
+    let help = save_dialog_help(nav_target().or(hover).unwrap_or(UiControl::LauncherSaveAs));
     let chars = (dialog.w - 2 * SAVE_DIALOG_MARGIN) / font::GLYPH_W;
     for (i, line) in wrap_text(help, chars, chars)
         .into_iter()

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -2028,13 +2028,23 @@ thread_local! {
         const { std::cell::Cell::new((None, 0.0)) };
     /// Whether that control stands open for changing.
     static NAV_OPEN: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    /// Whether the marker is up on the *other* surface -- the status bar
+    /// while this is a panel, or the other way about. The keyboard is in
+    /// charge either way, so the pointer lights nothing here either.
+    static NAV_ELSEWHERE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Say where the focus is, and how far through its breath, for the
 /// drawing about to happen.
-pub(in crate::video) fn set_nav_light(target: Option<UiControl>, mix: f32, open: bool) {
+pub(in crate::video) fn set_nav_light(
+    target: Option<UiControl>,
+    mix: f32,
+    open: bool,
+    elsewhere: bool,
+) {
     NAV_LIGHT.with(|light| light.set((target, mix.clamp(0.0, 1.0))));
     NAV_OPEN.with(|flag| flag.set(open));
+    NAV_ELSEWHERE.with(|flag| flag.set(elsewhere));
 }
 
 /// How lit a control is: all the way under the pointer, and as far as
@@ -2065,7 +2075,7 @@ fn lit(hover: Option<UiControl>, control: UiControl) -> f32 {
 
 /// Whether the focus is being shown at all, whatever it is standing on.
 fn nav_showing() -> bool {
-    nav_target().is_some()
+    nav_target().is_some() || NAV_ELSEWHERE.with(std::cell::Cell::get)
 }
 
 /// What the focus is standing on, if it is being shown.

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -2634,15 +2634,13 @@ fn draw_calibration(
         y += 18;
     }
     y += 6;
-    draw_panel_text(
-        frame,
-        rect.x + 16,
-        y,
-        &view.status,
-        PANEL_TEXT_ACCENT,
-        1,
-        scale,
-    );
+    // Wrapped to the panel: the prompt says what to do next and a line
+    // that ran off the edge would be saying it to nobody.
+    let chars = (rect.w.saturating_sub(32)) / font::GLYPH_W;
+    for line in wrap_text(&view.status, chars, chars) {
+        draw_panel_text(frame, rect.x + 16, y, &line, PANEL_TEXT_ACCENT, 1, scale);
+        y += font::GLYPH_H + 2;
+    }
     for (control, button_rect) in cal_button_rects(rect) {
         let label = match control {
             UiControl::CalSkip => "Skip",

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -5615,6 +5615,12 @@ fn control_field(control: UiControl) -> Option<LauncherField> {
 /// dead button has always been harmless, and taking the hit away would
 /// change what the mouse does.
 pub(in crate::video) fn control_live(ui: &UiState, control: UiControl) -> bool {
+    // The calibration panel greys Skip until a step may be skipped, and
+    // Save until every step is captured, by the same rule it draws them
+    // with: a marker on either while it is dead would disappear.
+    if let Some(Panel::Calibration(session)) = ui.panel.as_ref() {
+        return cal_button_enabled(control, session);
+    }
     let Some(Panel::Launcher(state)) = ui.panel.as_ref() else {
         return true;
     };

--- a/src/video/ui/tests.rs
+++ b/src/video/ui/tests.rs
@@ -194,6 +194,37 @@ fn clip_path_keeps_the_file_name() {
 
 /// The shortcuts panel is sized from its row count, so adding a row must
 /// not push the table (or the notes under it) off the display.
+/// The calibration prompt says what to do next, so it has to be
+/// readable: wrapped inside the panel, and clear of the buttons under
+/// it however many lines it takes.
+#[test]
+fn the_calibration_prompt_wraps_inside_its_panel() {
+    let rect = panel_rect(&Panel::Calibration(
+        crate::gamepad::CalibrationSession::new(),
+    ));
+    let chars = rect.w.saturating_sub(32) / font::GLYPH_W;
+    let status =
+        "All steps captured. Push controls to test, hold any button then hit save to finish.";
+    let lines = wrap_text(status, chars, chars);
+    assert!(lines.len() > 1, "this one needs more than a line");
+    for line in &lines {
+        assert!(
+            line.chars().count() <= chars,
+            "{line:?} runs past the panel's edge"
+        );
+    }
+    // Where the rows leave off, plus the wrapped prompt, still above the
+    // buttons along the bottom.
+    let rows = crate::gamepad::CalibrationSession::step_count();
+    let y = rect.y + 64 + rows * 18 + 6 + lines.len() * (font::GLYPH_H + 2);
+    let buttons = cal_button_rects(rect)[0].1;
+    assert!(
+        y <= buttons.y,
+        "the prompt reaches {y}, the buttons start at {}",
+        buttons.y
+    );
+}
+
 #[test]
 fn the_shortcuts_panel_fits_on_screen() {
     let h = shortcuts_panel_height();

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1064,6 +1064,21 @@ pub struct App {
     /// starts the list running after a pause, the way a held key does. Any
     /// of the launcher's scrolling lists can be the one being held.
     scroll_hold: Option<(UiControl, Instant)>,
+    /// A launcher stepper held down: which control, when its next step is
+    /// due, and when the hold began -- the ramping fields read their pace
+    /// off how long they have been held.
+    cycle_hold: Option<(UiControl, Instant, Instant)>,
+    /// Where the keyboard's or the pad's focus stands on the interface,
+    /// and whether it is being shown. Empty until something asks for it.
+    nav: crate::video::nav::Nav,
+    /// When the focus was last shown, for its breath.
+    nav_shown_at: Instant,
+    /// The button the current page was entered by, so going back leaves
+    /// the page the way it was come into rather than closing the whole
+    /// launcher. Forgotten once it has been gone back to.
+    nav_entered_from: Option<crate::video::nav::NavTarget>,
+    /// The pad's walk across the interface, while a surface is open.
+    pad_nav: PadNav,
     /// When the text caret next changes between lit and dark. `None` when
     /// nothing is being typed into, which is also what puts it back to lit
     /// for whichever box opens next.
@@ -1198,9 +1213,6 @@ pub struct App {
     /// What the bridge saw last pass, for edge detection: a held button
     /// must not re-fire every poll.
     pad_prev: crate::gamepad::PadState,
-    /// When a held d-pad direction may step the menu again, giving pad
-    /// navigation the scroll arrows' hold-to-repeat cadence.
-    pad_nav_repeat: Option<Instant>,
     /// Quit was asked for -- the pad's Quit-hotkey hold completed, or the
     /// player menu's Quit row was picked; the next event-loop pass exits.
     quit_requested: bool,
@@ -1962,6 +1974,11 @@ impl App {
             last_cursor_phys: None,
             volume_dragging: false,
             scroll_hold: None,
+            cycle_hold: None,
+            nav: crate::video::nav::Nav::default(),
+            nav_shown_at: Instant::now(),
+            nav_entered_from: None,
+            pad_nav: PadNav::default(),
             caret_flip_at: None,
             analyzer_dragging: false,
             mouse_captured: false,
@@ -2008,7 +2025,6 @@ impl App {
             gamepad_quit_hold: None,
             pad_last: None,
             pad_prev: crate::gamepad::PadState::default(),
-            pad_nav_repeat: None,
             quit_requested: false,
             joystick_input_mode,
             mouse_sensitivity,
@@ -2250,75 +2266,35 @@ impl App {
         }
     }
 
-    /// Let the pad walk the open menu, at the about_to_wait boundary where
-    /// the event loop is at hand.
+    /// Let the pad walk the interface, at the about_to_wait boundary
+    /// where the event loop is at hand.
     ///
     /// The Menu control (a calibrated binding, or Select/guide on the
-    /// database's standard layout) toggles the menu -- or closes an open
-    /// overlay panel; while the menu is up, the d-pad steps rows with the
-    /// scroll arrows' hold-to-repeat cadence, right descends into a
-    /// category, left ascends, fire activates the row, and the second
-    /// button backs out a level at a time, closing from the top -- the
-    /// same walk the arrow keys and Escape do. All edges are detected
-    /// against the previous pass, so a held button acts once.
-    fn drive_menu_with_pad(&mut self, event_loop: &ActiveEventLoop) {
+    /// database's standard layout) is the way in: it opens the menu, or
+    /// closes an open overlay panel. From there the pad walks whatever
+    /// is up -- the menu, the status bar, the machine configuration and
+    /// the panels beyond it -- because its directions, its fire and its
+    /// second button mean to the focus exactly what the arrow keys,
+    /// Return and Escape mean. The press is edged against the previous
+    /// pass, so a held button acts once; the walk keeps its own
+    /// hold-to-repeat.
+    fn drive_interface_with_pad(&mut self, event_loop: &ActiveEventLoop) {
         let pad = self.pad_last.unwrap_or_default();
         let prev = std::mem::replace(&mut self.pad_prev, pad);
         if pad.menu && !prev.menu {
-            if self.ui.panel.is_some() {
-                self.close_panel();
-                self.request_redraw();
-            } else {
-                self.toggle_menu();
-            }
+            self.toggle_pad_interface();
             return;
         }
-        if !self.ui.menu_open {
-            self.pad_nav_repeat = None;
-            return;
-        }
-        let js = pad.joystick;
-        let prev_js = prev.joystick;
-        let now = Instant::now();
-        let vertical = match (js.up, js.down) {
-            (true, false) => Some(false),
-            (false, true) => Some(true),
-            _ => None,
-        };
-        match vertical {
-            Some(forward) => {
-                let first = if forward { !prev_js.down } else { !prev_js.up };
-                let due = self.pad_nav_repeat.is_some_and(|due| now >= due);
-                if first || due {
-                    self.ui.menu_nav.step(&self.ui.menu_rows, forward);
-                    self.pad_nav_repeat = Some(if first {
-                        now + SCROLL_HOLD_DELAY
-                    } else {
-                        now + SCROLL_HOLD_EVERY
-                    });
-                    self.request_redraw();
-                }
-            }
-            None => self.pad_nav_repeat = None,
-        }
-        if js.right && !prev_js.right {
-            self.ui.menu_nav.descend(&self.ui.menu_rows);
-            self.request_redraw();
-        }
-        if js.left && !prev_js.left {
-            self.ui.menu_nav.ascend();
-            self.request_redraw();
-        }
-        if js.fire && !prev_js.fire {
-            self.activate_menu_row(Some(event_loop));
-            self.ensure_tool_windows_for_open_panels(event_loop);
-            self.request_redraw();
-        }
-        if js.button2 && !prev_js.button2 {
-            if !self.ui.menu_nav.ascend() {
-                self.close_menu();
-            }
-            self.request_redraw();
+        // Everything a surface offers is walked the same way, whichever
+        // hand is doing the walking: the pad's directions, its fire and
+        // its second button are the arrow keys, Return and Escape, and
+        // the focus knows what each means where it is standing.
+        // Any surface being up is enough: the pad does not have to be
+        // told twice that it is driving the interface, and needing a
+        // keyboard arrow first to wake it is the wrong way round for a
+        // machine being played from a sofa.
+        if self.nav.showing() || self.modal_ui_active() {
+            self.pad_drives_interface(pad.joystick, Some(event_loop));
         }
     }
 
@@ -3600,7 +3576,7 @@ impl ApplicationHandler for App {
                     }
                     (other, state) => {
                         let pressed = state == ElementState::Pressed;
-                        if pressed && self.ui_handle_key(other, text.as_deref()) {
+                        if pressed && self.ui_handle_key(other, text.as_deref(), Some(event_loop)) {
                             return;
                         }
                         // Open panels are modal: key presses must not leak
@@ -3764,6 +3740,7 @@ impl ApplicationHandler for App {
                         self.volume_dragging = false;
                         self.analyzer_dragging = false;
                         self.scroll_hold = None;
+                        self.cycle_hold = None;
                         if was_volume_dragging {
                             return;
                         }
@@ -3774,6 +3751,11 @@ impl ApplicationHandler for App {
                         if let Some(control) =
                             self.cursor_pos.and_then(|p| self.main_ui_control_at(p))
                         {
+                            // The pointer takes the focus with it: the line
+                            // goes out, and coming back to the keyboard
+                            // resumes from whatever the hand last pressed.
+                            self.nav
+                                .follow_pointer(crate::video::nav::NavTarget::Ui(control));
                             // A scroll arrow keeps running while it is held,
                             // and a fresh press starts the ramp again rather
                             // than picking up the speed the last one reached.
@@ -3781,6 +3763,14 @@ impl ApplicationHandler for App {
                                 self.scroll_hold =
                                     Some((control, Instant::now() + SCROLL_HOLD_DELAY));
                                 self.reset_scroll_rate(control);
+                            }
+                            // Every stepper in the launcher runs on while
+                            // it is held, so a setting with a long list is
+                            // never a hundred clicks away.
+                            if let UiControl::LauncherCycle { field, .. } = control {
+                                let now = Instant::now();
+                                self.cycle_hold =
+                                    Some((control, now + cycle_hold_delay(field), now));
                             }
                             self.activate_ui_control_with_event_loop(control, Some(event_loop));
                             self.ensure_tool_windows_for_open_panels(event_loop);
@@ -3887,10 +3877,17 @@ impl ApplicationHandler for App {
                             let layout = bar_layout(&self.media_bar());
                             match control_at(pos, &layout) {
                                 Some(BarControl::Volume) => {
+                                    self.nav.follow_pointer(crate::video::nav::NavTarget::Bar(
+                                        BarControl::Volume,
+                                    ));
                                     self.volume_dragging = true;
                                     self.set_output_volume_from_pos(pos);
                                 }
-                                Some(control) => self.activate_bar_control(control),
+                                Some(control) => {
+                                    self.nav
+                                        .follow_pointer(crate::video::nav::NavTarget::Bar(control));
+                                    self.activate_bar_control(control)
+                                }
                                 None => {}
                             }
                         }
@@ -4009,6 +4006,11 @@ impl ApplicationHandler for App {
                 };
                 let osd = self.active_osd_text();
                 let ui_hover = self.cursor_pos.and_then(|p| self.main_ui_control_at(p));
+                // Decided out here: inside the render borrow the frame is
+                // the renderer's, and the focus is the window's business.
+                let (nav_target, nav_mix) = self.nav_light();
+                let nav_is_open = self.nav.open();
+                let (nav_bar_target, nav_bar_mix) = self.nav_bar_light();
                 let recording = self.recorder.is_some();
                 // The MT-32's panel reads its display live off the engine, so
                 // it is only gathered when the panel is actually up.
@@ -4127,7 +4129,11 @@ impl ApplicationHandler for App {
                         kbdpanel::draw(frame, panel, keyboard_panel_top(), r.texture_scale);
                     }
                     if !super::status_bar_hidden() {
+                        // The bar lights its focus the way the
+                        // surfaces light theirs.
+                        statusbar::set_nav_light(nav_bar_target, nav_bar_mix);
                         draw_status_bar(frame, &view, r.texture_scale);
+                        statusbar::set_nav_light(None, 0.0);
                     }
                     // The picture loses its corners to a front's aperture
                     // and to a preset's bowed face; all three overlays live
@@ -4161,7 +4167,11 @@ impl ApplicationHandler for App {
                     if let Some((text, warning)) = &osd {
                         draw_osd(frame, text, *warning, r.texture_scale, corner);
                     }
+                    // The focus lights its control the way the pointer
+                    // does, breathing between the two.
+                    ui::set_nav_light(nav_target, nav_mix, nav_is_open);
                     ui::draw(frame, r.texture_scale, &self.ui, ui_hover, ui_data.as_ref());
+                    ui::set_nav_light(None, 0.0, false);
                     // The drag hint sits on top of everything: the drop will
                     // land wherever the drag is released, panels or not. The
                     // launcher refuses drops, so no hint over it.
@@ -4378,6 +4388,7 @@ impl ApplicationHandler for App {
         #[cfg(feature = "game-library")]
         self.poll_library_scan();
         self.repeat_held_scroll();
+        self.repeat_held_cycle();
         #[cfg(feature = "game-library")]
         if self
             .launcher_state_mut()
@@ -4417,7 +4428,10 @@ impl ApplicationHandler for App {
         let typing = self.blink_caret();
         // A held scroll arrow has no event of its own to wake on: the button
         // went down once and the repeats are this loop's own doing.
-        let scrolling = self.scroll_hold.is_some();
+        let scrolling = self.scroll_hold.is_some() || self.cycle_hold.is_some();
+        // The focus breathes, which is the window's own doing: nothing
+        // else would wake the loop to draw the next step of it.
+        let focused = self.nav.showing();
         // The About panel animates on the clock, so it too must keep the
         // loop awake while it is up.
         let about_open = matches!(self.ui.panel, Some(Panel::About));
@@ -4429,6 +4443,7 @@ impl ApplicationHandler for App {
                 || scrolling
                 || typing
                 || about_open
+                || focused
                 || pad_hotkey_watch
             {
                 ControlFlow::Poll
@@ -4446,6 +4461,11 @@ impl ApplicationHandler for App {
             // Poll the pad at a human rate rather than spinning a core;
             // plenty of granularity inside the quit hotkey's 1.5 s hold.
             std::thread::sleep(std::time::Duration::from_millis(16));
+        }
+        if focused && !running && !writing_image {
+            // A human rate for the breath, not a spinning core.
+            std::thread::sleep(std::time::Duration::from_millis(16));
+            self.request_redraw();
         }
         if about_open && !running && !writing_image {
             // The About animation likewise paces itself when the machine
@@ -4479,7 +4499,7 @@ impl ApplicationHandler for App {
         } else {
             self.pump_joystick_input();
         }
-        self.drive_menu_with_pad(event_loop);
+        self.drive_interface_with_pad(event_loop);
         if self.quit_requested {
             event_loop.exit();
             return;
@@ -5342,7 +5362,8 @@ impl App {
                     state.status = None;
                 }
             }
-            UiControl::LauncherTab(tab) => {
+            // Either way in goes to the same page.
+            UiControl::LauncherTab(tab) | UiControl::LauncherNavTab(tab) => {
                 if let Some(state) = self.launcher_state_mut() {
                     state.tab = tab;
                     // A message reports what the page just did, so it belongs
@@ -5619,7 +5640,7 @@ impl App {
                     state.status = None;
                 }
             }
-            UiControl::LauncherHostDiskSelect(index) => {
+            UiControl::LauncherHostDiskSelect(index) | UiControl::LauncherHostDiskEnable(index) => {
                 if let Some(state) = self.launcher_state_mut() {
                     state.setup.select_host_disk(index);
                     // A refused tick reports itself on the status line, where
@@ -5936,6 +5957,8 @@ mod app_input;
 mod app_launcher;
 mod app_media;
 mod app_menus;
+mod app_nav;
+use app_nav::{cycle_hold_delay, PadNav};
 mod app_panels;
 mod app_session;
 mod bezel;
@@ -5951,7 +5974,7 @@ mod kbdpanel;
 mod mt32panel;
 mod present;
 mod rtg_texture;
-mod statusbar;
+pub(in crate::video) mod statusbar;
 mod stickers;
 pub(super) use present::{scale_rect, texture_height, texture_width, Rect};
 pub(super) use statusbar::{draw_rect_bevel, fill_rect, fill_rect_blend};

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -147,11 +147,6 @@ pub(crate) fn host_routing_for(devices: [PortDevice; 2], mode: JoystickInputMode
     }
 }
 
-/// How long a control must be held, once every calibration step is
-/// captured, to hand the panel's buttons to the pad. Long enough that
-/// testing a control by pressing it never trips it by accident.
-const CAL_PAD_HOLD: std::time::Duration = std::time::Duration::from_millis(900);
-
 /// How the pad moves the mouse in Gamepad Mouse mode, in quadrature
 /// counts per second: where a held direction starts, and where both a
 /// held direction and a fully deflected stick end up. The slow end is
@@ -1249,11 +1244,8 @@ pub struct App {
     /// When the pad's calibrated Quit hotkey started being held, if it is
     /// down right now. Cleared by a release before the hold completes.
     gamepad_quit_hold: Option<Instant>,
-    /// Since when a control has been held on a finished calibration,
-    /// whether the pad has been seen at rest since it finished, and
-    /// whether the hold has completed and handed the panel over.
-    cal_pad_hold: Option<Instant>,
-    cal_pad_neutral: bool,
+    /// Whether the pad has been handed the calibration panel's buttons
+    /// and settled on one, so that is done once rather than every pass.
     cal_pad_drives: bool,
     /// When the pad last moved the mouse, and since when its held
     /// direction has been building speed. Both empty while the pad is
@@ -2076,8 +2068,6 @@ impl App {
             start_fullscreen,
             gamepad: crate::gamepad::GamepadReader::new(),
             gamepad_quit_hold: None,
-            cal_pad_hold: None,
-            cal_pad_neutral: false,
             cal_pad_drives: false,
             pad_mouse_at: None,
             pad_mouse_held: None,
@@ -2342,33 +2332,23 @@ impl App {
     /// what keeps a press meaning "test this" until a hold says otherwise.
     fn calibration_pad_drives(&mut self) -> Option<crate::gamepad::PadState> {
         let Some(Panel::Calibration(session)) = self.ui.panel.as_ref() else {
-            self.cal_pad_hold = None;
-            self.cal_pad_neutral = false;
             self.cal_pad_drives = false;
             return None;
         };
-        if !session.done() {
+        if !session.handed_over() {
             return None;
         }
         let live = session.live_pad();
-        if session.live_test().is_empty() {
-            // Nothing held, so the next hold is one someone made. A
-            // binding that reads active at rest -- a half-axis captured
-            // as a button, say -- would otherwise hand the panel over
-            // with nobody touching the pad.
-            self.cal_pad_neutral = true;
-            self.cal_pad_hold = None;
-        } else if self.cal_pad_neutral {
-            let since = *self.cal_pad_hold.get_or_insert_with(Instant::now);
-            if since.elapsed() >= CAL_PAD_HOLD && !self.cal_pad_drives {
-                self.cal_pad_drives = true;
-                // Whatever is held right now is what completed the hold,
-                // not a press meant for the buttons: the walk starts
-                // from here, so nothing already down acts.
-                self.pad_prev = live;
-            }
+        if !self.cal_pad_drives {
+            self.cal_pad_drives = true;
+            // Whatever is held right now is what completed the hold, not
+            // a press meant for the buttons: the walk starts from here,
+            // so nothing already down acts. Cancel is where it starts --
+            // the safe one of the two, and the near one.
+            self.pad_prev = live;
+            self.nav_show(Some(crate::video::nav::NavTarget::Ui(UiControl::CalCancel)));
         }
-        self.cal_pad_drives.then_some(live)
+        Some(live)
     }
 
     /// Let the pad walk the interface, at the about_to_wait boundary

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1244,6 +1244,10 @@ pub struct App {
     /// When the pad's calibrated Quit hotkey started being held, if it is
     /// down right now. Cleared by a release before the hold completes.
     gamepad_quit_hold: Option<Instant>,
+    /// The tool window last given the keyboard, which is the one in
+    /// front and so the one a "close this" means. `None` until one has
+    /// been opened.
+    tool_window_front: Option<ToolPanelKind>,
     /// Whether the pad has been handed the calibration panel's buttons
     /// and settled on one, so that is done once rather than every pass.
     cal_pad_drives: bool,
@@ -2068,6 +2072,7 @@ impl App {
             start_fullscreen,
             gamepad: crate::gamepad::GamepadReader::new(),
             gamepad_quit_hold: None,
+            tool_window_front: None,
             cal_pad_drives: false,
             pad_mouse_at: None,
             pad_mouse_held: None,
@@ -2342,10 +2347,12 @@ impl App {
         if !self.cal_pad_drives {
             self.cal_pad_drives = true;
             // Whatever is held right now is what completed the hold, not
-            // a press meant for the buttons: the walk starts from here,
-            // so nothing already down acts. Cancel is where it starts --
-            // the safe one of the two, and the near one.
+            // a press meant for the buttons: both the walk's own edges
+            // and the Menu button's start from here, so nothing already
+            // down acts on arrival. Cancel is where it starts -- the
+            // safe one of the two, and the near one.
             self.pad_prev = live;
+            self.seed_pad_nav(live.joystick);
             self.nav_show(Some(crate::video::nav::NavTarget::Ui(UiControl::CalCancel)));
         }
         Some(live)
@@ -3730,6 +3737,15 @@ impl ApplicationHandler for App {
                     } else {
                         self.track_uncaptured_cursor_motion(pos);
                     }
+                    // A hand actually moving the mouse takes over from
+                    // the keyboard: the marker goes away, though where it
+                    // stood is remembered, so going back to the keys
+                    // resumes from there. Only real motion counts, or a
+                    // pointer merely sitting still would keep taking it.
+                    if pos != previous_cursor_pos && self.nav.showing() {
+                        self.nav.hide();
+                        self.request_redraw();
+                    }
                     self.cursor_pos = pos;
                     if self.volume_dragging {
                         if let Some(pos) = pos {
@@ -4230,10 +4246,11 @@ impl ApplicationHandler for App {
                     }
                     if !super::status_bar_hidden() {
                         // The bar lights its focus the way the
-                        // surfaces light theirs.
-                        statusbar::set_nav_light(nav_bar_target, nav_bar_mix);
+                        // surfaces light theirs, and knows when the
+                        // marker is up on one of them instead.
+                        statusbar::set_nav_light(nav_bar_target, nav_bar_mix, nav_target.is_some());
                         draw_status_bar(frame, &view, r.texture_scale);
-                        statusbar::set_nav_light(None, 0.0);
+                        statusbar::set_nav_light(None, 0.0, false);
                     }
                     // The picture loses its corners to a front's aperture
                     // and to a preset's bowed face; all three overlays live
@@ -4269,9 +4286,9 @@ impl ApplicationHandler for App {
                     }
                     // The focus lights its control the way the pointer
                     // does, breathing between the two.
-                    ui::set_nav_light(nav_target, nav_mix, nav_is_open);
+                    ui::set_nav_light(nav_target, nav_mix, nav_is_open, nav_bar_target.is_some());
                     ui::draw(frame, r.texture_scale, &self.ui, ui_hover, ui_data.as_ref());
-                    ui::set_nav_light(None, 0.0, false);
+                    ui::set_nav_light(None, 0.0, false, false);
                     // The drag hint sits on top of everything: the drop will
                     // land wherever the drag is released, panels or not. The
                     // launcher refuses drops, so no hint over it.

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1249,9 +1249,11 @@ pub struct App {
     /// When the pad's calibrated Quit hotkey started being held, if it is
     /// down right now. Cleared by a release before the hold completes.
     gamepad_quit_hold: Option<Instant>,
-    /// Since when a control has been held on a finished calibration, and
-    /// whether that hold has completed and handed the panel to the pad.
+    /// Since when a control has been held on a finished calibration,
+    /// whether the pad has been seen at rest since it finished, and
+    /// whether the hold has completed and handed the panel over.
     cal_pad_hold: Option<Instant>,
+    cal_pad_neutral: bool,
     cal_pad_drives: bool,
     /// When the pad last moved the mouse, and since when its held
     /// direction has been building speed. Both empty while the pad is
@@ -2075,6 +2077,7 @@ impl App {
             gamepad: crate::gamepad::GamepadReader::new(),
             gamepad_quit_hold: None,
             cal_pad_hold: None,
+            cal_pad_neutral: false,
             cal_pad_drives: false,
             pad_mouse_at: None,
             pad_mouse_held: None,
@@ -2340,6 +2343,7 @@ impl App {
     fn calibration_pad_drives(&mut self) -> Option<crate::gamepad::PadState> {
         let Some(Panel::Calibration(session)) = self.ui.panel.as_ref() else {
             self.cal_pad_hold = None;
+            self.cal_pad_neutral = false;
             self.cal_pad_drives = false;
             return None;
         };
@@ -2348,11 +2352,20 @@ impl App {
         }
         let live = session.live_pad();
         if session.live_test().is_empty() {
+            // Nothing held, so the next hold is one someone made. A
+            // binding that reads active at rest -- a half-axis captured
+            // as a button, say -- would otherwise hand the panel over
+            // with nobody touching the pad.
+            self.cal_pad_neutral = true;
             self.cal_pad_hold = None;
-        } else {
+        } else if self.cal_pad_neutral {
             let since = *self.cal_pad_hold.get_or_insert_with(Instant::now);
-            if since.elapsed() >= CAL_PAD_HOLD {
+            if since.elapsed() >= CAL_PAD_HOLD && !self.cal_pad_drives {
                 self.cal_pad_drives = true;
+                // Whatever is held right now is what completed the hold,
+                // not a press meant for the buttons: the walk starts
+                // from here, so nothing already down acts.
+                self.pad_prev = live;
             }
         }
         self.cal_pad_drives.then_some(live)
@@ -2373,7 +2386,11 @@ impl App {
     fn drive_interface_with_pad(&mut self, event_loop: &ActiveEventLoop) {
         let pad = self.pad_last.unwrap_or_default();
         let prev = std::mem::replace(&mut self.pad_prev, pad);
-        if pad.menu && !prev.menu {
+        // Not while a calibration is up: the pad is there to work that
+        // panel, and a Menu binding just captured would put it away
+        // before it could be tested.
+        let calibrating = matches!(self.ui.panel, Some(Panel::Calibration(_)));
+        if pad.menu && !prev.menu && !calibrating {
             self.toggle_pad_interface();
             return;
         }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -147,6 +147,11 @@ pub(crate) fn host_routing_for(devices: [PortDevice; 2], mode: JoystickInputMode
     }
 }
 
+/// How long a control must be held, once every calibration step is
+/// captured, to hand the panel's buttons to the pad. Long enough that
+/// testing a control by pressing it never trips it by accident.
+const CAL_PAD_HOLD: std::time::Duration = std::time::Duration::from_millis(900);
+
 /// How the pad moves the mouse in Gamepad Mouse mode, in quadrature
 /// counts per second: where a held direction starts, and where both a
 /// held direction and a fully deflected stick end up. The slow end is
@@ -1244,6 +1249,10 @@ pub struct App {
     /// When the pad's calibrated Quit hotkey started being held, if it is
     /// down right now. Cleared by a release before the hold completes.
     gamepad_quit_hold: Option<Instant>,
+    /// Since when a control has been held on a finished calibration, and
+    /// whether that hold has completed and handed the panel to the pad.
+    cal_pad_hold: Option<Instant>,
+    cal_pad_drives: bool,
     /// When the pad last moved the mouse, and since when its held
     /// direction has been building speed. Both empty while the pad is
     /// not being spent on the mouse.
@@ -2065,6 +2074,8 @@ impl App {
             start_fullscreen,
             gamepad: crate::gamepad::GamepadReader::new(),
             gamepad_quit_hold: None,
+            cal_pad_hold: None,
+            cal_pad_drives: false,
             pad_mouse_at: None,
             pad_mouse_held: None,
             pad_last: None,
@@ -2321,6 +2332,32 @@ impl App {
         }
     }
 
+    /// Whether the pad has been handed the calibration panel's buttons,
+    /// and the pad state to walk them with.
+    ///
+    /// `None` while a control is still being captured or tested, which is
+    /// what keeps a press meaning "test this" until a hold says otherwise.
+    fn calibration_pad_drives(&mut self) -> Option<crate::gamepad::PadState> {
+        let Some(Panel::Calibration(session)) = self.ui.panel.as_ref() else {
+            self.cal_pad_hold = None;
+            self.cal_pad_drives = false;
+            return None;
+        };
+        if !session.done() {
+            return None;
+        }
+        let live = session.live_pad();
+        if session.live_test().is_empty() {
+            self.cal_pad_hold = None;
+        } else {
+            let since = *self.cal_pad_hold.get_or_insert_with(Instant::now);
+            if since.elapsed() >= CAL_PAD_HOLD {
+                self.cal_pad_drives = true;
+            }
+        }
+        self.cal_pad_drives.then_some(live)
+    }
+
     /// Let the pad walk the interface, at the about_to_wait boundary
     /// where the event loop is at hand.
     ///
@@ -2339,6 +2376,17 @@ impl App {
         if pad.menu && !prev.menu {
             self.toggle_pad_interface();
             return;
+        }
+        // The tool windows are deliberately not walked -- a debugger is
+        // not a thing to step around with a d-pad -- but a pad must be
+        // able to put one away again, since opening one from the menu is
+        // something a pad can do.
+        if let Some(kind) = self.topmost_tool_panel() {
+            if pad.joystick.button2 && !prev.joystick.button2 {
+                self.close_tool_panel(kind);
+                self.request_redraw();
+                return;
+            }
         }
         // Everything a surface offers is walked the same way, whichever
         // hand is doing the walking: the pad's directions, its fire and
@@ -4545,7 +4593,12 @@ impl ApplicationHandler for App {
             // the pad; drop any hold in progress rather than resuming it,
             // and give the menu bridge nothing stale to act on.
             self.gamepad_quit_hold = None;
-            self.pad_last = None;
+            // Once every step is captured, a press still means "test this
+            // control" -- so it is a *hold* that hands the panel's own
+            // buttons over, and from then on the pad walks them with the
+            // very bindings it has just been taught. Without this,
+            // finishing a calibration needs a mouse.
+            self.pad_last = self.calibration_pad_drives();
             if !running {
                 // Nothing paces the loop while the machine is not stepping;
                 // don't busy-spin just to poll the pad.

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -82,6 +82,10 @@ pub(crate) struct HostRouting {
     pub(crate) mouse: Option<usize>,
     /// Port the physical gamepad drives (joystick/CD32 devices only).
     pub(crate) gamepad: Option<usize>,
+    /// Port the gamepad drives as a mouse, in Gamepad Mouse mode: the
+    /// same port the host mouse has, since the machine is given one
+    /// mouse and two hands on it rather than two mice.
+    pub(crate) gamepad_mouse: Option<usize>,
     /// Port keyboard mapping 0 (cursor keys) drives; the device there may
     /// be a joystick/pad or a mouse (keyboard mouse emulation).
     pub(crate) keyboard: Option<usize>,
@@ -95,12 +99,15 @@ pub(crate) struct HostRouting {
 /// launcher's Input-tab summary, so what the GUI promises is exactly what
 /// the pump does. The rules are documented on [`App::host_routing`].
 pub(crate) fn host_routing_for(devices: [PortDevice; 2], mode: JoystickInputMode) -> HostRouting {
-    let mouse = devices.iter().position(|&d| d == PortDevice::Mouse);
+    let mouse = devices.iter().position(|&d| d.is_mouse());
     let mut remaining = (0..2).filter(|&p| {
         Some(p) != mouse
             && matches!(
                 devices[p],
-                PortDevice::Mouse | PortDevice::Joystick | PortDevice::Cd32Pad
+                PortDevice::Mouse
+                    | PortDevice::GamepadMouse
+                    | PortDevice::Joystick
+                    | PortDevice::Cd32Pad
             )
     });
     let first = remaining.next();
@@ -108,7 +115,7 @@ pub(crate) fn host_routing_for(devices: [PortDevice; 2], mode: JoystickInputMode
     let (gamepad, keyboard, keyboard2) = match (first, second, mode) {
         (None, _, _) => (None, None, None),
         (Some(p), None, JoystickInputMode::Gamepad) => {
-            if devices[p] == PortDevice::Mouse {
+            if devices[p].is_mouse() {
                 (None, None, None)
             } else {
                 (Some(p), None, None)
@@ -119,14 +126,44 @@ pub(crate) fn host_routing_for(devices: [PortDevice; 2], mode: JoystickInputMode
         // would itself have been claimed as the mouse port.
         (Some(p), Some(q), JoystickInputMode::Gamepad) => (Some(p), Some(q), Some(p)),
         (Some(p), Some(q), JoystickInputMode::Keyboard) => (Some(q), Some(p), Some(q)),
+        // The pad is spent on the mouse, so no joystick port hears from
+        // it: what is left over goes to the keyboard, which keeps its
+        // joystick on the other port rather than losing it to the mode.
+    };
+    // A pad spent on the mouse is not also a joystick: whatever port it
+    // would have driven goes to the keyboard instead, which keeps its
+    // own joystick rather than losing it to the choice of mouse.
+    let pad_mouse = devices.iter().position(|&d| d == PortDevice::GamepadMouse);
+    let (gamepad, keyboard) = match (pad_mouse, gamepad) {
+        (Some(_), Some(p)) => (None, keyboard.or(Some(p))),
+        _ => (gamepad, keyboard),
     };
     HostRouting {
         mouse,
         gamepad,
+        gamepad_mouse: pad_mouse,
         keyboard,
         keyboard2,
     }
 }
+
+/// How the pad moves the mouse in Gamepad Mouse mode, in quadrature
+/// counts per second: where a held direction starts, and where both a
+/// held direction and a fully deflected stick end up. The slow end is
+/// about half the keyboard's mouse emulation, slow enough to place a
+/// pointer on a gadget; the fast end crosses a PAL screen in about a
+/// second.
+const PAD_MOUSE_SLOW: f64 = 80.0;
+const PAD_MOUSE_FAST: f64 = 640.0;
+/// How long a held direction takes to reach the top speed.
+const PAD_MOUSE_RAMP: std::time::Duration = std::time::Duration::from_millis(650);
+/// How far a stick must be pushed before it is being pushed at all.
+/// Smaller than the threshold the digital directions use: a mouse wants
+/// the slow part of the throw that a switch has no use for.
+const PAD_MOUSE_DEADZONE: f64 = 0.15;
+/// The longest step the pointer is moved for in one pass, however long
+/// the loop was away. A pause or a stall should not fling it.
+const PAD_MOUSE_MAX_STEP: std::time::Duration = std::time::Duration::from_millis(50);
 
 /// Quadrature counter steps per scheduler quantum (~one frame) while a
 /// keyboard-mouse direction key is held: ~150 counts/second at PAL frame
@@ -1207,6 +1244,11 @@ pub struct App {
     /// When the pad's calibrated Quit hotkey started being held, if it is
     /// down right now. Cleared by a release before the hold completes.
     gamepad_quit_hold: Option<Instant>,
+    /// When the pad last moved the mouse, and since when its held
+    /// direction has been building speed. Both empty while the pad is
+    /// not being spent on the mouse.
+    pad_mouse_at: Option<Instant>,
+    pad_mouse_held: Option<Instant>,
     /// The pad state the last input pump published, for the menu bridge.
     /// `None` while no pad is connected or the calibration panel owns it.
     pad_last: Option<crate::gamepad::PadState>,
@@ -2023,6 +2065,8 @@ impl App {
             start_fullscreen,
             gamepad: crate::gamepad::GamepadReader::new(),
             gamepad_quit_hold: None,
+            pad_mouse_at: None,
+            pad_mouse_held: None,
             pad_last: None,
             pad_prev: crate::gamepad::PadState::default(),
             quit_requested: false,
@@ -2184,7 +2228,7 @@ impl App {
             .input
             .ports
             .iter()
-            .position(|p| p.device == PortDevice::Mouse)
+            .position(|p| p.device.is_mouse())
     }
 
     /// Which port each host input source drives this quantum. The host
@@ -2248,8 +2292,19 @@ impl App {
                 None => self.release_joystick_lines(port),
             }
         }
+        // In Gamepad Mouse mode the pad is spent on the mouse port
+        // instead of a joystick one: the routing has already taken it
+        // off the joysticks, so this is the only place it is heard.
+        if let Some(port) = r.gamepad_mouse {
+            match pad {
+                Some(state) if !ui_owns_pad => self.apply_pad_mouse_state(port, state),
+                // The UI has it, or it has gone: let go of the buttons
+                // rather than leaving one down over the guest.
+                _ => self.release_pad_mouse(port),
+            }
+        }
         if let Some(port) = r.keyboard {
-            if self.emu.bus().input.device(port) == PortDevice::Mouse {
+            if self.emu.bus().input.device(port).is_mouse() {
                 self.apply_keyboard_mouse_state(port);
             } else if self.auto_joy_engaged[port] {
                 self.apply_auto_joy_state(port);

--- a/src/video/window/app_debugger.rs
+++ b/src/video/window/app_debugger.rs
@@ -1246,7 +1246,7 @@ impl App {
             // Self-contained: the panel's own state is everything it draws.
             Panel::InputMap(_) => None,
             Panel::Calibration(session) => Some(ui::PanelViewData::Calibration(
-                build_calibration_view(session),
+                build_calibration_view(session, self.cal_pad_drives),
             )),
             Panel::Debugger(panel) => Some(ui::PanelViewData::Debugger(Box::new(
                 self.build_debugger_view(panel),

--- a/src/video/window/app_input.rs
+++ b/src/video/window/app_input.rs
@@ -156,6 +156,11 @@ impl App {
                 }) {
                 Ok(()) => {
                     self.mouse_captured = true;
+                    // The machine has the mouse, and with it the
+                    // keyboard: a marker left on the bar would keep
+                    // taking the guest's arrow keys and lighting
+                    // buttons behind its back.
+                    self.nav.clear();
                     self.cursor_pos = None;
                     self.last_display_cursor_pos = None;
                     self.mouse_delta_remainder = (0.0, 0.0);

--- a/src/video/window/app_input.rs
+++ b/src/video/window/app_input.rs
@@ -219,6 +219,85 @@ impl App {
         self.last_display_cursor_pos = Some(pos);
     }
 
+    /// Move the mouse with the pad, in Gamepad Mouse mode.
+    ///
+    /// A stick is proportional where the pad has one: a slight
+    /// deflection creeps and a full one crosses the screen, squared so
+    /// the slow end has room to be slow in. A d-pad has only on and off,
+    /// so it stands in with a hold that gathers speed -- a tap nudges,
+    /// and holding a direction ramps up to the same top speed the stick
+    /// reaches.
+    ///
+    /// Both go through the host mouse's own accumulator, so the machine
+    /// is given one mouse with two hands on it rather than two mice, and
+    /// the mouse-sensitivity setting means the same thing for both.
+    pub(super) fn apply_pad_mouse_state(&mut self, port: usize, pad: crate::gamepad::PadState) {
+        let now = Instant::now();
+        // Against the clock rather than the loop: the pointer must not
+        // move faster on a machine that polls more often. A long gap --
+        // the loop was asleep, or the machine was paused -- is clamped
+        // rather than spent all at once.
+        let dt = self
+            .pad_mouse_at
+            .replace(now)
+            .map(|then| now.saturating_duration_since(then))
+            .unwrap_or_default()
+            .min(PAD_MOUSE_MAX_STEP)
+            .as_secs_f64();
+        let js = pad.joystick;
+        let (mut dx, mut dy) = (0.0, 0.0);
+        let (sx, sy) = pad.stick;
+        let deflection = (f64::from(sx).powi(2) + f64::from(sy).powi(2)).sqrt();
+        if deflection > PAD_MOUSE_DEADZONE {
+            // Past the dead zone, and squared: what is left of the throw
+            // is spread over the whole speed range, so the first part of
+            // it is genuinely slow.
+            let travel = ((deflection - PAD_MOUSE_DEADZONE) / (1.0 - PAD_MOUSE_DEADZONE)).min(1.0);
+            let speed = PAD_MOUSE_FAST * travel * travel;
+            dx = f64::from(sx) / deflection * speed * dt;
+            // A stick reads up as positive; the screen reads down as
+            // positive.
+            dy = -f64::from(sy) / deflection * speed * dt;
+            self.pad_mouse_held = None;
+        } else {
+            let x = f64::from(i8::from(js.right) - i8::from(js.left));
+            let y = f64::from(i8::from(js.down) - i8::from(js.up));
+            if x != 0.0 || y != 0.0 {
+                let held = self
+                    .pad_mouse_held
+                    .get_or_insert(now)
+                    .elapsed()
+                    .as_secs_f64();
+                let ramp = (held / PAD_MOUSE_RAMP.as_secs_f64()).min(1.0);
+                let speed = PAD_MOUSE_SLOW + (PAD_MOUSE_FAST - PAD_MOUSE_SLOW) * ramp;
+                // Diagonals travel the same distance as the straights
+                // rather than the square's diagonal.
+                let length = (x * x + y * y).sqrt();
+                dx = x / length * speed * dt;
+                dy = y / length * speed * dt;
+            } else {
+                self.pad_mouse_held = None;
+            }
+        }
+        if dx != 0.0 || dy != 0.0 {
+            self.add_host_mouse_delta(dx, dy);
+        }
+        let input = &mut self.emu.bus_mut().input;
+        input.set_mouse_button(port, 0, js.fire);
+        input.set_mouse_button(port, 1, js.button2);
+    }
+
+    /// Let go of everything the pad was holding on the mouse, and forget
+    /// how long it had been held: the UI has taken the pad, or it has
+    /// been unplugged, and neither is a reason for a button to stick.
+    pub(super) fn release_pad_mouse(&mut self, port: usize) {
+        self.pad_mouse_held = None;
+        self.pad_mouse_at = None;
+        let input = &mut self.emu.bus_mut().input;
+        input.set_mouse_button(port, 0, false);
+        input.set_mouse_button(port, 1, false);
+    }
+
     pub(super) fn add_host_mouse_delta(&mut self, dx: f64, dy: f64) {
         if !dx.is_finite() || !dy.is_finite() {
             return;

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -20,6 +20,11 @@ impl App {
             state.setup.refresh_host_disks();
         }
         self.ui.panel = Some(Panel::Launcher(Box::new(state)));
+        // Every open starts on System, wherever the focus was standing
+        // before -- on the status bar, or on the page this one replaced.
+        // The first page is where the eye starts, so it is where the
+        // first arrow key should find the marker.
+        self.nav.park(self.nav_home());
         self.request_redraw();
     }
 

--- a/src/video/window/app_menus.rs
+++ b/src/video/window/app_menus.rs
@@ -641,23 +641,22 @@ impl App {
     /// closing the menu from the top, which is where Escape has nothing left
     /// to close.
     pub(super) fn handle_menu_key(&mut self, code: KeyCode, event_loop: &ActiveEventLoop) -> bool {
-        let ui = &mut self.ui;
+        use crate::video::nav::Dir;
         match code {
-            KeyCode::ArrowUp => ui.menu_nav.step(&ui.menu_rows, false),
-            KeyCode::ArrowDown => ui.menu_nav.step(&ui.menu_rows, true),
-            KeyCode::ArrowRight => {
-                ui.menu_nav.descend(&ui.menu_rows);
-            }
-            KeyCode::ArrowLeft => {
-                ui.menu_nav.ascend();
-            }
+            // The menu is a surface like any other: the arrows go to the
+            // focus, which knows the menu keeps its own cursor and where
+            // walking off the foot of it leads.
+            KeyCode::ArrowUp => return self.nav_move(Dir::Up, Some(event_loop)),
+            KeyCode::ArrowDown => return self.nav_move(Dir::Down, Some(event_loop)),
+            KeyCode::ArrowRight => return self.nav_move(Dir::Right, Some(event_loop)),
+            KeyCode::ArrowLeft => return self.nav_move(Dir::Left, Some(event_loop)),
             KeyCode::Enter | KeyCode::NumpadEnter => {
                 self.activate_menu_row(Some(event_loop));
                 self.ensure_tool_windows_for_open_panels(event_loop);
                 return true;
             }
             KeyCode::Escape => {
-                if !ui.menu_nav.ascend() {
+                if !self.ui.menu_nav.ascend() {
                     self.close_menu();
                 }
             }
@@ -712,7 +711,12 @@ impl App {
 
     /// Keys consumed by the open menu/panel (Escape, debugger hex entry).
     /// Returns true when the key was handled and must not reach the Amiga.
-    pub(super) fn ui_handle_key(&mut self, code: KeyCode, text: Option<&str>) -> bool {
+    pub(super) fn ui_handle_key(
+        &mut self,
+        code: KeyCode,
+        text: Option<&str>,
+        event_loop: Option<&ActiveEventLoop>,
+    ) -> bool {
         if self.ui.active() {
             // An armed Input Mapping row eats the next key, including Escape
             // (which cancels the binding rather than closing the panel).
@@ -765,6 +769,15 @@ impl App {
                 return true;
             }
         }
+        // Nothing above wanted it: the focus takes the arrows and Return,
+        // so an open surface can be walked and worked without a pointer.
+        // A focus that is showing keeps them even with nothing modal up
+        // -- walking off the foot of the menu leaves the marker on the
+        // status bar, and the bar is meant to be walked from there.
+        // Escape hands the keyboard back to the guest.
+        if (self.modal_ui_active() || self.nav.showing()) && self.handle_nav_key(code, event_loop) {
+            return true;
+        }
         // Tool panels (debugger, frame analyzer, console) take their keys
         // through their own windows' events, never from the main window:
         // an unclaimed key here belongs to the Amiga.
@@ -784,6 +797,14 @@ impl App {
             .launcher_state()
             .is_none_or(|state| state.login.is_none())
         {
+            return false;
+        }
+        // A dialog is walked as well as typed into. Up and down are
+        // always the focus's -- they are how the boxes and the buttons
+        // under them are got between -- and while the marker is on a
+        // button so are left, right and Return. Inside a box those stay
+        // the caret's, which is what they mean while typing.
+        if self.nav_dialog_key_is_focus(code, &[UiControl::LoginOk, UiControl::LoginCancel]) {
             return false;
         }
         match code {
@@ -850,6 +871,22 @@ impl App {
             .launcher_state()
             .is_none_or(|state| state.meta.is_none())
         {
+            return false;
+        }
+        // A dialog is walked as well as typed into. Up and down are
+        // always the focus's -- they are how the boxes and the buttons
+        // under them are got between -- and while the marker is on a
+        // button so are left, right and Return. Inside a box those stay
+        // the caret's, which is what they mean while typing.
+        if self.nav_dialog_key_is_focus(
+            code,
+            &[
+                UiControl::MetaSave,
+                UiControl::MetaClear,
+                UiControl::MetaCancel,
+                UiControl::MetaArt,
+            ],
+        ) {
             return false;
         }
         match code {
@@ -946,6 +983,14 @@ impl App {
         {
             return false;
         }
+        // The list takes the arrows only while the focus is standing on
+        // a row of it, where up and down are what scrolling is. It used
+        // to take them for the whole page, so arriving here left the
+        // focus unable to move at all -- and the letters across the top
+        // are a strip to be walked, not a list to be scrolled.
+        if !self.nav_focus_in_library() {
+            return false;
+        }
         // Return launches what is chosen, which is what Run would do: on
         // this page the selection is the game, so the two are one action.
         if matches!(code, KeyCode::Enter | KeyCode::NumpadEnter) {
@@ -959,6 +1004,13 @@ impl App {
             KeyCode::End => isize::MAX,
             _ => return false,
         };
+        // At an end of the list the arrow is not the list's. It walks
+        // off instead -- up to the letters over the games, down to the
+        // buttons under them -- rather than pressing against a row that
+        // cannot move.
+        if step.abs() == 1 && self.library_at_end(step) {
+            return false;
+        }
         let whdload_entry = self
             .launcher_state()
             .is_some_and(|state| state.setup.whdload_enabled());
@@ -975,6 +1027,9 @@ impl App {
             };
             state.step_library_focus(rows, visible);
         }
+        // The row the list chose is the row the focus stands on.
+        self.nav_sync_library();
+        self.nav_sync_dialog();
         self.request_redraw();
         true
     }
@@ -1067,6 +1122,13 @@ impl App {
                 .as_ref()
                 .is_some_and(|r| r.window.fullscreen().is_some());
             self.ui.menu_rows = self.build_menu(fullscreen);
+            // The menu opens with its last row chosen -- the foot of
+            // the list is where it hangs from -- so a hand on the
+            // keyboard or a pad has somewhere to start, and walking on
+            // down leaves the menu for the bar. The pointer takes the
+            // cursor from it the moment it moves.
+            let ui = &mut self.ui;
+            ui.menu_nav.step(&ui.menu_rows, false);
         } else {
             self.ui.menu_rows = Vec::new();
             self.apply_auto_mouse_capture();
@@ -1078,6 +1140,10 @@ impl App {
     pub(super) fn close_panel(&mut self) {
         self.analyzer_dragging = false;
         self.ui.panel = None;
+        // The surface the focus was walking has gone with it, and so has
+        // the way back into the page it was on.
+        self.nav.clear();
+        self.nav_entered_from = None;
         self.request_redraw();
     }
 }

--- a/src/video/window/app_menus.rs
+++ b/src/video/window/app_menus.rs
@@ -983,11 +983,9 @@ impl App {
         {
             return false;
         }
-        // The list takes the arrows only while the focus is standing on
-        // a row of it, where up and down are what scrolling is. It used
-        // to take them for the whole page, so arriving here left the
-        // focus unable to move at all -- and the letters across the top
-        // are a strip to be walked, not a list to be scrolled.
+        // The list takes these only while the focus is standing on a row
+        // of it: the letters across the top are a strip to be walked,
+        // not a list to be scrolled.
         if !self.nav_focus_in_library() {
             return false;
         }
@@ -997,40 +995,16 @@ impl App {
             self.launcher_run();
             return true;
         }
+        // Up and down belong to the focus, not to the keyboard: they are
+        // how the list is walked by either hand, and are spent on it in
+        // `nav_move`. Only the jumps to either end are the keyboard's
+        // own, having no direction a pad could give them.
         let step = match code {
-            KeyCode::ArrowUp => -1,
-            KeyCode::ArrowDown => 1,
             KeyCode::Home => isize::MIN,
             KeyCode::End => isize::MAX,
             _ => return false,
         };
-        // At an end of the list the arrow is not the list's. It walks
-        // off instead -- up to the letters over the games, down to the
-        // buttons under them -- rather than pressing against a row that
-        // cannot move.
-        if step.abs() == 1 && self.library_at_end(step) {
-            return false;
-        }
-        let whdload_entry = self
-            .launcher_state()
-            .is_some_and(|state| state.setup.whdload_enabled());
-        let visible = crate::video::ui::launcher_panel_rect(&self.ui)
-            .map(|rect| crate::video::ui::library_visible_rows(rect, whdload_entry))
-            .unwrap_or(1);
-        if let Some(state) = self.launcher_state_mut() {
-            let rows = match step {
-                isize::MIN | isize::MAX => step,
-                _ => {
-                    let rate = state.library.scroll_rate.rows_for_step(Instant::now());
-                    step * rate.max(1) as isize
-                }
-            };
-            state.step_library_focus(rows, visible);
-        }
-        // The row the list chose is the row the focus stands on.
-        self.nav_sync_library();
-        self.nav_sync_dialog();
-        self.request_redraw();
+        self.step_library_list(step);
         true
     }
 

--- a/src/video/window/app_nav.rs
+++ b/src/video/window/app_nav.rs
@@ -205,6 +205,9 @@ impl App {
         // A list longer than its box scrolls under the focus: stepping
         // off the last row it can show brings the next one into view
         // rather than leaving the list for the buttons under it.
+        if !dir.horizontal() && self.nav_library_step(dir) {
+            return true;
+        }
         if !dir.horizontal() {
             if let Some(next) = self.nav_host_disk_scroll(dir) {
                 self.nav_show(Some(next));
@@ -753,6 +756,63 @@ impl App {
             UiControl::LauncherHostDiskEnable(at) => UiControl::LauncherHostDiskWritable(at),
             _ => return None,
         }))
+    }
+
+    /// Spend a step on the game list the focus is standing in.
+    ///
+    /// Up and down in a list are what scrolling is, and they belong to
+    /// the focus rather than to the keyboard: a pad walking the same
+    /// list means the same thing by them. At an end of the list the
+    /// step is not the list's -- it walks off instead, up to the letters
+    /// over the games and down to the buttons under them, rather than
+    /// pressing against a row that cannot move.
+    #[cfg(feature = "game-library")]
+    fn nav_library_step(&mut self, dir: crate::video::nav::Dir) -> bool {
+        use crate::video::nav::Dir;
+        if !self.nav_focus_in_library() {
+            return false;
+        }
+        let step = match dir {
+            Dir::Up => -1,
+            Dir::Down => 1,
+            _ => return false,
+        };
+        if self.library_at_end(step) {
+            return false;
+        }
+        self.step_library_list(step);
+        true
+    }
+
+    #[cfg(not(feature = "game-library"))]
+    fn nav_library_step(&mut self, _dir: crate::video::nav::Dir) -> bool {
+        false
+    }
+
+    /// Move the game list's own selection, scrolling it into view, and
+    /// bring the marker with it. A held step gathers speed the way the
+    /// list's scroll arrows do; the jumps to either end are absolute.
+    #[cfg(feature = "game-library")]
+    pub(super) fn step_library_list(&mut self, step: isize) {
+        let whdload_entry = self
+            .launcher_state()
+            .is_some_and(|state| state.setup.whdload_enabled());
+        let visible = crate::video::ui::launcher_panel_rect(&self.ui)
+            .map(|rect| crate::video::ui::library_visible_rows(rect, whdload_entry))
+            .unwrap_or(1);
+        if let Some(state) = self.launcher_state_mut() {
+            let rows = match step {
+                isize::MIN | isize::MAX => step,
+                _ => {
+                    let rate = state.library.scroll_rate.rows_for_step(Instant::now());
+                    step * rate.max(1) as isize
+                }
+            };
+            state.step_library_focus(rows, visible);
+        }
+        // The row the list chose is the row the focus stands on.
+        self.nav_sync_library();
+        self.request_redraw();
     }
 
     /// Scroll the host-disk list under the focus, where the step would

--- a/src/video/window/app_nav.rs
+++ b/src/video/window/app_nav.rs
@@ -319,6 +319,12 @@ impl App {
             self.request_redraw();
             return true;
         }
+        // Noted before the press, since a machine that starts takes the
+        // launcher down with it and the focus with that.
+        let starts_machine = matches!(
+            focus,
+            crate::video::nav::NavTarget::Ui(UiControl::LauncherRun)
+        ) || self.nav_focus_in_library();
         if crate::video::nav::is_stepper(focus) {
             self.nav.toggle_open();
         } else {
@@ -347,6 +353,16 @@ impl App {
                 if crate::video::nav::find(&items, row).is_some() {
                     self.nav.show(Some(row));
                 }
+            }
+            // Starting a machine is the moment Auto capture would have
+            // taken the mouse, had a panel not been covering the display
+            // when the window last took focus. It is asked again here so
+            // that starting from a pad or the keyboard ends up in the
+            // same state as starting with a click. Click and Manual are
+            // left alone: each says when the grab is taken, and a Run
+            // pressed without a mouse in hand is not that moment.
+            if starts_machine && self.ui.panel.is_none() {
+                self.apply_auto_mouse_capture();
             }
             // A button that opened a page has gone with the page it
             // opened. The focus belongs on the new page, not back at the

--- a/src/video/window/app_nav.rs
+++ b/src/video/window/app_nav.rs
@@ -1201,6 +1201,11 @@ impl App {
             self.nav.clear();
         } else if self.ui.panel.is_some() {
             self.close_panel();
+        } else if let Some(kind) = self.topmost_tool_panel() {
+            // A tool window is what is up, so it is what the button puts
+            // away: opening the menu behind it would leave the thing in
+            // front of it still there.
+            self.close_tool_panel(kind);
         } else {
             // The menu is the way in. It opens with its own cursor on
             // the foot of its list -- the menu is a tree, and keeps that

--- a/src/video/window/app_nav.rs
+++ b/src/video/window/app_nav.rs
@@ -320,11 +320,17 @@ impl App {
             return true;
         }
         // Noted before the press, since a machine that starts takes the
-        // launcher down with it and the focus with that.
-        let starts_machine = matches!(
-            focus,
-            crate::video::nav::NavTarget::Ui(UiControl::LauncherRun)
-        ) || self.nav_focus_in_library();
+        // launcher down with it and the focus with that. A game chosen
+        // from the list starts one as surely as Run does.
+        #[cfg(feature = "game-library")]
+        let from_list = self.nav_focus_in_library();
+        #[cfg(not(feature = "game-library"))]
+        let from_list = false;
+        let starts_machine = from_list
+            || matches!(
+                focus,
+                crate::video::nav::NavTarget::Ui(UiControl::LauncherRun)
+            );
         if crate::video::nav::is_stepper(focus) {
             self.nav.toggle_open();
         } else {

--- a/src/video/window/app_nav.rs
+++ b/src/video/window/app_nav.rs
@@ -1,0 +1,1160 @@
+//! The App side of keyboard and controller navigation: what the focus
+//! stands on, what moves it, and what a press means once it is there.
+//!
+//! The model lives in [`crate::video::nav`], which knows nothing of the
+//! window: it derives a map of places to stand by sampling the same
+//! hit-test the pointer uses, and answers where a step goes. What is
+//! here is everything that needs the running application -- reading the
+//! surfaces for that map, spending a step on an open stepper or a list
+//! that scrolls, naming the few steps geometry cannot answer, and
+//! publishing where the marker is so the drawing can light it.
+
+use super::*;
+
+/// How long one breath of the focus takes, and how far it fades at the
+/// bottom of it: the control lights the way the pointer lights it, and
+/// breathes between that and its resting face.
+const NAV_PULSE_MS: u64 = 1_700;
+
+const NAV_PULSE_FLOOR: f32 = 0.45;
+
+/// How long a pad direction is held before the focus starts walking on
+/// its own, and how the gaps close up as it keeps being held.
+const PAD_NAV_DELAY: std::time::Duration = std::time::Duration::from_millis(420);
+
+/// The launcher's steppers repeat while they are held. Most settle at a
+/// readable pace -- a value a second, so a held arrow walks the list
+/// without ever running away with it -- but the few whose ranges are
+/// counted in dozens ramp instead, the way the scroll arrows and the
+/// synth's own do.
+const CYCLE_HOLD_EVERY: std::time::Duration = std::time::Duration::from_millis(1000);
+
+const CYCLE_RAMP_DELAY: std::time::Duration = std::time::Duration::from_millis(400);
+
+/// The pad's own walk: which way it is being held, since when, when the
+/// next step falls due, and whether its buttons were down last time --
+/// a button fires on its press, not for as long as it is held.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct PadNav {
+    held: Option<crate::video::nav::Dir>,
+    since: Instant,
+    next: Instant,
+    fire: bool,
+    back: bool,
+}
+
+impl Default for PadNav {
+    fn default() -> Self {
+        let now = Instant::now();
+        Self {
+            held: None,
+            since: now,
+            next: now,
+            fire: false,
+            back: false,
+        }
+    }
+}
+
+fn pad_nav_every(held: std::time::Duration) -> std::time::Duration {
+    let ms = match held.as_millis() {
+        0..=1_200 => 180,
+        1_201..=2_600 => 110,
+        _ => 70,
+    };
+    std::time::Duration::from_millis(ms)
+}
+
+/// Whether a stepper's range is long enough to want the ramp.
+pub(super) fn cycle_ramps(field: crate::video::launcher::LauncherField) -> bool {
+    use crate::video::launcher::LauncherField as F;
+    matches!(
+        field,
+        F::MouseSensitivity | F::AudioStereoSeparation | F::FloppyVolume
+    ) || crate::video::launcher::field_is_bootpri(field)
+}
+
+/// How long a held stepper waits before its first repeat.
+pub(super) fn cycle_hold_delay(
+    field: crate::video::launcher::LauncherField,
+) -> std::time::Duration {
+    if cycle_ramps(field) {
+        CYCLE_RAMP_DELAY
+    } else {
+        CYCLE_HOLD_EVERY
+    }
+}
+
+/// The gap to the next repeat, given how long the arrow has been held.
+pub(super) fn cycle_hold_every(
+    field: crate::video::launcher::LauncherField,
+    held_for: std::time::Duration,
+) -> std::time::Duration {
+    if !cycle_ramps(field) {
+        return CYCLE_HOLD_EVERY;
+    }
+    let ms = match held_for.as_millis() {
+        0..=1_800 => 140,
+        1_801..=4_000 => 55,
+        _ => 25,
+    };
+    std::time::Duration::from_millis(ms)
+}
+
+/// Whether a status-bar control would do anything if it were pressed.
+/// A greyed button is not somewhere to stand: the focus walks past a
+/// swap with nothing to swap to, and an eject with nothing in the
+/// drive, the way the eye does.
+pub(super) fn bar_control_live(media: &MediaBar, control: BarControl) -> bool {
+    let drive = |idx: usize| media.drives.get(idx).copied().unwrap_or_default();
+    match control {
+        BarControl::DriveLoad(idx) => drive(idx).connected && !drive(idx).bridged,
+        BarControl::DriveSwap(idx) => {
+            let d = drive(idx);
+            d.connected && d.multi && !d.bridged
+        }
+        BarControl::DriveEject(idx) => {
+            let d = drive(idx);
+            d.connected && d.inserted && !d.bridged
+        }
+        BarControl::CdEject => media.cd == Some(true),
+        _ => true,
+    }
+}
+
+/// Whether a control is one of the buttons along the foot of the
+/// configuration screen. They are not settings: walking left along them
+/// means walking along them.
+pub(super) fn launcher_action_control(control: UiControl) -> bool {
+    matches!(
+        control,
+        UiControl::LauncherLoad
+            | UiControl::LauncherSave
+            | UiControl::LauncherSaveAs
+            | UiControl::LauncherDefaults
+            | UiControl::LauncherRun
+    )
+}
+
+impl App {
+    /// Everywhere the focus can stand on the interface as it is now,
+    /// read off the pointer's own hit-testing.
+    pub(super) fn nav_items(&self) -> Vec<crate::video::nav::NavItem> {
+        let mut items = crate::video::nav::map(&self.ui, texture_width(1), texture_height(1));
+        // The status bar is part of the same space: it sits under the
+        // panels on the screen, so stepping down off the bottom of one
+        // reaches it and stepping back up returns. Hidden, it is not
+        // there to be walked -- a player build never shows it at all.
+        if crate::video::status_bar_hidden() {
+            return items;
+        }
+        let media = self.media_bar();
+        let layout = bar_layout(&media);
+        items.extend(crate::video::nav::bar_map(
+            status_bar_rect(),
+            |pos| control_at(pos, &layout).filter(|control| bar_control_live(&media, *control)),
+            volume_control_hit_rect(),
+        ));
+        items
+    }
+
+    /// Move the focus, or spend the direction on an open stepper.
+    pub(super) fn nav_move(
+        &mut self,
+        dir: crate::video::nav::Dir,
+        event_loop: Option<&ActiveEventLoop>,
+    ) -> bool {
+        use crate::video::nav::{Dir, NavTarget};
+        // The menu keeps its own cursor -- it is a tree, not a page --
+        // so while it is open the focus is that cursor, whichever hand
+        // is moving it.
+        if self.ui.menu_open {
+            let ui = &mut self.ui;
+            match dir {
+                // The menu does not cycle: the top of a level is the
+                // top. Walking off the foot of it leaves the menu
+                // altogether, landing on the button it hangs from, so
+                // the bar can be walked from there.
+                Dir::Up => {
+                    ui.menu_nav.step_within(&ui.menu_rows, false);
+                }
+                Dir::Down if ui.menu_nav.cursor().is_none() => {
+                    ui.menu_nav.step(&ui.menu_rows, true);
+                }
+                Dir::Down => {
+                    if !ui.menu_nav.step_within(&ui.menu_rows, true) && ui.menu_nav.depth() == 0 {
+                        self.close_menu();
+                        self.nav_show(Some(crate::video::nav::NavTarget::Bar(BarControl::Menu)));
+                    }
+                }
+                Dir::Right => {
+                    ui.menu_nav.descend(&ui.menu_rows);
+                }
+                Dir::Left => {
+                    ui.menu_nav.ascend();
+                }
+            }
+            self.request_redraw();
+            return true;
+        }
+        let items = self.nav_items();
+        if items.is_empty() {
+            return false;
+        }
+        self.nav.settle(&items, self.nav_home());
+        // A list longer than its box scrolls under the focus: stepping
+        // off the last row it can show brings the next one into view
+        // rather than leaving the list for the buttons under it.
+        if !dir.horizontal() {
+            if let Some(next) = self.nav_host_disk_scroll(dir) {
+                self.nav_show(Some(next));
+                self.request_redraw();
+                return true;
+            }
+        }
+        // A dialog is walked in the order it reads, not in the order it
+        // is laid out: its picture is a tall block beside the boxes
+        // rather than above the first of them, so what the eye calls
+        // the next thing down is not what is under it.
+        if !dir.horizontal() {
+            if let Some(next) = self.nav_dialog_step(&items, dir) {
+                self.nav_show(Some(next));
+                self.nav_sync_dialog();
+                self.request_redraw();
+                return true;
+            }
+        }
+        // An open stepper spends left and right on its value; up and
+        // down close it and move on, so the focus is never trapped.
+        if self.nav.open() {
+            if dir.horizontal() {
+                if let Some(arrow) = self
+                    .nav
+                    .focus()
+                    .and_then(|t| crate::video::nav::stepper_arrow(t, dir))
+                {
+                    self.activate_nav_target(arrow, event_loop);
+                    self.request_redraw();
+                    return true;
+                }
+                // The volume has no arrows of its own: the direction is
+                // the step, and holding it gathers speed like every
+                // other held control here.
+                if let Some(NavTarget::Bar(BarControl::Volume)) = self.nav.focus() {
+                    let steps = if dir == Dir::Right { 1 } else { -1 };
+                    self.adjust_output_volume(steps * VOLUME_STEP_PERCENT);
+                    self.request_redraw();
+                    return true;
+                }
+            }
+            self.nav.close();
+        }
+        let mut next = crate::video::nav::step(&items, self.nav.focus(), dir);
+        // The two rules the column follows, which geometry alone gets
+        // wrong on pages whose settings do not begin beside it: right
+        // from a category opens its page at the first setting, and left
+        // from anywhere in that page comes back to the category. The
+        // page you are on is the button you came in by.
+        match dir {
+            Dir::Right => {
+                if let Some(first) = self.nav_first_setting(&items) {
+                    next = Some(first);
+                } else if next.is_none() {
+                    next = self.nav_row_across(&items, dir);
+                }
+            }
+            Dir::Left => {
+                // Left walks the row it is on first -- from Clear back
+                // to the Browse beside it, from one image format to the
+                // one before it -- and only leaves the page when that
+                // row has run out.
+                if let Some(row) = self.nav_row_across(&items, dir) {
+                    next = Some(row);
+                } else if let Some(letters) = self.nav_library_letters(&items) {
+                    next = Some(letters);
+                } else if !next.is_some_and(crate::video::nav::in_page) {
+                    if let Some(home) = self.nav_column_home(&items) {
+                        next = Some(home);
+                    }
+                }
+            }
+            _ => {}
+        }
+        if next.is_some() || !self.nav.showing() {
+            self.nav_show(next.or_else(|| self.nav.focus()));
+        }
+        self.nav_sync_library();
+        self.nav_sync_dialog();
+        self.request_redraw();
+        true
+    }
+
+    /// Work whatever the focus stands on: a stepper opens, everything
+    /// else is pressed. The first press only shows the focus, so the
+    /// interface never acts on a control nobody could see was chosen.
+    pub(super) fn nav_press(&mut self, event_loop: Option<&ActiveEventLoop>) -> bool {
+        if self.ui.menu_open {
+            self.activate_menu_row(event_loop);
+            if let Some(event_loop) = event_loop {
+                self.ensure_tool_windows_for_open_panels(event_loop);
+            }
+            self.request_redraw();
+            return true;
+        }
+        let items = self.nav_items();
+        if items.is_empty() {
+            return false;
+        }
+        self.nav.settle(&items, self.nav_home());
+        let Some(focus) = self.nav.focus() else {
+            self.nav_show(items.first().map(|i| i.target));
+            self.request_redraw();
+            return true;
+        };
+        if !self.nav.showing() {
+            self.nav_show(Some(focus));
+            self.request_redraw();
+            return true;
+        }
+        if crate::video::nav::is_stepper(focus) {
+            self.nav.toggle_open();
+        } else {
+            self.activate_nav_target(focus, event_loop);
+            if let Some(event_loop) = event_loop {
+                self.ensure_tool_windows_for_open_panels(event_loop);
+            }
+            // A button that changes the page is the way into it, and so
+            // is the way back out: going back from anywhere in the page
+            // returns to it rather than closing the launcher.
+            if matches!(
+                focus,
+                crate::video::nav::NavTarget::Ui(
+                    UiControl::LauncherTab(_) | UiControl::LauncherNavTab(_)
+                )
+            ) {
+                self.nav_entered_from = Some(focus);
+            }
+            // Pressing a category button changes the page under the
+            // focus; what it paints has to follow.
+            let items = self.nav_items();
+            // A tick is marked and left: what was being looked at is the
+            // game, not its tick, so the focus goes back to the row it
+            // came across from. Right again returns to the tick.
+            if let Some(row) = Self::nav_row_beside(focus) {
+                if crate::video::nav::find(&items, row).is_some() {
+                    self.nav.show(Some(row));
+                }
+            }
+            // A button that opened a page has gone with the page it
+            // opened. The focus belongs on the new page, not back at the
+            // top of the column.
+            if crate::video::nav::find(&items, focus).is_none() {
+                if let Some(entry) = self.nav_page_entry(&items) {
+                    self.nav.show(Some(entry));
+                }
+            }
+            self.nav.settle(&items, self.nav_home());
+            self.nav_sync_library();
+            self.nav_sync_dialog();
+        }
+        self.request_redraw();
+        true
+    }
+
+    /// Step back out: an open stepper closes, and otherwise the surface
+    /// itself goes -- which is what the second button means everywhere
+    /// else it is pressed.
+    pub(super) fn nav_back(&mut self) {
+        if self.nav.open() {
+            self.nav.close();
+            self.request_redraw();
+            return;
+        }
+        if self.ui.menu_open {
+            if !self.ui.menu_nav.ascend() {
+                self.close_menu();
+            }
+            self.request_redraw();
+            return;
+        }
+        // Back out of the page before back out of the launcher: the
+        // focus returns to the button it came in by, and only a second
+        // press closes the panel.
+        if let Some(entered) = self.nav_entered_from {
+            let items = self.nav_items();
+            let inside = self.nav.focus().is_some_and(crate::video::nav::in_page)
+                && self.nav.focus() != Some(entered);
+            if inside && crate::video::nav::find(&items, entered).is_some() {
+                self.nav_entered_from = None;
+                self.nav_show(Some(entered));
+                self.request_redraw();
+                return;
+            }
+        }
+        if self.ui.panel.is_some() {
+            self.close_panel();
+        }
+    }
+
+    /// Put the focus somewhere and start its breath afresh, so a step
+    /// always begins bright rather than wherever the last one left the
+    /// pulse.
+    fn nav_show(&mut self, target: Option<crate::video::nav::NavTarget>) {
+        self.nav_shown_at = Instant::now();
+        self.nav.show(target);
+    }
+
+    /// Work whatever the focus is standing on, whichever surface it
+    /// belongs to.
+    fn activate_nav_target(
+        &mut self,
+        target: crate::video::nav::NavTarget,
+        event_loop: Option<&ActiveEventLoop>,
+    ) {
+        match target {
+            crate::video::nav::NavTarget::Ui(control) => {
+                self.activate_ui_control_with_event_loop(control, event_loop);
+            }
+            crate::video::nav::NavTarget::Bar(control) => self.activate_bar_control(control),
+        }
+    }
+
+    /// Walk the interface with the arrows, and work it with Return.
+    ///
+    /// A stepper opens rather than firing: its arrows light, left and
+    /// right change the value, and Return closes it again. Everything
+    /// else is simply pressed, which is what a single-choice control
+    /// means.
+    pub(super) fn handle_nav_key(
+        &mut self,
+        code: KeyCode,
+        event_loop: Option<&ActiveEventLoop>,
+    ) -> bool {
+        use crate::video::nav::Dir;
+        let dir = match code {
+            KeyCode::ArrowUp => Some(Dir::Up),
+            KeyCode::ArrowDown => Some(Dir::Down),
+            KeyCode::ArrowLeft => Some(Dir::Left),
+            KeyCode::ArrowRight => Some(Dir::Right),
+            _ => None,
+        };
+        if let Some(dir) = dir {
+            return self.nav_move(dir, event_loop);
+        }
+        if matches!(code, KeyCode::Enter | KeyCode::NumpadEnter | KeyCode::Space) {
+            return self.nav_press(event_loop);
+        }
+        // With a surface open Escape has already been spent closing it
+        // by the time this is reached, so what is left is a marker
+        // standing on the bar over a running machine: put it away and
+        // the keyboard is the guest's again.
+        if code == KeyCode::Escape && self.nav.showing() {
+            self.nav.clear();
+            self.request_redraw();
+            return true;
+        }
+        false
+    }
+
+    /// Where the focus starts when whatever it was standing on has
+    /// gone -- a page change, most often. The configuration screen's
+    /// own answer is the first of its category buttons, which is where
+    /// the eye starts on it too.
+    pub(super) fn nav_home(&self) -> Option<crate::video::nav::NavTarget> {
+        use crate::video::launcher::LauncherTab;
+        let Some(Panel::Launcher(state)) = self.ui.panel.as_ref() else {
+            return None;
+        };
+        // A dialog over the page is the only thing being answered while
+        // it is up, so it is where the focus starts: on the first of the
+        // three things the Save dialog offers, and on the one thing the
+        // confirm asks.
+        if state.save_dialog {
+            return Some(crate::video::nav::NavTarget::Ui(
+                crate::video::ui::SAVE_ACTIONS[0],
+            ));
+        }
+        if state.confirm_reset {
+            return Some(crate::video::nav::NavTarget::Ui(
+                UiControl::LauncherConfirmReset,
+            ));
+        }
+        if let Some(first) = self.nav_dialog_order().first() {
+            return Some(*first);
+        }
+        Some(crate::video::nav::NavTarget::Ui(UiControl::LauncherTab(
+            LauncherTab::System,
+        )))
+    }
+
+    /// Where the focus stands when a page opens.
+    ///
+    /// Right off a category button, and again when a button that
+    /// changed the page has gone with it: pressing one of the rows
+    /// across the top of a page opens a page whose own row is a Back
+    /// button, so the thing that was being stood on no longer exists.
+    /// Without this the focus fell back to the first category and the
+    /// page that had just been opened was left behind.
+    fn nav_page_entry(
+        &self,
+        items: &[crate::video::nav::NavItem],
+    ) -> Option<crate::video::nav::NavTarget> {
+        use crate::video::nav::NavTarget;
+        let column = self
+            .launcher_state()
+            .map(|state| state.tab.parent_tab().unwrap_or(state.tab))
+            .and_then(|tab| {
+                crate::video::nav::find(items, NavTarget::Ui(UiControl::LauncherTab(tab)))
+            });
+        let right_of_column = column.map_or(0, |item| item.rect.x + item.rect.w);
+        // The game page is a list with a strip of letters over it, and
+        // that is what it is opened for: right off its button goes to
+        // the letters, or straight into the list when there are too few
+        // games for the strip to be drawn.
+        #[cfg(feature = "game-library")]
+        {
+            let library = items
+                .iter()
+                .filter(|item| {
+                    matches!(
+                        item.target,
+                        NavTarget::Ui(UiControl::LauncherLibraryJump(_))
+                    )
+                })
+                .min_by_key(|item| item.rect.x)
+                .or_else(|| {
+                    items
+                        .iter()
+                        .filter(|item| {
+                            matches!(
+                                item.target,
+                                NavTarget::Ui(UiControl::LauncherLibraryPick(_))
+                            )
+                        })
+                        .min_by_key(|item| item.rect.y)
+                });
+            if let Some(item) = library {
+                return Some(item.target);
+            }
+        }
+        // A page with sibling pages opens on that row: it is the first
+        // thing across the top of the page, and the settings under it
+        // belong to whichever of them is chosen.
+        let pages = items
+            .iter()
+            .filter(|item| {
+                matches!(
+                    item.target,
+                    crate::video::nav::NavTarget::Ui(UiControl::LauncherNavTab(_))
+                )
+            })
+            .min_by_key(|item| (item.rect.y, item.rect.x));
+        if let Some(item) = pages {
+            return Some(item.target);
+        }
+        items
+            .iter()
+            .filter(|item| {
+                let NavTarget::Ui(control) = item.target else {
+                    return false;
+                };
+                // The settings themselves: not the rows the page hangs
+                // under, nor the buttons along its foot.
+                !matches!(
+                    control,
+                    UiControl::LauncherTab(_)
+                        | UiControl::LauncherNavTab(_)
+                        | UiControl::LauncherModel(_)
+                        | UiControl::PanelClose
+                ) && !launcher_action_control(control)
+                    && item.rect.x >= right_of_column
+            })
+            .min_by_key(|item| (item.rect.y, item.rect.x))
+            .map(|item| item.target)
+    }
+
+    /// The first setting of the page, for stepping right out of the
+    /// category column: the top-left of the settings, wherever that
+    /// happens to sit. Pages whose settings start well below the column
+    /// button, or well to the right of it, have nothing beside the
+    /// button at all, and geometry alone leaves the focus where it was.
+    fn nav_first_setting(
+        &self,
+        items: &[crate::video::nav::NavItem],
+    ) -> Option<crate::video::nav::NavTarget> {
+        use crate::video::nav::NavTarget;
+        let NavTarget::Ui(UiControl::LauncherTab(_)) = self.nav.focus()? else {
+            return None;
+        };
+        self.nav_page_entry(items)
+    }
+
+    fn nav_column_home(
+        &self,
+        items: &[crate::video::nav::NavItem],
+    ) -> Option<crate::video::nav::NavTarget> {
+        use crate::video::nav::NavTarget;
+        let NavTarget::Ui(control) = self.nav.focus()? else {
+            return None;
+        };
+        if matches!(
+            control,
+            UiControl::LauncherTab(_) | UiControl::LauncherNavTab(_) | UiControl::LauncherModel(_)
+        ) || launcher_action_control(control)
+        {
+            return None;
+        }
+        let state = self.launcher_state()?;
+        let column = state.tab.parent_tab().unwrap_or(state.tab);
+        let home = NavTarget::Ui(UiControl::LauncherTab(column));
+        let seat = crate::video::nav::find(items, home)?;
+        let here = crate::video::nav::find(items, NavTarget::Ui(control))?;
+        // Only from the right of the column: a control already in it,
+        // or left of it, has somewhere else to be.
+        (here.rect.x >= seat.rect.x + seat.rect.w).then_some(home)
+    }
+
+    /// The first of the letters over the game list.
+    ///
+    /// Left off a game goes back up to the strip it was jumped to by,
+    /// which is the way back out of a list that fills its box: there is
+    /// nothing beside a row of it to step onto.
+    #[cfg(feature = "game-library")]
+    fn nav_library_letters(
+        &self,
+        items: &[crate::video::nav::NavItem],
+    ) -> Option<crate::video::nav::NavTarget> {
+        use crate::video::nav::NavTarget;
+        if !matches!(
+            self.nav.focus(),
+            Some(NavTarget::Ui(UiControl::LauncherLibraryPick(_)))
+        ) {
+            return None;
+        }
+        items
+            .iter()
+            .filter(|item| {
+                matches!(
+                    item.target,
+                    NavTarget::Ui(UiControl::LauncherLibraryJump(_))
+                )
+            })
+            .min_by_key(|item| item.rect.x)
+            .map(|item| item.target)
+    }
+
+    #[cfg(not(feature = "game-library"))]
+    fn nav_library_letters(
+        &self,
+        _items: &[crate::video::nav::NavItem],
+    ) -> Option<crate::video::nav::NavTarget> {
+        None
+    }
+
+    /// Where a step across a row of one of the lists goes.
+    ///
+    /// A row is as wide as its box and its cells are drawn inside it,
+    /// so neither is beyond the other and the geometry has nothing to
+    /// find either side: these steps have to be named. Right walks the
+    /// cells of the row and then leaves the list -- to the buttons under
+    /// the games, which up off them comes back from; to Run off a
+    /// favourite, which is what a favourite is chosen for; and to Mount
+    /// off a host disk. Left walks back through them to the row.
+    fn nav_row_across(
+        &self,
+        items: &[crate::video::nav::NavItem],
+        dir: crate::video::nav::Dir,
+    ) -> Option<crate::video::nav::NavTarget> {
+        use crate::video::nav::{Dir, NavTarget};
+        let focus = self.nav.focus()?;
+        if dir == Dir::Left {
+            let row = Self::nav_row_beside(focus)?;
+            return crate::video::nav::find(items, row).map(|item| item.target);
+        }
+        if dir != Dir::Right {
+            return None;
+        }
+        let NavTarget::Ui(control) = focus else {
+            return None;
+        };
+        let beside = |tick: UiControl| {
+            crate::video::nav::find(items, NavTarget::Ui(tick)).map(|item| item.target)
+        };
+        let mount = || {
+            crate::video::nav::find(items, NavTarget::Ui(UiControl::LauncherHostDiskMount))
+                .map(|item| item.target)
+        };
+        #[cfg(feature = "game-library")]
+        {
+            let buttons = || {
+                items
+                    .iter()
+                    .filter(|item| {
+                        matches!(
+                            item.target,
+                            NavTarget::Ui(
+                                UiControl::LauncherLibraryRefresh
+                                    | UiControl::LauncherLibraryUpdate
+                                    | UiControl::LauncherLibraryEdit
+                            )
+                        )
+                    })
+                    .min_by_key(|item| item.rect.x)
+                    .map(|item| item.target)
+            };
+            let run = || {
+                crate::video::nav::find(items, NavTarget::Ui(UiControl::LauncherRun))
+                    .map(|item| item.target)
+            };
+            match control {
+                UiControl::LauncherLibraryPick(at) => {
+                    return beside(UiControl::LauncherLibraryFavourite(at)).or_else(buttons)
+                }
+                UiControl::LauncherLibraryFavourite(_) => return buttons(),
+                UiControl::LauncherLibraryFavouritePick(at) => {
+                    return beside(UiControl::LauncherLibraryFavouriteRemove(at)).or_else(run)
+                }
+                UiControl::LauncherLibraryFavouriteRemove(_) => return run(),
+                _ => {}
+            }
+        }
+        match control {
+            UiControl::LauncherHostDiskSelect(at) => beside(UiControl::LauncherHostDiskAttach(at))
+                .or_else(|| beside(UiControl::LauncherHostDiskWritable(at)))
+                .or_else(mount),
+            UiControl::LauncherHostDiskAttach(at) => {
+                beside(UiControl::LauncherHostDiskWritable(at)).or_else(mount)
+            }
+            UiControl::LauncherHostDiskWritable(at) => {
+                beside(UiControl::LauncherHostDiskEnable(at)).or_else(mount)
+            }
+            UiControl::LauncherHostDiskEnable(_) => mount(),
+            _ => None,
+        }
+    }
+
+    /// What sits left of a cell drawn inside a row, if this is one.
+    fn nav_row_beside(
+        target: crate::video::nav::NavTarget,
+    ) -> Option<crate::video::nav::NavTarget> {
+        use crate::video::nav::NavTarget;
+        let NavTarget::Ui(control) = target else {
+            return None;
+        };
+        Some(NavTarget::Ui(match control {
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherLibraryFavourite(at) => UiControl::LauncherLibraryPick(at),
+            #[cfg(feature = "game-library")]
+            UiControl::LauncherLibraryFavouriteRemove(at) => {
+                UiControl::LauncherLibraryFavouritePick(at)
+            }
+            UiControl::LauncherHostDiskAttach(at) => UiControl::LauncherHostDiskSelect(at),
+            UiControl::LauncherHostDiskWritable(at) => UiControl::LauncherHostDiskAttach(at),
+            UiControl::LauncherHostDiskEnable(at) => UiControl::LauncherHostDiskWritable(at),
+            _ => return None,
+        }))
+    }
+
+    /// Scroll the host-disk list under the focus, where the step would
+    /// otherwise leave a list that has more to show.
+    ///
+    /// Only the rows in view are places to stand -- they are what the
+    /// hit-test answers for -- so without this a list of twenty disks
+    /// could only ever be walked as far as the eighth.
+    fn nav_host_disk_scroll(
+        &mut self,
+        dir: crate::video::nav::Dir,
+    ) -> Option<crate::video::nav::NavTarget> {
+        use crate::video::nav::{Dir, NavTarget};
+        use crate::video::ui::HOST_DISK_VISIBLE_ROWS;
+        let NavTarget::Ui(control) = self.nav.focus()? else {
+            return None;
+        };
+        let at = Self::host_disk_row_of(control)?;
+        let state = self.launcher_state()?;
+        let disks = state.setup.host_disks().len();
+        let scroll = state.setup.host_disk_scroll();
+        let (next, step) = match dir {
+            Dir::Down if at + 1 < disks && at + 1 >= scroll + HOST_DISK_VISIBLE_ROWS => (at + 1, 1),
+            Dir::Up if at > 0 && at - 1 < scroll => (at - 1, -1),
+            _ => return None,
+        };
+        self.launcher_state_mut()?
+            .setup
+            .scroll_host_disks(step, HOST_DISK_VISIBLE_ROWS);
+        Some(NavTarget::Ui(Self::host_disk_row_at(control, next)))
+    }
+
+    /// Which row of the host-disk list a control belongs to.
+    fn host_disk_row_of(control: UiControl) -> Option<usize> {
+        match control {
+            UiControl::LauncherHostDiskSelect(at)
+            | UiControl::LauncherHostDiskAttach(at)
+            | UiControl::LauncherHostDiskWritable(at)
+            | UiControl::LauncherHostDiskEnable(at) => Some(at),
+            _ => None,
+        }
+    }
+
+    /// The same control on another row, so a scroll keeps the focus in
+    /// the column it was walking down.
+    fn host_disk_row_at(control: UiControl, at: usize) -> UiControl {
+        match control {
+            UiControl::LauncherHostDiskAttach(_) => UiControl::LauncherHostDiskAttach(at),
+            UiControl::LauncherHostDiskWritable(_) => UiControl::LauncherHostDiskWritable(at),
+            UiControl::LauncherHostDiskEnable(_) => UiControl::LauncherHostDiskEnable(at),
+            _ => UiControl::LauncherHostDiskSelect(at),
+        }
+    }
+
+    /// The order a dialog is walked in, top to bottom.
+    ///
+    /// Empty unless one is up, which is what makes this the walk: a
+    /// dialog is the only thing being answered while it is there, so
+    /// its own order is the only one that matters.
+    #[cfg(feature = "game-library")]
+    fn nav_dialog_order(&self) -> Vec<crate::video::nav::NavTarget> {
+        use crate::video::launcher::{LoginField, MetaField};
+        use crate::video::nav::NavTarget::Ui;
+        let Some(state) = self.launcher_state() else {
+            return Vec::new();
+        };
+        if state.meta.is_some() {
+            let mut order = vec![Ui(UiControl::MetaArt)];
+            order.extend(MetaField::ALL.iter().map(|&f| Ui(UiControl::MetaField(f))));
+            order.extend([
+                Ui(UiControl::MetaSave),
+                Ui(UiControl::MetaClear),
+                Ui(UiControl::MetaCancel),
+            ]);
+            return order;
+        }
+        if state.login.is_some() {
+            return vec![
+                Ui(UiControl::LoginField(LoginField::User)),
+                Ui(UiControl::LoginField(LoginField::Pass)),
+                Ui(UiControl::LoginOk),
+                Ui(UiControl::LoginCancel),
+            ];
+        }
+        Vec::new()
+    }
+
+    #[cfg(not(feature = "game-library"))]
+    fn nav_dialog_order(&self) -> Vec<crate::video::nav::NavTarget> {
+        Vec::new()
+    }
+
+    /// The next place along that order, or `None` where there is no
+    /// dialog up or no further to go.
+    fn nav_dialog_step(
+        &self,
+        items: &[crate::video::nav::NavItem],
+        dir: crate::video::nav::Dir,
+    ) -> Option<crate::video::nav::NavTarget> {
+        use crate::video::nav::Dir;
+        let order: Vec<_> = self
+            .nav_dialog_order()
+            .into_iter()
+            .filter(|target| crate::video::nav::find(items, *target).is_some())
+            .collect();
+        if order.is_empty() {
+            return None;
+        }
+        let Some(focus) = self.nav.focus() else {
+            return order.first().copied();
+        };
+        let at = order.iter().position(|target| *target == focus)?;
+        match dir {
+            Dir::Down => order.get(at + 1).copied(),
+            Dir::Up => at.checked_sub(1).and_then(|at| order.get(at).copied()),
+            _ => None,
+        }
+    }
+
+    /// Whether a key pressed in a dialog belongs to the focus rather
+    /// than to the box being typed into.
+    #[cfg(feature = "game-library")]
+    pub(super) fn nav_dialog_key_is_focus(&self, code: KeyCode, buttons: &[UiControl]) -> bool {
+        use crate::video::nav::NavTarget;
+        if matches!(code, KeyCode::ArrowUp | KeyCode::ArrowDown) {
+            return true;
+        }
+        let on_button =
+            matches!(self.nav.focus(), Some(NavTarget::Ui(control)) if buttons.contains(&control));
+        on_button
+            && matches!(
+                code,
+                KeyCode::ArrowLeft
+                    | KeyCode::ArrowRight
+                    | KeyCode::Enter
+                    | KeyCode::NumpadEnter
+                    | KeyCode::Space
+            )
+    }
+
+    /// Put the dialog's own caret in the box the focus is standing on.
+    ///
+    /// A dialog keeps its own focus -- it is what the caret blinks in
+    /// and what typing goes into -- and the marker walking it is a
+    /// second one. On the same dialog they must be the same box.
+    #[cfg(feature = "game-library")]
+    pub(super) fn nav_sync_dialog(&mut self) {
+        use crate::video::nav::NavTarget;
+        let Some(NavTarget::Ui(control)) = self.nav.focus() else {
+            return;
+        };
+        match control {
+            UiControl::LoginField(field) => {
+                if let Some(login) = self.launcher_login_mut() {
+                    login.focus_on(field);
+                }
+            }
+            UiControl::MetaField(field) => {
+                if let Some(meta) = self.launcher_meta_mut() {
+                    meta.focus_on(field);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[cfg(not(feature = "game-library"))]
+    pub(super) fn nav_sync_dialog(&mut self) {}
+
+    /// Put the focus on the row the list has chosen.
+    ///
+    /// A list keeps its own selection -- it is what scrolls, and what
+    /// Return launches -- and the marker walking about the page is a
+    /// second one. On the same list they must be the same row, or the
+    /// box shows two chosen games and stepping across to a tick takes
+    /// the tick of the wrong one.
+    #[cfg(feature = "game-library")]
+    pub(super) fn nav_sync_library(&mut self) {
+        use crate::video::launcher::LibraryFocus;
+        use crate::video::nav::NavTarget;
+        let Some(NavTarget::Ui(control)) = self.nav.focus() else {
+            return;
+        };
+        let games = matches!(
+            control,
+            UiControl::LauncherLibraryPick(_) | UiControl::LauncherLibraryFavourite(_)
+        );
+        let starred = matches!(
+            control,
+            UiControl::LauncherLibraryFavouritePick(_)
+                | UiControl::LauncherLibraryFavouriteRemove(_)
+        );
+        if !games && !starred {
+            return;
+        }
+        let Some(state) = self.launcher_state_mut() else {
+            return;
+        };
+        // Standing in a list is what gives that list the focus, which is
+        // what draws its chosen row: the other list shows none.
+        state.library.focus = if games {
+            LibraryFocus::Games
+        } else {
+            LibraryFocus::Favourites
+        };
+        let drawn = if games {
+            state.library.selected.saturating_sub(state.library.scroll)
+        } else {
+            state
+                .library
+                .favourite_selected
+                .saturating_sub(state.library.favourite_scroll)
+        };
+        let at = match control {
+            UiControl::LauncherLibraryPick(_) => UiControl::LauncherLibraryPick(drawn),
+            UiControl::LauncherLibraryFavourite(_) => UiControl::LauncherLibraryFavourite(drawn),
+            UiControl::LauncherLibraryFavouritePick(_) => {
+                UiControl::LauncherLibraryFavouritePick(drawn)
+            }
+            _ => UiControl::LauncherLibraryFavouriteRemove(drawn),
+        };
+        self.nav.park(Some(NavTarget::Ui(at)));
+    }
+
+    #[cfg(not(feature = "game-library"))]
+    pub(super) fn nav_sync_library(&mut self) {}
+
+    /// Whether the list the focus is standing in has run out this way.
+    #[cfg(feature = "game-library")]
+    pub(super) fn library_at_end(&self, step: isize) -> bool {
+        use crate::video::launcher::LibraryFocus;
+        self.launcher_state().is_some_and(|state| {
+            let (at, len) = match state.library.focus {
+                LibraryFocus::Games => (state.library.selected, state.library.games.len()),
+                LibraryFocus::Favourites => (
+                    state.library.favourite_selected,
+                    state.library.db.favourite_count(),
+                ),
+            };
+            len == 0 || if step < 0 { at == 0 } else { at + 1 >= len }
+        })
+    }
+
+    /// Whether the focus is standing on the game list, whose own
+    /// arrows scroll it rather than moving the focus.
+    #[cfg(feature = "game-library")]
+    pub(super) fn nav_focus_in_library(&self) -> bool {
+        use crate::video::nav::NavTarget;
+        matches!(
+            self.nav.focus(),
+            Some(NavTarget::Ui(
+                UiControl::LauncherLibraryPick(_) | UiControl::LauncherLibraryFavouritePick(_)
+            ))
+        )
+    }
+
+    /// The line under the focused control, and the light on an open
+    /// stepper's arrows. Drawn over the interface rather than inside
+    /// it: what the focus is doing belongs to the window, not to the
+    /// surface it is walking.
+    /// What the surfaces need to know before they draw: where the focus
+    /// stands and how far through its breath it is.
+    pub(super) fn nav_light(&self) -> (Option<UiControl>, f32) {
+        let Some(target) = self.nav.shown() else {
+            return (None, 0.0);
+        };
+        // A stepper's two arrows are one place: the surface is told the
+        // one, whichever end the map happened to meet first.
+        match crate::video::nav::normalise(target) {
+            crate::video::nav::NavTarget::Ui(control) => (Some(control), self.nav_mix()),
+            crate::video::nav::NavTarget::Bar(_) => (None, 0.0),
+        }
+    }
+
+    /// The bar's half of the same answer: it draws itself, so it is
+    /// told separately.
+    pub(super) fn nav_bar_light(&self) -> (Option<BarControl>, f32) {
+        match self.nav.shown() {
+            Some(crate::video::nav::NavTarget::Bar(control)) => (Some(control), self.nav_mix()),
+            _ => (None, 0.0),
+        }
+    }
+
+    /// How lit the focused control stands: breathing while it is merely
+    /// chosen, full while it stands open for changing.
+    pub(super) fn nav_mix(&self) -> f32 {
+        if self.nav.open() {
+            1.0
+        } else {
+            self.nav_pulse()
+        }
+    }
+
+    /// Where the focus's breath stands: dim at the bottom of it, full
+    /// at the top. A pure function of the clock, so it never depends on
+    /// how often the window happens to redraw.
+    fn nav_pulse(&self) -> f32 {
+        let ms = self.nav_shown_at.elapsed().as_millis() as u64 % NAV_PULSE_MS;
+        let phase = ms as f32 / NAV_PULSE_MS as f32 * std::f32::consts::TAU;
+        let swing = (1.0 - NAV_PULSE_FLOOR) / 2.0;
+        NAV_PULSE_FLOOR + swing * (1.0 + phase.sin())
+    }
+
+    /// Walk the interface with the pad: the stick and the hat move the
+    /// focus, the fire button works what it is standing on, and the
+    /// second button steps back out -- closing an open stepper, then
+    /// the surface itself.
+    ///
+    /// A held direction repeats, slowly at first and then faster, the
+    /// way every other held control in this interface does; the buttons
+    /// fire once each on the press, because a button that repeated
+    /// would open and close a setting under your thumb.
+    pub(super) fn pad_drives_interface(
+        &mut self,
+        pad: crate::gamepad::JoystickState,
+        event_loop: Option<&ActiveEventLoop>,
+    ) {
+        use crate::video::nav::Dir;
+        let now = Instant::now();
+        let dir = if pad.up {
+            Some(Dir::Up)
+        } else if pad.down {
+            Some(Dir::Down)
+        } else if pad.left {
+            Some(Dir::Left)
+        } else if pad.right {
+            Some(Dir::Right)
+        } else {
+            None
+        };
+        match dir {
+            None => self.pad_nav.held = None,
+            Some(dir) => {
+                let fresh = self.pad_nav.held != Some(dir);
+                if fresh {
+                    self.pad_nav.held = Some(dir);
+                    self.pad_nav.since = now;
+                    self.pad_nav.next = now + PAD_NAV_DELAY;
+                    self.nav_move(dir, event_loop);
+                } else if now >= self.pad_nav.next {
+                    let held = now.saturating_duration_since(self.pad_nav.since);
+                    self.pad_nav.next = now + pad_nav_every(held);
+                    self.nav_move(dir, event_loop);
+                }
+            }
+        }
+        if pad.fire && !self.pad_nav.fire {
+            self.nav_press(event_loop);
+        }
+        self.pad_nav.fire = pad.fire;
+        if pad.button2 && !self.pad_nav.back {
+            self.nav_back();
+        }
+        self.pad_nav.back = pad.button2;
+    }
+
+    /// The pad asking for the interface, or asking to be rid of it: the
+    /// menu opens with the focus already on its first row, and closes
+    /// again the same way. Whatever else is open closes first, so one
+    /// button always leads back to the machine.
+    pub(super) fn toggle_pad_interface(&mut self) {
+        if self.ui.menu_open {
+            self.close_menu();
+            self.nav.clear();
+        } else if self.ui.panel.is_some() {
+            self.close_panel();
+        } else {
+            // The menu is the way in. It opens with its own cursor on
+            // the foot of its list -- the menu is a tree, and keeps that
+            // cursor rather than a place on a map -- and the pad walks
+            // from there into the bar and the panels beyond it.
+            self.toggle_menu();
+        }
+        self.request_redraw();
+    }
+
+    /// Step a held launcher stepper. The pointer must still be on the
+    /// arrow, the way a held scroll arrow works: a button that kept
+    /// firing from under the pointer would be one you cannot get away
+    /// from.
+    pub(super) fn repeat_held_cycle(&mut self) {
+        let Some((control, due, started)) = self.cycle_hold else {
+            return;
+        };
+        if self.cursor_pos.and_then(|p| self.main_ui_control_at(p)) != Some(control) {
+            self.cycle_hold = None;
+            return;
+        }
+        let now = Instant::now();
+        if now < due {
+            return;
+        }
+        let UiControl::LauncherCycle { field, .. } = control else {
+            self.cycle_hold = None;
+            return;
+        };
+        self.cycle_hold = Some((
+            control,
+            now + cycle_hold_every(field, now - started),
+            started,
+        ));
+        self.activate_ui_control_with_event_loop(control, None);
+        self.request_redraw();
+    }
+}

--- a/src/video/window/app_nav.rs
+++ b/src/video/window/app_nav.rs
@@ -424,7 +424,7 @@ impl App {
     /// Put the focus somewhere and start its breath afresh, so a step
     /// always begins bright rather than wherever the last one left the
     /// pulse.
-    fn nav_show(&mut self, target: Option<crate::video::nav::NavTarget>) {
+    pub(super) fn nav_show(&mut self, target: Option<crate::video::nav::NavTarget>) {
         self.nav_shown_at = Instant::now();
         self.nav.show(target);
     }

--- a/src/video/window/app_nav.rs
+++ b/src/video/window/app_nav.rs
@@ -43,6 +43,31 @@ pub(super) struct PadNav {
     back: bool,
 }
 
+impl PadNav {
+    /// Start from what the pad is doing right now rather than from
+    /// nothing, so a control already down when the walk is handed over
+    /// is not read as a press the moment it arrives.
+    fn seeded(pad: crate::gamepad::JoystickState) -> Self {
+        use crate::video::nav::Dir;
+        Self {
+            held: if pad.up {
+                Some(Dir::Up)
+            } else if pad.down {
+                Some(Dir::Down)
+            } else if pad.left {
+                Some(Dir::Left)
+            } else if pad.right {
+                Some(Dir::Right)
+            } else {
+                None
+            },
+            fire: pad.fire,
+            back: pad.button2,
+            ..Self::default()
+        }
+    }
+}
+
 impl Default for PadNav {
     fn default() -> Self {
         let now = Instant::now();
@@ -184,7 +209,17 @@ impl App {
                 Dir::Down => {
                     if !ui.menu_nav.step_within(&ui.menu_rows, true) && ui.menu_nav.depth() == 0 {
                         self.close_menu();
-                        self.nav_show(Some(crate::video::nav::NavTarget::Bar(BarControl::Menu)));
+                        // Onto the button the menu hangs from -- unless
+                        // the bar is not being shown at all, as in a
+                        // player build, where there is no such button
+                        // and the marker would stand on nothing.
+                        if crate::video::status_bar_hidden() {
+                            self.nav.clear();
+                        } else {
+                            self.nav_show(Some(crate::video::nav::NavTarget::Bar(
+                                BarControl::Menu,
+                            )));
+                        }
                     }
                 }
                 Dir::Right => {
@@ -864,7 +899,16 @@ impl App {
         self.launcher_state_mut()?
             .setup
             .scroll_host_disks(step, HOST_DISK_VISIBLE_ROWS);
-        Some(NavTarget::Ui(Self::host_disk_row_at(control, next)))
+        // The column the walk was in may not exist on the row it lands
+        // on: the attach cell is blank, and no place to stand, until a
+        // disk is ticked. The row itself always is.
+        let landing = Self::host_disk_row_at(control, next);
+        let live = crate::video::ui::control_live(&self.ui, landing);
+        Some(NavTarget::Ui(if live {
+            landing
+        } else {
+            UiControl::LauncherHostDiskSelect(next)
+        }))
     }
 
     /// Which row of the host-disk list a control belongs to.
@@ -1147,6 +1191,12 @@ impl App {
     /// way every other held control in this interface does; the buttons
     /// fire once each on the press, because a button that repeated
     /// would open and close a setting under your thumb.
+    /// Start the pad's walk from what it is doing now, so a control
+    /// already down does not act as it arrives.
+    pub(super) fn seed_pad_nav(&mut self, pad: crate::gamepad::JoystickState) {
+        self.pad_nav = PadNav::seeded(pad);
+    }
+
     pub(super) fn pad_drives_interface(
         &mut self,
         pad: crate::gamepad::JoystickState,

--- a/src/video/window/app_panels.rs
+++ b/src/video/window/app_panels.rs
@@ -11,6 +11,15 @@ impl App {
         kind: ToolPanelKind,
         event: WindowEvent,
     ) {
+        // Whichever tool window the host last gave the keyboard to is
+        // the one in front, and so the one a "close this" means. Opening
+        // one focuses it, so it starts out true of the newest.
+        if matches!(
+            event,
+            WindowEvent::Focused(true) | WindowEvent::KeyboardInput { .. }
+        ) {
+            self.tool_window_front = Some(kind);
+        }
         match event {
             WindowEvent::CloseRequested => self.close_tool_panel(kind),
             WindowEvent::KeyboardInput {
@@ -1177,6 +1186,8 @@ impl App {
         // tool window opened and left alone showed an unpainted surface
         // until the next mouse move or key press asked for a frame.
         window.request_redraw();
+        // Newly opened is newly in front, until another is touched.
+        self.tool_window_front = Some(kind);
         let inner = window.inner_size();
         *self.tool_window_slot(kind) = Some(ToolWindow {
             window,
@@ -1189,13 +1200,19 @@ impl App {
         self.request_redraw();
     }
 
-    /// The open tool panel a "close this" means, when one is open at all.
-    /// The last in order, so a stack of them comes down one at a time.
+    /// The open tool panel a "close this" means: the one in front, which
+    /// is whichever was last given the keyboard. Where that is not known
+    /// -- none has been touched since it opened -- the last in order, so
+    /// a stack of them still comes down one at a time.
     pub(super) fn topmost_tool_panel(&self) -> Option<ToolPanelKind> {
-        ToolPanelKind::ALL
-            .into_iter()
-            .rev()
-            .find(|&kind| self.tool_panel_is_open(kind))
+        self.tool_window_front
+            .filter(|&kind| self.tool_panel_is_open(kind))
+            .or_else(|| {
+                ToolPanelKind::ALL
+                    .into_iter()
+                    .rev()
+                    .find(|&kind| self.tool_panel_is_open(kind))
+            })
     }
 
     pub(super) fn close_tool_panel(&mut self, kind: ToolPanelKind) {
@@ -1261,7 +1278,10 @@ impl App {
         };
         match self.gamepad.save_calibration(session) {
             Ok(()) => {
-                self.ui.panel = None;
+                // By the same door every other panel leaves: putting the
+                // panel down by hand left the marker standing on a
+                // control that had gone with it.
+                self.close_panel();
                 self.show_osd("Gamepad calibration saved");
             }
             Err(e) => {

--- a/src/video/window/app_panels.rs
+++ b/src/video/window/app_panels.rs
@@ -1173,6 +1173,10 @@ impl App {
             texture_width(texture_scale),
             texture_height(texture_scale)
         );
+        // Paint it now rather than waiting for something to happen: a
+        // tool window opened and left alone showed an unpainted surface
+        // until the next mouse move or key press asked for a frame.
+        window.request_redraw();
         let inner = window.inner_size();
         *self.tool_window_slot(kind) = Some(ToolWindow {
             window,
@@ -1183,6 +1187,15 @@ impl App {
             surface_size: (inner.width.max(1), inner.height.max(1)),
         });
         self.request_redraw();
+    }
+
+    /// The open tool panel a "close this" means, when one is open at all.
+    /// The last in order, so a stack of them comes down one at a time.
+    pub(super) fn topmost_tool_panel(&self) -> Option<ToolPanelKind> {
+        ToolPanelKind::ALL
+            .into_iter()
+            .rev()
+            .find(|&kind| self.tool_panel_is_open(kind))
     }
 
     pub(super) fn close_tool_panel(&mut self, kind: ToolPanelKind) {

--- a/src/video/window/host_input.rs
+++ b/src/video/window/host_input.rs
@@ -59,6 +59,7 @@ pub(super) fn entry_char_for_key(code: KeyCode) -> Option<char> {
 /// step with its captured binding, and a prompt for what to do next.
 pub(super) fn build_calibration_view(
     session: &crate::gamepad::CalibrationSession,
+    pad_has_the_buttons: bool,
 ) -> ui::CalibrationView {
     use crate::gamepad::CalibrationSession;
     let pad_line = if session.backend_missing() {
@@ -80,8 +81,11 @@ pub(super) fn build_calibration_view(
     let status = if session.backend_missing() {
         "Calibration needs a gamepad backend (not available headless).".to_string()
     } else if session.done() {
-        if session.live_test().is_empty() {
-            "All steps captured. Push controls to test, then Save.".to_string()
+        if pad_has_the_buttons {
+            "The pad has the buttons: pick Save or Cancel with it.".to_string()
+        } else if session.live_test().is_empty() {
+            "All steps captured. Push controls to test, hold any button then hit save to finish."
+                .to_string()
         } else {
             format!("Testing: {}", session.live_test())
         }

--- a/src/video/window/host_input.rs
+++ b/src/video/window/host_input.rs
@@ -82,9 +82,9 @@ pub(super) fn build_calibration_view(
         "Calibration needs a gamepad backend (not available headless).".to_string()
     } else if session.done() {
         if pad_has_the_buttons {
-            "The pad has the buttons: pick Save or Cancel with it.".to_string()
+            "All steps captured. Choose Save or Cancel.".to_string()
         } else if session.live_test().is_empty() {
-            "All steps captured. Push controls to test, hold any button then hit save to finish."
+            "All steps captured. Push controls to test, hold any control for Save or Cancel."
                 .to_string()
         } else {
             format!("Testing: {}", session.live_test())
@@ -92,9 +92,9 @@ pub(super) fn build_calibration_view(
     } else if !session.connected() {
         "Waiting for a controller to be connected.".to_string()
     } else if session.can_skip() {
-        "Push and hold the control, or Skip if the pad lacks it.".to_string()
+        "Push the control, or hold any control if the pad lacks it.".to_string()
     } else {
-        "Push and hold the control on the pad.".to_string()
+        "Push the control on the pad.".to_string()
     };
     ui::CalibrationView {
         pad_line,

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -7,6 +7,52 @@
 
 use super::*;
 
+// Where the focus stands on the bar while it is being drawn, and how
+// far through its breath it is. The bar's buttons light for the focus
+// exactly as they light under the pointer, in the focus's own blue.
+thread_local! {
+    static NAV_LIGHT: std::cell::Cell<(Option<BarControl>, f32)> =
+        const { std::cell::Cell::new((None, 0.0)) };
+}
+
+/// Say where the focus is on the bar, for the drawing about to happen.
+pub(in crate::video) fn set_nav_light(target: Option<BarControl>, mix: f32) {
+    NAV_LIGHT.with(|light| light.set((target, mix.clamp(0.0, 1.0))));
+}
+
+/// How lit a control is: all the way under the pointer, and as far as
+/// the breath has come when the focus is on it. Negative says the
+/// focus has it, so one number carries both.
+fn lit(hover: Option<BarControl>, control: BarControl) -> f32 {
+    // The focus is asked first: a control the mouse is resting on
+    // still breathes when the keyboard walks onto it.
+    let focused = NAV_LIGHT.with(|light| {
+        let (target, mix) = light.get();
+        if target == Some(control) {
+            mix
+        } else {
+            0.0
+        }
+    });
+    if focused != 0.0 {
+        return -focused;
+    }
+    // And while the marker is up at all, the keyboard is in charge: a
+    // hand left resting on the mouse would otherwise mark a second
+    // control wherever it happens to sit. Moving the mouse puts the
+    // marker away, and the pointer has the bar back.
+    if NAV_LIGHT.with(|light| light.get().0.is_some()) {
+        return 0.0;
+    }
+    if hover == Some(control) {
+        1.0
+    } else {
+        0.0
+    }
+}
+
+use crate::video::ui::light_face;
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_scale: usize) {
     let status = view.status;
@@ -59,7 +105,7 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
                 frame,
                 scale_rect(rect, texture_scale),
                 idx,
-                hover == Some(BarControl::DriveLoad(idx)),
+                lit(hover, BarControl::DriveLoad(idx)),
                 texture_scale,
             );
         }
@@ -68,7 +114,7 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
                 frame,
                 scale_rect(rect, texture_scale),
                 drive.multi && !drive.bridged,
-                hover == Some(BarControl::DriveSwap(idx)),
+                lit(hover, BarControl::DriveSwap(idx)),
                 texture_scale,
             );
         }
@@ -79,7 +125,7 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
                 // Greyed on a bridged drive: the disk is in a real drive and
                 // comes out by hand, not from here.
                 drive.inserted && !drive.bridged,
-                hover == Some(BarControl::DriveEject(idx)),
+                lit(hover, BarControl::DriveEject(idx)),
                 texture_scale,
             );
         }
@@ -88,7 +134,7 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
         draw_cd_button(
             frame,
             scale_rect(rect, texture_scale),
-            hover == Some(BarControl::CdLoad),
+            lit(hover, BarControl::CdLoad),
             texture_scale,
         );
     }
@@ -97,7 +143,7 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
             frame,
             scale_rect(rect, texture_scale),
             view.media.cd == Some(true),
-            hover == Some(BarControl::CdEject),
+            lit(hover, BarControl::CdEject),
             texture_scale,
         );
     }
@@ -105,14 +151,14 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
         frame,
         scale_rect(joystick_toggle_rect(), texture_scale),
         view.joystick_input_mode,
-        hover == Some(BarControl::Joystick),
+        lit(hover, BarControl::Joystick),
         texture_scale,
     );
     draw_keyboard_button(
         frame,
         scale_rect(keyboard_toggle_rect(), texture_scale),
         view.keyboard_panel_shown,
-        hover == Some(BarControl::Keyboard),
+        lit(hover, BarControl::Keyboard),
         texture_scale,
     );
     if view.control_connected {
@@ -127,62 +173,67 @@ pub(super) fn draw_status_bar(frame: &mut [u8], view: &StatusBarView, texture_sc
             texture_scale,
         );
     }
-    draw_volume_control(frame, status.output_volume_percent, texture_scale);
+    draw_volume_control(
+        frame,
+        status.output_volume_percent,
+        lit(hover, BarControl::Volume),
+        texture_scale,
+    );
     draw_menu_button(
         frame,
         scale_rect(menu_button_rect(), texture_scale),
-        hover == Some(BarControl::Menu),
+        lit(hover, BarControl::Menu),
         texture_scale,
     );
     draw_shot_button(
         frame,
         scale_rect(shot_button_rect(), texture_scale),
-        hover == Some(BarControl::Screenshot),
+        lit(hover, BarControl::Screenshot),
         texture_scale,
     );
     draw_pause_button(
         frame,
         scale_rect(pause_button_rect(), texture_scale),
         view.paused,
-        hover == Some(BarControl::Pause),
+        lit(hover, BarControl::Pause),
         texture_scale,
     );
     draw_power_button(
         frame,
         scale_rect(power_button_rect(), texture_scale),
         view.powered_on,
-        hover == Some(BarControl::Power),
+        lit(hover, BarControl::Power),
         texture_scale,
     );
     draw_reboot_button(
         frame,
         scale_rect(reboot_button_rect(), texture_scale),
-        hover == Some(BarControl::Reboot),
+        lit(hover, BarControl::Reboot),
         texture_scale,
     );
 }
 
 /// Per-drive status feeding the media controls in the status bar.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub(super) struct DriveBar {
+pub(in crate::video) struct DriveBar {
     /// Drive is wired up this session; unconnected drives get no controls.
-    pub(super) connected: bool,
+    pub(in crate::video) connected: bool,
     /// A disk is currently inserted (enables the eject button).
-    pub(super) inserted: bool,
+    pub(in crate::video) inserted: bool,
     /// More than one image is queued for this drive (enables swap).
-    pub(super) multi: bool,
+    pub(in crate::video) multi: bool,
     /// Backed by a real drive on a bridge. The buttons still draw, so the
     /// drive is visibly there and numbered, but there is no media for the
     /// emulator to load, swap, or eject -- the disk is in someone's hand.
-    pub(super) bridged: bool,
+    pub(in crate::video) bridged: bool,
 }
 
 /// Removable-media status for the bar: the floppy drives plus the CD
 /// drive (None on machines without one, Some(disc inserted) otherwise).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct MediaBar {
-    pub(super) drives: [DriveBar; 4],
-    pub(super) cd: Option<bool>,
+pub(in crate::video) struct MediaBar {
+    pub(in crate::video) drives: [DriveBar; 4],
+    pub(in crate::video) cd: Option<bool>,
 }
 
 /// Everything draw_status_bar needs for one frame.
@@ -202,7 +253,7 @@ pub(super) struct StatusBarView {
 
 /// A clickable status-bar control, used for hit-testing and hover.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum BarControl {
+pub(in crate::video) enum BarControl {
     Power,
     Pause,
     Reboot,
@@ -223,7 +274,7 @@ pub(super) enum BarControl {
 /// The fixed controls (volume, screenshot, pause, power, reboot) keep
 /// their own rect functions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct BarLayout {
+pub(in crate::video) struct BarLayout {
     pub(super) drive_load: [Option<Rect>; 4],
     pub(super) drive_swap: [Option<Rect>; 4],
     pub(super) drive_eject: [Option<Rect>; 4],
@@ -235,7 +286,7 @@ pub(super) struct BarLayout {
 /// One or two drives sit in a single full-height row; three or four
 /// stack two-up in shorter rows, so even the worst case (four drives
 /// plus CD) keeps the counter and ends clear of the volume control.
-pub(super) fn bar_layout(media: &MediaBar) -> BarLayout {
+pub(in crate::video) fn bar_layout(media: &MediaBar) -> BarLayout {
     let mut layout = BarLayout {
         drive_load: [None; 4],
         drive_swap: [None; 4],
@@ -311,7 +362,7 @@ pub(super) fn bar_layout(media: &MediaBar) -> BarLayout {
 }
 
 /// Map a cursor position to the status-bar control under it.
-pub(super) fn control_at(pos: (i32, i32), layout: &BarLayout) -> Option<BarControl> {
+pub(in crate::video) fn control_at(pos: (i32, i32), layout: &BarLayout) -> Option<BarControl> {
     for idx in 0..4 {
         if layout.drive_load[idx].is_some_and(|r| r.contains(pos)) {
             return Some(BarControl::DriveLoad(idx));
@@ -356,7 +407,7 @@ pub(super) fn control_at(pos: (i32, i32), layout: &BarLayout) -> Option<BarContr
     None
 }
 
-pub(super) fn status_bar_rect() -> Rect {
+pub(in crate::video) fn status_bar_rect() -> Rect {
     Rect {
         x: 0,
         y: status_bar_top(),
@@ -487,7 +538,7 @@ pub(super) fn menu_button_rect() -> Rect {
     }
 }
 
-pub(super) fn volume_control_hit_rect() -> Rect {
+pub(in crate::video) fn volume_control_hit_rect() -> Rect {
     Rect {
         x: VOLUME_SLIDER_X - 8,
         y: status_bar_top() + STATUS_CONTROL_Y,
@@ -605,11 +656,20 @@ pub(super) fn draw_fdd_track_counter(frame: &mut [u8], track: Option<u8>, textur
     }
 }
 
-pub(super) fn draw_volume_control(frame: &mut [u8], percent: u8, texture_scale: usize) {
+pub(super) fn draw_volume_control(
+    frame: &mut [u8],
+    percent: u8,
+    hovered: f32,
+    texture_scale: usize,
+) {
     let percent = percent.min(100);
     draw_speaker_glyph(frame, texture_scale);
 
     let rect = scale_rect(volume_slider_track_rect(), texture_scale);
+    // The slider lights under the pointer as the buttons beside it do:
+    // it is as clickable as they are, and looked as though it were not.
+    // What lights is the track itself -- the rectangle the hand takes
+    // hold of -- and not the speaker beside it.
     fill_rect(frame, rect, LED_BEZEL_DARK, texture_scale);
     draw_rect_bevel(frame, rect, LED_BEZEL_LIGHT, STATUS_BOTTOM, texture_scale);
 
@@ -641,8 +701,16 @@ pub(super) fn draw_volume_control(frame: &mut [u8], percent: u8, texture_scale: 
         );
     }
 
+    // The knob is what lights: it is the thing the hand takes hold of,
+    // and the track it runs in keeps its own colours. Standing open for
+    // changing it holds the blue steady instead of breathing.
     let knob = scale_rect(volume_slider_knob_rect(percent), texture_scale);
-    fill_rect(frame, knob, BUTTON_FACE, texture_scale);
+    fill_rect(
+        frame,
+        knob,
+        light_face(BUTTON_FACE, BUTTON_FACE_HOVER, hovered),
+        texture_scale,
+    );
     draw_rect_bevel(
         frame,
         knob,
@@ -652,12 +720,8 @@ pub(super) fn draw_volume_control(frame: &mut [u8], percent: u8, texture_scale: 
     );
 }
 
-pub(super) fn draw_button_base(frame: &mut [u8], rect: Rect, hover: bool, texture_scale: usize) {
-    let face = if hover {
-        BUTTON_FACE_HOVER
-    } else {
-        BUTTON_FACE
-    };
+pub(super) fn draw_button_base(frame: &mut [u8], rect: Rect, hover: f32, texture_scale: usize) {
+    let face = light_face(BUTTON_FACE, BUTTON_FACE_HOVER, hover);
     fill_rect(frame, rect, face, texture_scale);
     draw_rect_bevel(
         frame,
@@ -672,7 +736,7 @@ pub(super) fn draw_disk_button(
     frame: &mut [u8],
     rect: Rect,
     drive_idx: usize,
-    hover: bool,
+    hover: f32,
     texture_scale: usize,
 ) {
     draw_button_base(frame, rect, hover, texture_scale);
@@ -685,10 +749,15 @@ pub(super) fn draw_swap_button(
     frame: &mut [u8],
     rect: Rect,
     enabled: bool,
-    hover: bool,
+    hover: f32,
     texture_scale: usize,
 ) {
-    draw_button_base(frame, rect, hover && enabled, texture_scale);
+    draw_button_base(
+        frame,
+        rect,
+        if enabled { hover } else { 0.0 },
+        texture_scale,
+    );
     let color = if enabled {
         BUTTON_GLYPH
     } else {
@@ -759,10 +828,15 @@ pub(super) fn draw_eject_button(
     frame: &mut [u8],
     rect: Rect,
     enabled: bool,
-    hover: bool,
+    hover: f32,
     texture_scale: usize,
 ) {
-    draw_button_base(frame, rect, hover && enabled, texture_scale);
+    draw_button_base(
+        frame,
+        rect,
+        if enabled { hover } else { 0.0 },
+        texture_scale,
+    );
     let color = if enabled {
         BUTTON_GLYPH
     } else {
@@ -797,7 +871,7 @@ pub(super) fn draw_eject_button(
 }
 
 /// CD load/swap button: a compact disc.
-pub(super) fn draw_cd_button(frame: &mut [u8], rect: Rect, hover: bool, texture_scale: usize) {
+pub(super) fn draw_cd_button(frame: &mut [u8], rect: Rect, hover: f32, texture_scale: usize) {
     draw_button_base(frame, rect, hover, texture_scale);
     let s = texture_scale;
     // Disc centre and radii in unscaled button-local pixels.
@@ -829,7 +903,7 @@ pub(super) fn draw_cd_button(frame: &mut [u8], rect: Rect, hover: bool, texture_
 }
 
 /// Menu button: three stacked bars (opens the pop-up menu).
-pub(super) fn draw_menu_button(frame: &mut [u8], rect: Rect, hover: bool, texture_scale: usize) {
+pub(super) fn draw_menu_button(frame: &mut [u8], rect: Rect, hover: f32, texture_scale: usize) {
     draw_button_base(frame, rect, hover, texture_scale);
     let s = texture_scale;
     for row in 0..3 {
@@ -848,7 +922,7 @@ pub(super) fn draw_menu_button(frame: &mut [u8], rect: Rect, hover: bool, textur
 }
 
 /// Screenshot button: a small camera.
-pub(super) fn draw_shot_button(frame: &mut [u8], rect: Rect, hover: bool, texture_scale: usize) {
+pub(super) fn draw_shot_button(frame: &mut [u8], rect: Rect, hover: f32, texture_scale: usize) {
     draw_button_base(frame, rect, hover, texture_scale);
     let s = texture_scale;
     // Viewfinder bump, then the body, then the lens.
@@ -1265,15 +1339,11 @@ pub(super) fn draw_led(
     }
 }
 
-pub(super) fn draw_reboot_button(frame: &mut [u8], rect: Rect, hover: bool, texture_scale: usize) {
+pub(super) fn draw_reboot_button(frame: &mut [u8], rect: Rect, hover: f32, texture_scale: usize) {
     fill_rect(
         frame,
         rect,
-        if hover {
-            BUTTON_FACE_HOVER
-        } else {
-            BUTTON_FACE
-        },
+        light_face(BUTTON_FACE, BUTTON_FACE_HOVER, hover),
         texture_scale,
     );
     draw_rect_bevel(
@@ -1292,17 +1362,13 @@ pub(super) fn draw_power_button(
     frame: &mut [u8],
     rect: Rect,
     powered_on: bool,
-    hover: bool,
+    hover: f32,
     texture_scale: usize,
 ) {
     fill_rect(
         frame,
         rect,
-        if hover {
-            BUTTON_FACE_HOVER
-        } else {
-            BUTTON_FACE
-        },
+        light_face(BUTTON_FACE, BUTTON_FACE_HOVER, hover),
         texture_scale,
     );
     draw_rect_bevel(
@@ -1326,17 +1392,13 @@ pub(super) fn draw_pause_button(
     frame: &mut [u8],
     rect: Rect,
     paused: bool,
-    hover: bool,
+    hover: f32,
     texture_scale: usize,
 ) {
     fill_rect(
         frame,
         rect,
-        if hover {
-            BUTTON_FACE_HOVER
-        } else {
-            BUTTON_FACE
-        },
+        light_face(BUTTON_FACE, BUTTON_FACE_HOVER, hover),
         texture_scale,
     );
     // Paused, the moulding turns over -- the MT-32 panel's pressed
@@ -1370,7 +1432,7 @@ pub(super) fn draw_joystick_button(
     frame: &mut [u8],
     rect: Rect,
     mode: JoystickInputMode,
-    hover: bool,
+    hover: f32,
     texture_scale: usize,
 ) {
     draw_button_base(frame, rect, hover, texture_scale);
@@ -1416,7 +1478,7 @@ pub(super) fn draw_keyboard_button(
     frame: &mut [u8],
     rect: Rect,
     shown: bool,
-    hover: bool,
+    hover: f32,
     texture_scale: usize,
 ) {
     draw_button_base(frame, rect, hover, texture_scale);

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -13,10 +13,15 @@ use super::*;
 thread_local! {
     static NAV_LIGHT: std::cell::Cell<(Option<BarControl>, f32)> =
         const { std::cell::Cell::new((None, 0.0)) };
+    /// Whether the marker is up on a panel rather than here. The
+    /// keyboard is in charge either way, so the pointer lights nothing
+    /// in the bar while it is.
+    static NAV_ELSEWHERE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Say where the focus is on the bar, for the drawing about to happen.
-pub(in crate::video) fn set_nav_light(target: Option<BarControl>, mix: f32) {
+pub(in crate::video) fn set_nav_light(target: Option<BarControl>, mix: f32, elsewhere: bool) {
+    NAV_ELSEWHERE.with(|flag| flag.set(elsewhere));
     NAV_LIGHT.with(|light| light.set((target, mix.clamp(0.0, 1.0))));
 }
 
@@ -41,7 +46,7 @@ fn lit(hover: Option<BarControl>, control: BarControl) -> f32 {
     // hand left resting on the mouse would otherwise mark a second
     // control wherever it happens to sit. Moving the mouse puts the
     // marker away, and the pointer has the bar back.
-    if NAV_LIGHT.with(|light| light.get().0.is_some()) {
+    if NAV_LIGHT.with(|light| light.get().0.is_some()) || NAV_ELSEWHERE.with(std::cell::Cell::get) {
         return 0.0;
     }
     if hover == Some(control) {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -588,10 +588,53 @@ fn a_handed_over_calibration_puts_the_marker_on_cancel() {
         Some(NavTarget::Ui(UiControl::CalCancel)),
         "and the marker starts on Cancel"
     );
+    // The control that completed the hold is very often Fire. Arriving
+    // with it down must not read as a press, or Cancel is chosen the
+    // instant the pad is handed the buttons.
+    let held = crate::gamepad::JoystickState {
+        fire: true,
+        ..Default::default()
+    };
+    app.seed_pad_nav(held);
+    app.pad_drives_interface(held, None);
+    assert_eq!(
+        app.nav.focus(),
+        Some(NavTarget::Ui(UiControl::CalCancel)),
+        "a control already down does not press on arrival"
+    );
+    assert!(app.ui.panel.is_some(), "and the panel is still up");
     // Save is a place to stand only once every step is captured, which
     // it is here; Skip never is once there is nothing left to skip.
     assert!(crate::video::ui::control_live(&app.ui, UiControl::CalSave));
     assert!(!crate::video::ui::control_live(&app.ui, UiControl::CalSkip));
+}
+
+/// Left off the R/W cell of a disk nobody has ticked returns to the row,
+/// there being no attach cell in between to return to.
+#[test]
+fn left_off_an_unticked_disks_cell_returns_to_its_row() {
+    use crate::bus::PortDevice;
+    use crate::video::launcher::LauncherTab;
+    use crate::video::nav::{Dir, NavTarget};
+    use crate::video::ui::UiControl;
+
+    let mut app = test_app();
+    app.open_launcher();
+    let state = app.launcher_state_mut().expect("the launcher is open");
+    state.tab = LauncherTab::HostDisk;
+    state.setup.fake_host_disks(4);
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(0, PortDevice::Mouse);
+    app.nav
+        .show(Some(NavTarget::Ui(UiControl::LauncherHostDiskWritable(0))));
+    app.nav_move(Dir::Left, None);
+    assert_eq!(
+        app.nav.focus(),
+        Some(NavTarget::Ui(UiControl::LauncherHostDiskSelect(0))),
+        "and not out of the page altogether"
+    );
 }
 
 #[test]

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -820,6 +820,21 @@ fn the_game_page_walks_from_the_button_that_opens_it() {
         at(UiControl::LauncherLibraryPick(5)),
         "and the marker is on the row it chose"
     );
+    // The same step by the other hand: a pad walks the list through the
+    // focus, which is where the walk lives, rather than through the
+    // keyboard's own handling of it.
+    walk(&mut app, Dir::Down);
+    assert_eq!(
+        app.launcher_state().map(|state| state.library.selected),
+        Some(6),
+        "the list moves for a pad too"
+    );
+    assert_eq!(app.nav.focus(), at(UiControl::LauncherLibraryPick(6)));
+    walk(&mut app, Dir::Up);
+    assert_eq!(
+        app.launcher_state().map(|state| state.library.selected),
+        Some(5)
+    );
     // Marking a game is done from its tick, and hands the focus back to
     // the game: what was being looked at is the row, not the tick.
     assert_eq!(

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -628,7 +628,7 @@ fn input_mapping_panel_rebinds_only_on_save() {
     // only; the live map is untouched until Save.
     app.activate_ui_control(UiControl::RemapBind(fire_index));
     assert!(
-        app.ui_handle_key(KeyCode::KeyQ, None),
+        app.ui_handle_key(KeyCode::KeyQ, None, None),
         "capture eats the key"
     );
     assert_eq!(
@@ -675,10 +675,10 @@ fn input_mapping_panel_discards_edits_when_closed() {
     let before = app.keymap.clone();
     app.open_input_mapping();
     app.activate_ui_control(UiControl::RemapBind(0));
-    app.ui_handle_key(KeyCode::KeyP, None);
+    app.ui_handle_key(KeyCode::KeyP, None, None);
     // Escape while a row is armed cancels the binding, not the panel.
     app.activate_ui_control(UiControl::RemapBind(0));
-    assert!(app.ui_handle_key(KeyCode::Escape, None));
+    assert!(app.ui_handle_key(KeyCode::Escape, None, None));
     assert!(app.ui.panel.is_some(), "Escape cancelled the capture only");
 
     app.activate_ui_control(UiControl::PanelClose);
@@ -742,6 +742,175 @@ fn pick_menu(app: &mut super::App, path: &[&str]) {
     }
 }
 
+/// The game page's walk, through the window's own rules rather than
+/// the geometry under them: a row is as wide as its box and its tick is
+/// drawn inside it, so every step across this page is one the window
+/// names, and each of them has been got wrong at least once.
+#[test]
+#[cfg(feature = "game-library")]
+fn the_game_page_walks_from_the_button_that_opens_it() {
+    use crate::video::launcher::LauncherTab;
+    use crate::video::nav::{Dir, NavTarget};
+    use crate::video::ui::UiControl;
+
+    let mut app = test_app();
+    app.open_launcher();
+    let state = app.launcher_state_mut().expect("the launcher is open");
+    state.tab = LauncherTab::WhdloadLibrary;
+    state.library.games =
+        crate::gamelib::Library::of_titles((0..40).map(|i| format!("Game {i:03}")));
+    for i in 0..3 {
+        let title = format!("Game {i:03}");
+        state.library.db.toggle_favourite(&title, &title);
+    }
+    app.nav.show(Some(NavTarget::Ui(UiControl::LauncherTab(
+        LauncherTab::WhdloadLibrary,
+    ))));
+    fn walk(app: &mut super::App, dir: Dir) -> Option<NavTarget> {
+        app.nav_move(dir, None);
+        app.nav.focus()
+    }
+    // Up and down inside a list are the list's own, so they go in by
+    // the same door a key does rather than straight to the focus.
+    fn press(app: &mut super::App, code: winit::keyboard::KeyCode) {
+        app.ui_handle_key(code, None, None);
+    }
+    let at = |control| Some(NavTarget::Ui(control));
+
+    // Right off the button opens the page on its letters, not on the
+    // row of sibling pages every other page opens on: this page is a
+    // list, and the letters are how a list is got about.
+    assert_eq!(
+        walk(&mut app, Dir::Right),
+        at(UiControl::LauncherLibraryJump(0)),
+        "right off the button lands on the first letter"
+    );
+    assert_eq!(
+        walk(&mut app, Dir::Down),
+        at(UiControl::LauncherLibraryPick(0))
+    );
+    // Across a row: its tick, and back off the tick to the row.
+    assert_eq!(
+        walk(&mut app, Dir::Right),
+        at(UiControl::LauncherLibraryFavourite(0))
+    );
+    assert_eq!(
+        walk(&mut app, Dir::Left),
+        at(UiControl::LauncherLibraryPick(0))
+    );
+    // And left off the row goes back up to the letters.
+    assert_eq!(
+        walk(&mut app, Dir::Left),
+        at(UiControl::LauncherLibraryJump(0))
+    );
+    // Down inside the list moves the list's own selection, and the
+    // marker goes with it: one chosen row, never two.
+    app.nav
+        .show(Some(NavTarget::Ui(UiControl::LauncherLibraryPick(0))));
+    for _ in 0..5 {
+        press(&mut app, winit::keyboard::KeyCode::ArrowDown);
+    }
+    assert_eq!(
+        app.launcher_state().map(|state| state.library.selected),
+        Some(5),
+        "the list scrolled"
+    );
+    assert_eq!(
+        app.nav.focus(),
+        at(UiControl::LauncherLibraryPick(5)),
+        "and the marker is on the row it chose"
+    );
+    // Marking a game is done from its tick, and hands the focus back to
+    // the game: what was being looked at is the row, not the tick.
+    assert_eq!(
+        walk(&mut app, Dir::Right),
+        at(UiControl::LauncherLibraryFavourite(5))
+    );
+    app.nav_press(None);
+    assert_eq!(
+        app.nav.focus(),
+        at(UiControl::LauncherLibraryPick(5)),
+        "marking a favourite leaves the tick"
+    );
+    assert!(
+        app.launcher_state()
+            .is_some_and(|state| state.library.db.favourite_count() == 4),
+        "and marked it"
+    );
+    // Right off a tick leaves the list for the buttons under it, and up
+    // off those comes back to the list rather than to the scroll arrow
+    // in the corner of the box.
+    app.nav
+        .show(Some(NavTarget::Ui(UiControl::LauncherLibraryFavourite(0))));
+    assert_eq!(
+        walk(&mut app, Dir::Right),
+        at(UiControl::LauncherLibraryRefresh)
+    );
+    assert!(matches!(
+        walk(&mut app, Dir::Up),
+        Some(NavTarget::Ui(UiControl::LauncherLibraryPick(_)))
+    ));
+    // Under the buttons are the favourites, which is the only way down
+    // to them, and right off one of those is Run.
+    app.nav
+        .show(Some(NavTarget::Ui(UiControl::LauncherLibraryRefresh)));
+    assert_eq!(
+        walk(&mut app, Dir::Down),
+        at(UiControl::LauncherLibraryFavouritePick(0))
+    );
+    assert_eq!(
+        walk(&mut app, Dir::Right),
+        at(UiControl::LauncherLibraryFavouriteRemove(0))
+    );
+    assert_eq!(walk(&mut app, Dir::Right), at(UiControl::LauncherRun));
+}
+
+/// A list longer than its box scrolls under the focus, and the focus
+/// keeps the column it was walking down.
+#[test]
+fn the_host_disk_list_scrolls_under_the_focus() {
+    use crate::video::launcher::LauncherTab;
+    use crate::video::nav::{Dir, NavTarget};
+    use crate::video::ui::{UiControl, HOST_DISK_VISIBLE_ROWS};
+
+    let mut app = test_app();
+    app.open_launcher();
+    let state = app.launcher_state_mut().expect("the launcher is open");
+    state.tab = LauncherTab::HostDisk;
+    state.setup.fake_host_disks(20);
+    let last = HOST_DISK_VISIBLE_ROWS - 1;
+    app.nav
+        .show(Some(NavTarget::Ui(UiControl::LauncherHostDiskSelect(last))));
+    // Off the last row it can show: the list moves, not the focus out
+    // of it.
+    app.nav_move(Dir::Down, None);
+    assert_eq!(
+        app.nav.focus(),
+        Some(NavTarget::Ui(UiControl::LauncherHostDiskSelect(last + 1))),
+        "the next disk down"
+    );
+    assert_eq!(
+        app.launcher_state()
+            .map(|state| state.setup.host_disk_scroll()),
+        Some(1),
+        "and the list scrolled to show it"
+    );
+    // Back up at the top of the window, the same in reverse.
+    for _ in 0..HOST_DISK_VISIBLE_ROWS {
+        app.nav_move(Dir::Up, None);
+    }
+    assert_eq!(
+        app.nav.focus(),
+        Some(NavTarget::Ui(UiControl::LauncherHostDiskSelect(0))),
+    );
+    assert_eq!(
+        app.launcher_state()
+            .map(|state| state.setup.host_disk_scroll()),
+        Some(0),
+        "and the list came back with it"
+    );
+}
+
 #[test]
 fn opening_the_menu_builds_it_and_closing_puts_it_away() {
     let mut app = test_app();
@@ -766,7 +935,14 @@ fn opening_the_menu_builds_it_and_closing_puts_it_away() {
     assert!(!app.ui.menu_open && app.ui.menu_rows.is_empty());
     app.activate_bar_control(super::BarControl::Menu);
     assert_eq!(app.ui.menu_nav.depth(), 0);
-    assert_eq!(app.ui.menu_nav.cursor(), None);
+    // A fresh open starts at the foot of the list, where the menu hangs
+    // from: a hand on the keyboard has somewhere to begin, and walking
+    // on down leaves the menu for the bar.
+    assert_eq!(
+        app.ui.menu_nav.cursor(),
+        Some(app.ui.menu_rows.len() - 1),
+        "the last row is chosen, not the one left over from before"
+    );
 }
 
 #[test]
@@ -5129,7 +5305,7 @@ fn modal_panel_swallows_amiga_key_presses() {
     app.ui.panel = Some(Panel::About);
 
     // Escape closes the panel.
-    assert!(app.ui_handle_key(KeyCode::Escape, None));
+    assert!(app.ui_handle_key(KeyCode::Escape, None, None));
     assert!(app.ui.panel.is_none());
 
     // Hex entry arrives through the debugger's own tool window: digits
@@ -5173,11 +5349,11 @@ fn tool_windows_are_not_modal_over_the_main_window() {
         "tool panels must not gate main-window Amiga input"
     );
     assert!(
-        !app.ui_handle_key(KeyCode::KeyS, None),
+        !app.ui_handle_key(KeyCode::KeyS, None, None),
         "a main-window key is not claimed by a tool panel"
     );
     assert!(
-        !app.ui_handle_key(KeyCode::Escape, None),
+        !app.ui_handle_key(KeyCode::Escape, None, None),
         "a main-window Escape reaches the Amiga"
     );
     assert!(app.debugger_panel.is_some());
@@ -6731,7 +6907,7 @@ fn drop_chooser_escape_cancels_without_insert() {
     app.handle_dropped_files(vec![PathBuf::from("disk.adf")]);
     assert!(matches!(app.ui.panel, Some(Panel::DropChooser(_))));
 
-    assert!(app.ui_handle_key(KeyCode::Escape, None));
+    assert!(app.ui_handle_key(KeyCode::Escape, None, None));
     assert!(app.ui.panel.is_none());
     assert!(!app.emu.bus().floppy.disk_inserted(0));
     assert!(!app.emu.bus().floppy.disk_inserted(1));
@@ -6750,7 +6926,7 @@ fn drop_chooser_digit_selects_listed_drive() {
     app.handle_dropped_files(vec![adf.clone()]);
     assert!(matches!(app.ui.panel, Some(Panel::DropChooser(_))));
 
-    assert!(app.ui_handle_key(KeyCode::Digit2, None));
+    assert!(app.ui_handle_key(KeyCode::Digit2, None, None));
     assert!(app.ui.panel.is_none());
     assert!(app.emu.bus().floppy.disk_inserted(2));
     std::fs::remove_file(&adf).unwrap();

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -574,8 +574,22 @@ fn a_held_control_hands_the_calibration_panel_to_the_pad() {
     app.ui.panel = Some(Panel::Calibration(
         crate::gamepad::CalibrationSession::finished_for_test(),
     ));
-    // Nothing held: the panel keeps the pad, and the buttons are not
-    // being walked.
+    // Held from the moment the last step was captured -- a binding that
+    // reads active at rest looks exactly like this -- hands nothing
+    // over, however long it lasts: the pad has not been seen at rest.
+    if let Some(Panel::Calibration(session)) = app.ui.panel.as_mut() {
+        session.hold_for_test("Fire");
+    }
+    app.calibration_pad_drives();
+    app.cal_pad_hold = Some(std::time::Instant::now() - super::CAL_PAD_HOLD);
+    assert!(
+        app.calibration_pad_drives().is_none(),
+        "a control held since the end is not a hold anyone made"
+    );
+    // At rest, and the panel keeps the pad.
+    if let Some(Panel::Calibration(session)) = app.ui.panel.as_mut() {
+        session.hold_for_test("");
+    }
     assert!(app.calibration_pad_drives().is_none());
     // Held, but not for long enough yet.
     if let Some(Panel::Calibration(session)) = app.ui.panel.as_mut() {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -427,6 +427,7 @@ fn host_routing_assigns_sources_by_device_and_mode() {
         HostRouting {
             mouse,
             gamepad,
+            gamepad_mouse: None,
             keyboard,
             keyboard2,
         }
@@ -478,6 +479,48 @@ fn host_routing_assigns_sources_by_device_and_mode() {
     app.joystick_input_mode = JoystickInputMode::Keyboard;
     assert_eq!(app.host_routing(), routing(Some(0), None, None, None));
     assert!(!app.keyboard_mapping_active(0));
+}
+
+/// A gamepad spent on the mouse is not also a joystick, and the mode it
+/// displaces is only displaced while it is chosen.
+#[test]
+fn a_gamepad_mouse_takes_the_pad_off_the_joystick() {
+    use crate::bus::PortDevice;
+    use crate::video::window::{host_routing_for, HostRouting};
+
+    let routing = |devices, mode| host_routing_for(devices, mode);
+    let devices = [PortDevice::GamepadMouse, PortDevice::Joystick];
+    // The pad drives the mouse in port 1; port 2's joystick falls to the
+    // keyboard rather than being left with nothing.
+    assert_eq!(
+        routing(devices, JoystickInputMode::Gamepad),
+        HostRouting {
+            mouse: Some(0),
+            gamepad: None,
+            gamepad_mouse: Some(0),
+            keyboard: Some(1),
+            keyboard2: None,
+        }
+    );
+    // The mode itself is untouched: it is what the ports go back to the
+    // moment the mouse stops being a gamepad's.
+    assert_eq!(
+        routing(devices, JoystickInputMode::Keyboard),
+        routing(devices, JoystickInputMode::Gamepad),
+        "with the pad on the mouse, both modes leave the joystick to the keyboard"
+    );
+    let plain = [PortDevice::Mouse, PortDevice::Joystick];
+    assert_eq!(
+        routing(plain, JoystickInputMode::Gamepad),
+        HostRouting {
+            mouse: Some(0),
+            gamepad: Some(1),
+            gamepad_mouse: None,
+            keyboard: None,
+            keyboard2: None,
+        },
+        "and switching the mouse back hands the pad its joystick again"
+    );
 }
 
 #[test]

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -564,48 +564,32 @@ fn a_gamepad_mouse_moves_the_mouse_it_is_plugged_into() {
     assert!(!app.emu.bus().input.ports[0].fire);
 }
 
-/// A finished calibration hands its own buttons to the pad, but only
-/// after a hold: a press still means "test this control".
+/// A finished calibration hands its own buttons to the pad once the
+/// session says a hold has asked for them, and lands on Cancel.
 #[test]
-fn a_held_control_hands_the_calibration_panel_to_the_pad() {
+fn a_handed_over_calibration_puts_the_marker_on_cancel() {
+    use crate::video::nav::NavTarget;
     use crate::video::ui::{Panel, UiControl};
 
     let mut app = test_app();
     app.ui.panel = Some(Panel::Calibration(
         crate::gamepad::CalibrationSession::finished_for_test(),
     ));
-    // Held from the moment the last step was captured -- a binding that
-    // reads active at rest looks exactly like this -- hands nothing
-    // over, however long it lasts: the pad has not been seen at rest.
-    if let Some(Panel::Calibration(session)) = app.ui.panel.as_mut() {
-        session.hold_for_test("Fire");
-    }
-    app.calibration_pad_drives();
-    app.cal_pad_hold = Some(std::time::Instant::now() - super::CAL_PAD_HOLD);
     assert!(
         app.calibration_pad_drives().is_none(),
-        "a control held since the end is not a hold anyone made"
+        "the panel keeps the pad while its bindings are being tested"
     );
-    // At rest, and the panel keeps the pad.
     if let Some(Panel::Calibration(session)) = app.ui.panel.as_mut() {
-        session.hold_for_test("");
+        session.hand_over_for_test();
     }
-    assert!(app.calibration_pad_drives().is_none());
-    // Held, but not for long enough yet.
-    if let Some(Panel::Calibration(session)) = app.ui.panel.as_mut() {
-        session.hold_for_test("Fire");
-    }
-    assert!(app.calibration_pad_drives().is_none(), "not yet");
-    // Once the hold has run its course the pad has the buttons, and
-    // keeps them: letting go is how Save gets pressed.
-    app.cal_pad_hold = Some(std::time::Instant::now() - super::CAL_PAD_HOLD);
     assert!(app.calibration_pad_drives().is_some(), "handed over");
-    if let Some(Panel::Calibration(session)) = app.ui.panel.as_mut() {
-        session.hold_for_test("");
-    }
-    assert!(app.calibration_pad_drives().is_some(), "and keeps them");
+    assert_eq!(
+        app.nav.focus(),
+        Some(NavTarget::Ui(UiControl::CalCancel)),
+        "and the marker starts on Cancel"
+    );
     // Save is a place to stand only once every step is captured, which
-    // it is here.
+    // it is here; Skip never is once there is nothing left to skip.
     assert!(crate::video::ui::control_live(&app.ui, UiControl::CalSave));
     assert!(!crate::video::ui::control_live(&app.ui, UiControl::CalSkip));
 }

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -564,6 +564,38 @@ fn a_gamepad_mouse_moves_the_mouse_it_is_plugged_into() {
     assert!(!app.emu.bus().input.ports[0].fire);
 }
 
+/// A finished calibration hands its own buttons to the pad, but only
+/// after a hold: a press still means "test this control".
+#[test]
+fn a_held_control_hands_the_calibration_panel_to_the_pad() {
+    use crate::video::ui::{Panel, UiControl};
+
+    let mut app = test_app();
+    app.ui.panel = Some(Panel::Calibration(
+        crate::gamepad::CalibrationSession::finished_for_test(),
+    ));
+    // Nothing held: the panel keeps the pad, and the buttons are not
+    // being walked.
+    assert!(app.calibration_pad_drives().is_none());
+    // Held, but not for long enough yet.
+    if let Some(Panel::Calibration(session)) = app.ui.panel.as_mut() {
+        session.hold_for_test("Fire");
+    }
+    assert!(app.calibration_pad_drives().is_none(), "not yet");
+    // Once the hold has run its course the pad has the buttons, and
+    // keeps them: letting go is how Save gets pressed.
+    app.cal_pad_hold = Some(std::time::Instant::now() - super::CAL_PAD_HOLD);
+    assert!(app.calibration_pad_drives().is_some(), "handed over");
+    if let Some(Panel::Calibration(session)) = app.ui.panel.as_mut() {
+        session.hold_for_test("");
+    }
+    assert!(app.calibration_pad_drives().is_some(), "and keeps them");
+    // Save is a place to stand only once every step is captured, which
+    // it is here.
+    assert!(crate::video::ui::control_live(&app.ui, UiControl::CalSave));
+    assert!(!crate::video::ui::control_live(&app.ui, UiControl::CalSkip));
+}
+
 #[test]
 fn numpad_mapping_stands_in_for_the_missing_gamepad() {
     use crate::bus::PortDevice;

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -523,6 +523,47 @@ fn a_gamepad_mouse_takes_the_pad_off_the_joystick() {
     );
 }
 
+/// The pad moves the mouse the machine already has: the counters move,
+/// and its buttons are the mouse's.
+#[test]
+fn a_gamepad_mouse_moves_the_mouse_it_is_plugged_into() {
+    use crate::bus::PortDevice;
+    use crate::gamepad::{JoystickState, PadState};
+
+    let mut app = test_app();
+    app.emu
+        .bus_mut()
+        .input
+        .set_port_device(0, PortDevice::GamepadMouse);
+    let counters = |app: &super::App| {
+        let p = &app.emu.bus().input.ports[0];
+        (p.counter_x, p.counter_y)
+    };
+    let before = counters(&app);
+
+    // A stick held right, for two passes: the first only starts the
+    // clock, and the second is the one that has a span to move over.
+    let pad = PadState {
+        joystick: JoystickState {
+            fire: true,
+            ..Default::default()
+        },
+        stick: (1.0, 0.0),
+        ..Default::default()
+    };
+    app.apply_pad_mouse_state(0, pad);
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    app.apply_pad_mouse_state(0, pad);
+    let after = counters(&app);
+    assert_ne!(after.0, before.0, "the pointer moved across");
+    assert_eq!(after.1, before.1, "and not down");
+    assert!(app.emu.bus().input.ports[0].fire, "fire is the left button");
+
+    // Let go, and the button goes with it.
+    app.release_pad_mouse(0);
+    assert!(!app.emu.bus().input.ports[0].fire);
+}
+
 #[test]
 fn numpad_mapping_stands_in_for_the_missing_gamepad() {
     use crate::bus::PortDevice;


### PR DESCRIPTION
## Keyboard and controller navigation, and a mouse a gamepad can move

Everything the mouse can reach — the launcher, the menu, the status bar, the overlay panels — can now be reached with the arrow keys or a controller. Port 1 also gains a fifth device: a mouse the gamepad moves.

### Navigation

`src/video/nav.rs` holds the model and knows nothing of the window. It derives its map of places to stand by sampling the same hit-test the pointer uses, so layout has one source of truth and nothing is registered twice. `window/app_nav.rs` holds the App side: reading the surfaces, spending a step on an open stepper or a list that scrolls, and naming the few steps geometry cannot answer.

- Sideways means along the row; down means the row below and whatever in it is nearest across the screen. The category column and the page beside it are two tracks that stay separate all the way down. Edges hold.
- A control under the focus takes the same blue a chosen button has and breathes; tick boxes and cover art take green on the edge; a list shows its own chosen row. While the marker is up the pointer lights nothing.
- Lists are walked with up and down, which move the list's own selection and scroll it — one chosen row, never two. Right steps across to a row's tick and then out of the list.
- What cannot be pressed is not a place to stand: the drawing greys such controls and refuses them any light, so a marker on one would simply disappear.
- A pad walks all of it with its d-pad, fire and second button. The Menu button from #503 is the way in from a running machine.

The debugger, frame analyzer and console are deliberately not walked, but `Esc` closes the focused one and the pad's second button closes the top one.

### Gamepad Mouse

`[input] port1 = "gamepad-mouse"` is the same quadrature mouse the machine always sees, moved by a gamepad as well as by the host's own — one mouse with two hands on it, not two mice. Both go through the same accumulator, so the mouse-sensitivity setting scales the pad too, and the Amiga cannot tell which moved it.

A stick is proportional where the pad has one, squared so the slow end of the throw has room to be slow in; a d-pad stands in with a hold that gathers speed. Motion is integrated against the clock, not the loop. Fire is the left button, the second button the right.

One pad cannot be a mouse and a joystick at once, so while this device is chosen no joystick port hears from it — whichever port it would have driven falls to the keyboard. That is a routing decision, not a change of mode: switching the port back restores whatever the joystick input was set to. Port 1 only, refused elsewhere with a plain message.

### Calibration

A control is bound by being **pressed** — it must go from inactive to active, so a control already down when a step begins can never be captured by a step that is not asking for it. Which press it was is known when the control comes back up, because until then it could be a **hold**, and a hold skips the step for a pad that lacks that control. The same gesture ends the testing phase and hands the panel's Save and Cancel to the pad.

This fixes calibrations that named the same code for Up, Down and Fire: capture took the first pressed button in code order, so a pad reporting anything as down at rest was captured by step after step.

### Also

- `PortDevice::GamepadMouse` is last in the enum so existing save states keep their variant positions; `STATE_VERSION` bumped to 61 as the four appended variants before it were.
- `nav_items()` skips the status bar when it is hidden, which matters for every publisher-kit player build.

### Testing

2,774 unit tests pass; clippy and `cargo fmt --check` clean on the workspace and on `crates/copperline-player`. The walk is covered twice over: the geometry against maps built from real launcher pages, and the steps the window names on top of it against a real App driven by real key presses. 27 files, +4,652/−541.


https://github.com/user-attachments/assets/2171305c-2522-42f1-ad0a-5e052e91f0b1

