### PR TITLE
serial: drive the CIA-B RS-232 handshake inputs from the host sink

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -961,6 +961,17 @@ impl WebEmu {
         self.emu.bus().cia_b.port_a_pins() & 0x80 == 0
     }
 
+    /// Raise or drop the serial port's carrier-detect input (CIA-B PA5, /CD)
+    /// as the page's far end connects and hangs up. The bridge always
+    /// presents itself as a present, ready device (DSR and CTS asserted);
+    /// carrier is the one line a byte-stream bridge knows the state of, and
+    /// it is what a guest terminal or BBS watches to notice a hang-up. Call
+    /// with `true` when the socket opens and `false` when it closes; a page
+    /// that never calls it leaves the guest seeing a modem with no call up.
+    pub fn serial_set_carrier(&mut self, connected: bool) {
+        self.serial.set_carrier(connected);
+    }
+
     /// Snapshot the whole emulated machine (RAM, ROM, chipset, CPU, the
     /// floppy images themselves) into a `.clstate` blob, the same format the
     /// desktop builds write, so a state saved here loads there and back. The

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -732,6 +732,7 @@ async function boot() {
     machine.set_phosphor?.(phosphorPersistence);
     emu = machine;
     window.__emu = emu; // for debugging/automation
+    serialApplyCarrier(); // a socket opened before (or across) this boot
     lastFddTrack = null; // a new machine starts the track latch over
     // Nothing is held down in a machine that has just been built, so the
     // on-screen keyboard forgets rather than sending release codes into it.
@@ -1257,9 +1258,19 @@ function setSerialStatus(text) {
 }
 
 // The far end's carrier, as the guest sees it on CIA-B /CD: up while the
-// socket is open, down otherwise. Older wasm bundles have no setter.
+// socket is open, down otherwise. The desired state lives here rather than
+// only in the machine, because the socket and the machine have independent
+// lifetimes: a raw-mode socket can open before boot, and a crashed machine
+// is discarded and rebuilt while the socket stays up. Every new machine
+// gets the cached state applied (serialApplyCarrier below, called after
+// `emu` is installed). Older wasm bundles have no setter.
+let serialCarrier = false;
 function serialSetCarrier(connected) {
-  if (emu && typeof emu.serial_set_carrier === 'function') emu.serial_set_carrier(connected);
+  serialCarrier = connected;
+  serialApplyCarrier();
+}
+function serialApplyCarrier() {
+  if (emu && typeof emu.serial_set_carrier === 'function') emu.serial_set_carrier(serialCarrier);
 }
 
 function serialTeardown() {

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -1256,6 +1256,12 @@ function setSerialStatus(text) {
   if (serialStatus) serialStatus.textContent = text;
 }
 
+// The far end's carrier, as the guest sees it on CIA-B /CD: up while the
+// socket is open, down otherwise. Older wasm bundles have no setter.
+function serialSetCarrier(connected) {
+  if (emu && typeof emu.serial_set_carrier === 'function') emu.serial_set_carrier(connected);
+}
+
 function serialTeardown() {
   if (serialWs) {
     // Neuter the handlers first: close() fires onclose asynchronously, and
@@ -1264,6 +1270,7 @@ function serialTeardown() {
     serialWs.close();
     serialWs = null;
   }
+  serialSetCarrier(false);
   serialTelnet = null;
   serialDtrGated = false;
   serialRxQueue = [];
@@ -1309,7 +1316,10 @@ function serialOpen() {
   serialRxQueue = [];
   if (serialConnectBtn) serialConnectBtn.textContent = 'Disconnect';
   setSerialStatus('connecting...');
-  ws.onopen = () => setSerialStatus(`connected (${serialTelnet ? 'telnet' : 'raw'})`);
+  ws.onopen = () => {
+    serialSetCarrier(true);
+    setSerialStatus(`connected (${serialTelnet ? 'telnet' : 'raw'})`);
+  };
   ws.onclose = () => serialDisconnect('disconnected');
   ws.onerror = () => setSerialStatus('connection failed');
   ws.onmessage = (e) => {

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -633,7 +633,8 @@ the selected drive's head or `undefined` when no drive is selected (latch
 the last value so a counter does not flicker), and `drive_connected(n)` /
 `disk_name(n)` describe DF0-DF3 -- a `disk_name` of `undefined` means the
 drive is empty. `serial_send(bytes)`,
-`serial_take()`, `serial_input_backlog()` and `serial_dtr()` bridge
+`serial_take()`, `serial_input_backlog()`, `serial_dtr()` and
+`serial_set_carrier(bool)` bridge
 Paula's serial port to whatever byte stream the page likes (see
 [the serial bridge section](#browser-serial-bridge)). The presentation pointer is only
 valid until the next `run` call -- rebuild the typed-array view every frame,
@@ -935,6 +936,13 @@ telnet BBS, with a terminal program running on the guest. Three calls:
   set the CIA bit themselves -- and drops it on exit and at reset, so this
   is the "a terminal is actually listening" signal, exactly what a real
   modem keys off.
+- `serial_set_carrier(connected)` drives the port's carrier-detect input
+  (CIA-B PA5, `/CD`) the other way: call it with `true` when the page's
+  socket opens and `false` when it closes. The bridge always presents
+  itself to the guest as a present, ready device (DSR and CTS asserted);
+  carrier is what a guest terminal or BBS watches to notice a hang-up. A
+  page that never calls it leaves the guest seeing a modem with no call
+  up, which 3-wire software ignores.
 
 Browsers cannot open raw TCP, so the page's transport is a WebSocket to a
 gateway that forwards to the real service --

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1240,6 +1240,21 @@ Paula's serial in/out is connected:
   The slave path (`/dev/pts/N`) is logged at startup; attach a terminal
   with e.g. `minicom -D`, `screen`, or `cu -l`.
 
+Every mode also drives the port's RS-232 handshake inputs, which the guest
+reads on CIA-B port A (`/DSR`, `/CTS`, `/CD`) and `serial.device` reports
+through `SDCMD_QUERY` and honours in 7-wire mode. `off` (and `midi`, whose
+interface only uses the data lines) is an unplugged cable: every input
+floats high, so a guest waiting for CTS or carrier waits forever, as on a
+real machine with nothing attached. `stdout` is a ready device with no
+call behind it: DSR and CTS asserted, no carrier. `tcp` and `tcp-connect`
+behave as a modem: DSR and CTS asserted from startup, and carrier only
+while a client is connected (or the dial-out is up) -- so a guest BBS sees
+the caller hang up as carrier loss, and a terminal program sees the remote
+drop the same way. `pty` reports a host terminal with the port open (all
+three asserted), since a null-modem cable crosses its DTR and RTS to
+these inputs and the terminal's side cannot be observed from here. The
+guest's own `/DTR` and `/RTS` outputs are the CIA's pins as written.
+
 With an `AUX:` shell on the Amiga side, `tcp`/`pty` give a remote AmigaDOS
 console. `--serial MODE` overrides the mode per run,
 `--serial-connect HOST:PORT` sets the dial-out target (and implies

--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -263,8 +263,12 @@ creating another access, forwards one strobe to the attached parallel
 peripheral, and feeds an accepted byte's `/ACK` edge back through CIA-A
 FLAG. With no peripheral attached the line remains unacknowledged, like an
 unplugged cable. CIA-B carries the floppy control lines (motor, select,
-side, step), the FLAG input pulsed by the disk index, and the parallel
-status lines (BUSY/POUT/SEL on port A bits 0-2). PB6/PB7 pulse-output mode
+side, step), the FLAG input pulsed by the disk index, the parallel
+status lines (BUSY/POUT/SEL on port A bits 0-2), and the RS-232 control
+lines: /DSR, /CTS, and /CD inputs on port A bits 3-5, driven through the
+inverting 1489 receivers by whatever the serial port is wired to on the
+host (see [peripherals](peripherals.md#serial-sink)), and the /RTS and
+/DTR outputs on bits 6-7. PB6/PB7 pulse-output mode
 holds the selected pin low for one E-clock; reading PRB observes the pulse
 without shortening it.
 

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -620,6 +620,8 @@ Default live-audio warnings are emitted from the producer side at the same
 one-second cadence, and only when an underrun, overrun, or stale-frame
 counter is nonzero.
 
+(serial-sink)=
+
 ## Serial (`serial.rs`)
 
 Paula's SERDAT transmit path lands on a `SerialSink`. The default
@@ -639,6 +641,28 @@ A `SerialSink` that can *produce* input must override
 Paula's per-tick UART step takes an idle fast path that skips the receiver
 entirely while it reports false -- the TCP and pty sinks poll a counter
 there, never a syscall.
+
+The sink is also the device on the far end of the RS-232 cable, so it owns
+the handshake inputs. `SerialSink::control_lines` reports DSR, CTS, and
+carrier detect as asserted-or-not (`SerialControlLines`); the bus samples
+it on every guest read of CIA-B PRA and overlays PA3-5 with the levels the
+motherboard's inverting 1489 receivers would present (asserted = pin low,
+undriven = pulled high), leaving pins the guest has switched to outputs
+CIA-driven -- the same shape as the Centronics status overlay on PA0-2.
+The guest's `/DTR` (PA7) and `/RTS` (PA6) outputs are the CIA's own pins,
+readable by a host bridge through `Cia::port_a_pins`. The default is an
+unplugged cable (every input high), which is what the inert and MIDI sinks
+keep; `StdoutSink` is a ready device with no carrier; `TcpSerialSink`
+is a modem whose carrier follows the live connection (an atomic flag the
+acceptor/reader thread maintains, so the PRA read never touches the
+writer lock); `PtySerialSink` is a null-modem peer with its port open;
+`ChannelSerialSink` starts ready-without-carrier and lets the frontend set
+the lines (`ChannelSerialHandle::set_carrier`, exported to the browser as
+`serial_set_carrier`). The lines are host-side state like the bytes
+themselves -- never serialized, never part of the deterministic timeline.
+Paula has no framing-error or parity hardware: a received word always
+carries its stop bit(s) set, and `serial.device` computes parity in
+software, so neither needs a model here.
 
 CCP serial observability is a host-side tap beside `SerialSink`, not another
 serial device. When a control connection subscribes, each successfully

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -6621,9 +6621,23 @@ impl Bus {
             // (BUSY, POUT, SEL), pulled up when nothing drives them. An
             // attached peripheral holds them at its own levels; pins the
             // guest has switched to outputs stay CIA-driven.
+            let ddr = self.cia_b.port_a_ddr();
             if let Some(lines) = self.parallel_port.control_lines() {
-                let inputs = !self.cia_b.port_a_ddr() & 0x07;
+                let inputs = !ddr & 0x07;
                 v = (v & !inputs) | (lines & inputs);
+            }
+            // CIA-B PA3-5 are the RS-232 handshake inputs /DSR, /CTS, and
+            // /CD, arriving through the motherboard's inverting 1489
+            // receivers: a line the far-end device asserts reads as a low
+            // pin, and an unasserted (or unplugged) line is pulled up.
+            // serial.device's 7-wire handshake and SDCMD_QUERY status read
+            // them here. The levels come from whatever the serial port is
+            // wired to on the host; pins the guest has switched to outputs
+            // stay CIA-driven, like the Centronics inputs above.
+            let inputs = !ddr & crate::serial::CIAB_PA_SERIAL_INPUTS;
+            if inputs != 0 {
+                let levels = self.paula.serial.control_lines().cia_b_pa_levels();
+                v = (v & !inputs) | (levels & inputs);
             }
         }
         trace!("cia_b R reg={:X} sz={} val={:02X}", reg, size, v);

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -728,8 +728,10 @@ fn parallel_peripheral_drives_cia_b_centronics_status_inputs() {
     let addr = |reg: usize| (reg as u64) << 8;
 
     // An empty port: BUSY, POUT, and SEL float high on the pull-ups, like
-    // the serial handshake lines on PA3-7. parallel.device reads this as a
-    // busy offline printer and never sends a byte, as on a real machine.
+    // the serial handshake inputs on PA3-5 with nothing on the serial port
+    // (the test bus's sink is an unplugged cable). parallel.device reads
+    // this as a busy offline printer and never sends a byte, as on a real
+    // machine.
     assert_eq!(bus.cia_b_read(addr(REG_PRA), 1), 0xFF);
 
     // A printer holds SEL high with BUSY and POUT low, so the guest reads
@@ -749,6 +751,64 @@ fn parallel_peripheral_drives_cia_b_centronics_status_inputs() {
     assert_eq!(bus.cia_b_read(addr(REG_PRA), 1), 0xFD);
 
     let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn serial_device_drives_cia_b_handshake_inputs() {
+    use crate::serial::{SerialControlLines, CIAB_PA_CD, CIAB_PA_CTS, CIAB_PA_DSR};
+
+    struct LinesSerial(SerialControlLines);
+    impl SerialSink for LinesSerial {
+        fn write_byte(&mut self, _b: u8, _at_cck: u64) {}
+        fn flush(&mut self) {}
+        fn control_lines(&self) -> SerialControlLines {
+            self.0
+        }
+    }
+
+    let mut bus = empty_bus();
+    let addr = |reg: usize| (reg as u64) << 8;
+
+    // Nothing on the serial port: /DSR, /CTS, and /CD float high, so a
+    // 7-wire guest waits for CTS forever, as on a real machine with no
+    // cable.
+    assert_eq!(bus.cia_b_read(addr(REG_PRA), 1), 0xFF);
+
+    // A present device with no carrier asserts DSR and CTS; the 1489
+    // receivers invert them, so the guest reads those pins low and /CD
+    // still high.
+    bus.paula.serial = Box::new(LinesSerial(SerialControlLines::READY));
+    assert_eq!(
+        bus.cia_b_read(addr(REG_PRA), 1),
+        0xFF & !(CIAB_PA_DSR | CIAB_PA_CTS) as u64
+    );
+
+    // Carrier up: all three low. This is the byte serial.device hands back
+    // in SDCMD_QUERY's io_Status low byte.
+    bus.paula.serial = Box::new(LinesSerial(SerialControlLines::CONNECTED));
+    assert_eq!(
+        bus.cia_b_read(addr(REG_PRA), 1),
+        0xFF & !(CIAB_PA_DSR | CIAB_PA_CTS | CIAB_PA_CD) as u64
+    );
+
+    // The CIA's own outputs are untouched: dropping /DTR (PA7) and raising
+    // /RTS (PA6) reads back exactly as written.
+    let _ = bus.cia_b_write(addr(REG_DDRA), 1, 0xC0);
+    let _ = bus.cia_b_write(addr(REG_PRA), 1, 0x40);
+    assert_eq!(
+        bus.cia_b_read(addr(REG_PRA), 1),
+        0x7F & !(CIAB_PA_DSR | CIAB_PA_CTS | CIAB_PA_CD) as u64
+    );
+
+    // A handshake pin the guest switches to an output stays CIA-driven even
+    // while the device asserts the line: /CTS written high as an output
+    // reads back high.
+    let _ = bus.cia_b_write(addr(REG_DDRA), 1, u64::from(0xC0 | CIAB_PA_CTS));
+    let _ = bus.cia_b_write(addr(REG_PRA), 1, u64::from(0x40 | CIAB_PA_CTS));
+    assert_eq!(
+        bus.cia_b_read(addr(REG_PRA), 1),
+        0x7F & !(CIAB_PA_DSR | CIAB_PA_CD) as u64
+    );
 }
 
 #[test]

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -867,6 +867,10 @@ impl MidiSerialSink {
 }
 
 impl SerialSink for MidiSerialSink {
+    // `control_lines` keeps the trait default, an unplugged cable: a MIDI
+    // interface hangs off TXD/RXD through its own current-loop drivers and
+    // leaves the RS-232 handshake pins unconnected.
+
     fn synth_source_name(&self) -> &'static str {
         #[cfg(feature = "coppersynth")]
         if self.csynth.is_some() {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -118,6 +118,20 @@ impl SerialControlLines {
         cd: true,
     };
 
+    /// Pack into a bitmask for lock-free mirrors (bit 0 = DSR, 1 = CTS,
+    /// 2 = CD). Round-trips through [`from_bits`](Self::from_bits).
+    fn to_bits(self) -> u8 {
+        u8::from(self.dsr) | u8::from(self.cts) << 1 | u8::from(self.cd) << 2
+    }
+
+    fn from_bits(bits: u8) -> Self {
+        Self {
+            dsr: bits & 1 != 0,
+            cts: bits & 2 != 0,
+            cd: bits & 4 != 0,
+        }
+    }
+
     /// The pin levels CIA-B port A samples on PA3-5, inverted through the
     /// 1489 receivers: bit clear where a line is asserted, set where it is
     /// not. Other bits are zero.
@@ -664,6 +678,7 @@ pub const CHANNEL_OUTPUT_CAPACITY: usize = 256 * 1024;
 
 /// Queues shared between a [`ChannelSerialSink`] (owned by Paula) and the
 /// [`ChannelSerialHandle`] the host frontend keeps.
+#[derive(Default)]
 struct ChannelSerialShared {
     /// Host -> guest bytes waiting for Paula's receiver.
     input: VecDeque<u8>,
@@ -671,21 +686,6 @@ struct ChannelSerialShared {
     output: VecDeque<u8>,
     /// Output bytes evicted because the frontend stopped draining.
     output_dropped: u64,
-    /// What the frontend's far end is driving at the handshake inputs.
-    control_lines: SerialControlLines,
-}
-
-impl Default for ChannelSerialShared {
-    fn default() -> Self {
-        Self {
-            input: VecDeque::new(),
-            output: VecDeque::new(),
-            output_dropped: 0,
-            // A bridge is present and accepting data from the start; the
-            // frontend raises carrier once its own connection is up.
-            control_lines: SerialControlLines::READY,
-        }
-    }
 }
 
 /// Bidirectional in-process serial bridge with no host I/O of its own: the
@@ -701,6 +701,12 @@ pub struct ChannelSerialSink {
     /// Signed for the same transient-debt reason as
     /// [`TcpSerialSink::buffered`].
     buffered: std::sync::Arc<std::sync::atomic::AtomicIsize>,
+    /// The handshake lines the frontend's far end is driving, as
+    /// [`SerialControlLines`] bits. An atomic for the same reason as
+    /// `buffered`: the bus samples `control_lines` on every guest CIA-B
+    /// PRA read, which must never wait on the frontend holding the queue
+    /// mutex in `push_input`/`take_output`.
+    lines: std::sync::Arc<std::sync::atomic::AtomicU8>,
 }
 
 impl ChannelSerialSink {
@@ -709,11 +715,24 @@ impl ChannelSerialSink {
     pub fn pair() -> (Self, ChannelSerialHandle) {
         let shared = std::sync::Arc::new(std::sync::Mutex::new(ChannelSerialShared::default()));
         let buffered = std::sync::Arc::new(std::sync::atomic::AtomicIsize::new(0));
+        // A bridge is present and accepting data from the start; the
+        // frontend raises carrier once its own connection is up.
+        let lines = std::sync::Arc::new(std::sync::atomic::AtomicU8::new(
+            SerialControlLines::READY.to_bits(),
+        ));
         let handle = ChannelSerialHandle {
             shared: std::sync::Arc::clone(&shared),
             buffered: std::sync::Arc::clone(&buffered),
+            lines: std::sync::Arc::clone(&lines),
         };
-        (Self { shared, buffered }, handle)
+        (
+            Self {
+                shared,
+                buffered,
+                lines,
+            },
+            handle,
+        )
     }
 }
 
@@ -745,7 +764,7 @@ impl SerialSink for ChannelSerialSink {
     }
 
     fn control_lines(&self) -> SerialControlLines {
-        self.shared.lock().unwrap().control_lines
+        SerialControlLines::from_bits(self.lines.load(std::sync::atomic::Ordering::Acquire))
     }
 
     fn flush(&mut self) {}
@@ -756,6 +775,7 @@ impl SerialSink for ChannelSerialSink {
 pub struct ChannelSerialHandle {
     shared: std::sync::Arc<std::sync::Mutex<ChannelSerialShared>>,
     buffered: std::sync::Arc<std::sync::atomic::AtomicIsize>,
+    lines: std::sync::Arc<std::sync::atomic::AtomicU8>,
 }
 
 impl ChannelSerialHandle {
@@ -806,7 +826,8 @@ impl ChannelSerialHandle {
     /// raises carrier when that connection opens and drops it when it
     /// closes, which is how a guest BBS or terminal notices the hang-up.
     pub fn set_control_lines(&self, lines: SerialControlLines) {
-        self.shared.lock().unwrap().control_lines = lines;
+        self.lines
+            .store(lines.to_bits(), std::sync::atomic::Ordering::Release);
     }
 
     /// Raise or drop carrier detect alone, keeping DSR and CTS asserted:
@@ -821,7 +842,7 @@ impl ChannelSerialHandle {
 
     /// The control inputs currently presented to the guest.
     pub fn control_lines(&self) -> SerialControlLines {
-        self.shared.lock().unwrap().control_lines
+        SerialControlLines::from_bits(self.lines.load(std::sync::atomic::Ordering::Acquire))
     }
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -68,6 +68,74 @@ impl SerialTimeAnchor {
     }
 }
 
+/// CIA-B port A pin of the RS-232 /DSR input (Data Set Ready, DB25 pin 6).
+pub const CIAB_PA_DSR: u8 = 1 << 3;
+/// CIA-B port A pin of the RS-232 /CTS input (Clear To Send, DB25 pin 5).
+pub const CIAB_PA_CTS: u8 = 1 << 4;
+/// CIA-B port A pin of the RS-232 /CD input (Carrier Detect, DB25 pin 8).
+pub const CIAB_PA_CD: u8 = 1 << 5;
+/// The three RS-232 control inputs on CIA-B port A. The outputs /RTS (PA6)
+/// and /DTR (PA7) are the CIA's own pins; the remaining PA0-2 are the
+/// Centronics status inputs.
+pub const CIAB_PA_SERIAL_INPUTS: u8 = CIAB_PA_DSR | CIAB_PA_CTS | CIAB_PA_CD;
+
+/// The RS-232 control lines the device on the far end of the serial cable
+/// drives back at the Amiga: DSR, CTS, and carrier detect. Each is `true`
+/// when the line is asserted (the RS-232 ON state). The motherboard's 1489
+/// receivers invert them onto CIA-B port A -- an asserted line reads as a
+/// LOW pin, and a line nothing drives is pulled up -- so `serial.device`'s
+/// 7-wire handshake and `SDCMD_QUERY` status see exactly what the attached
+/// device is saying.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SerialControlLines {
+    /// Data Set Ready: the far-end device is powered and present.
+    pub dsr: bool,
+    /// Clear To Send: the far-end device accepts data right now.
+    pub cts: bool,
+    /// Carrier Detect: a connection exists beyond the far-end device (a
+    /// modem has a carrier; a null-modem peer has its port open).
+    pub cd: bool,
+}
+
+impl SerialControlLines {
+    /// Nothing plugged in: every input floats high on its pull-up.
+    pub const UNPLUGGED: Self = Self {
+        dsr: false,
+        cts: false,
+        cd: false,
+    };
+    /// A device is present and accepting data, but has no carrier: a modem
+    /// with no call up, or a bridge with no client connected.
+    pub const READY: Self = Self {
+        dsr: true,
+        cts: true,
+        cd: false,
+    };
+    /// A device is present, accepting data, and connected through.
+    pub const CONNECTED: Self = Self {
+        dsr: true,
+        cts: true,
+        cd: true,
+    };
+
+    /// The pin levels CIA-B port A samples on PA3-5, inverted through the
+    /// 1489 receivers: bit clear where a line is asserted, set where it is
+    /// not. Other bits are zero.
+    pub fn cia_b_pa_levels(self) -> u8 {
+        let mut high = CIAB_PA_SERIAL_INPUTS;
+        if self.dsr {
+            high &= !CIAB_PA_DSR;
+        }
+        if self.cts {
+            high &= !CIAB_PA_CTS;
+        }
+        if self.cd {
+            high &= !CIAB_PA_CD;
+        }
+        high
+    }
+}
+
 pub trait SerialSink: Send {
     /// Transmit one byte. `at_cck` is the emulated color clock the byte finished
     /// shifting out on, a monotonic power-on count. Sinks that only want the data
@@ -103,6 +171,18 @@ pub trait SerialSink: Send {
     /// one-word receive buffer instead). Output-only sinks keep the default.
     fn can_produce_input(&self) -> bool {
         false
+    }
+
+    /// The RS-232 control inputs (/DSR, /CTS, /CD) the far-end device is
+    /// driving at CIA-B port A right now. The bus samples this on every
+    /// guest read of CIA-B PRA, so it must be cheap and must not block.
+    /// The default is an unplugged cable -- every input pulled high -- which
+    /// is what a guest waiting on CTS or carrier sees on a real machine with
+    /// nothing attached. Sinks that stand in for a real device override it:
+    /// a present device asserts DSR and CTS, and carrier follows whether
+    /// the connection beyond it is up.
+    fn control_lines(&self) -> SerialControlLines {
+        SerialControlLines::UNPLUGGED
     }
 
     /// Whether this host endpoint can remain attached during run-ahead.
@@ -195,6 +275,11 @@ pub struct TcpSerialSink {
     /// dips to a transient -1 "debt" instead of wrapping to a stuck-huge
     /// unsigned value.
     buffered: std::sync::Arc<std::sync::atomic::AtomicIsize>,
+    /// Whether a peer is connected right now: set by the acceptor (or at
+    /// dial time), cleared when the connection ends. This is the modem's
+    /// carrier as the guest sees it on CIA-B /CD; an atomic so the bus can
+    /// sample it on every PRA read without touching the writer lock.
+    connected: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// The bound listen address (resolves port 0 to the real port) in listen
     /// mode; the connected peer in connect mode.
     local_addr: std::net::SocketAddr,
@@ -219,6 +304,8 @@ impl TcpSerialSink {
         let acceptor_writer = std::sync::Arc::clone(&writer);
         let buffered = std::sync::Arc::new(std::sync::atomic::AtomicIsize::new(0));
         let reader_buffered = std::sync::Arc::clone(&buffered);
+        let connected = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let acceptor_connected = std::sync::Arc::clone(&connected);
         std::thread::Builder::new()
             .name("serial-tcp".into())
             .spawn(move || loop {
@@ -234,6 +321,7 @@ impl TcpSerialSink {
                         continue;
                     }
                 }
+                acceptor_connected.store(true, std::sync::atomic::Ordering::Release);
                 let mut buf = [0u8; 512];
                 let mut stream = stream;
                 loop {
@@ -252,11 +340,13 @@ impl TcpSerialSink {
                 }
                 log::info!("serial: client {peer} disconnected");
                 *acceptor_writer.lock().unwrap() = None;
+                acceptor_connected.store(false, std::sync::atomic::Ordering::Release);
             })?;
         Ok(Self {
             rx,
             writer,
             buffered,
+            connected,
             local_addr,
         })
     }
@@ -278,6 +368,8 @@ impl TcpSerialSink {
         let reader_writer = std::sync::Arc::clone(&writer);
         let buffered = std::sync::Arc::new(std::sync::atomic::AtomicIsize::new(0));
         let reader_buffered = std::sync::Arc::clone(&buffered);
+        let connected = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let reader_connected = std::sync::Arc::clone(&connected);
         std::thread::Builder::new()
             .name("serial-tcp-connect".into())
             .spawn(move || {
@@ -299,11 +391,13 @@ impl TcpSerialSink {
                 }
                 log::info!("serial: {peer} disconnected");
                 *reader_writer.lock().unwrap() = None;
+                reader_connected.store(false, std::sync::atomic::Ordering::Release);
             })?;
         Ok(Self {
             rx,
             writer,
             buffered,
+            connected,
             local_addr: peer,
         })
     }
@@ -322,6 +416,8 @@ impl SerialSink for TcpSerialSink {
         if let Some(w) = guard.as_mut() {
             if w.write_all(&[b]).is_err() {
                 *guard = None;
+                self.connected
+                    .store(false, std::sync::atomic::Ordering::Release);
             }
         }
     }
@@ -341,6 +437,18 @@ impl SerialSink for TcpSerialSink {
 
     fn can_produce_input(&self) -> bool {
         true
+    }
+
+    /// The bridge is a modem: powered and accepting data (DSR, CTS) from
+    /// the moment it is configured, with carrier only while a peer is
+    /// connected -- so a guest BBS sees the caller hang up as carrier loss,
+    /// and a terminal program sees the dial-out drop the same way.
+    fn control_lines(&self) -> SerialControlLines {
+        if self.connected.load(std::sync::atomic::Ordering::Acquire) {
+            SerialControlLines::CONNECTED
+        } else {
+            SerialControlLines::READY
+        }
     }
 
     fn flush(&mut self) {}
@@ -534,6 +642,14 @@ impl SerialSink for PtySerialSink {
         true
     }
 
+    /// A null-modem cable to a host terminal. Its DTR and RTS cross to our
+    /// DSR/CD and CTS, and the terminal's side is invisible from here (the
+    /// sink keeps the slave open itself), so the lines are reported as a
+    /// terminal that has the port open.
+    fn control_lines(&self) -> SerialControlLines {
+        SerialControlLines::CONNECTED
+    }
+
     fn flush(&mut self) {
         let _ = self.master.flush();
     }
@@ -548,7 +664,6 @@ pub const CHANNEL_OUTPUT_CAPACITY: usize = 256 * 1024;
 
 /// Queues shared between a [`ChannelSerialSink`] (owned by Paula) and the
 /// [`ChannelSerialHandle`] the host frontend keeps.
-#[derive(Default)]
 struct ChannelSerialShared {
     /// Host -> guest bytes waiting for Paula's receiver.
     input: VecDeque<u8>,
@@ -556,6 +671,21 @@ struct ChannelSerialShared {
     output: VecDeque<u8>,
     /// Output bytes evicted because the frontend stopped draining.
     output_dropped: u64,
+    /// What the frontend's far end is driving at the handshake inputs.
+    control_lines: SerialControlLines,
+}
+
+impl Default for ChannelSerialShared {
+    fn default() -> Self {
+        Self {
+            input: VecDeque::new(),
+            output: VecDeque::new(),
+            output_dropped: 0,
+            // A bridge is present and accepting data from the start; the
+            // frontend raises carrier once its own connection is up.
+            control_lines: SerialControlLines::READY,
+        }
+    }
 }
 
 /// Bidirectional in-process serial bridge with no host I/O of its own: the
@@ -614,6 +744,10 @@ impl SerialSink for ChannelSerialSink {
         true
     }
 
+    fn control_lines(&self) -> SerialControlLines {
+        self.shared.lock().unwrap().control_lines
+    }
+
     fn flush(&mut self) {}
 }
 
@@ -665,6 +799,30 @@ impl ChannelSerialHandle {
     pub fn output_overflow(&self) -> u64 {
         self.shared.lock().unwrap().output_dropped
     }
+
+    /// Set the RS-232 control inputs the guest sees on CIA-B (/DSR, /CTS,
+    /// /CD). The sink starts as a present, ready device with no carrier
+    /// ([`SerialControlLines::READY`]); a frontend bridging to a socket
+    /// raises carrier when that connection opens and drops it when it
+    /// closes, which is how a guest BBS or terminal notices the hang-up.
+    pub fn set_control_lines(&self, lines: SerialControlLines) {
+        self.shared.lock().unwrap().control_lines = lines;
+    }
+
+    /// Raise or drop carrier detect alone, keeping DSR and CTS asserted:
+    /// the one line a byte-stream bridge actually knows the state of.
+    pub fn set_carrier(&self, connected: bool) {
+        self.set_control_lines(if connected {
+            SerialControlLines::CONNECTED
+        } else {
+            SerialControlLines::READY
+        });
+    }
+
+    /// The control inputs currently presented to the guest.
+    pub fn control_lines(&self) -> SerialControlLines {
+        self.shared.lock().unwrap().control_lines
+    }
 }
 
 /// Inert sink: discards output and never produces input. Placeholder used
@@ -709,6 +867,13 @@ impl SerialSink for StdoutSink {
         if b == b'\n' || self.buf.len() >= 256 {
             self.flush();
         }
+    }
+
+    /// The host console is a serial printer or terminal that is always
+    /// ready for data (DSR, CTS) but has no call behind it, so a guest
+    /// polling for carrier sees none rather than a phantom caller.
+    fn control_lines(&self) -> SerialControlLines {
+        SerialControlLines::READY
     }
 
     fn flush(&mut self) {
@@ -806,6 +971,90 @@ mod tests {
             .unwrap();
         peer.read_exact(&mut got).unwrap();
         assert_eq!(&got, b"x");
+    }
+
+    #[test]
+    fn control_lines_invert_onto_cia_b_port_a_pins() {
+        // Unplugged: the 1489 outputs idle high on the pull-ups.
+        assert_eq!(
+            SerialControlLines::UNPLUGGED.cia_b_pa_levels(),
+            CIAB_PA_DSR | CIAB_PA_CTS | CIAB_PA_CD
+        );
+        // A present device with no carrier: /DSR and /CTS low, /CD high.
+        assert_eq!(SerialControlLines::READY.cia_b_pa_levels(), CIAB_PA_CD);
+        // Connected through: all three low.
+        assert_eq!(SerialControlLines::CONNECTED.cia_b_pa_levels(), 0);
+        // Each line maps to its own pin.
+        let cts_only = SerialControlLines {
+            dsr: false,
+            cts: true,
+            cd: false,
+        };
+        assert_eq!(cts_only.cia_b_pa_levels(), CIAB_PA_DSR | CIAB_PA_CD);
+        // The default sink (an output-only byte sink) is an unplugged cable.
+        assert_eq!(
+            NullSerialSink.control_lines(),
+            SerialControlLines::UNPLUGGED
+        );
+        assert_eq!(StdoutSink::new().control_lines(), SerialControlLines::READY);
+    }
+
+    fn wait_for_lines(sink: &dyn SerialSink, want: SerialControlLines, what: &str) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while sink.control_lines() != want {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "{what}: lines stuck at {:?}",
+                sink.control_lines()
+            );
+            std::thread::yield_now();
+        }
+    }
+
+    #[test]
+    fn tcp_listen_sink_carrier_follows_the_client() {
+        let mut sink = TcpSerialSink::listen("127.0.0.1:0").unwrap();
+        // A listening modem is powered and ready, but nobody has called.
+        assert_eq!(sink.control_lines(), SerialControlLines::READY);
+
+        let client = std::net::TcpStream::connect(sink.local_addr()).unwrap();
+        wait_for_lines(&sink, SerialControlLines::CONNECTED, "client connect");
+
+        // The caller hangs up: carrier drops, DSR and CTS stay up.
+        drop(client);
+        wait_for_lines(&sink, SerialControlLines::READY, "client hang-up");
+        // Output into the dropped connection stays a no-op and keeps carrier
+        // down.
+        sink.write_byte(b'x', 0);
+        assert_eq!(sink.control_lines(), SerialControlLines::READY);
+    }
+
+    #[test]
+    fn tcp_connect_sink_carrier_drops_when_the_remote_hangs_up() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let accepted = std::thread::spawn(move || listener.accept().unwrap().0);
+        let sink = TcpSerialSink::connect(&addr.to_string()).unwrap();
+        let peer = accepted.join().unwrap();
+        // The dial-out succeeded, so carrier is up from the start.
+        assert_eq!(sink.control_lines(), SerialControlLines::CONNECTED);
+
+        drop(peer);
+        wait_for_lines(&sink, SerialControlLines::READY, "remote hang-up");
+    }
+
+    #[test]
+    fn channel_sink_control_lines_follow_the_handle() {
+        let (sink, handle) = ChannelSerialSink::pair();
+        // A bridge is present and ready before the page has a connection.
+        assert_eq!(sink.control_lines(), SerialControlLines::READY);
+        assert_eq!(handle.control_lines(), SerialControlLines::READY);
+        handle.set_carrier(true);
+        assert_eq!(sink.control_lines(), SerialControlLines::CONNECTED);
+        handle.set_carrier(false);
+        assert_eq!(sink.control_lines(), SerialControlLines::READY);
+        handle.set_control_lines(SerialControlLines::UNPLUGGED);
+        assert_eq!(sink.control_lines(), SerialControlLines::UNPLUGGED);
     }
 
     #[test]


### PR DESCRIPTION
Closes a long-standing gap: the serial bridges never drove /DSR, /CTS, or /CD, so CIA-B PA3-5 always read as an unplugged cable and a guest opening `serial.device` in 7-wire mode waited on CTS forever no matter what was attached, and no guest could ever see a carrier.

## Model

The sink is the device on the far end of the RS-232 cable, so `SerialSink` now reports its control lines (`SerialControlLines`: DSR/CTS/CD as asserted-or-not) and the bus overlays guest reads of CIA-B PRA with the levels the motherboard's inverting 1489 receivers would present: asserted = pin low, undriven = pulled up, and pins the guest switches to outputs stay CIA-driven - the same shape as the existing Centronics status overlay on PA0-2. `serial.device`'s `SDCMD_QUERY` io_Status low byte is exactly this register.

Per sink:
- `off`, `midi`: unplugged (a MIDI interface hangs off TXD/RXD only);
- `stdout`: a present, ready device with no carrier - no phantom caller on the default mode;
- `tcp` / `tcp-connect`: a modem - DSR and CTS from startup, carrier only while the client/dial-out connection is live (an atomic maintained by the acceptor/reader thread, so the PRA read never touches the writer lock). A guest BBS sees the caller hang up as carrier loss;
- `pty`: a null-modem peer with its port open (its side is unobservable - the sink holds the slave open);
- browser channel sink: starts ready, page-controlled via the new `serial_set_carrier(bool)` wasm export, wired to the try page's WebSocket open/close.

## Verification

End-to-end under Kickstart 3.1 with a small guest program printing CIA-B PRA over the UART while a CCP session watched the serial event tap: `E7` idle (DSR+CTS low, CD high), `C7` while a TCP client was connected, back to `E7` after the hang-up; the connected client read the same bytes off the socket. Unit tests cover the pin inversion, the TCP carrier lifecycle on both listen and connect sinks, the channel handle, and the bus overlay (including DDR-switched pins staying CIA-driven).

Aside from that run: AROS reads `FF` here because its `cia.resource` sets CIA-B DDRA=0xff (all outputs) where Kickstart uses 0xc0 - honoring the DDR is correct on our side; the one-line fix belongs upstream in AROS.

Docs: configuration guide (per-mode handshake behaviour), browser chapter (`serial_set_carrier`), internals peripherals + chipset chapters.

Tests: full suite (2829 lib tests), clippy, fmt clean.