### PR TITLE
build(deps): coordinate Cargo workspace updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,75 +1,37 @@
 version: 2
 updates:
-  # Native emulator and command-line tools.
+  # Keep all independent Cargo workspaces in one update block. Some of them
+  # depend on the root package by path, so updating a shared dependency in
+  # only one lockfile leaves the others unable to build with --locked.
+  # group-by makes one PR per non-patch dependency across every affected
+  # directory; patch releases stay in one consolidated PR.
   - package-ecosystem: cargo
-    directory: /
+    directories:
+      - /
+      - /crates/copperline-web
+      - /crates/copperline-player
+      - /crates/cputest-runner
+      - /crates/hostsocket-plugin
+      - /crates/zz9k-plugin
+      - /tools/bezel-preview
+      - /fuzz
     schedule:
       interval: weekly
     groups:
       patch-updates:
         update-types: ["patch"]
+      shared-dependency-updates:
+        group-by: dependency-name
     ignore:
       # Save states deliberately remain on bincode 1.x; see Cargo.toml.
       - dependency-name: bincode
-
-  # Standalone browser and publisher frontends.
-  - package-ecosystem: cargo
-    directory: /crates/copperline-web
-    schedule:
-      interval: weekly
-    groups:
-      patch-updates:
-        update-types: ["patch"]
-    ignore:
-      - dependency-name: bincode
-  - package-ecosystem: cargo
-    directory: /crates/copperline-player
-    schedule:
-      interval: weekly
-    groups:
-      patch-updates:
-        update-types: ["patch"]
-    ignore:
-      - dependency-name: bincode
-
-  # Development, plugin, and fuzz workspaces with independent lockfiles.
-  - package-ecosystem: cargo
-    directory: /crates/cputest-runner
-    schedule:
-      interval: weekly
-    groups:
-      patch-updates:
-        update-types: ["patch"]
-  - package-ecosystem: cargo
-    directory: /crates/hostsocket-plugin
-    schedule:
-      interval: weekly
-    groups:
-      patch-updates:
-        update-types: ["patch"]
-  - package-ecosystem: cargo
-    directory: /crates/zz9k-plugin
-    schedule:
-      interval: weekly
-    groups:
-      patch-updates:
-        update-types: ["patch"]
-  - package-ecosystem: cargo
-    directory: /tools/bezel-preview
-    schedule:
-      interval: weekly
-    groups:
-      patch-updates:
-        update-types: ["patch"]
-  - package-ecosystem: cargo
-    directory: /fuzz
-    schedule:
-      interval: weekly
-    groups:
-      patch-updates:
-        update-types: ["patch"]
-    ignore:
-      - dependency-name: bincode
+      # Wasmtime is part of the save-state contract and is intentionally pinned
+      # to an LTS line. Keep receiving that line's security/bugfix patches, but
+      # require a planned state-version migration for a new runtime series.
+      - dependency-name: wasmtime
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   - package-ecosystem: github-actions
     directory: /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -175,7 +175,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1288,7 +1288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2088,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.10.14"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c645c53f1fc33ff9dadbb9e554a1e9b43bc04ea633f8ebf15a167fc604e16f5"
+checksum = "825375341ee9ceda9695888bb620fe27a0db82eb69005ba7bdb8ebe7d85ae53e"
 dependencies = [
  "cranelift-codegen 0.132.3",
  "cranelift-frontend 0.132.3",
@@ -2784,7 +2784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.36.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3299,7 +3299,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3641,7 +3641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3737,10 +3737,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4165,12 +4165,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.256.0"
+version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1"
+checksum = "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.256.0",
+ "wasmparser 0.257.1",
 ]
 
 [[package]]
