### PR TITLE
video: add guarded run-ahead latency reduction

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -89,6 +89,15 @@ pacing_budget = "cycles"
 # rewind_budget_mb = 256
 # rewind_interval_frames = 25
 
+# Run-ahead input-latency reduction. In a compatible windowed session, each
+# refresh commits one frame, snapshots it, executes this many silent future
+# frames, presents the last, then restores the snapshot. The host therefore
+# needs roughly (run_ahead_frames + 1)x realtime headroom; start with 1.
+# Host-coupled devices and diagnostics that cannot be rewound make the setting
+# temporarily inactive, with the reason shown in the Run Ahead menu's OSD.
+# 0..4; adjust live from Emulation Settings > Run Ahead.
+# run_ahead_frames = 0
+
 
 [cpu]
 

--- a/crates/copperline-player/src/main.rs
+++ b/crates/copperline-player/src/main.rs
@@ -156,6 +156,7 @@ fn main() -> Result<()> {
         cfg.mouse_capture,
         config::about_machine_lines(&cfg),
         raw_for_app,
+        cfg.runahead_machine_block_reason(),
         live_audio,
         copperline::sampler::SamplerRequest::default(),
     );

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -340,6 +340,7 @@ warp_speed = "max"         # turbo limit: "2x", "4x", "8x", "16x", or "max"
 rewind = false             # true = record rewind history from power-on
 rewind_budget_mb = 256     # host memory the rewind history may hold
 rewind_interval_frames = 25 # emulated frames per rewind step
