### PR TITLE
ci: enforce dependency advisory and licence policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,31 @@ jobs:
         # host-network runtime tests whose timing is unrelated to the MSRV.
         run: cargo +"$MSRV" test --locked --lib --no-run
 
+  cargo-deny:
+    name: Dependency policy (${{ matrix.name }})
+    # The browser and publisher player are standalone workspaces with their
+    # own lockfiles, so check all three shipped dependency graphs explicitly.
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: core
+            manifest: Cargo.toml
+          - name: browser
+            manifest: crates/copperline-web/Cargo.toml
+          - name: player
+            manifest: crates/copperline-player/Cargo.toml
+    steps:
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: ${{ matrix.manifest }}
+          arguments: --all-features --locked --config deny.toml
+          command-arguments: --hide-inclusion-graph
+          # Duplicate-version and git-wildcard findings are deliberate
+          # warnings; hide only their verbose dependency inclusion graphs.
+
   unit-tests:
     name: Unit tests
     needs: build

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,77 @@
+# Shared cargo-deny policy for the native emulator and its shipped web/player
+# frontends. Run with `cargo deny --all-features --locked check`; CI applies
+# the same file to each standalone manifest.
+
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+# Each exception is dated, narrow, and explains why an upgrade cannot remove
+# it. Published vulnerabilities still fail the job by default.
+ignore = [
+    # 2026-08-21: unmaintained warning, not a vulnerability, and there is
+    # no safe upgrade -- it arrives transitively through
+    # winit -> sctk-adwaita -> ab_glyph -> owned_ttf_parser. Revisit when
+    # the winit stack moves to the skrifa-based font crates.
+    "RUSTSEC-2026-0192",
+    # 2026-08-21: unmaintained warning on bincode 1.x, not a published
+    # vulnerability. It decodes both
+    # the descriptor and the component stream of .clstate save states --
+    # files this project itself treats as untrusted input (see
+    # src/savestate.rs). The format is
+    # length-prefixed and bounds-checked, no known vulnerability is
+    # published against it, and migrating to bincode 2 changes the on-disk
+    # format, so that migration needs its own compatibility change rather
+    # than being hidden in a dependency-policy PR. Revisit by 2026-11-21.
+    "RUSTSEC-2025-0141",
+]
+
+[licenses]
+version = 2
+allow = [
+    "GPL-3.0-or-later",
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "bzip2-1.0.6",
+    "BSL-1.0",
+    "ISC",
+    "Unicode-3.0",
+    "Zlib",
+    "CDLA-Permissive-2.0",
+    "MPL-2.0",
+    "LGPL-2.1-or-later",
+    "LGPL-3.0-or-later",
+    "CC0-1.0",
+    "MIT-0",
+    "0BSD",
+    "Unlicense",
+]
+# Copperline itself is GPL-3.0-or-later; everything it vendors or links
+# must be compatible with that. Anything outside the allow list fails the
+# check and needs an explicit, reviewed exception here.
+confidence-threshold = 0.93
+
+[bans]
+multiple-versions = "warn"
+# Git dependencies have no Cargo version requirement, so cargo-deny reports
+# them as wildcards even when Cargo pins a revision in the lockfile. Keep the
+# signal visible without failing the source-policy job.
+wildcards = "warn"
+deny = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# Project-owned sources: mt32-rs and Coppersynth are revision-pinned in the
+# manifest; FluxBridge currently follows its maintained main branch.
+allow-git = [
+    "https://github.com/CopperlineHQ/mt32-rs",
+    "https://github.com/CopperlineHQ/Coppersynth",
+    "https://github.com/CopperlineHQ/FluxBridge",
+]


### PR DESCRIPTION
Supersedes the cargo-deny portion of #506.

## Summary

- Enforce RustSec advisory, licence, registry, and Git-source policy.
- Check the independently locked core, browser, and publisher-player dependency graphs.
- Keep duplicate-version, Git-wildcard, stale-ignore, and other warning reports visible while hiding only verbose inclusion graphs.
- Document narrow, dated exceptions for the two unmaintained dependencies currently in the graph.

## Cleanup from #506

The policy is limited to shipped graphs that pass today, uses the actual project-owned Git sources, and describes the real bincode 1.x exposure: `.clstate` is untrusted input, but a format migration needs a separate compatibility change. The rationale does not depend on the separate fuzzing PR. Known vulnerable plugin-only dependency graphs are not papered over with a broad exception.

## Validation

- `cargo deny --all-features --locked --config deny.toml check --hide-inclusion-graph`
- The same checks passed for `crates/copperline-web`
- The same checks passed for `crates/copperline-player`
- Warning diagnostics remained visible in all three runs
- Workflow YAML parse