@@ -4188,9 +4188,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.256.0"
+version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c"
+checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
 dependencies = [
  "bitflags 2.13.1",
  "indexmap",
@@ -4409,22 +4409,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "256.0.0"
+version = "257.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ad42723fc9222da007f05812a3249c9a4ee7af79d497fc2a2079579ad7efe6"
+checksum = "3c416ee8044cf88c5280e3d87c322b009525eb25142cf7428f0a90ea88febc3b"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.256.0",
+ "wasm-encoder 0.257.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.256.0"
+version = "1.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cc86c54d8011b3202e265bfebada440733ea3a788ffaf46d395f7d2fdeacfb"
+checksum = "672e5495f00c5fc6c6b502205bae4708aa4dd13d969754438743afe0a8af0f1d"
 dependencies = [
  "wast",
 ]
@@ -4786,7 +4786,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ gdb = []
 fluxbridge = ["dep:fluxbridge"]
 
 [dependencies]
-m68k = { version = "0.10", features = ["serde"] }
+m68k = { version = "0.11", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.

--- a/crates/copperline-player/Cargo.lock
+++ b/crates/copperline-player/Cargo.lock
@@ -1545,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.10.14"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c645c53f1fc33ff9dadbb9e554a1e9b43bc04ea633f8ebf15a167fc604e16f5"
+checksum = "825375341ee9ceda9695888bb620fe27a0db82eb69005ba7bdb8ebe7d85ae53e"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/crates/copperline-web/Cargo.lock
+++ b/crates/copperline-web/Cargo.lock
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.10.14"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c645c53f1fc33ff9dadbb9e554a1e9b43bc04ea633f8ebf15a167fc604e16f5"
+checksum = "825375341ee9ceda9695888bb620fe27a0db82eb69005ba7bdb8ebe7d85ae53e"
 dependencies = [
  "serde",
 ]

--- a/crates/cputest-runner/Cargo.lock
+++ b/crates/cputest-runner/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "m68k"
-version = "0.10.14"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c645c53f1fc33ff9dadbb9e554a1e9b43bc04ea633f8ebf15a167fc604e16f5"
+checksum = "825375341ee9ceda9695888bb620fe27a0db82eb69005ba7bdb8ebe7d85ae53e"
 
 [[package]]
 name = "shlex"

--- a/crates/cputest-runner/Cargo.toml
+++ b/crates/cputest-runner/Cargo.toml
@@ -15,7 +15,7 @@ name = "cputest-runner"
 path = "src/main.rs"
 
 [dependencies]
-m68k = "0.10"
+m68k = "0.11"
 
 [build-dependencies]
 cc = "1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2106,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.10.14"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c645c53f1fc33ff9dadbb9e554a1e9b43bc04ea633f8ebf15a167fc604e16f5"
+checksum = "825375341ee9ceda9695888bb620fe27a0db82eb69005ba7bdb8ebe7d85ae53e"
 dependencies = [
  "cranelift-codegen 0.132.3",
  "cranelift-frontend 0.132.3",

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -2864,14 +2864,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/m68k/m68k-0.10.14.crate",
-        "sha256": "6c645c53f1fc33ff9dadbb9e554a1e9b43bc04ea633f8ebf15a167fc604e16f5",
-        "dest": "cargo/vendor/m68k-0.10.14"
+        "url": "https://static.crates.io/crates/m68k/m68k-0.11.0.crate",
+        "sha256": "825375341ee9ceda9695888bb620fe27a0db82eb69005ba7bdb8ebe7d85ae53e",
+        "dest": "cargo/vendor/m68k-0.11.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6c645c53f1fc33ff9dadbb9e554a1e9b43bc04ea633f8ebf15a167fc604e16f5\", \"files\": {}}",
-        "dest": "cargo/vendor/m68k-0.10.14",
+        "contents": "{\"package\": \"825375341ee9ceda9695888bb620fe27a0db82eb69005ba7bdb8ebe7d85ae53e\", \"files\": {}}",
+        "dest": "cargo/vendor/m68k-0.11.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5573,14 +5573,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-encoder/wasm-encoder-0.256.0.crate",
-        "sha256": "ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1",
-        "dest": "cargo/vendor/wasm-encoder-0.256.0"
+        "url": "https://static.crates.io/crates/wasm-encoder/wasm-encoder-0.257.1.crate",
+        "sha256": "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085",
+        "dest": "cargo/vendor/wasm-encoder-0.257.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-encoder-0.256.0",
+        "contents": "{\"package\": \"7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-encoder-0.257.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5599,14 +5599,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasmparser/wasmparser-0.256.0.crate",
-        "sha256": "60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c",
-        "dest": "cargo/vendor/wasmparser-0.256.0"
+        "url": "https://static.crates.io/crates/wasmparser/wasmparser-0.257.1.crate",
+        "sha256": "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a",
+        "dest": "cargo/vendor/wasmparser-0.257.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c\", \"files\": {}}",
-        "dest": "cargo/vendor/wasmparser-0.256.0",
+        "contents": "{\"package\": \"d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmparser-0.257.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5794,27 +5794,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wast/wast-256.0.0.crate",
-        "sha256": "a3ad42723fc9222da007f05812a3249c9a4ee7af79d497fc2a2079579ad7efe6",
-        "dest": "cargo/vendor/wast-256.0.0"
+        "url": "https://static.crates.io/crates/wast/wast-257.0.1.crate",
+        "sha256": "3c416ee8044cf88c5280e3d87c322b009525eb25142cf7428f0a90ea88febc3b",
+        "dest": "cargo/vendor/wast-257.0.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a3ad42723fc9222da007f05812a3249c9a4ee7af79d497fc2a2079579ad7efe6\", \"files\": {}}",
-        "dest": "cargo/vendor/wast-256.0.0",
+        "contents": "{\"package\": \"3c416ee8044cf88c5280e3d87c322b009525eb25142cf7428f0a90ea88febc3b\", \"files\": {}}",
+        "dest": "cargo/vendor/wast-257.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wat/wat-1.256.0.crate",
-        "sha256": "37cc86c54d8011b3202e265bfebada440733ea3a788ffaf46d395f7d2fdeacfb",
-        "dest": "cargo/vendor/wat-1.256.0"
+        "url": "https://static.crates.io/crates/wat/wat-1.257.1.crate",
+        "sha256": "672e5495f00c5fc6c6b502205bae4708aa4dd13d969754438743afe0a8af0f1d",
+        "dest": "cargo/vendor/wat-1.257.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"37cc86c54d8011b3202e265bfebada440733ea3a788ffaf46d395f7d2fdeacfb\", \"files\": {}}",
-        "dest": "cargo/vendor/wat-1.256.0",
+        "contents": "{\"package\": \"672e5495f00c5fc6c6b502205bae4708aa4dd13d969754438743afe0a8af0f1d\", \"files\": {}}",
+        "dest": "cargo/vendor/wat-1.257.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {


### PR DESCRIPTION
## Summary

- update `m68k` to 0.11.0 in the emulator and cputest runner
- update the root WAT toolchain to 1.257.1
- synchronize the browser, player, cputest, fuzz, root, and Flatpak dependency artifacts
- consolidate all Cargo update directories into one Dependabot block and group shared updates across directories
- keep bincode suppressed and reject Wasmtime major/minor jumps while still allowing 36.x patch/security updates

`m68k` 0.11 changes JIT tracing/profiling but does not change the serialized CPU shape, so this does not require another save-state version bump. Wasmtime remains at 36.0.13 because changing the runtime series is explicitly part of the save-state compatibility contract.

## Dependabot PR disposition

Supersedes #542, #543, #544, #545, and #547.

Does not adopt #546: that Wasmtime jump needs a planned API migration and save-state version bump, so #546 should be closed.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo build --release --locked`
- `cargo test --release --locked`
- all eight committed Cargo lockfiles resolve with `--locked`
- headless, benchmark, frontend-only, browser/WASM, player, and cputest builds
- all fuzz harnesses build under nightly without changing `fuzz/Cargo.lock`
- cargo-deny for core, browser, and player
- Flatpak cargo sources regenerate byte-for-byte
