### PR TITLE
Fix/coppersynth nvram name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,8 +601,8 @@ dependencies = [
 
 [[package]]
 name = "coppersynth"
-version = "0.10.0"
-source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=823fb7cf50cf08fbac2b1cf9d5fc648240c95886#823fb7cf50cf08fbac2b1cf9d5fc648240c95886"
+version = "0.14.0"
+source = "git+https://github.com/CopperlineHQ/Coppersynth?rev=38873e283aa9f2e6d2574d6c71e9a2cf9d0b42a2#38873e283aa9f2e6d2574d6c71e9a2cf9d0b42a2"
 dependencies = [
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ m68k = { version = "0.10", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.
-coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "823fb7cf50cf08fbac2b1cf9d5fc648240c95886", optional = true }
+coppersynth = { git = "https://github.com/CopperlineHQ/Coppersynth", rev = "38873e283aa9f2e6d2574d6c71e9a2cf9d0b42a2", optional = true }
 pixels = { version = "0.17", optional = true }
 winit = { version = "0.30", optional = true }
 anyhow = "1"

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -2,8 +2,8 @@
     {
         "type": "git",
         "url": "https://github.com/copperlinehq/coppersynth",
-        "commit": "823fb7cf50cf08fbac2b1cf9d5fc648240c95886",
-        "dest": "flatpak-cargo/git/coppersynth-823fb7c"
+        "commit": "38873e283aa9f2e6d2574d6c71e9a2cf9d0b42a2",
+        "dest": "flatpak-cargo/git/coppersynth-38873e2"
     },
     {
         "type": "git",
@@ -826,12 +826,12 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-823fb7c/.\" \"cargo/vendor/coppersynth\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/coppersynth-38873e2/.\" \"cargo/vendor/coppersynth\""
         ]
     },
     {
         "type": "inline",
-        "contents": "[package]\nname = \"coppersynth\"\nversion = \"0.10.0\"\nauthors = [\"Lee Hobson\"]\nedition = \"2021\"\nlicense = \"MIT\"\ndescription = \"Copperline's General MIDI sound module: a Sound Canvas-flavoured SoundFont synth with an MT-32 translation layer and front panel model\"\nrepository = \"https://github.com/CopperlineHQ/Coppersynth\"\npublish = false\n\n[dependencies.zip]\nversion = \"8\"\ndefault-features = false\nfeatures = [\"deflate\"]\n\n[build-dependencies]\nzip = \"8\"\n",
+        "contents": "[package]\nname = \"coppersynth\"\nversion = \"0.14.0\"\nauthors = [\"Lee Hobson\"]\nedition = \"2021\"\nlicense = \"MIT\"\ndescription = \"Copperline's General MIDI sound module: a Sound Canvas-flavoured SoundFont synth with an MT-32 translation layer and front panel model\"\nrepository = \"https://github.com/CopperlineHQ/Coppersynth\"\npublish = false\n\n[dependencies.zip]\nversion = \"8\"\ndefault-features = false\nfeatures = [\"deflate\"]\n\n[build-dependencies]\nzip = \"8\"\n",
         "dest": "cargo/vendor/coppersynth",
         "dest-filename": "Cargo.toml"
     },
@@ -6989,7 +6989,7 @@
     },
     {
         "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"823fb7cf50cf08fbac2b1cf9d5fc648240c95886\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"38873e283aa9f2e6d2574d6c71e9a2cf9d0b42a2\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -457,7 +457,7 @@ pub fn akiko_nvram_file() -> PathBuf {
 /// Coppersynth's battery-backed memory, kept with the machines' other
 /// batteries.
 pub fn coppersynth_nvram_file() -> PathBuf {
-    battery_ram("copperline.nvram")
+    battery_ram("coppersynth.nvram")
 }
 
 // --- where a dialog opens ------------------------------------------------


### PR DESCRIPTION
## The synth catches up to 0.14.0, and its battery gets the correct name

Two small things, both about the Coppersynth side of the wiring.

### The battery file is named after the unit

`coppersynth_nvram_file()` wrote `copperline.nvram` — the emulator's name on
the synth's memory, sitting in `nvram/` beside `battmem.nvram` and
`cd32-nvram.bin`, both of which are named for the hardware whose battery they
hold. It is `coppersynth.nvram` now. 

### The pin moves to Coppersynth 0.14.0

`823fb7cf` → `38873e28`. What comes with it:

- **MIDI values are bytes.** The synth's public API took channel, key,
  velocity and controller as `i32` and range-checked them at every entry.
  They are `u8` now, so the type carries the range. No call site here needed
  changing.
- **The reverb comes down.** Its return level drops two and a half decibels;
  the room was too loud over the band.
- **Attenuation is ranged where the specification ranges it** — on the total
  of generator, modulator and NRPN, composed first and checked once, rather
  than on values a preset stores as offsets. A bank within its rights renders
  the same samples it always did.
- **A volume envelope falls the full 96 dB** the specification asks for,
  where it had been falling 80.1. Every note held through its decay had been
  sitting a little louder than its bank asked for.

### Checks

Release build, full test suite, `cargo fmt --check` across the root and the
three standalone workspaces, `cargo clippy --all-targets --all-features
--locked -- -D warnings`, and `cargo tree --locked` on all five committed
lockfiles.