### PR TITLE
floppy: keep DMA pending while the mechanism is idle

### DIFF
--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -338,6 +338,13 @@ The synthesized drive sounds ([](../guide/configuration)) are driven by
 this model's real state transitions -- motor spin-up, seeks, the
 empty-drive poll click.
 
+Disk DMA against a mechanism that cannot deliver cells -- no media in the
+drive, or the motor line off -- arms normally and then pends: Paula has no
+readiness interlock and waits for data forever, so the guest's own timeout
+governs. A media insert or motor start mid-transfer brings the pending
+transfer to life exactly as on hardware; nothing completes early (the
+turbo burst also refuses drives that are not ready).
+
 ## Known AGA/ECS gaps and non-goals
 
 Most ECS and AGA behaviour is implemented (the register notes above and

--- a/src/floppy/mod.rs
+++ b/src/floppy/mod.rs
@@ -1378,7 +1378,10 @@ impl FloppyController {
         is_selected: bool,
         chip_ram: &mut [u8],
     ) -> bool {
-        if !self.drives[idx].motor_on || self.drives[idx].cached.is_empty() {
+        // A bridged bay retains a filler track while its physical drive is
+        // empty. No media still means no cells reach Paula, regardless of
+        // what is cached for the bridge transport.
+        if !self.drive_can_transfer_cells(idx) {
             return false;
         }
         // Free-running comparator mode comes from the mirrored ADKCON; an
@@ -1520,7 +1523,9 @@ impl FloppyController {
         is_selected: bool,
         chip_ram: &mut [u8],
     ) -> bool {
-        if !self.drives[idx].motor_on || self.drives[idx].cached.is_empty() {
+        // Match the read path: a bridge filler track must not make an empty
+        // physical drive accept a write.
+        if !self.drive_can_transfer_cells(idx) {
             return false;
         }
         let Some(mut dma) = self.dma.take() else {
@@ -1539,6 +1544,14 @@ impl FloppyController {
                 break;
             }
             self.drives[idx].rotation_acc_cck -= word_cck;
+            if dma.write_start_pending {
+                // A start position sampled while the mechanism was idle is
+                // not meaningful (inserting media resets rotation). Latch
+                // the actual head position when the first word is consumed.
+                dma.write_start_pending = false;
+                dma.write_start_word = self.drives[idx].rotation_bit / 16;
+                dma.write_start_bit = (self.drives[idx].rotation_bit % 16) as u8;
+            }
             let word = read_chip_word(chip_ram, self.dskpt);
             dma.write_words.push(word);
             self.advance_dskpt();
@@ -1607,7 +1620,7 @@ impl FloppyController {
 
     fn next_completion_cck_raw(&self, dmacon: u16) -> Option<u32> {
         let dma = self.dma.as_ref()?;
-        if !self.dma_enabled(dmacon) || dma.wait_sync {
+        if !self.dma_enabled(dmacon) || dma.wait_sync || !self.drive_can_transfer_cells(dma.drive) {
             return None;
         }
         let drive = &self.drives[dma.drive];
@@ -1625,6 +1638,15 @@ impl FloppyController {
             drive.head_cck_for_bits(bits.max(1))
         };
         Some((cck.min(u64::from(u32::MAX)) as u32).max(1))
+    }
+
+    /// Whether the active track can currently deliver cells to Paula. Keep
+    /// the completion predictor on the same boundary as the read/write
+    /// engines: an armed transfer over an idle or empty mechanism remains
+    /// pending, but has no completion event for STOP-state pacing to chase.
+    fn drive_can_transfer_cells(&self, drive_idx: usize) -> bool {
+        let drive = &self.drives[drive_idx];
+        drive.motor_on && drive.has_media() && !drive.cached.is_empty()
     }
 
     pub fn next_sync_irq_cck(&self, dmacon: u16) -> Option<u32> {
@@ -1731,22 +1753,27 @@ impl FloppyController {
         // arming enters the transfer state regardless, and data starts
         // flowing once the mechanism delivers stable cells. A drive that is
         // still spinning up must therefore arm normally instead of faking an
-        // instant, dataless completion -- trackloaders (Gods, Shadow of the
-        // Beast disk 2) issue the read within the spin-up window and poll the
-        // buffer for arriving data, dead-spinning if it never fills.
-        // TODO: media-less and motor-off drives should also arm and idle
-        // (real Paula would wait for sync forever); they keep the instant
-        // completion until the software relying on it is characterized.
-        if !self.drives[idx].has_media() || !self.drives[idx].motor_on {
-            if crate::envcfg::flag("COPPERLINE_DIAG_DISK") {
-                log::info!(
-                    "disk-dma refused: df{idx} media={} motor_on={} motor_cck={}",
-                    self.drives[idx].has_media(),
-                    self.drives[idx].motor_on,
-                    self.drives[idx].motor_cck,
-                );
-            }
-            return self.no_drive_completion();
+        // instant, dataless completion. A trackloader may arm within the
+        // spin-up window and poll its buffer for the data that arrives later.
+        //
+        // The same honesty covers a drive with no media or a stopped
+        // platter: the transfer arms and then idles, because no cells pass
+        // under the head for the shifter to drain. Real Paula waits for
+        // sync forever in that state; the guest's own timeout governs, and
+        // a media insert or motor start mid-transfer brings the transfer to
+        // life exactly as on hardware. The read and write tick paths idle
+        // without motor, media, and cached cells, and the turbo burst refuses
+        // drives that are not ready, so nothing completes early.
+        if (!self.drives[idx].has_media() || !self.drives[idx].motor_on)
+            && crate::envcfg::flag("COPPERLINE_DIAG_DISK")
+        {
+            log::info!(
+                "disk-dma armed against an idle mechanism: df{idx} media={} motor_on={} \
+                 motor_cck={} (transfer will pend until the mechanism delivers)",
+                self.drives[idx].has_media(),
+                self.drives[idx].motor_on,
+                self.drives[idx].motor_cck,
+            );
         }
 
         let track = self.track_for_drive(idx);
@@ -1776,6 +1803,8 @@ impl FloppyController {
             write_words: Vec::new(),
             write_start_word,
             write_start_bit,
+            write_start_pending: write
+                && (!self.drives[idx].has_media() || !self.drives[idx].motor_on),
         });
         if self.turbo() {
             self.turbo_grace_cck = TURBO_DMA_GRACE_CCK;
@@ -1841,6 +1870,8 @@ impl FloppyController {
         dma.track = new_track;
         dma.write_start_word = self.drives[drive_idx].rotation_bit / 16;
         dma.write_start_bit = (self.drives[drive_idx].rotation_bit % 16) as u8;
+        dma.write_start_pending =
+            !self.drives[drive_idx].has_media() || !self.drives[drive_idx].motor_on;
         self.dma = Some(dma);
     }
 
@@ -3673,6 +3704,9 @@ struct DiskDma {
     write_words: Vec<u16>,
     write_start_word: usize,
     write_start_bit: u8,
+    /// Set when a write arms without a delivering mechanism. The rotational
+    /// start is re-latched from the first word actually consumed.
+    write_start_pending: bool,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/src/floppy/tests.rs
+++ b/src/floppy/tests.rs
@@ -1485,7 +1485,7 @@ fn dskbytr_dmaon_waits_for_double_dsklen_arm() -> Result<()> {
 }
 
 #[test]
-fn dskbytr_dmaon_stays_clear_when_armed_dma_cannot_start() -> Result<()> {
+fn dskbytr_dmaon_stays_set_while_armed_dma_waits_for_the_motor() -> Result<()> {
     let raw_words = [0x1234, 0x5678];
     let path = temp_ext2_raw(&raw_words)?;
     let cfg = FloppyConfig {
@@ -1503,15 +1503,114 @@ fn dskbytr_dmaon_stays_clear_when_armed_dma_cannot_start() -> Result<()> {
     };
     let mut ctrl = FloppyController::from_config(&cfg)?;
 
-    // Selected drive with media but the motor line off: the armed DSKLEN
-    // still takes the instant-completion path and DMAON stays clear.
+    // Selected drive with media but the motor line off: the transfer arms
+    // and pends -- real Paula waits for data forever -- so DMAON stays set
+    // and nothing completes until the platter turns.
     ctrl.write_prb(!CIAB_DSKSEL0);
 
     let len = DSKLEN_DMAEN | 1;
     let dmacon = DMACON_DMAEN | DMACON_DISK;
     assert!(!ctrl.write_dsklen(len, 0));
-    assert!(ctrl.write_dsklen(len, 0));
-    assert_eq!(ctrl.read_dskbytr(dmacon, 0) & DMAON, 0);
+    assert!(!ctrl.write_dsklen(len, 0));
+    assert_ne!(ctrl.read_dskbytr(dmacon, 0) & DMAON, 0);
+    assert_eq!(ctrl.next_completion_cck(dmacon), None);
+    let mut chip_ram = vec![0u8; 4];
+    assert!(!ctrl.tick(MOTOR_READY_CCK * 4, dmacon, &mut chip_ram));
+    assert_eq!(read_chip_word(&chip_ram, 0), 0);
+
+    let _ = fs::remove_file(path);
+    Ok(())
+}
+
+#[test]
+fn read_dma_with_no_media_arms_and_pends_until_media_arrives() -> Result<()> {
+    let raw_words = [0x1234, 0x5678];
+    let path = temp_ext2_raw(&raw_words)?;
+    let mut ctrl = FloppyController::default();
+    let mut chip_ram = vec![0u8; 4];
+
+    // DF0 selected, motor spinning, but the bay is empty: the transfer
+    // arms and idles -- no cells pass under the head, so no completion
+    // interrupt ever fires and the guest's own timeout governs.
+    ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
+    ctrl.tick(MOTOR_READY_CCK, 0, &mut []);
+    let len = DSKLEN_DMAEN | 1;
+    let dmacon = DMACON_DMAEN | DMACON_DISK;
+    assert!(!ctrl.write_dsklen(len, 0));
+    assert!(!ctrl.write_dsklen(len, 0));
+    assert_ne!(ctrl.read_dskbytr(dmacon, 0) & DMAON, 0);
+    assert_eq!(ctrl.next_completion_cck(dmacon), None);
+
+    // Several revolutions of waiting deliver nothing.
+    for _ in 0..8 {
+        assert!(!ctrl.tick(
+            FloppyController::word_cck_for_track_words(raw_words.len()) * 125,
+            dmacon,
+            &mut chip_ram
+        ));
+    }
+    assert_eq!(read_chip_word(&chip_ram, 0), 0);
+
+    // Inserting media mid-transfer brings it to life exactly as sliding a
+    // disk into a real drive would.
+    ctrl.insert_disk_image(0, path.clone(), true)?;
+    ctrl.ensure_track(0, 0);
+    assert!(ctrl.next_completion_cck(dmacon).is_some());
+    assert!(ctrl.tick(
+        FloppyController::word_cck_for_track_words(raw_words.len()),
+        dmacon,
+        &mut chip_ram
+    ));
+    assert_eq!(read_chip_word(&chip_ram, 0), raw_words[0]);
+
+    let _ = fs::remove_file(path);
+    Ok(())
+}
+
+#[test]
+fn read_dma_with_motor_off_pends_until_the_motor_starts() -> Result<()> {
+    let raw_words = [0x1234, 0x5678];
+    let path = temp_ext2_raw(&raw_words)?;
+    let cfg = FloppyConfig {
+        bridges: std::array::from_fn(|_| None),
+        speed: 100,
+        drives: [
+            Some(FloppyDriveConfig {
+                path: path.clone(),
+                write_protected: true,
+            }),
+            None,
+            None,
+            None,
+        ],
+    };
+    let mut ctrl = FloppyController::from_config(&cfg)?;
+    let mut chip_ram = vec![0u8; 4];
+    let len = DSKLEN_DMAEN | 1;
+    let dmacon = DMACON_DMAEN | DMACON_DISK;
+
+    // Media present, drive selected, motor line off: the read arms and
+    // pends through several spin-up windows without completing.
+    ctrl.write_prb(!CIAB_DSKSEL0);
+    assert!(!ctrl.write_dsklen(len, 0));
+    assert!(!ctrl.write_dsklen(len, 0));
+    assert_eq!(ctrl.next_completion_cck(dmacon), None);
+    assert!(!ctrl.tick(MOTOR_READY_CCK * 3, dmacon, &mut chip_ram));
+    assert_eq!(read_chip_word(&chip_ram, 0), 0);
+
+    // Starting the motor spins the platter up and the pending transfer
+    // completes with the track data.
+    ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
+    let word_cck = FloppyController::word_cck_for_track_words(raw_words.len());
+    let mut completed = false;
+    for _ in 0..(MOTOR_READY_CCK / word_cck + 4) {
+        if ctrl.tick(word_cck, dmacon, &mut chip_ram) {
+            completed = true;
+            break;
+        }
+    }
+    assert!(completed, "the transfer completes after the motor starts");
+    assert_eq!(read_chip_word(&chip_ram, 0), raw_words[0]);
 
     let _ = fs::remove_file(path);
     Ok(())
@@ -1864,24 +1963,40 @@ fn motor_off_blocks_read_dma_until_next_spinup() -> Result<()> {
 
     ctrl.set_dskpt_low(0);
     let len = DSKLEN_DMAEN | 1;
-    assert!(!ctrl.write_dsklen(len, 0));
-    assert!(ctrl.write_dsklen(len, 0));
     let dmacon = DMACON_DMAEN | DMACON_DISK;
-    assert_eq!(ctrl.read_dskbytr(dmacon, 0) & DMAON, 0);
+    // Arming against the stopped platter enters the transfer state and
+    // pends: no cells pass under the head, so nothing completes.
+    assert!(!ctrl.write_dsklen(len, 0));
+    assert!(!ctrl.write_dsklen(len, 0));
+    assert_ne!(ctrl.read_dskbytr(dmacon, 0) & DMAON, 0);
 
     // Leave the motor off long enough for the platter to spin down fully,
-    // so the drive must spin back up before the next read can run.
+    // so the drive must spin back up before data can flow.
     ctrl.tick(MOTOR_READY_CCK, 0, &mut chip_ram);
+    assert!(!ctrl.tick(MOTOR_READY_CCK, dmacon, &mut chip_ram));
     ctrl.write_prb(0xFF);
     ctrl.write_prb(selected_motor_on);
     assert_ne!(ctrl.cia_a_status_bits() & CIAA_DSKRDY, 0);
     ctrl.tick(MOTOR_READY_CCK, 0, &mut chip_ram);
     assert_eq!(ctrl.cia_a_status_bits() & CIAA_DSKRDY, 0);
 
-    let len = DSKLEN_DMAEN | 1;
-    assert!(!ctrl.write_dsklen(len, 0));
-    assert!(!ctrl.write_dsklen(len, 0));
-    assert_ne!(ctrl.read_dskbytr(dmacon, 0) & DMAON, 0);
+    // The pending transfer completes once the platter is turning again.
+    let word_cck = FloppyController::word_cck_for_track_words(raw_words.len());
+    let mut completed = false;
+    for _ in 0..(MOTOR_READY_CCK / word_cck + 4) {
+        if ctrl.tick(word_cck, dmacon, &mut chip_ram) {
+            completed = true;
+            break;
+        }
+    }
+    assert!(completed, "the transfer completes after the spin-up");
+    // The platter kept its rotation position across the motor-off window,
+    // so the pending read resumes wherever the head now is on the track.
+    let word = read_chip_word(&chip_ram, 0);
+    assert!(
+        raw_words.contains(&word),
+        "resumed read delivers real track data, got {word:#06x}"
+    );
 
     let _ = fs::remove_file(path);
     Ok(())
@@ -3519,6 +3634,62 @@ fn raw_track_write_dma_uses_raw_index_timing() -> Result<()> {
     tick_index_flag_sync(&mut ctrl);
     assert!(ctrl.take_index_pulse());
     assert_eq!(ctrl.drives[0].rotation_word_index(), 0);
+
+    let _ = fs::remove_file(path);
+    Ok(())
+}
+
+#[test]
+fn write_dma_armed_without_media_starts_at_inserted_disks_rotation() -> Result<()> {
+    let raw_words = [0x1111, 0x2222, 0x3333, 0x4444];
+    let path = temp_ext2_raw(&raw_words)?;
+    let mut ctrl = FloppyController::default();
+    let mut chip_ram = vec![0xAB, 0xCD];
+    let dmacon = DMACON_DMAEN | DMACON_DISK;
+
+    // Arm a write with DF0 selected and its motor running, but no media.
+    // The controller's old rotational position must not decide where data
+    // lands after a disk is inserted.
+    ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
+    ctrl.tick(MOTOR_READY_CCK, 0, &mut []);
+    ctrl.drives[0].set_rotation_word(2);
+    ctrl.drives[0].rotation_acc_cck = 0;
+    ctrl.set_dskpt_low(0);
+    let len = DSKLEN_DMAEN | DSKLEN_WRITE | 1;
+    assert!(!ctrl.write_dsklen(len, 0));
+    assert!(!ctrl.write_dsklen(len, 0));
+    assert_eq!(ctrl.next_completion_cck(dmacon), None);
+
+    let word_cck = FloppyController::word_cck_for_track_words(raw_words.len());
+    assert!(!ctrl.tick(word_cck * 125, dmacon, &mut chip_ram));
+
+    // Insertion starts the platter at index. The pending write therefore
+    // begins at word zero, where cells first become available, rather than
+    // at the stale pre-insert position.
+    ctrl.insert_disk_image(0, path.clone(), false)?;
+    ctrl.ensure_track(0, 0);
+    assert!(ctrl.next_completion_cck(dmacon).is_some());
+    assert!(ctrl.tick(word_cck, dmacon, &mut chip_ram));
+
+    let cfg = FloppyConfig {
+        bridges: std::array::from_fn(|_| None),
+        speed: 100,
+        drives: [
+            Some(FloppyDriveConfig {
+                path: path.clone(),
+                write_protected: false,
+            }),
+            None,
+            None,
+            None,
+        ],
+    };
+    let mut reloaded = FloppyController::from_config(&cfg)?;
+    reloaded.ensure_track(0, 0);
+    assert_eq!(
+        reloaded.drives[0].cached_words(),
+        [0xABC9, 0x2222, 0x3333, 0x4444]
+    );
 
     let _ = fs::remove_file(path);
     Ok(())

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -212,7 +212,10 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      byte length (WAVE/MP3 audio tracks, reopened and re-indexed on
 //      load) and its extents gained a storage tag (file bytes or an
 //      unstored PREGAP/POSTGAP).
-pub const STATE_VERSION: u32 = 62;
+//  63: DiskDma gained `write_start_pending`, so a write armed against an
+//      idle floppy mechanism re-latches its rotational start when cells
+//      first arrive.
+pub const STATE_VERSION: u32 = 63;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {


### PR DESCRIPTION
Supersedes the idle floppy-DMA portion of #506.

## Summary

- Arm Paula disk DMA while the selected mechanism has no media or its motor is stopped.
- Leave the transfer pending until real disk cells become available, for both read and write DMA.
- Suppress completion predictions while the same mechanism guard prevents cells from reaching Paula.
- Avoid treating bridge filler tracks as writable media.
- Re-latch a pending write at the inserted disk's actual rotation before consuming its first word.
- Bump the save-state format for the new pending-write latch and document the hardware behavior.

## Cleanup from #506

The original change allowed the idle path to flow through synthetic/filler track state, which made writes especially fragile. This version gives the controller an explicit pending state, starts data movement only when the mechanism can supply a real track position, and keeps STOP-state event prediction on that same boundary rather than advertising phantom word deadlines.

## Validation

- No-media and motor-off read-DMA prediction/transfer regressions
- No-media write-DMA prediction and post-insert position regression
- `DSKBYTR.DMAON` pending-state regression
- `cargo test --locked floppy::tests` (134 passed)
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
