### PR TITLE
Harden the CHD and save-state parsers against hostile headers

### DIFF
--- a/src/cdrom/chd.rs
+++ b/src/cdrom/chd.rs
@@ -98,7 +98,7 @@ struct RawTrack {
 /// fields needed for the bounds are decoded; everything else is left to the
 /// crate, which re-reads the header from offset 0.
 fn bound_raw_header(reader: &mut BufReader<File>, path: &Path) -> Result<()> {
-    use std::io::Read;
+    use std::io::{Read, Seek, SeekFrom};
 
     const MAGIC: &[u8; 8] = b"MComprHD";
     const HEADER_BYTES: usize = 124;
@@ -164,6 +164,38 @@ fn bound_raw_header(reader: &mut BufReader<File>, path: &Path) -> Result<()> {
             bail!(
                 "{}: CHD describes {count} hunks of {hunk_bytes} bytes, more than any CD \
                  holds",
+                path.display()
+            );
+        }
+    }
+    // A v5 compressed hunk map carries its own byte count as a u32 at the
+    // map offset, and the chd crate allocates that many bytes before
+    // reading them -- up to 4 GiB from one word of a hostile file. The map
+    // is stored verbatim, so it must fit inside the file; refuse one that
+    // does not before the crate sizes a buffer from it.
+    if version == 5 && be32(&raw, 16) != 0 {
+        let map_offset = be64(&raw, 40);
+        let file_len = reader
+            .seek(SeekFrom::End(0))
+            .map_err(|e| anyhow!("{}: reading CHD map header: {e}", path.display()))?;
+        let mut map_head = [0u8; 4];
+        let map_bytes = map_offset
+            .checked_add(16)
+            .filter(|&end| end <= file_len)
+            .and_then(|_| {
+                reader.seek(SeekFrom::Start(map_offset)).ok()?;
+                reader.read_exact(&mut map_head).ok()?;
+                Some(u64::from(u32::from_be_bytes(map_head)))
+            })
+            .ok_or_else(|| {
+                anyhow!(
+                    "{}: CHD map offset {map_offset} lies past the end of the file",
+                    path.display()
+                )
+            })?;
+        if map_offset + 16 + map_bytes > file_len {
+            bail!(
+                "{}: CHD compressed map claims {map_bytes} bytes, past the end of the file",
                 path.display()
             );
         }
@@ -790,6 +822,20 @@ mod tests {
         );
         let err = CdImage::load(&path).unwrap_err();
         assert!(err.to_string().contains("not a CD-ROM CHD"), "{err:#}");
+
+        // A compressed image's map carries its own u32 byte count at the
+        // map offset, and the crate allocates it before reading it: claim
+        // 2 GiB of map in a 100 KB file. The codec tag (offset 16) marks
+        // the image compressed; the map offset is the u64 at offset 40
+        // (124 in this builder's layout).
+        patch_header(&path, 56, &(HUNK_BYTES).to_be_bytes());
+        patch_header(&path, 16, b"cdlz");
+        patch_header(&path, 124, &0x8000_0000u32.to_be_bytes());
+        let err = CdImage::load(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("past the end of the file"),
+            "{err:#}"
+        );
         let _ = std::fs::remove_file(&path);
     }
 

--- a/src/cdrom/chd.rs
+++ b/src/cdrom/chd.rs
@@ -25,6 +25,16 @@ use std::path::{Path, PathBuf};
 const FRAME_BYTES: usize = RAW_SECTOR_BYTES + 96;
 /// chdman pads each track's frames to this boundary in the hunk stream.
 const TRACK_PADDING: u32 = 4;
+/// The largest hunk MAME's own header validation accepts (`chd.cpp`:
+/// `hunkbytes >= 65536 * 256` is rejected). The `chd` crate applies the
+/// same bound to v1-v4 headers but skips v5 validation entirely.
+const MAX_HUNK_BYTES: u32 = 65536 * 256;
+/// The most frames a CD-ROM CHD can describe: a 100-minute disc at 75
+/// frames per second, comfortably past the 99:59:74 Red Book limit and
+/// the overburned 99-minute media that exist. The header's logical size
+/// is what the hunk map is allocated from, so it is bounded by what a
+/// disc can physically hold before the map is touched.
+const MAX_DISC_FRAMES: u64 = 100 * 60 * 75;
 
 pub(super) struct ChdImage {
     chd: Chd<BufReader<File>>,
@@ -73,12 +83,102 @@ struct RawTrack {
     postgap: u32,
 }
 
+/// Refuse a CHD whose header describes more than a CD can hold, before the
+/// `chd` crate acts on it. `Chd::open` sizes the whole hunk map
+/// (`hunk_count * 12` bytes, then walks it) and the codecs' hunk-sized
+/// buffers straight from the header's words, computes the hunk count with
+/// unchecked arithmetic, and performs no bounds checks at all on a v5
+/// header -- the only kind chdman has written since 2012 -- so a 124-byte
+/// file claiming a terabyte disc would otherwise take the process down in
+/// the allocator (or an overflow panic) instead of being refused. Both were
+/// found by the `cd_image` fuzz target.
+///
+/// The layout read here is MAME's: magic and version, then per version the
+/// logical size and hunk size, which together fix the hunk count. Only the
+/// fields needed for the bounds are decoded; everything else is left to the
+/// crate, which re-reads the header from offset 0.
+fn bound_raw_header(reader: &mut BufReader<File>, path: &Path) -> Result<()> {
+    use std::io::Read;
+
+    const MAGIC: &[u8; 8] = b"MComprHD";
+    const HEADER_BYTES: usize = 124;
+    let be32 = |raw: &[u8], at: usize| u32::from_be_bytes(raw[at..at + 4].try_into().unwrap());
+    let be64 = |raw: &[u8], at: usize| u64::from_be_bytes(raw[at..at + 8].try_into().unwrap());
+
+    let mut raw = [0u8; HEADER_BYTES];
+    reader.read_exact(&mut raw).map_err(|_| {
+        anyhow!(
+            "{}: not a readable CHD image: header truncated",
+            path.display()
+        )
+    })?;
+    if &raw[..8] != MAGIC {
+        bail!("{}: not a readable CHD image: bad magic", path.display());
+    }
+    let length = be32(&raw, 8) as usize;
+    let version = be32(&raw, 12);
+    // (logical bytes, hunk bytes, hunk count) as the header states them.
+    let (logical_bytes, hunk_bytes, hunk_count) = match (version, length) {
+        // v3 and v4 carry an explicit hunk count; the hunk size sits after
+        // the MD5s in v3 and directly after the metadata offset in v4.
+        (3, 120) => (be64(&raw, 28), be32(&raw, 76), Some(be32(&raw, 24))),
+        (4, 108) => (be64(&raw, 28), be32(&raw, 44), Some(be32(&raw, 24))),
+        // v5 derives the hunk count from the logical size.
+        (5, 124) => (be64(&raw, 32), be32(&raw, 56), None),
+        // v1/v2 are hard-disk-only formats with no CD track metadata.
+        (1 | 2, _) => bail!("{}: not a CD-ROM CHD (v{version} image)", path.display()),
+        _ => bail!(
+            "{}: not a readable CHD image: unknown version {version} (header {length} bytes)",
+            path.display()
+        ),
+    };
+    if hunk_bytes == 0
+        || hunk_bytes >= MAX_HUNK_BYTES
+        || !(hunk_bytes as usize).is_multiple_of(FRAME_BYTES)
+    {
+        bail!(
+            "{}: not a CD-ROM CHD (hunk {hunk_bytes} bytes; expected hunks of whole \
+             {FRAME_BYTES}-byte CD frames)",
+            path.display()
+        );
+    }
+    if version == 5 && be32(&raw, 60) as usize != FRAME_BYTES {
+        bail!(
+            "{}: not a CD-ROM CHD (unit {} bytes; expected {FRAME_BYTES}-byte CD frames)",
+            path.display(),
+            be32(&raw, 60)
+        );
+    }
+    let max_bytes = MAX_DISC_FRAMES * FRAME_BYTES as u64;
+    if logical_bytes > max_bytes {
+        bail!(
+            "{}: CHD describes {logical_bytes} bytes, more than any CD holds \
+             ({MAX_DISC_FRAMES} frames of {FRAME_BYTES} bytes)",
+            path.display()
+        );
+    }
+    // Every hunk of a CD image holds at least one frame, so the stated
+    // hunk count is bounded by the frame count too.
+    if let Some(count) = hunk_count {
+        if u64::from(count) * u64::from(hunk_bytes) > max_bytes + u64::from(hunk_bytes) {
+            bail!(
+                "{}: CHD describes {count} hunks of {hunk_bytes} bytes, more than any CD \
+                 holds",
+                path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
 impl ChdImage {
     /// Open a CHD CD image and lay its tracks out on the logical disc.
     pub(super) fn load(path: &Path) -> Result<(Self, Vec<CdTrack>, u32)> {
         let file =
             File::open(path).with_context(|| format!("opening CD image {}", path.display()))?;
-        let mut chd = Chd::open(BufReader::new(file), None)
+        let mut reader = BufReader::new(file);
+        bound_raw_header(&mut reader, path)?;
+        let mut chd = Chd::open(reader, None)
             .map_err(|e| anyhow!("{}: not a readable CHD image: {e}", path.display()))?;
         if chd.header().has_parent() {
             bail!(
@@ -89,7 +189,8 @@ impl ChdImage {
         let unit_bytes = chd.header().unit_bytes();
         let hunk_bytes = chd.header().hunk_size();
         // The zero-hunk check guards the frames_per_hunk divisions below;
-        // the chd crate also rejects such headers, but do not rely on it.
+        // `bound_raw_header` already refused such files, but the values
+        // used from here on are the crate's, so check those.
         if unit_bytes as usize != FRAME_BYTES
             || hunk_bytes == 0
             || !(hunk_bytes as usize).is_multiple_of(FRAME_BYTES)
@@ -630,6 +731,65 @@ mod tests {
         write_chd_v5(&path, 0, FRAME_BYTES as u32, &[], &[]);
         let err = CdImage::load(&path).unwrap_err();
         assert!(format!("{err:#}").contains("CHD"), "{err:#}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Rewrite one big-endian field of an on-disk CHD v5 header in place.
+    fn patch_header(path: &Path, offset: usize, value: &[u8]) {
+        let mut bytes = std::fs::read(path).unwrap();
+        bytes[offset..offset + value.len()].copy_from_slice(value);
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    #[test]
+    fn header_claiming_more_than_a_disc_holds_is_rejected_before_the_map_is_allocated() {
+        // A valid one-frame image whose header is then edited to describe a
+        // terabyte of CD frames. The chd crate sizes the hunk map from that
+        // word alone (hunk_count * 12 bytes, then walks it), so without the
+        // pre-check a corrupt or hostile 124-byte header takes the process
+        // down in the allocator instead of producing an error. Found by the
+        // cd_image fuzz target.
+        let path = temp_path("terabyte.chd");
+        let data = track_frames(&[frame(&[0u8; DATA_SECTOR_BYTES])]);
+        write_chd_v5(
+            &path,
+            HUNK_BYTES,
+            FRAME_BYTES as u32,
+            &data,
+            &[cht2(
+                "TRACK:1 TYPE:MODE1 SUBTYPE:NONE FRAMES:1 PREGAP:0 PGTYPE:MODE1 \
+                 PGSUB:NONE POSTGAP:0",
+            )],
+        );
+        // logical_bytes is the u64 at offset 32 of the v5 header.
+        patch_header(&path, 32, &(1u64 << 40).to_be_bytes());
+        let err = CdImage::load(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("more than any CD holds"),
+            "{err:#}"
+        );
+        // Near u64::MAX the crate's own hunk-count arithmetic
+        // (`logical + hunk - 1`) overflows before it validates anything;
+        // the raw-header bound has to come first.
+        patch_header(&path, 32, &u64::MAX.to_be_bytes());
+        let err = CdImage::load(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("more than any CD holds"),
+            "{err:#}"
+        );
+
+        // The hunk size (u32 at offset 56) is bounded the same way: MAME
+        // refuses hunks of 16 MiB and up, and the codecs allocate
+        // hunk-sized buffers before any data is read.
+        patch_header(&path, 32, &(data.len() as u64).to_be_bytes());
+        patch_header(
+            &path,
+            56,
+            &(MAX_HUNK_BYTES + FRAME_BYTES as u32 - MAX_HUNK_BYTES % FRAME_BYTES as u32)
+                .to_be_bytes(),
+        );
+        let err = CdImage::load(&path).unwrap_err();
+        assert!(err.to_string().contains("not a CD-ROM CHD"), "{err:#}");
         let _ = std::fs::remove_file(&path);
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -235,7 +235,7 @@ fn deserialize_component<R: std::io::Read, T: serde::de::DeserializeOwned>(
     r: &mut R,
     what: &str,
 ) -> Result<T> {
-    bincode::deserialize_from(r).map_err(|e| anyhow!("reading {what}: {e}"))
+    crate::savestate::deserialize_from_state(r).map_err(|e| anyhow!("reading {what}: {e}"))
 }
 
 /// Machine-level runtime state outside `CpuCore` and `Bus` that a save

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -41,6 +41,92 @@ use std::path::Path;
 use crate::config::MachineDescriptor;
 use crate::cpu::M68kMachine;
 
+/// Deserialize one bincode value from a save-state stream, on the wire
+/// format `bincode::deserialize_from` uses (fixed-width integers, trailing
+/// bytes allowed), but through [`StateReader`] so that no allocation is
+/// sized from the stream's own length prefixes.
+pub(crate) fn deserialize_from_state<R: Read, T: serde::de::DeserializeOwned>(
+    reader: R,
+) -> bincode::Result<T> {
+    use bincode::Options;
+    bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .allow_trailing_bytes()
+        .deserialize_from_custom(StateReader::new(reader))
+}
+
+/// How much a byte buffer grows per read while a length-prefixed string or
+/// byte vector is being filled: the most a state can over-allocate past the
+/// data it actually holds.
+const STATE_FILL_CHUNK: usize = 1 << 20;
+
+/// A bincode reader for untrusted state streams. bincode's own `IoReader`
+/// sizes every string and byte-vector buffer from the stream's length
+/// prefix before reading a byte of it, so a corrupt or hostile `.clstate`
+/// naming a multi-gigabyte chip RAM takes the process down in the
+/// allocator (capacity overflow, or an abort) instead of failing the load.
+/// This reader fills such buffers in [`STATE_FILL_CHUNK`] steps, so a bogus
+/// length runs into the end of the stream having allocated no more than one
+/// chunk beyond the bytes that exist, and the load fails with an ordinary
+/// error. Found by the `savestate` fuzz target. Reads that are not
+/// length-prefixed pass straight through, so the reader never consumes
+/// more of the underlying stream than the value being decoded.
+pub(crate) struct StateReader<R> {
+    inner: R,
+    buf: Vec<u8>,
+}
+
+impl<R: Read> StateReader<R> {
+    pub(crate) fn new(inner: R) -> Self {
+        Self {
+            inner,
+            buf: Vec::new(),
+        }
+    }
+
+    fn fill(&mut self, length: usize) -> bincode::Result<()> {
+        self.buf.clear();
+        while self.buf.len() < length {
+            let start = self.buf.len();
+            let want = (length - start).min(STATE_FILL_CHUNK);
+            self.buf.resize(start + want, 0);
+            self.inner.read_exact(&mut self.buf[start..])?;
+        }
+        Ok(())
+    }
+}
+
+impl<R: Read> Read for StateReader<R> {
+    fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(out)
+    }
+}
+
+impl<'a, R: Read> bincode::BincodeRead<'a> for StateReader<R> {
+    fn forward_read_str<V>(&mut self, length: usize, visitor: V) -> bincode::Result<V::Value>
+    where
+        V: serde::de::Visitor<'a>,
+    {
+        self.fill(length)?;
+        let string = std::str::from_utf8(&self.buf)
+            .map_err(|e| Box::new(bincode::ErrorKind::InvalidUtf8Encoding(e)))?;
+        visitor.visit_str(string)
+    }
+
+    fn get_byte_buffer(&mut self, length: usize) -> bincode::Result<Vec<u8>> {
+        self.fill(length)?;
+        Ok(std::mem::take(&mut self.buf))
+    }
+
+    fn forward_read_bytes<V>(&mut self, length: usize, visitor: V) -> bincode::Result<V::Value>
+    where
+        V: serde::de::Visitor<'a>,
+    {
+        self.fill(length)?;
+        visitor.visit_bytes(&self.buf)
+    }
+}
+
 const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 
 /// Save-state format version. The payload is bincode of the live state
@@ -331,7 +417,7 @@ pub fn load_from_reader<R: Read>(
     }
     // Read the descriptor straight from the reader; bincode consumes exactly
     // its encoded bytes, leaving the reader positioned at the zlib stream.
-    let descriptor: MachineDescriptor = bincode::deserialize_from(&mut reader)
+    let descriptor: MachineDescriptor = deserialize_from_state(&mut reader)
         .map_err(|e| anyhow!("reading machine descriptor: {e}"))?;
     let mut decoder = ZlibDecoder::new(reader);
     machine.apply_state(&mut decoder)?;
@@ -686,6 +772,50 @@ mod tests {
         let err = load(&mut machine, &path).unwrap_err();
         assert!(format!("{err:#}").contains("format version"));
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn state_reader_matches_bincode_wire_format_across_chunk_boundaries() {
+        #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
+        struct Sample {
+            name: String,
+            ram: Vec<u8>,
+            words: Vec<u16>,
+            tail: u32,
+        }
+        let sample = Sample {
+            name: "A1200".into(),
+            // Longer than one fill chunk, so a byte vector is assembled
+            // from several reads.
+            ram: (0..STATE_FILL_CHUNK * 2 + 777).map(|i| i as u8).collect(),
+            words: vec![1, 2, 3],
+            tail: 0xDEAD_BEEF,
+        };
+        let bytes = bincode::serialize(&sample).unwrap();
+        let back: Sample = deserialize_from_state(&bytes[..]).unwrap();
+        assert_eq!(back, sample);
+    }
+
+    #[test]
+    fn state_reader_refuses_length_prefixes_past_the_stream_without_allocating_them() {
+        // A byte vector claiming u64::MAX bytes, then nothing. bincode's own
+        // reader resizes its buffer to that length first (capacity
+        // overflow); this reader runs into the end of the stream instead.
+        let bogus = [0xFFu8; 8];
+        let err = deserialize_from_state::<_, Vec<u8>>(&bogus[..]).unwrap_err();
+        assert!(
+            matches!(*err, bincode::ErrorKind::Io(_)),
+            "expected an end-of-stream error, got {err}"
+        );
+        let err = deserialize_from_state::<_, String>(&bogus[..]).unwrap_err();
+        assert!(matches!(*err, bincode::ErrorKind::Io(_)), "{err}");
+        // A plausible but oversized length (a claimed 1 GiB chip RAM in a
+        // 16-byte stream) is refused the same way, having allocated no more
+        // than one chunk.
+        let mut oversized = (1u64 << 30).to_le_bytes().to_vec();
+        oversized.extend_from_slice(&[0u8; 8]);
+        let err = deserialize_from_state::<_, Vec<u8>>(&oversized[..]).unwrap_err();
+        assert!(matches!(*err, bincode::ErrorKind::Io(_)), "{err}");
     }
 
     #[test]

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -71,6 +71,15 @@ const STATE_FILL_CHUNK: usize = 1 << 20;
 /// error. Found by the `savestate` fuzz target. Reads that are not
 /// length-prefixed pass straight through, so the reader never consumes
 /// more of the underlying stream than the value being decoded.
+///
+/// The guarantee is deliberately "memory tracks bytes actually present in
+/// the stream", not an absolute cap: state components arrive through a
+/// zlib decoder, and a state's legitimate decompressed size is unbounded
+/// by design (memory-backed disk images -- HDZ, directory mounts -- ride
+/// in the payload), so any fixed limit would refuse real states. A
+/// crafted stream that really supplies gigabytes therefore costs
+/// gigabytes to load, the same deal as opening any large image the user
+/// points the emulator at.
 pub(crate) struct StateReader<R> {
     inner: R,
     buf: Vec<u8>,
@@ -778,20 +787,30 @@ mod tests {
     fn state_reader_matches_bincode_wire_format_across_chunk_boundaries() {
         #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
         struct Sample {
+            // A String is the type that actually reaches
+            // `BincodeRead::get_byte_buffer` in bincode 1 (`Vec<u8>` goes
+            // through serde's element-wise sequence path); longer than two
+            // fill chunks, so the buffer is assembled from several reads.
             name: String,
             ram: Vec<u8>,
             words: Vec<u16>,
             tail: u32,
         }
         let sample = Sample {
-            name: "A1200".into(),
-            // Longer than one fill chunk, so a byte vector is assembled
-            // from several reads.
-            ram: (0..STATE_FILL_CHUNK * 2 + 777).map(|i| i as u8).collect(),
+            name: "A1200-"
+                .chars()
+                .cycle()
+                .take(STATE_FILL_CHUNK * 2 + 777)
+                .collect(),
+            ram: (0..4096).map(|i| i as u8).collect(),
             words: vec![1, 2, 3],
             tail: 0xDEAD_BEEF,
         };
         let bytes = bincode::serialize(&sample).unwrap();
+        assert!(
+            bytes.len() > STATE_FILL_CHUNK * 2,
+            "string must span chunks"
+        );
         let back: Sample = deserialize_from_state(&bytes[..]).unwrap();
         assert_eq!(back, sample);
     }


### PR DESCRIPTION
First findings from actually running the cargo-fuzz harnesses (#517) as a sustained local campaign rather than the CI build-gate.

## cd_image target: three crashes in CHD loading

- A 124-byte v5 header claiming a terabyte disc made `Chd::open` allocate (and walk) a multi-gigabyte hunk map before any validation: the `chd` crate skips bounds checks entirely for v5 headers, sizes the map as `hunk_count * 12` from the header words alone, and the codecs allocate hunk-sized buffers the same way. libFuzzer caught it as a 12.8 GB malloc; on a real host it is an allocator abort or a swap storm from parsing an attacker-supplied file.
- A logical size near `u64::MAX` panicked with `attempt to add with overflow` inside the crate's own hunk-count arithmetic (`chd-0.3.4/src/header.rs:865`), before any caller-side check on the parsed header could run.
- A v5 compressed hunk map carries its own u32 byte count at the map offset, and the crate allocates that many bytes before reading them (`map.rs` `read_map_v5`) - up to 4 GiB from one word of a file whose header passes every other bound.

The fix reads the raw header first and refuses anything a CD cannot be: hunks must be whole 2448-byte frames under MAME's own 16 MiB hunk bound, the logical size (and the v3/v4 stated hunk count) must fit a 100-minute disc, and a compressed map's stated size must fit inside the file. v1/v2 are hard-disk-only formats and are refused as non-CD CHDs. A regression test patches a valid image's header to all three hostile shapes; the real chdman image still loads (`tests/chd_cd.rs`, run locally against Pinball Fantasies EU).

## savestate target: capacity-overflow panic in bincode

bincode 1's `IoReader` resizes its buffer to a string/byte-vector length prefix before reading a byte of it, so a mutated `.clstate` naming a multi-gigabyte chip RAM panicked with a capacity overflow instead of failing the load. Save-state components now deserialize through a custom `BincodeRead` that fills length-prefixed buffers in 1 MiB steps, so a bogus length runs into the end of the stream having allocated at most one chunk past the bytes that exist and fails with the ordinary error path the truncated-payload test already covers. The wire format is byte-identical (fixint, trailing bytes allowed); a round-trip test crosses the chunk boundary to prove it, and `STATE_VERSION` is untouched.

All four reproducers now return clean errors under the fuzz build (debug assertions + ASan); the campaign is running on with the fixes in place. dms, floppy_image, and hardfile_classification have run multi-hour with no findings so far.

Tests: full suite (2829 lib tests), clippy, fmt clean; `cargo test --release --test chd_cd -- --ignored` against a real CHD.