+run_ahead_frames = 0       # run-ahead input-latency reduction, 0..4 (0 = off)
 ```
 
 The deterministic cycle-driven core is the only emulation timing. It is
@@ -396,6 +397,29 @@ carried no information.)
   Turning the menu item off releases the retained snapshots. The same
   determinism preconditions as reverse debugging apply -- a real-time clock
   and host disk writes are not rolled back.
+- `run_ahead_frames` reduces input latency in compatible windowed sessions.
+  Each refresh commits one ordinary frame, snapshots the machine, executes
+  the requested number of future frames, presents the last future image, and
+  restores the snapshot. Audio, serial output, and control events come only
+  from the committed frame; speculative output is discarded. The committed
+  machine timeline is therefore unchanged. This costs one whole-machine
+  snapshot per refresh and roughly `(run_ahead_frames + 1)`x realtime host
+  performance, so start at 1 and raise it only while the performance overlay
+  shows comfortable headroom. Large values also skip visible intermediate
+  animation.
+
+  Run-ahead stays inactive when a speculative frame could observe or change
+  host state that the snapshot cannot restore. This includes warp and
+  headless capture, RTG output, rewind/reverse debugging, debugger stops,
+  injected faults, validation/SMC/heat-map/frame-analyzer observers,
+  instruction or waveform traces, a connected control client, video recording, loaded
+  save states, live serial or parallel devices, writable or physical floppy
+  media, mounted CDs, hard-drive and host-directory storage, host networking
+  or plugin boards, MHI decoding, and a live or persistent RTC/NVRAM. Offline
+  WAV and stem capture are supported: speculative audio is discarded at the
+  mixer before any sink receives it. The **Run Ahead** item under Emulation
+  Settings adjusts the level live and reports the current blocking reason.
+  `--run-ahead FRAMES` overrides the config for one run.
 
 ## `[cpu]`
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -458,6 +458,16 @@ Shown only when something is on the port.
   [Configuration](configuration.md)). It shares its substrate with the
   debugger's reverse controls, so the same determinism caveats apply -- see
   [](../debugger/reverse).
+- **Run Ahead**: input-latency reduction for play. Each display refresh
+  commits one frame, runs a few silent future frames, presents the last future
+  image, and rewinds to the committed boundary. Level **1 frame** is the best
+  starting point; higher levels need proportionally more host CPU (watch the
+  performance overlay) and skip more intermediate animation. When a live
+  device, writable medium, debugger, capture, or other host coupling makes
+  speculation unsafe, selecting a level keeps it configured but the OSD says
+  why it is inactive. The start-up value is
+  `[emulation] run_ahead_frames` or `--run-ahead`; the full compatibility list
+  is in [Configuration](configuration.md).
 
 ### Warp Settings
 

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -420,6 +420,28 @@ capture paths call `finish_render_for_current_frame` so screenshots, frame
 dumps, recordings, debugger step, and run-to-PC output use the requested
 emulated frame.
 
+Run-ahead (`[emulation] run_ahead_frames`) sits above this pipeline. A burst
+first retires one committed anchor frame, snapshots the machine, and then
+retires `n` speculative frames with per-frame pacing suppressed. Every
+speculative frame is silent: `AudioMux` drops all master/source/channel fanout,
+and Paula withholds completed serial words from both its sink and observer.
+The final future frame is synchronously rendered while its Bus is still live;
+only then is the anchor restored. Rendering after restore would present the
+past, and merely submitting a worker job before restore would race the
+fallback renderer. One `pace_runahead_burst` call at the end uses the anchor's
+emulated time, so snapshot, speculation, rendering, and restore all share one
+display-period budget. Speculative frames contribute host busy time but not
+the committed-frame counter.
+
+The eligibility gate is deliberately conservative. It excludes any device or
+observer with host state that `M68kMachine::write_state` cannot rewind; the
+user guide lists the current set. A snapshot or restore failure disables
+run-ahead for the session instead of silently advancing by extra frames. If
+stepping or rendering interrupts a burst after speculation has started, the
+anchor restore is still attempted before run-ahead is disabled: output from
+those abandoned future frames was suppressed and they cannot become the
+committed timeline.
+
 Progressive frames have two exact reuse checks. First, two consecutive
 renders with identical lightweight inputs arm a pre-render key containing
 every captured bitplane row, sprite line/latch, register/event stream,

--- a/src/akiko.rs
+++ b/src/akiko.rs
@@ -584,6 +584,13 @@ impl Akiko {
         self.nvram = Nvram::new(Some(path));
     }
 
+    /// Whether the CD32 EEPROM is backed by a host file. Its I2C STOP
+    /// condition flushes dirty bytes immediately, which cannot be undone by
+    /// restoring a speculative machine snapshot.
+    pub fn persistent_nvram(&self) -> bool {
+        self.nvram.path.is_some()
+    }
+
     /// Resolved I2C bus levels from the CPU-side latches: an input
     /// direction floats high through the pull-ups.
     fn nvram_bus_levels(&self) -> (bool, bool) {

--- a/src/audio/mux.rs
+++ b/src/audio/mux.rs
@@ -88,6 +88,10 @@ struct StemWriters {
 pub struct AudioMux {
     master: Box<dyn AudioSink>,
     stems: Option<StemWriters>,
+    /// Host-output policy for speculative run-ahead frames. Kept at the
+    /// fan-out point so neither the live sink nor any offline stem observes
+    /// guest time that will immediately be rewound.
+    discard_output: bool,
 }
 
 impl AudioMux {
@@ -95,6 +99,7 @@ impl AudioMux {
         Self {
             master,
             stems: None,
+            discard_output: false,
         }
     }
 
@@ -182,6 +187,9 @@ impl AudioMux {
     /// same value every mixed-master sink (live or `--audio-wav`) has
     /// always received. Also feeds the `master` stem writer, if enabled.
     pub fn push_master(&mut self, left: f32, right: f32) {
+        if self.discard_output {
+            return;
+        }
         self.master.push(left, right);
         if let Some(stems) = &mut self.stems {
             if let Some(writer) = &mut stems.master {
@@ -218,6 +226,10 @@ impl AudioMux {
         self.master.set_live_output_suspended(suspended);
     }
 
+    pub fn set_live_output_discard(&mut self, on: bool) {
+        self.discard_output = on;
+    }
+
     pub fn reset_live_output_after_timeline_jump(&mut self) {
         self.master.reset_live_output_after_timeline_jump();
     }
@@ -234,6 +246,9 @@ impl AudioMux {
     /// "mt32", "drivesounds") for `Source`-granularity stem capture.
     /// A no-op unless stems are enabled and this source was registered.
     pub fn push_source(&mut self, source: &'static str, left: f32, right: f32) {
+        if self.discard_output {
+            return;
+        }
         if let Some(stems) = &mut self.stems {
             if let Some(writer) = stems.sources.get_mut(source) {
                 let _ = writer.write_sample(left);
@@ -252,6 +267,9 @@ impl AudioMux {
         channel: &'static str,
         sample: f32,
     ) {
+        if self.discard_output {
+            return;
+        }
         if let Some(stems) = &mut self.stems {
             if let Some(writer) = stems.channels.get_mut(&(source, channel)) {
                 let _ = writer.write_sample(sample);

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -4354,10 +4354,76 @@ impl Bus {
         std::mem::swap(&mut self.paula.audio, &mut live.paula.audio);
         std::mem::swap(&mut self.parallel_port, &mut live.parallel_port);
         self.blitter_trace = live.blitter_trace.take();
+        self.paula.adopt_host_taps(&mut live.paula);
         // Drive speed is host configuration, not machine state: a loaded
         // state keeps the running session's setting.
         self.floppy.set_speed_percent(live.floppy.speed_percent());
         Ok(())
+    }
+
+    /// Why the live machine cannot safely execute frames that are then
+    /// rewound. This covers dynamic host couplings that a static config
+    /// cannot: mounted media, persistent clock/NVRAM storage, peripherals,
+    /// and active trace writers.
+    pub fn runahead_host_block_reason(&self) -> Option<&'static str> {
+        if let Some(reason) = self.floppy.runahead_block_reason() {
+            return Some(reason);
+        }
+        if self.cd_disc_inserted() {
+            // CdImage deserialization reopens its source files. Keeping that
+            // out of a per-refresh restore also avoids replaying host-backed
+            // decoder state for audio tracks.
+            return Some("CD image mounted");
+        }
+        if self
+            .akiko
+            .as_ref()
+            .is_some_and(crate::akiko::Akiko::persistent_nvram)
+        {
+            return Some("persistent CD32 NVRAM");
+        }
+        if self.rtc_present && !self.rtc.runahead_safe() {
+            return Some("live or persistent real-time clock");
+        }
+        if !self.parallel_port.runahead_safe() {
+            return Some("parallel host peripheral");
+        }
+        if self.wave_on {
+            return Some("waveform capture");
+        }
+        if self.blitter_trace.is_some()
+            || crate::envcfg::var_os("COPPERLINE_DUMP_BLITMEM").is_some()
+        {
+            return Some("file-backed hardware trace");
+        }
+        None
+    }
+
+    /// Why transient debugger state makes speculative execution unsafe.
+    /// These observers are deliberately absent from save states, and restore
+    /// carries some of them forward from the abandoned Bus. Letting them run
+    /// speculatively would consume one-shot faults, record discarded accesses,
+    /// or silently disarm the frame analyzer on every anchor restore.
+    pub fn runahead_debug_block_reason(&self) -> Option<&'static str> {
+        if !self.ui_beam_traps.is_empty() || !self.ui_copper_breaks.is_empty() {
+            return Some("debugger stop conditions armed");
+        }
+        if self.bus_faults_armed() {
+            return Some("injected bus fault armed");
+        }
+        if self.chipset_validation_armed() {
+            return Some("chipset validation armed");
+        }
+        if self.smc_detection_armed() {
+            return Some("SMC detection armed");
+        }
+        if self.heat_map_armed() {
+            return Some("memory heat map armed");
+        }
+        if self.frame_analyzer_enabled {
+            return Some("frame analyzer armed");
+        }
+        None
     }
 
     /// Acquire physical disks named by a fully decoded state. Deserialization
@@ -4536,6 +4602,10 @@ impl Bus {
 
     pub fn set_live_audio_suspended(&mut self, suspended: bool) {
         self.paula.set_live_audio_suspended(suspended);
+    }
+
+    pub fn set_live_audio_discard(&mut self, on: bool) {
+        self.paula.set_live_audio_discard(on);
     }
 
     pub fn reset_live_audio_after_timeline_jump(&mut self) {

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -527,6 +527,11 @@ pub struct Paula {
     toccata_muted: bool,
     #[serde(skip)]
     mhi_muted: bool,
+    /// While a run-ahead frame is speculative, keep host-only UART output,
+    /// debugger scopes, and the recording tap quiet. Guest-visible Paula and
+    /// mixer state still advance normally and are then rewound.
+    #[serde(skip)]
+    speculative_host_quiet: bool,
     // Rolling output-level scopes for the debugger's oscilloscope meters:
     // one per Paula channel plus one per line-mixed source (CD-DA, the
     // in-process MIDI synth, a Toccata board, an MHI board). Each holds the
@@ -599,6 +604,7 @@ impl Paula {
             synth_muted: false,
             toccata_muted: false,
             mhi_muted: false,
+            speculative_host_quiet: false,
             channel_scope: std::array::from_fn(|_| {
                 std::collections::VecDeque::with_capacity(AUDIO_SCOPE_LEN + 1)
             }),
@@ -627,6 +633,29 @@ impl Paula {
     /// Enable or disable the bounded host-side serial transmit tap.
     pub fn set_serial_observation_enabled(&mut self, enabled: bool) {
         self.serial_observer = enabled.then(crate::serial::SerialObserver::default);
+    }
+
+    pub fn set_speculative_host_quiet(&mut self, on: bool) {
+        self.speculative_host_quiet = on;
+    }
+
+    /// Move host-only audio inspection state from the live Paula into a
+    /// freshly deserialized one. Save states deliberately omit these taps;
+    /// without carrying them across, every run-ahead rewind would clear the
+    /// Audio-tab mutes, scopes, and recording buffer.
+    pub(crate) fn adopt_host_taps(&mut self, live: &mut Paula) {
+        self.channel_muted = live.channel_muted;
+        self.cd_muted = live.cd_muted;
+        self.synth_muted = live.synth_muted;
+        self.toccata_muted = live.toccata_muted;
+        self.mhi_muted = live.mhi_muted;
+        self.synth_silent = live.synth_silent;
+        std::mem::swap(&mut self.capture, &mut live.capture);
+        std::mem::swap(&mut self.channel_scope, &mut live.channel_scope);
+        std::mem::swap(&mut self.cd_scope, &mut live.cd_scope);
+        std::mem::swap(&mut self.synth_scope, &mut live.synth_scope);
+        std::mem::swap(&mut self.toccata_scope, &mut live.toccata_scope);
+        std::mem::swap(&mut self.mhi_scope, &mut live.mhi_scope);
     }
 
     /// Drain transmissions completed since the last poll, plus the number of
@@ -919,6 +948,10 @@ impl Paula {
         self.audio.set_live_output_suspended(suspended);
     }
 
+    pub fn set_live_audio_discard(&mut self, on: bool) {
+        self.audio.set_live_output_discard(on);
+    }
+
     pub fn reset_live_audio_after_timeline_jump(&mut self) {
         self.audio.reset_live_output_after_timeline_jump();
     }
@@ -1199,14 +1232,16 @@ impl Paula {
                         // Stop bit done: this many clocks are left of the span.
                         let at_cck = end_cck.saturating_sub(u64::from(remaining));
                         let word = Self::serial_tx_data_word(&shift);
-                        if let Some(observer) = self.serial_observer.as_mut() {
-                            observer.push(crate::serial::SerialTxObservation {
-                                word,
-                                long: shift.long,
-                                at_cck,
-                            });
+                        if !self.speculative_host_quiet {
+                            if let Some(observer) = self.serial_observer.as_mut() {
+                                observer.push(crate::serial::SerialTxObservation {
+                                    word,
+                                    long: shift.long,
+                                    at_cck,
+                                });
+                            }
+                            self.serial.write_word(word, shift.long, at_cck);
                         }
-                        self.serial.write_word(word, shift.long, at_cck);
                     }
                     self.serial_tx_pin_high = true;
                     irq |= self.load_serial_shift_if_idle();
@@ -1921,6 +1956,7 @@ impl Paula {
     }
 
     fn push_mixed_frame(&mut self) {
+        let observe_host = !self.speculative_host_quiet;
         // Mix and push host-rate stereo frames into the sink. Paula
         // stereo routing follows the common A500/A600/A1200 and
         // Minimig mapping: channels 0 and 3 go left, 1 and 2 right.
@@ -1939,10 +1975,12 @@ impl Paula {
         // Tap each channel's output level (DAC sample * volume, -128..127)
         // for the debugger oscilloscopes. This is pre-mute so a muted
         // channel's trace still shows its activity (drawn greyed).
-        for i in 0..4 {
-            let level = ((self.chans[i].current as i32 * self.chans[i].audvol as i32) / 64)
-                .clamp(-128, 127);
-            scope_push(&mut self.channel_scope[i], level as i8);
+        if observe_host {
+            for i in 0..4 {
+                let level = ((self.chans[i].current as i32 * self.chans[i].audvol as i32) / 64)
+                    .clamp(-128, 127);
+                scope_push(&mut self.channel_scope[i], level as i8);
+            }
         }
         let l_raw = self.channel_mixed_sample(0) + self.channel_mixed_sample(3);
         let r_raw = self.channel_mixed_sample(1) + self.channel_mixed_sample(2);
@@ -1976,7 +2014,9 @@ impl Paula {
         // Record the pre-mute CD level for the debugger scope, then apply
         // the developer CD mute so the trace still shows activity while the
         // stream is silenced in the mix.
-        scope_push(&mut self.cd_scope, scope_level(cd_left, cd_right));
+        if observe_host {
+            scope_push(&mut self.cd_scope, scope_level(cd_left, cd_right));
+        }
         if self.cd_muted {
             cd_left = 0.0;
             cd_right = 0.0;
@@ -2001,7 +2041,9 @@ impl Paula {
                 None => self.synth_silent = true,
             }
         }
-        scope_push(&mut self.synth_scope, scope_level(synth_left, synth_right));
+        if observe_host {
+            scope_push(&mut self.synth_scope, scope_level(synth_left, synth_right));
+        }
         if self.synth_muted {
             synth_left = 0.0;
             synth_right = 0.0;
@@ -2014,10 +2056,12 @@ impl Paula {
         // rate before pushing here (see `Toccata::tick`), so this is a
         // plain per-frame pop like CD-DA, not a rate conversion.
         let (mut toccata_left, mut toccata_right) = self.toccata_audio.next_sample();
-        scope_push(
-            &mut self.toccata_scope,
-            scope_level(toccata_left, toccata_right),
-        );
+        if observe_host {
+            scope_push(
+                &mut self.toccata_scope,
+                scope_level(toccata_left, toccata_right),
+            );
+        }
         if self.toccata_muted {
             toccata_left = 0.0;
             toccata_right = 0.0;
@@ -2029,7 +2073,9 @@ impl Paula {
         // Likewise, an MHI board resamples its own decoded-MPEG-rate output
         // to the mixer rate before pushing here (see `Mhi::advance_mixer`).
         let (mut mhi_left, mut mhi_right) = self.mhi_audio.next_sample();
-        scope_push(&mut self.mhi_scope, scope_level(mhi_left, mhi_right));
+        if observe_host {
+            scope_push(&mut self.mhi_scope, scope_level(mhi_left, mhi_right));
+        }
         if self.mhi_muted {
             mhi_left = 0.0;
             mhi_right = 0.0;
@@ -2037,7 +2083,7 @@ impl Paula {
         left += mhi_left;
         right += mhi_right;
         self.audio.push_source("mhi", mhi_left, mhi_right);
-        if let Some(capture) = &mut self.capture {
+        if let (true, Some(capture)) = (observe_host, self.capture.as_mut()) {
             capture.push((left, right));
         }
         let (mut out_left, mut out_right) = (left * self.output_volume, right * self.output_volume);
@@ -3423,6 +3469,19 @@ mod tests {
         assert_eq!(observations[0].word, 0x0041);
         assert!(!observations[0].long);
         assert_eq!(observations[0].at_cck, 100);
+    }
+
+    #[test]
+    fn speculative_serial_completion_stays_inside_paula() {
+        let (mut paula, written, _) = paula_with_collect_serial_words();
+        paula.set_serial_observation_enabled(true);
+        paula.set_speculative_host_quiet(true);
+
+        assert_eq!(paula.write_serdat(0x0141), INT_TBE);
+        assert_eq!(paula.tick_serial(10, 100), 0);
+        assert!(written.lock().unwrap().is_empty());
+        assert!(paula.take_serial_observations().0.is_empty());
+        assert_ne!(paula.read_serdatr() & (1 << 12), 0);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -692,6 +692,15 @@ where
                         .map_err(|_| anyhow!("--autofire rate must be a whole number of Hz"))?,
                 );
             }
+            "--run-ahead" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| anyhow!("--run-ahead requires a frame count (0 = off)"))?;
+                overrides.run_ahead_frames =
+                    Some(value.parse::<u8>().map_err(|_| {
+                        anyhow!("--run-ahead must be a whole number of frames (0..4)")
+                    })?);
+            }
             "--serial" => {
                 overrides.serial = Some(args.next().ok_or_else(|| {
                     anyhow!("--serial requires a mode (off/stdout/midi/tcp/tcp-connect/pty)")
@@ -1346,6 +1355,8 @@ fn print_help() {
          --port2 DEVICE                 controller in port 2 (default: joystick;\n  \
          \x20                            cd32 on the CD32 profile)\n  \
          --autofire HZ                  pulse a held fire button at HZ (0 = off, the default)\n  \
+         --run-ahead FRAMES             run-ahead input-latency reduction, 0..4 frames\n  \
+         \x20                            (0 = off, the default; windowed sessions only)\n  \
          \x20                            (--model/--cpu/etc. override the config file or defaults)\n  \
          --screenshot-after SECS PATH   save a PNG to PATH after SECS emulated seconds, then exit\n  \
          --save-state-after SECS PATH   write a save state to PATH after SECS emulated seconds,\n  \

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1219,6 +1219,15 @@ pub struct Emulation {
     /// Emulated frames between rewind snapshots, and therefore the granularity
     /// of one rewind step. Larger is cheaper but coarser.
     pub rewind_interval_frames: u64,
+    /// Run-ahead input-latency reduction: each display refresh retires
+    /// `run_ahead_frames` extra emulated frames past the anchor, presents the
+    /// final frame of that burst, then rewinds to the anchor boundary. Host
+    /// input sampled before the burst therefore lands in guest time up to
+    /// `run_ahead_frames` earlier relative to what is on screen. Costs a
+    /// whole-machine snapshot plus `(run_ahead_frames + 1)`x realtime host
+    /// speed. Host-coupled devices and diagnostics that cannot be rewound
+    /// leave the configured value selected but temporarily inactive.
+    pub run_ahead_frames: u8,
 }
 
 /// Default rewind snapshot budget in MiB when `[emulation] rewind` is on.
@@ -1226,6 +1235,11 @@ pub const REWIND_DEFAULT_BUDGET_MB: usize = 256;
 /// Default emulated frames between rewind snapshots: half a second of PAL,
 /// which is a comfortable step size for a rewind hotkey.
 pub const REWIND_DEFAULT_INTERVAL_FRAMES: u64 = 25;
+
+/// Fastest configurable run-ahead. Beyond a handful of frames the burst no
+/// longer fits in one display refresh on realistic hosts, and skipping too
+/// many guest animation frames reads as rubber-banding.
+pub const RUN_AHEAD_MAX_FRAMES: u8 = 4;
 
 // ---------------------------------------------------------------------------
 // Autofire
@@ -2218,6 +2232,7 @@ impl Default for Config {
                 rewind: false,
                 rewind_budget_mb: REWIND_DEFAULT_BUDGET_MB,
                 rewind_interval_frames: REWIND_DEFAULT_INTERVAL_FRAMES,
+                run_ahead_frames: 0,
             },
             chip_ram_bytes: 512 * 1024,
             fast_ram_bytes: 0,
@@ -2304,6 +2319,39 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Why this resolved machine shape cannot use per-refresh run-ahead
+    /// snapshots. These devices retain or mutate host state outside the
+    /// serialized core. Dynamic media and observers are checked on the live
+    /// Bus by the window session.
+    pub fn runahead_machine_block_reason(&self) -> Option<&'static str> {
+        if !self.filesys.is_empty() {
+            return Some("host directory volume");
+        }
+        if !self.host_disks.is_empty() {
+            return Some("physical host disk");
+        }
+        if self.ide.master.is_some()
+            || self.ide.slave.is_some()
+            || self.scsi.units.iter().any(Option::is_some)
+            || self.lide.drives.iter().any(Option::is_some)
+        {
+            return Some("hard-drive or ATAPI image");
+        }
+        if self.a2065_net.is_some() {
+            return Some("A2065 network board");
+        }
+        if self.hostsocket_net.is_some() || self.hostsocket_transport.is_some() {
+            return Some("HostSocket network board");
+        }
+        if !self.wasm_boards.is_empty() {
+            return Some("WASM expansion board");
+        }
+        if self.mhi {
+            return Some("MHI decoder board");
+        }
+        None
+    }
+
     /// Load a config, applying command-line overrides on top of whatever the
     /// file (or the built-in defaults, when `path` is `None`) provides. The
     /// overrides are injected into the raw TOML view before validation, so
@@ -2445,6 +2493,9 @@ pub struct ConfigOverrides {
     /// Autofire rate in Hz (`--autofire`), 0 for off. Same validation as
     /// `[input] autofire_hz`.
     pub autofire_hz: Option<u8>,
+    /// Run-ahead frames (`--run-ahead`), 0 for off. Same validation as
+    /// `[emulation] run_ahead_frames`.
+    pub run_ahead_frames: Option<u8>,
     /// Serial port wiring (`--serial`): "off", "stdout", "midi", "tcp",
     /// "tcp-connect", or "pty" ("none" and "terminal" parse as
     /// compatibility aliases of the first two). Same parser as
@@ -2574,6 +2625,7 @@ impl ConfigOverrides {
             && self.port1.is_none()
             && self.port2.is_none()
             && self.autofire_hz.is_none()
+            && self.run_ahead_frames.is_none()
             && self.serial.is_none()
             && self.serial_connect.is_none()
             && self.midi_out.is_none()
@@ -2728,6 +2780,9 @@ impl ConfigOverrides {
         }
         if let Some(hz) = self.autofire_hz {
             raw.input.autofire_hz = Some(hz);
+        }
+        if let Some(frames) = self.run_ahead_frames {
+            raw.emulation.run_ahead_frames = Some(frames);
         }
         if let Some(mode) = &self.serial {
             raw.serial.mode = Some(mode.clone());

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -1000,6 +1000,10 @@ pub(crate) struct RawEmulation {
     /// Emulated frames between rewind snapshots (one rewind step).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) rewind_interval_frames: Option<u64>,
+    /// Run-ahead input-latency reduction: present the frame `n` emulated
+    /// frames in the future of the anchor each display refresh (0 = off).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) run_ahead_frames: Option<u8>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4777,3 +4777,48 @@ fn toml_path(path: &Path) -> String {
         .replace('\\', "\\\\")
         .replace('"', "\\\"")
 }
+
+#[test]
+fn emulation_run_ahead_frames_parses_and_rejects_out_of_range() -> Result<()> {
+    assert_eq!(parse_config("")?.emulation.run_ahead_frames, 0);
+    let cfg = parse_config(
+        r#"
+            [emulation]
+            run_ahead_frames = 2
+            "#,
+    )?;
+    assert_eq!(cfg.emulation.run_ahead_frames, 2);
+    assert!(parse_config("[emulation]\nrun_ahead_frames = 5").is_err());
+    Ok(())
+}
+
+#[test]
+fn runahead_machine_gate_rejects_host_coupled_storage() -> Result<()> {
+    assert_eq!(parse_config("")?.runahead_machine_block_reason(), None);
+
+    let cfg = parse_config(
+        r#"
+            [[filesys]]
+            path = "shared"
+        "#,
+    )?;
+    assert_eq!(
+        cfg.runahead_machine_block_reason(),
+        Some("host directory volume")
+    );
+
+    let cfg = parse_config(
+        r#"
+            [machine]
+            profile = "A600"
+
+            [ide]
+            master = "disk.hdf"
+        "#,
+    )?;
+    assert_eq!(
+        cfg.runahead_machine_block_reason(),
+        Some("hard-drive or ATAPI image")
+    );
+    Ok(())
+}

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -129,6 +129,18 @@ impl TryFrom<RawConfig> for Config {
                 Some(0) => bail!("[emulation] rewind_interval_frames must be at least 1"),
                 Some(n) => n,
             },
+            run_ahead_frames: match raw.emulation.run_ahead_frames {
+                None => defaults.emulation.run_ahead_frames,
+                Some(n) => {
+                    if n > crate::config::RUN_AHEAD_MAX_FRAMES {
+                        bail!(
+                            "[emulation] run_ahead_frames must be 0..={}",
+                            crate::config::RUN_AHEAD_MAX_FRAMES
+                        );
+                    }
+                    n
+                }
+            },
         };
         let chip_ram_bytes = match raw.memory.chip.as_deref() {
             None => defaults.chip_ram_bytes,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1950,6 +1950,42 @@ impl M68kMachine {
         self.ui_stop.is_some()
     }
 
+    /// Whether an interactive debugger condition could stop inside a
+    /// speculative frame. Run-ahead remains off while one is armed so the
+    /// debugger always stops on the committed timeline.
+    pub fn ui_debug_stops_armed(&self) -> bool {
+        self.ui_breaks.armed()
+    }
+
+    /// Whether the environment-driven headless debugger is observing the
+    /// machine. Its counters, traces, and screenshots are host-side and must
+    /// not see frames that will be rewound.
+    pub fn headless_debugger_armed(&self) -> bool {
+        self.dbg.is_some()
+    }
+
+    /// Why interactive or environment-driven debugger state cannot observe
+    /// speculative frames. Unlike CPU and chipset state, these counters,
+    /// files, and rolling views intentionally survive a machine restore.
+    pub fn runahead_debug_block_reason(&self) -> Option<&'static str> {
+        if self.ui_debug_stops_armed() {
+            return Some("debugger stop conditions armed");
+        }
+        if let Some(reason) = self.bus.bus.runahead_debug_block_reason() {
+            return Some(reason);
+        }
+        if self.headless_debugger_armed() {
+            return Some("COPPERLINE_DBG_* debugger armed");
+        }
+        if self.ui_trace.is_some() {
+            return Some("instruction trace active");
+        }
+        if self.ui_pc_history_enabled {
+            return Some("debugger PC history active");
+        }
+        None
+    }
+
     /// Promote a custom-register watch or beam-trap hit recorded by the
     /// bus (which sees every writer and every colour clock, including
     /// while the CPU sits in STOP) into the machine-level stop reason.

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -65,6 +65,13 @@ pub struct Emulator {
     /// (headless screenshot/frame-dump runs). The emulated result is
     /// identical either way.
     paced: bool,
+    /// Run-ahead burst phase (see `set_runahead_phase`): while set, the
+    /// per-frame pacing sleep inside `step_real` is suppressed.
+    runahead_phase: bool,
+    /// Whether the frame currently being stepped is speculative. Host audio
+    /// and serial output are withheld, and committed-frame statistics do not
+    /// count work that the next burst will re-emulate.
+    runahead_speculative: bool,
     cpu_cycles_per_instruction: f64,
     real_pacing_budget_mode: RealPacingBudgetMode,
     /// Fast batch/trace-JIT CPU execution (`[cpu] jit`). The run loop then
@@ -448,6 +455,8 @@ impl Emulator {
             machine,
             stats: EmuStats::default(),
             paced,
+            runahead_phase: false,
+            runahead_speculative: false,
             cpu_cycles_per_instruction,
             real_pacing_budget_mode,
             cpu_jit: false,
@@ -806,6 +815,66 @@ impl Emulator {
         self.reset_live_audio_after_timeline_jump();
         self.reanchor_realtime_clock();
         Ok(())
+    }
+
+    /// Enter or leave the run-ahead burst phase. While in the phase, the
+    /// per-frame pacing sleep inside `step_real` is suppressed; the caller
+    /// paces once per burst against the anchor frame's end time instead
+    /// (`pace_runahead_burst`).
+    pub fn set_runahead_phase(&mut self, on: bool) {
+        self.runahead_phase = on;
+    }
+
+    pub fn runahead_phase(&self) -> bool {
+        self.runahead_phase
+    }
+
+    /// Mark subsequent emulation as speculative. The machine still executes
+    /// normally, but output that cannot be rewound is withheld until the same
+    /// guest time is executed as the next committed anchor.
+    pub fn set_runahead_speculative(&mut self, on: bool) {
+        self.runahead_speculative = on;
+        let bus = self.bus_mut();
+        bus.set_live_audio_discard(on);
+        bus.paula.set_speculative_host_quiet(on);
+    }
+
+    /// Serialize the machine at a run-ahead anchor boundary. Same-process
+    /// bincode like the reverse-debug ring (no framing), taken at a frame
+    /// boundary where `M68kMachine::write_state` is consistent.
+    pub fn runahead_snapshot(&self) -> Result<Vec<u8>> {
+        self.snapshot_blob()
+    }
+
+    /// Restore an anchor snapshot produced by [`Self::runahead_snapshot`].
+    /// Unlike [`Self::restore_blob`] this deliberately does NOT reset the
+    /// live audio stream or re-anchor real-time pacing: the audible
+    /// timeline continues uninterrupted across the rewind, and the pacing
+    /// coordinate keeps marching forward while emulated time oscillates
+    /// within the burst. Host-side Paula settings survive as usual.
+    pub fn runahead_restore(&mut self, blob: &[u8]) -> Result<()> {
+        let mono = self.bus_mut().paula.mono_output();
+        let separation = self.bus_mut().paula.stereo_separation();
+        let filter = self.bus_mut().paula.led_filter_mode();
+        let mut cursor = std::io::Cursor::new(blob);
+        self.machine.apply_state(&mut cursor)?;
+        self.bus_mut().paula.set_mono_output(mono);
+        self.bus_mut().paula.set_stereo_separation(separation);
+        self.bus_mut().paula.set_led_filter_mode(filter);
+        self.reset_realtime_quantum();
+        Ok(())
+    }
+
+    /// Pace a completed run-ahead burst. `anchor_end_seconds` is the
+    /// emulated time at the end of the iteration's anchor (first) frame:
+    /// presented frames advance one per iteration, so wall-clock budget per
+    /// iteration is one frame period even though the burst retired more.
+    /// No-op when unpaced (warp/headless).
+    pub fn pace_runahead_burst(&mut self, anchor_end_seconds: f64) {
+        if !self.paced {
+            return;
+        }
+        self.pace_to_emulated_target(anchor_end_seconds);
     }
 
     /// Capture a snapshot into the ring if one is due at the current frame.
@@ -1567,7 +1636,9 @@ impl Emulator {
             self.stats.started_at = Some(crate::timebase::Instant::now());
         }
         self.step_real()?;
-        self.stats.frames += 1;
+        if !self.runahead_speculative {
+            self.stats.frames += 1;
+        }
         // Capture a reverse-debug snapshot at this frame boundary when one is
         // due (no-op unless reverse mode is armed). Frame boundaries are the
         // only safe capture points -- mid-frame the renderer capture buffers
@@ -1576,7 +1647,10 @@ impl Emulator {
         // Evaluate a time-targeted reverse watchpoint when its target is
         // reached (no-op unless armed).
         self.tt_poll_reverse_watch()?;
-        if crate::envcfg::flag("COPPERLINE_DIAG_PCSAMPLE") && self.stats.frames.is_multiple_of(50) {
+        if !self.runahead_speculative
+            && crate::envcfg::flag("COPPERLINE_DIAG_PCSAMPLE")
+            && self.stats.frames.is_multiple_of(50)
+        {
             log::info!(
                 "pcsample frame={} pc={:#010X} sr={:#06X}",
                 self.stats.frames,
@@ -1619,8 +1693,10 @@ impl Emulator {
         self.realtime_quantum_remaining = remaining;
         self.realtime_quantum_cpu_idle = remaining != 0 && cpu_idle;
         // Pace presentation to wall-clock only for the interactive window;
-        // headless runs advance the deterministic core unthrottled.
-        let slept = if self.paced {
+        // headless runs advance the deterministic core unthrottled. During a
+        // run-ahead burst the sleep is deferred to the burst's anchor target
+        // (`pace_runahead_burst`), so speculative frames retire unpaced.
+        let slept = if self.paced && !self.runahead_phase {
             self.sleep_until_realtime_device_time()
         } else {
             Duration::ZERO
@@ -1802,17 +1878,21 @@ impl Emulator {
     /// Returns the host time actually slept, so the caller can subtract it
     /// from the frame's busy-time accounting.
     fn sleep_until_realtime_device_time(&mut self) -> Duration {
+        let emulated_now = self.bus().emulated_seconds();
+        self.pace_to_emulated_target(emulated_now)
+    }
+
+    /// Sleep until wall-clock reaches `emulated_now` minus the live-audio
+    /// lead. Shared by the per-frame pacer and the run-ahead burst pacer
+    /// (which passes an anchor-frame target instead of the current time).
+    fn pace_to_emulated_target(&mut self, emulated_now: f64) -> Duration {
         let Some(started_at) = self.stats.started_at else {
             return Duration::ZERO;
         };
         let mut slept = Duration::ZERO;
         let now = Instant::now();
         let live_audio_lead_seconds = self.bus().live_audio_output_lead_seconds();
-        let target = realtime_device_time_target(
-            started_at,
-            self.bus().emulated_seconds(),
-            live_audio_lead_seconds,
-        );
+        let target = realtime_device_time_target(started_at, emulated_now, live_audio_lead_seconds);
         if let Some(wait) = target.and_then(|target| target.checked_duration_since(now)) {
             let sleep_started = Instant::now();
             std::thread::sleep(wait);
@@ -4131,5 +4211,83 @@ mod tests {
 
         assert_eq!(*resets.borrow(), 1);
         let _ = std::fs::remove_file(path);
+    }
+
+    #[derive(Default)]
+    struct RunaheadProbe {
+        pushed: std::cell::Cell<u64>,
+    }
+
+    struct RunaheadProbeSink(std::rc::Rc<RunaheadProbe>);
+
+    impl crate::audio::AudioSink for RunaheadProbeSink {
+        fn push(&mut self, _left: f32, _right: f32) {
+            self.0.pushed.set(self.0.pushed.get() + 1);
+        }
+        fn flush(&mut self) {}
+    }
+
+    #[test]
+    fn runahead_restore_rewinds_machine_state_and_keeps_positions_monotonic() {
+        let mut emu = emulator_with_audio(Box::new(RunaheadProbeSink(std::rc::Rc::new(
+            RunaheadProbe::default(),
+        ))));
+        emu.step_frame().unwrap();
+        let retired_at_anchor = emu.retired_instructions;
+        let blob = emu.runahead_snapshot().unwrap();
+
+        // Advance past the anchor and leave a marker in chip RAM.
+        emu.step_frame().unwrap();
+        assert!(emu.retired_instructions > retired_at_anchor);
+        emu.bus_mut().mem.chip_ram[0x2000] = 0xAB;
+
+        emu.runahead_restore(&blob).unwrap();
+        assert_eq!(
+            emu.bus().mem.chip_ram[0x2000],
+            0,
+            "writes after the anchor are rolled back by the restore"
+        );
+        assert!(
+            emu.retired_instructions >= retired_at_anchor,
+            "the position coordinate stays monotonic across an anchor restore"
+        );
+    }
+
+    #[test]
+    fn speculative_audio_is_withheld_from_the_sink() {
+        let probe = std::rc::Rc::new(RunaheadProbe::default());
+        let mut emu = emulator_with_audio(Box::new(RunaheadProbeSink(probe.clone())));
+        emu.set_runahead_speculative(true);
+        emu.step_frame().unwrap();
+        assert_eq!(probe.pushed.get(), 0);
+
+        emu.set_runahead_speculative(false);
+        emu.step_frame().unwrap();
+        assert!(probe.pushed.get() > 0, "committed output flows again");
+    }
+
+    #[test]
+    fn speculative_frames_do_not_inflate_committed_frame_statistics() {
+        let mut emu = emulator_with_audio(Box::new(crate::audio::NullSink));
+        emu.step_frame().unwrap();
+        let committed = emu.stats.frames;
+
+        emu.set_runahead_speculative(true);
+        emu.step_frame().unwrap();
+        assert_eq!(emu.stats.frames, committed);
+
+        emu.set_runahead_speculative(false);
+        emu.step_frame().unwrap();
+        assert_eq!(emu.stats.frames, committed + 1);
+    }
+
+    #[test]
+    fn audio_debug_taps_survive_a_runahead_restore() {
+        let mut emu = emulator_with_audio(Box::new(crate::audio::NullSink));
+        emu.step_frame().unwrap();
+        let blob = emu.runahead_snapshot().unwrap();
+        emu.bus_mut().paula.toggle_channel_muted(2);
+        emu.runahead_restore(&blob).unwrap();
+        assert!(emu.bus().paula.channel_muted(2));
     }
 }

--- a/src/floppy/mod.rs
+++ b/src/floppy/mod.rs
@@ -688,6 +688,25 @@ impl FloppyController {
         self.drives.iter().any(|d| d.bridge.is_some())
     }
 
+    /// Why this controller cannot be replayed speculatively. A physical
+    /// mechanism cannot rewind, and a writable image flushes completed guest
+    /// writes to its host file. Read-only image media is fully serialized.
+    pub fn runahead_block_reason(&self) -> Option<&'static str> {
+        #[cfg(feature = "fluxbridge")]
+        if self.drives.iter().any(FloppyDrive::is_bridged) {
+            return Some("physical floppy drive");
+        }
+        if self.drives.iter().any(|drive| {
+            drive
+                .image
+                .as_ref()
+                .is_some_and(|image| !image.write_protected)
+        }) {
+            return Some("writable floppy image");
+        }
+        None
+    }
+
     /// Whether any fitted bay serves from an image. Drive speed only shapes
     /// how fast a track is served from one: a real drive's data rate is the
     /// disk's own, so with every fitted bay physical there is nothing for the

--- a/src/floppy/tests.rs
+++ b/src/floppy/tests.rs
@@ -12,6 +12,19 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+#[test]
+fn runahead_gate_tracks_the_inserted_images_write_protection() -> Result<()> {
+    let mut ctrl = FloppyController::default();
+    assert_eq!(ctrl.runahead_block_reason(), None);
+
+    ctrl.insert_disk_image_bytes(0, vec![0; ADF_SIZE], PathBuf::from("readonly.adf"), true)?;
+    assert_eq!(ctrl.runahead_block_reason(), None);
+
+    ctrl.insert_disk_image_bytes(0, vec![0; ADF_SIZE], PathBuf::from("writable.adf"), false)?;
+    assert_eq!(ctrl.runahead_block_reason(), Some("writable floppy image"));
+    Ok(())
+}
+
 /// A write reaches a real platter a revolution after it is handed over,
 /// and until it does the drive still holds the recording from *before*
 /// it. Reading in that window would show the guest a disk that no longer

--- a/src/main.rs
+++ b/src/main.rs
@@ -1047,6 +1047,11 @@ fn main() -> Result<()> {
         cfg.mouse_capture,
         config::about_machine_lines(&cfg),
         raw_cfg,
+        if cli.load_state.is_some() {
+            Some("loaded save state")
+        } else {
+            cfg.runahead_machine_block_reason()
+        },
         live_audio,
         copperline::sampler::SamplerRequest::from_config(&cfg.parallel),
     );
@@ -1180,6 +1185,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         config::MouseCapture::default(),
         vec![config::ABOUT_PLACEHOLDER_LINE.to_string()],
         raw_cfg,
+        None,
         audio_output_enabled,
         // The placeholder runs no sampler; run_machine attaches it on Run.
         copperline::sampler::SamplerRequest::default(),

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -53,6 +53,13 @@ pub trait ParallelPort: Send {
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
     }
+
+    /// Whether speculative run-ahead frames may touch this peripheral.
+    /// A printer writes an irreversible host stream and a sampler consumes
+    /// live input, so only the unplugged port opts in.
+    fn runahead_safe(&self) -> bool {
+        false
+    }
 }
 
 pub struct NullParallelPort;
@@ -60,6 +67,10 @@ pub struct NullParallelPort;
 impl ParallelPort for NullParallelPort {
     fn strobe(&mut self, _data: u8, _at_cck: u64) -> bool {
         false
+    }
+
+    fn runahead_safe(&self) -> bool {
+        true
     }
 }
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -149,6 +149,20 @@ impl Rtc {
         self.clock().frozen()
     }
 
+    /// Whether repeated speculative execution and rewind is self-contained.
+    /// A seeded clock advances only in emulated time. An RP5C01 is also safe
+    /// only without a battery-RAM file, because guest writes flush that file
+    /// immediately and a host write cannot be rewound with the machine.
+    pub fn runahead_safe(&self) -> bool {
+        if self.seed().is_none() {
+            return false;
+        }
+        match self {
+            Rtc::Msm6242(_) => true,
+            Rtc::Rp5c01(chip) => chip.battmem_path.is_none(),
+        }
+    }
+
     /// The Unix-seconds instant register reads decompose right now.
     pub fn current_unix(&self, emulated_secs: f64) -> u64 {
         self.clock().current_unix(emulated_secs)

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -105,6 +105,16 @@ pub trait SerialSink: Send {
         false
     }
 
+    /// Whether this host endpoint can remain attached during run-ahead.
+    /// Speculative transmissions are withheld until their committed
+    /// re-emulation, so an output-only byte stream is safe when it has no
+    /// host-timing or connection state. Endpoints that can feed bytes back
+    /// into the guest, schedule MIDI, or own a live connection keep the
+    /// conservative default.
+    fn runahead_safe(&self) -> bool {
+        false
+    }
+
     /// Update the emulated-to-host time mapping (see [`SerialTimeAnchor`]).
     /// Sinks that schedule output store it; others ignore it.
     fn set_time_anchor(&mut self, _anchor: SerialTimeAnchor) {}
@@ -666,6 +676,10 @@ impl SerialSink for NullSerialSink {
     fn write_byte(&mut self, _b: u8, _at_cck: u64) {}
 
     fn flush(&mut self) {}
+
+    fn runahead_safe(&self) -> bool {
+        true
+    }
 }
 
 pub struct StdoutSink {
@@ -704,6 +718,10 @@ impl SerialSink for StdoutSink {
             let _ = stdout.flush();
             self.buf.clear();
         }
+    }
+
+    fn runahead_safe(&self) -> bool {
+        true
     }
 }
 

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -2274,6 +2274,9 @@ pub struct MachineSetup {
     pacing_budget: PacingBudget,
     realtime_priority: bool,
     warp: WarpSpeed,
+    /// The config screen has no control for run-ahead yet, but must preserve
+    /// a value loaded from TOML or the CLI when it rebuilds RawConfig.
+    run_ahead_frames: u8,
     joystick_input_mode: JoystickInputMode,
     mouse_sensitivity: u8,
     mouse_capture: MouseCapture,
@@ -2542,6 +2545,7 @@ impl MachineSetup {
             pacing_budget: cfg.emulation.pacing_budget,
             realtime_priority: cfg.emulation.realtime_priority,
             warp: cfg.emulation.warp_speed,
+            run_ahead_frames: cfg.emulation.run_ahead_frames,
             joystick_input_mode: cfg.joystick_input_mode,
             mouse_sensitivity: cfg.mouse_sensitivity,
             mouse_capture: cfg.mouse_capture,
@@ -3046,6 +3050,9 @@ impl MachineSetup {
         if self.warp != base.emulation.warp_speed {
             raw.emulation.warp_speed = Some(self.warp.label().to_ascii_lowercase());
         }
+        if self.run_ahead_frames != base.emulation.run_ahead_frames {
+            raw.emulation.run_ahead_frames = Some(self.run_ahead_frames);
+        }
         if self.joystick_input_mode != base.joystick_input_mode {
             raw.input.joystick = Some(self.joystick_input_mode.label().to_string());
         }
@@ -3318,6 +3325,7 @@ impl MachineSetup {
         self.pacing_budget = base.emulation.pacing_budget;
         self.realtime_priority = base.emulation.realtime_priority;
         self.warp = base.emulation.warp_speed;
+        self.run_ahead_frames = base.emulation.run_ahead_frames;
         self.joystick_input_mode = base.joystick_input_mode;
         self.mouse_sensitivity = base.mouse_sensitivity;
         self.mouse_capture = base.mouse_capture;

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -1,6 +1,13 @@
 use super::*;
 
 #[test]
+fn run_ahead_frames_survives_the_config_screen_round_trip() {
+    let raw: RawConfig = toml::from_str("[emulation]\nrun_ahead_frames = 2\n").unwrap();
+    let setup = MachineSetup::from_raw(&raw).unwrap();
+    assert_eq!(setup.to_raw().emulation.run_ahead_frames, Some(2));
+}
+
+#[test]
 fn ram_initialisation_controls_cycle_and_round_trip() {
     let raw: RawConfig = toml::from_str("[memory]\ninit = \"random:0xBEEF\"\n").unwrap();
     let mut setup = MachineSetup::from_raw(&raw).unwrap();

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -60,6 +60,8 @@ pub enum MenuAction {
     SetPortDevice(usize, PortDevice),
     SetJoystickInput(JoystickInputMode),
     SetAutofire(u8),
+    /// Run-ahead input-latency reduction level in frames (0 = off).
+    SetRunAhead(u8),
     /// Show or hide the on-screen Amiga keyboard.
     ToggleKeyboardPanel,
 
@@ -458,6 +460,7 @@ pub struct MenuState<'a> {
     pub recording: bool,
     pub input_recording: bool,
     pub autofire_hz: u8,
+    pub run_ahead_frames: u8,
     pub joystick_input_mode: JoystickInputMode,
     /// Whether the on-screen Amiga keyboard is up.
     pub keyboard_panel: bool,
@@ -1061,7 +1064,31 @@ fn emulation_rows(s: &MenuState) -> Vec<MenuRow> {
     vec![
         MenuRow::submenu("Floppy Speed", speeds).available(s.floppy_speed_applies),
         MenuRow::toggle("Rewind", MenuAction::ToggleRewind, s.rewind),
+        MenuRow::submenu("Run Ahead", run_ahead_rows(s)),
     ]
+}
+
+/// Run-ahead levels offered by the menu; 0 is off. Mirrors
+/// `RUN_AHEAD_MAX_FRAMES` from the config.
+fn run_ahead_rows(s: &MenuState) -> Vec<MenuRow> {
+    let label = |n: u8| {
+        if n == 0 {
+            "Off".to_string()
+        } else if n == 1 {
+            "1 frame".to_string()
+        } else {
+            format!("{n} frames")
+        }
+    };
+    (0..=crate::config::RUN_AHEAD_MAX_FRAMES)
+        .map(|n| {
+            MenuRow::choice(
+                &label(n),
+                MenuAction::SetRunAhead(n),
+                s.run_ahead_frames == n,
+            )
+        })
+        .collect()
 }
 
 fn warp_rows(s: &MenuState) -> Vec<MenuRow> {
@@ -1297,6 +1324,7 @@ mod tests {
             recording: false,
             input_recording: false,
             autofire_hz: 0,
+            run_ahead_frames: 0,
             joystick_input_mode: JoystickInputMode::Gamepad,
             keyboard_panel: false,
             port_devices: [PortDevice::Mouse, PortDevice::Joystick],

--- a/src/video/ui/tests.rs
+++ b/src/video/ui/tests.rs
@@ -2997,6 +2997,7 @@ fn panels_render_into_their_rects() {
         recording: false,
         input_recording: false,
         autofire_hz: 0,
+        run_ahead_frames: 0,
         joystick_input_mode: JoystickInputMode::Gamepad,
         keyboard_panel: false,
         port_devices: [

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1354,6 +1354,13 @@ pub struct App {
     /// host input policy, not machine state: it gates a *held* fire button
     /// into a pulse train, so nothing changes unless the user holds fire.
     autofire_hz: u8,
+    /// Run-ahead frames for input-latency reduction, 0 = off (see
+    /// `[emulation] run_ahead_frames`). A presentation policy: the machine
+    /// state at every committed frame boundary is identical with it on or off.
+    run_ahead_frames: u8,
+    /// Static incompatibility derived from the resolved machine config.
+    /// Dynamic media/peripheral checks live on the Bus.
+    runahead_machine_block: Option<&'static str>,
     /// Pop-up menu and main-window overlay state. Debugger and frame
     /// analyzer panes live in separate tool-window state so they can be
     /// open at the same time.
@@ -1879,6 +1886,7 @@ impl App {
         mouse_capture: crate::config::MouseCapture,
         about_machine_lines: Vec<String>,
         machine_config: RawConfig,
+        runahead_machine_block: Option<&'static str>,
         // Effective live-audio state for this machine: for a real machine the
         // caller's --audio/--noaudio-resolved value; for the config-screen
         // placeholder the config intent (so a state loaded over it gets sound).
@@ -1939,6 +1947,11 @@ impl App {
             .autofire_hz
             .unwrap_or(0)
             .min(crate::config::AUTOFIRE_MAX_HZ);
+        let run_ahead_frames = machine_config
+            .emulation
+            .run_ahead_frames
+            .unwrap_or(0)
+            .min(crate::config::RUN_AHEAD_MAX_FRAMES);
         let mut app = Self {
             emu,
             serial_is_midi,
@@ -2105,6 +2118,8 @@ impl App {
             keyboard_joy_held: [keymap::HeldKeys::default(); keymap::MAPPING_COUNT],
             keymap: keymap::KeyMap::load(),
             autofire_hz,
+            run_ahead_frames,
+            runahead_machine_block,
             ui: UiState::default(),
             menu_hover_arm: None,
             about_opened_at: Instant::now(),
@@ -2126,6 +2141,15 @@ impl App {
         app.attach_session_sampler();
         if app.rewind_armed {
             app.arm_rewind_ring();
+        }
+        if let (true, Some(reason)) = (
+            app.run_ahead_frames > 0 && app.powered_on,
+            app.runahead_block_reason(),
+        ) {
+            warn!(
+                "run-ahead ({} frames) configured but inactive: {reason}",
+                app.run_ahead_frames
+            );
         }
         app
     }
@@ -4636,6 +4660,11 @@ impl ApplicationHandler for App {
         // frame must be rendered, so warp's output frame-skip burst must not
         // apply there.
         let headless_capture = !self.auto_shot.is_empty() || self.frame_dump.is_some();
+        // A completed run-ahead burst renders its future frame before the
+        // anchor is restored. Suppress the generic post-step render in that
+        // case or it would immediately replace the future image with the
+        // rewound anchor.
+        let mut runahead_presented = false;
         // Run one scheduler quantum. Rebuild the host framebuffer only
         // when Agnus has crossed into a new frame; the expensive renderer
         // reconstructs a completed hardware frame, not an instruction slice.
@@ -4651,43 +4680,100 @@ impl ApplicationHandler for App {
             // effective speed is the warp level times the refresh rate, host
             // CPU permitting. Real-time pacing and headless capture stay at one
             // frame per loop.
-            let (frame_cap, time_budget) = self.warp_burst_plan(headless_capture);
+            // Run-ahead retires one extra speculative frame per configured
+            // level on top of the presented frame: input sampled this pass
+            // lands up to that many frames earlier relative to what is on
+            // screen. The committed anchor supplies audio and host output;
+            // later frames are silent speculation, with only the last image
+            // presented before the anchor snapshot restores machine state.
+            let (total_frames, runahead, time_budget) = self.burst_frames(headless_capture);
             let burst_start = Instant::now();
             let mut frames_done = 0usize;
+            let mut anchor_end_seconds: Option<f64> = None;
+            let mut anchor_snapshot: Option<Vec<u8>> = None;
+            let mut burst_complete = true;
+            self.emu.set_runahead_phase(runahead > 0);
             loop {
+                let speculative = runahead > 0 && frames_done > 0;
+                self.emu.set_runahead_speculative(speculative);
                 if let Err(e) = self.emu.step_frame() {
                     error!("emulator step halted: {e:?}");
                     self.cpu_halted = true;
                     self.sync_live_audio_suspension();
+                    burst_complete = false;
                     break;
                 }
                 #[cfg(feature = "control")]
-                self.control_emit_events();
+                if !speculative {
+                    self.control_emit_events();
+                }
                 frames_done += 1;
+                if runahead > 0 && frames_done == 1 {
+                    anchor_end_seconds = Some(self.emu.bus().emulated_seconds());
+                    match self.emu.runahead_snapshot() {
+                        Ok(blob) => anchor_snapshot = Some(blob),
+                        Err(e) => {
+                            warn!("run-ahead disabled: anchor snapshot failed: {e:?}");
+                            self.run_ahead_frames = 0;
+                            burst_complete = false;
+                            break;
+                        }
+                    }
+                }
                 // The warp-launch gate ends its warp the frame the guest
                 // loads the target program.
                 if self.poll_warp_launch() {
+                    burst_complete = false;
                     break;
                 }
                 // A breakpoint/watchpoint hit pauses the machine and brings
                 // the debugger window up with the reason; end the burst so the
                 // stop surfaces at the frame where it happened.
                 if self.surface_debug_stop() {
+                    burst_complete = false;
                     break;
                 }
                 // A remote run_until frame/cck target completes the
                 // pending resume and pauses at its boundary.
                 #[cfg(feature = "control")]
                 if self.control_run_target_reached() {
+                    burst_complete = false;
                     break;
                 }
-                if frames_done >= frame_cap {
+                if frames_done >= total_frames {
                     break;
                 }
                 if let Some(budget) = time_budget {
                     if burst_start.elapsed() >= budget {
+                        burst_complete = false;
                         break;
                     }
+                }
+            }
+            self.emu.set_runahead_phase(false);
+            self.emu.set_runahead_speculative(false);
+            if runahead > 0 {
+                let speculated = frames_done > 1;
+                if burst_complete && speculated {
+                    // Rendering must finish while the future Bus is still
+                    // live. The worker otherwise races the restore and the
+                    // generic renderer below can present the anchor instead.
+                    runahead_presented = self.finish_render_for_current_frame();
+                    if !runahead_presented {
+                        error!("run-ahead disabled: speculative frame was not renderable");
+                        self.run_ahead_frames = 0;
+                        burst_complete = false;
+                    }
+                }
+                self.restore_runahead_anchor(
+                    anchor_snapshot.as_deref(),
+                    burst_complete,
+                    speculated,
+                );
+                // Include snapshot, render, and restore cost in the same
+                // display-period budget by pacing last against the anchor.
+                if let Some(anchor_end) = anchor_end_seconds {
+                    self.emu.pace_runahead_burst(anchor_end);
                 }
             }
             self.refresh_tool_windows_paced(event_loop);
@@ -4745,7 +4831,8 @@ impl ApplicationHandler for App {
         }
         // While powered off, leave the parked test screen in place; the
         // emulator is not advancing, so there is no new frame to show.
-        let mut rendered = self.powered_on && self.render_emulated_frame_if_needed();
+        let mut rendered =
+            self.powered_on && (runahead_presented || self.render_emulated_frame_if_needed());
         if self.recorder.is_some() && self.powered_on {
             rendered |= self.finish_render_for_current_frame();
         }

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -1350,6 +1350,7 @@ impl App {
             self.serial_is_midi = self.emu.bus_mut().midi_serial_mut().is_some();
         }
         self.machine_config = raw;
+        self.runahead_machine_block = cfg.runahead_machine_block_reason();
         // Re-derive the sampler from the launcher's parallel config and attach it
         // to the fresh machine (the printer attaches inside build_machine, since
         // its byte sink is Send).
@@ -1387,6 +1388,16 @@ impl App {
         self.set_mouse_sensitivity(cfg.mouse_sensitivity);
         self.mouse_capture = cfg.mouse_capture;
         self.autofire_hz = cfg.autofire_hz;
+        self.run_ahead_frames = cfg
+            .emulation
+            .run_ahead_frames
+            .min(crate::config::RUN_AHEAD_MAX_FRAMES);
+        if let (true, Some(reason)) = (self.run_ahead_frames > 0, self.runahead_block_reason()) {
+            warn!(
+                "run-ahead ({} frames) configured but inactive: {reason}",
+                self.run_ahead_frames
+            );
+        }
         // Rewind history belongs to the machine that recorded it, so the new
         // machine starts a fresh ring under its own config (or none at all).
         self.rewind_budget_mb = cfg.emulation.rewind_budget_mb;

--- a/src/video/window/app_menus.rs
+++ b/src/video/window/app_menus.rs
@@ -115,6 +115,7 @@ impl App {
             recording: self.recorder.is_some(),
             input_recording: self.input_recorder.is_some(),
             autofire_hz: self.autofire_hz,
+            run_ahead_frames: self.run_ahead_frames,
             joystick_input_mode: self.joystick_input_mode,
             port_devices: [
                 self.emu.bus().input.device(0),
@@ -343,6 +344,25 @@ impl App {
                 let label = crate::config::autofire_label(hz);
                 info!("autofire: {label}");
                 self.show_osd(format!("Autofire: {label}"));
+                self.request_redraw();
+            }
+            A::SetRunAhead(frames) => {
+                self.run_ahead_frames = frames;
+                let label = if frames == 0 {
+                    "off".to_string()
+                } else {
+                    format!("{frames} frame{}", if frames == 1 { "" } else { "s" })
+                };
+                match (frames > 0).then(|| self.runahead_block_reason()).flatten() {
+                    Some(reason) => {
+                        info!("run-ahead: {label} (inactive: {reason})");
+                        self.show_osd(format!("Run Ahead: {label} (inactive: {reason})"));
+                    }
+                    None => {
+                        info!("run-ahead: {label}");
+                        self.show_osd(format!("Run Ahead: {label}"));
+                    }
+                }
                 self.request_redraw();
             }
             A::ToggleKeyboardPanel => self.toggle_keyboard_panel(),

--- a/src/video/window/app_session.rs
+++ b/src/video/window/app_session.rs
@@ -139,6 +139,93 @@ impl App {
         }
     }
 
+    /// The run-ahead level in effect for this burst, or zero while the
+    /// machine is transiently stopped or has a host-side incompatibility.
+    pub(super) fn runahead_effective_frames(&self) -> u8 {
+        if self.run_ahead_frames == 0
+            || !self.powered_on
+            || self.cpu_halted
+            || self.paused
+            || self.runahead_block_reason().is_some()
+        {
+            return 0;
+        }
+        self.run_ahead_frames
+    }
+
+    /// Why speculative execution is unsafe for the current session. A
+    /// configured level stays selected while blocked, and the menu/log can
+    /// surface this reason instead of silently pretending it is active.
+    pub(super) fn runahead_block_reason(&self) -> Option<&'static str> {
+        if !self.emu.paced() {
+            return Some("warp active");
+        }
+        if self.emu.time_travel_enabled() {
+            return Some("rewind/reverse history armed");
+        }
+        if self.rtg_present_dims.is_some() || self.emu.bus().rtg_active() {
+            return Some("RTG display active");
+        }
+        if self.recorder.is_some() {
+            return Some("video recording active");
+        }
+        if self.serial_is_midi {
+            return Some("MIDI device on the serial port");
+        }
+        if !self.emu.bus().paula.serial.runahead_safe() {
+            return Some("live serial host endpoint");
+        }
+        if self.control_client_attached() {
+            return Some("control client attached");
+        }
+        if let Some(reason) = self.emu.machine.runahead_debug_block_reason() {
+            return Some(reason);
+        }
+        self.runahead_machine_block
+            .or_else(|| self.emu.bus().runahead_host_block_reason())
+    }
+
+    /// Restore the committed boundary after any speculative execution. An
+    /// incomplete burst is not presentable and disables run-ahead for the
+    /// session, but it is still an abandoned timeline whose host output was
+    /// suppressed, so it must never be promoted by skipping the restore.
+    pub(super) fn restore_runahead_anchor(
+        &mut self,
+        anchor_snapshot: Option<&[u8]>,
+        burst_complete: bool,
+        speculated: bool,
+    ) {
+        if !speculated {
+            return;
+        }
+        match anchor_snapshot {
+            Some(blob) => {
+                if let Err(e) = self.emu.runahead_restore(blob) {
+                    error!("run-ahead disabled: anchor restore failed: {e:?}");
+                    self.run_ahead_frames = 0;
+                }
+            }
+            None => {
+                error!("run-ahead disabled: speculative burst has no anchor snapshot");
+                self.run_ahead_frames = 0;
+            }
+        }
+        if !burst_complete {
+            self.run_ahead_frames = 0;
+        }
+    }
+
+    fn control_client_attached(&self) -> bool {
+        #[cfg(feature = "control")]
+        {
+            self.control.as_ref().is_some_and(|c| c.handle.connected())
+        }
+        #[cfg(not(feature = "control"))]
+        {
+            false
+        }
+    }
+
     /// How many emulated frames to retire before presenting the next frame, and
     /// an optional wall-clock budget that bounds that burst. Warp's output frame
     /// skip applies only while warp is engaged and not doing headless capture;
@@ -158,6 +245,22 @@ impl App {
                 .time_budget_ms()
                 .map(std::time::Duration::from_millis),
         )
+    }
+
+    /// Combine warp output-frame skipping with run-ahead without allowing
+    /// either policy to collapse the other's frame cap. Scheduled capture is
+    /// unthrottled and archives committed frames, so it uses neither.
+    pub(super) fn burst_frames(
+        &self,
+        headless_capture: bool,
+    ) -> (usize, u8, Option<std::time::Duration>) {
+        let (frame_cap, time_budget) = self.warp_burst_plan(headless_capture);
+        let runahead = if frame_cap == 1 && time_budget.is_none() && !headless_capture {
+            self.runahead_effective_frames()
+        } else {
+            0
+        };
+        (frame_cap + usize::from(runahead), runahead, time_budget)
     }
 
     /// Cycle the warp/turbo output frame-skip level (2x -> 4x -> 8x -> 16x ->
@@ -307,6 +410,10 @@ impl App {
                 let restoring_over_placeholder = self.restoring_over_placeholder();
                 self.powered_on = true;
                 self.cpu_halted = false;
+                // A state can carry host-coupled hardware that is unrelated
+                // to the session's remembered config. Keep the conservative
+                // gate until a freshly resolved machine is launched.
+                self.runahead_machine_block = Some("loaded save state");
                 // Force a fresh presentation: the restored frame counter
                 // may equal (or precede) the last rendered one.
                 self.reset_render_pipeline();

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -2038,6 +2038,103 @@ fn cycle_warp_speed_walks_the_levels() {
 }
 
 #[test]
+fn burst_frames_preserves_warp_and_runahead_frame_counts() {
+    let mut app = test_app();
+    app.warp_speed = WarpSpeed::X4;
+    assert_eq!(app.burst_frames(false), (4, 0, None));
+
+    app.emu.set_paced(true);
+    app.emu.bus_mut().set_rtc_present(false);
+    app.run_ahead_frames = 2;
+    assert_eq!(app.runahead_block_reason(), None);
+    assert_eq!(app.burst_frames(false), (3, 2, None));
+    assert_eq!(
+        app.burst_frames(true),
+        (1, 0, None),
+        "scheduled capture uses committed frames only"
+    );
+}
+
+#[test]
+fn armed_debugger_stop_blocks_runahead() {
+    let mut app = test_app();
+    app.emu.set_paced(true);
+    app.emu.bus_mut().set_rtc_present(false);
+    app.run_ahead_frames = 1;
+    assert_eq!(app.runahead_effective_frames(), 1);
+
+    app.emu.machine.ui_set_breakpoint(0x00FC_0000, None, 0);
+    assert_eq!(app.runahead_effective_frames(), 0);
+    assert_eq!(
+        app.runahead_block_reason(),
+        Some("debugger stop conditions armed")
+    );
+}
+
+#[test]
+fn transient_debug_observers_block_runahead() {
+    let mut app = test_app();
+    app.emu.set_paced(true);
+    app.emu.bus_mut().set_rtc_present(false);
+    app.run_ahead_frames = 1;
+
+    app.emu
+        .bus_mut()
+        .inject_bus_fault(crate::bus::FaultInjection {
+            start: 0x1000,
+            end: 0x1001,
+            on_read: true,
+            on_write: false,
+            remaining: Some(1),
+            hits: 0,
+        });
+    assert_eq!(
+        app.runahead_block_reason(),
+        Some("injected bus fault armed")
+    );
+    app.emu.bus_mut().clear_injected_bus_faults();
+
+    app.emu.bus_mut().set_chipset_validation(true);
+    assert_eq!(
+        app.runahead_block_reason(),
+        Some("chipset validation armed")
+    );
+    app.emu.bus_mut().set_chipset_validation(false);
+
+    app.emu.bus_mut().set_smc_detection(true);
+    assert_eq!(app.runahead_block_reason(), Some("SMC detection armed"));
+    app.emu.bus_mut().set_smc_detection(false);
+
+    app.emu.bus_mut().set_heat_map(Some((0, 0x10000)));
+    assert_eq!(app.runahead_block_reason(), Some("memory heat map armed"));
+    app.emu.bus_mut().set_heat_map(None);
+
+    app.emu.bus_mut().set_frame_analyzer_enabled(true);
+    assert_eq!(app.runahead_block_reason(), Some("frame analyzer armed"));
+    app.emu.bus_mut().set_frame_analyzer_enabled(false);
+
+    app.emu.machine.ui_set_pc_history_enabled(true);
+    assert_eq!(
+        app.runahead_block_reason(),
+        Some("debugger PC history active")
+    );
+}
+
+#[test]
+fn incomplete_speculative_burst_restores_anchor_before_disabling_runahead() {
+    let mut app = test_app();
+    app.run_ahead_frames = 2;
+    app.emu.bus_mut().mem.chip_ram[0x2000] = 0x12;
+    let anchor = app.emu.runahead_snapshot().unwrap();
+
+    app.emu.bus_mut().mem.chip_ram[0x2000] = 0xAB;
+    app.restore_runahead_anchor(Some(&anchor), false, true);
+
+    assert_eq!(app.emu.bus().mem.chip_ram[0x2000], 0x12);
+    assert_eq!(app.run_ahead_frames, 0);
+}
+
+#[test]
 fn mouse_delta_integrator_keeps_fractional_remainder() {
     let mut delta = 0.75;
     assert_eq!(take_integral_mouse_delta(&mut delta), 0);
@@ -3975,6 +4072,7 @@ fn test_app_with_audio_cpu_and_program(
         crate::config::MouseCapture::Click,
         vec!["Machine: test".to_string()],
         crate::config::RawConfig::default(),
+        None,
         true,
         crate::sampler::SamplerRequest::default(),
     )


### PR DESCRIPTION
Supersedes the run-ahead portion of #506 with a ground-up transactional rewrite.

## Summary

- Add `[emulation] run_ahead_frames`, `--run-ahead`, and a live **Emulation Settings → Run Ahead** menu (0–4 frames).
- Commit one ordinary audible frame per refresh, snapshot at its boundary, execute silent future frames, render the last future frame, then restore the committed anchor.
- Pace the whole snapshot/speculate/render/restore transaction against the anchor frame so all work shares the normal display-period budget.
- Suppress speculative output at the shared audio and serial fan-out points, including live audio, WAV/stems, serial sinks, observers, scopes, and recording taps.
- Preserve host-only audio controls and debugger taps across the same-process restore.
- Document the algorithm, performance cost, CLI/config/UI surface, and compatibility rules.

## Safety model

Run-ahead remains selected but inactive whenever a frame could observe or mutate host state that the machine snapshot cannot rewind. The gate covers warp/headless capture, rewind, debugger stops, injected faults, validation/SMC/heat-map/frame-analyzer observers, instruction and waveform traces, RTG and video recording, control clients, live serial/parallel endpoints, writable or physical floppy media, CDs, persistent RTC/NVRAM, hard drives/host directories, networking, plugin boards, MHI, and loaded save states.

Any burst that executed a speculative frame attempts the anchor restore, including a step or render interruption. An incomplete burst then disables run-ahead for the session, so future frames whose output and accounting were suppressed can never become the committed timeline. Snapshot or restore failures also disable the feature.

## Validation

- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`
- `cargo test --locked runahead` (8 passed)
- `cargo check --no-default-features --features frontend,cpu-jit --locked`
- `cargo check --manifest-path crates/copperline-player/Cargo.toml --locked`
- Focused incomplete-burst restoration, transient-debugger gate, snapshot/restore, speculative audio/serial, committed statistics, config, media-gate, and burst-count tests
