### PR TITLE
WASM: add DF1 to the hosted emulator

### DIFF
--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -89,7 +89,10 @@ jobs:
           import { readFileSync } from 'fs';
           import init, { WebEmu } from './pkg-smoke-glue.mjs';
           await init({ module_or_path: readFileSync('./pkg/copperline_web_bg.wasm') });
-          const emu = new WebEmu('A500', 'PAL');
+          const emu = new WebEmu('A500', 'PAL', 2);
+          if (!emu.drive_connected(0) || !emu.drive_connected(1) || emu.drive_connected(2)) {
+            throw new Error('browser floppy drive count was not applied');
+          }
           if (emu.presentation_revision() !== 0) {
             throw new Error('fresh presentation revision is not zero');
           }

--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -93,6 +93,14 @@ jobs:
           if (!emu.drive_connected(0) || !emu.drive_connected(1) || emu.drive_connected(2)) {
             throw new Error('browser floppy drive count was not applied');
           }
+          for (const invalid of [0, 5, 2.5, 257, NaN, Infinity]) {
+            try {
+              new WebEmu('A500', 'PAL', invalid);
+              throw new Error(`invalid browser floppy drive count was accepted: ${invalid}`);
+            } catch (error) {
+              if (String(error).includes('was accepted')) throw error;
+            }
+          }
           if (emu.presentation_revision() !== 0) {
             throw new Error('fresh presentation revision is not zero');
           }

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -294,7 +294,7 @@ impl WebEmu {
     pub fn new(
         model: Option<String>,
         video: Option<String>,
-        floppy_drives: Option<u8>,
+        floppy_drives: Option<f64>,
     ) -> Result<WebEmu, JsValue> {
         let mut cfg = match model.as_deref().map(str::trim) {
             None | Some("") => Config::default(),
@@ -305,12 +305,13 @@ impl WebEmu {
             Some(name) => cfg.video_standard = parse_video_standard(name).map_err(js_err)?,
         }
         if let Some(count) = floppy_drives {
-            if !(1..=4).contains(&count) {
+            if !count.is_finite() || count.fract() != 0.0 || !(1.0..=4.0).contains(&count) {
                 return Err(JsValue::from_str(&format!(
-                    "floppy drive count must be between 1 and 4, got {count}"
+                    "floppy drive count must be a finite integer between 1 and 4, got {count}"
                 )));
             }
-            cfg.floppy_connected = std::array::from_fn(|drive| drive < usize::from(count));
+            let count = count as usize;
+            cfg.floppy_connected = std::array::from_fn(|drive| drive < count);
         }
         let audio = Rc::new(RefCell::new(Vec::new()));
         let sink = WebAudioSink { buf: audio.clone() };

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -286,9 +286,16 @@ impl WebEmu {
     /// `video` picks the video standard ("PAL" or "NTSC", the desktop's
     /// `[chipset] video` key) on top of whatever the profile chose; omitted
     /// or empty keeps the profile's own standard (PAL for every offered
-    /// profile). An unknown name throws, like an unknown model.
+    /// profile). `floppy_drives` fits one to four drives, matching the
+    /// desktop's `[floppy] drives` setting; omitted, the profile default stays
+    /// in place (one drive for the offered models). An unknown name or invalid
+    /// drive count throws.
     #[wasm_bindgen(constructor)]
-    pub fn new(model: Option<String>, video: Option<String>) -> Result<WebEmu, JsValue> {
+    pub fn new(
+        model: Option<String>,
+        video: Option<String>,
+        floppy_drives: Option<u8>,
+    ) -> Result<WebEmu, JsValue> {
         let mut cfg = match model.as_deref().map(str::trim) {
             None | Some("") => Config::default(),
             Some(name) => machine_profile_defaults(parse_machine_model(name).map_err(js_err)?),
@@ -296,6 +303,14 @@ impl WebEmu {
         match video.as_deref().map(str::trim) {
             None | Some("") => {}
             Some(name) => cfg.video_standard = parse_video_standard(name).map_err(js_err)?,
+        }
+        if let Some(count) = floppy_drives {
+            if !(1..=4).contains(&count) {
+                return Err(JsValue::from_str(&format!(
+                    "floppy drive count must be between 1 and 4, got {count}"
+                )));
+            }
+            cfg.floppy_connected = std::array::from_fn(|drive| drive < usize::from(count));
         }
         let audio = Rc::new(RefCell::new(Vec::new()));
         let sink = WebAudioSink { buf: audio.clone() };

--- a/crates/copperline-web/www/package.json
+++ b/crates/copperline-web/www/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test render-stride.test.js"
+    "test": "node --check try.js && node --test render-stride.test.js"
   }
 }

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -557,7 +557,6 @@ async function load() {
       );
     }
   } catch (e) {
-    const inserted = insertedDiskDescription(' (write-protected)');
     setLoadStatus(
       `AROS ROMs failed to load (${e.message ?? e}) - load your own Kickstart to boot`,
     );
@@ -812,6 +811,7 @@ async function boot() {
     // Leave a fresh status behind: the old line ("inserts at boot", an
     // earlier failure) would otherwise go stale into any bug report filed
     // while the machine runs.
+    const inserted = insertedDiskDescription(' (write-protected)');
     setLoadStatus(
       // A ROM-less boot is only ever a landing place for a state load,
       // which overwrites this line the moment it lands.

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -31,6 +31,41 @@ const bootBtn = $('boot');
 const loadStatus = $('load-status');
 const statLine = $('stat');
 
+// The hosted page fits DF0 + DF1. A page shell may place its own #df1 and
+// #eject1 controls; older shells only know DF0, so add the second pair beside
+// their existing controls. Keeping this in the published glue means the wasm
+// API, controller and copperline.dev page acquire DF1 in the same release.
+const PAGE_FLOPPY_DRIVES = 2;
+
+function ensureDf1Controls() {
+  const df0 = $('df0');
+  if (df0 && !$('df1')) {
+    const label = document.createElement('label');
+    const df0Label = df0.closest('label');
+    if (df0Label) label.className = df0Label.className;
+    label.append('Insert DF1\u2026 ');
+    const input = document.createElement('input');
+    input.id = 'df1';
+    input.type = 'file';
+    input.hidden = true;
+    if (df0.hasAttribute('accept')) input.accept = df0.accept;
+    label.appendChild(input);
+    (df0Label ?? df0).insertAdjacentElement('afterend', label);
+  }
+
+  const eject0 = $('eject');
+  if (eject0 && !$('eject1')) {
+    eject0.textContent = 'Eject DF0';
+    const eject1 = document.createElement('button');
+    eject1.id = 'eject1';
+    eject1.className = eject0.className;
+    eject1.textContent = 'Eject DF1';
+    eject0.insertAdjacentElement('afterend', eject1);
+  }
+}
+
+ensureDf1Controls();
+
 // iOS's document picker only offers files whose extensions map to a
 // system-known type: .bin, .zip and .gz are fine, but .rom, .adf and
 // friends grey out, locking iPhone/iPad users out of their own dumps.
@@ -42,6 +77,7 @@ if (
   (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
 ) {
   $('df0').removeAttribute('accept');
+  $('df1').removeAttribute('accept');
   $('kick').removeAttribute('accept');
 }
 
@@ -181,12 +217,13 @@ async function fetchBytes(url, label) {
 // the machine is running.
 
 let bootRom = null; // { rom, ext, label } - what the boot button will fit
-let pendingDisk = null; // { bytes, name } - inserted right after boot
-let df0Name = null; // what the page believes is in DF0, for bug reports
-// The page's copy of the last disk that went into DF0. The inserted bytes
-// live inside the machine, so switching the machine model (which builds a
-// new one) re-inserts from this stash; kept forever, like the ROM stash.
-let lastDisk = null; // { bytes, name }
+// Per-drive page state. Pickers can fill either drive before boot; the last
+// uploaded bytes stay available so a model/video rebuild can re-insert them
+// into the replacement machine. A disk restored only from a save state has
+// no page-side bytes and therefore cannot cross such a rebuild.
+const pendingDisks = Array(4).fill(null); // { bytes, name }, inserted at boot
+const diskNames = Array(4).fill(null); // page's view, for reports and captions
+const lastDisks = Array(4).fill(null); // last uploaded { bytes, name }
 
 function refreshBootButton() {
   bootBtn.disabled = !(wasm && bootRom);
@@ -305,23 +342,49 @@ async function forgetStoredRom() {
 
 // Route disk bytes from any source (picker, URL, drop): insert into a
 // running machine, or stash them for the boot button to insert after boot.
-function insertDisk(bytes, name) {
-  lastDisk = { bytes, name };
+function insertDisk(bytes, name, drive = 0) {
+  if (drive < 0 || drive >= PAGE_FLOPPY_DRIVES) {
+    throw new Error(`DF${drive} is not fitted`);
+  }
+  lastDisks[drive] = { bytes, name };
   if (emu) {
-    emu.insert_floppy(0, bytes, name);
-    setLoadStatus(`DF0: ${name} (write-protected)`);
+    emu.insert_floppy(drive, bytes, name);
+    setLoadStatus(`DF${drive}: ${name} (write-protected)`);
     lastFddTrack = null; // desktop clears its track latch on insert too
     updateStatusDisks();
   } else {
-    pendingDisk = { bytes, name };
-    setLoadStatus(`DF0: ${name} (inserts at boot)`);
+    pendingDisks[drive] = { bytes, name };
+    setLoadStatus(`DF${drive}: ${name} (inserts at boot)`);
   }
-  df0Name = name;
+  diskNames[drive] = name;
 }
 
-// A disk image can also come from a link: /try/?df0=<url> fetches it and
-// inserts it at boot, so a bootable demo is one shareable URL, and the
-// "DF0 from URL" button does the same for a pasted address. The fetch
+function queuedDiskDescription() {
+  return pendingDisks
+    .map((disk, drive) => (disk ? `DF${drive}: ${disk.name}` : null))
+    .filter(Boolean)
+    .join(', ');
+}
+
+function insertedDiskDescription(suffix = '') {
+  return diskNames
+    .map((name, drive) => (name ? `DF${drive}: ${name}${suffix}` : null))
+    .filter(Boolean)
+    .join(', ');
+}
+
+function keepUploadedDisksForRebuild() {
+  for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
+    if (diskNames[drive] && lastDisks[drive]?.name === diskNames[drive]) {
+      pendingDisks[drive] = lastDisks[drive];
+    }
+  }
+}
+
+// Disk images can also come from a link: /try/?df0=<url>&df1=<url> fetches
+// either or both and inserts them at boot, so a multi-disk demo is one
+// shareable URL. The "DF0 from URL" button does the same for a pasted boot
+// disk address. The fetch
 // happens in the visitor's browser and nothing is proxied, so the host
 // must allow cross-origin GETs (same-origin always works, archive.org
 // does too).
@@ -355,7 +418,7 @@ function nameFromUrlPath(pathname, fallback) {
 // the cap only keeps a mislinked file from buffering unbounded.
 const ROM_URL_MAX_BYTES = 4 << 20;
 
-async function insertDiskFromUrl(url) {
+async function insertDiskFromUrl(url, drive = 0) {
   let parsed;
   try {
     parsed = new URL(url, location.href);
@@ -377,7 +440,7 @@ async function insertDiskFromUrl(url) {
     }
     const bytes = new Uint8Array(await resp.arrayBuffer());
     if (bytes.length > DISK_URL_MAX_BYTES) throw new Error('file too large');
-    insertDisk(bytes, name);
+    insertDisk(bytes, name, drive);
   } catch (e) {
     // A TypeError is the opaque network/CORS failure; HTTP and size errors
     // speak for themselves.
@@ -474,24 +537,27 @@ async function load() {
     // A Kickstart picked (or remembered) while the ROMs were downloading
     // wins; a ?kick= failure rides along either way.
     const problem = romUrlProblem ? ` (${romUrlProblem})` : '';
+    const queued = queuedDiskDescription();
+    const queuedVerb = pendingDisks.filter(Boolean).length === 1 ? 'inserts' : 'insert';
     if (!bootRom) {
       bootRom = arosRom;
       // A disk that landed first (file picker or ?df0= fetch) keeps its
       // place in the status line.
       setLoadStatus(
-        (pendingDisk
-          ? `ready - DF0: ${pendingDisk.name} inserts at boot`
+        (queued
+          ? `ready - ${queued} ${queuedVerb} at boot`
           : 'ready - boots the open-source AROS ROM') + problem,
       );
     } else {
       setLoadStatus(
         `ready - boots ${bootRom.label}` +
           (bootRom.remembered ? ' (remembered in this browser)' : '') +
-          (pendingDisk ? ` - DF0: ${pendingDisk.name} inserts at boot` : '') +
+          (queued ? ` - ${queued} ${queuedVerb} at boot` : '') +
           problem,
       );
     }
   } catch (e) {
+    const inserted = insertedDiskDescription(' (write-protected)');
     setLoadStatus(
       `AROS ROMs failed to load (${e.message ?? e}) - load your own Kickstart to boot`,
     );
@@ -700,7 +766,11 @@ async function boot() {
     // shell, or the list not knowing better) builds the default A500. The
     // video argument picks PAL/NTSC the same way; a bundle older than both
     // ignores the extra arguments.
-    const machine = new WebEmu(machineModel ?? undefined, videoStandard ?? undefined);
+    const machine = new WebEmu(
+      machineModel ?? undefined,
+      videoStandard ?? undefined,
+      PAGE_FLOPPY_DRIVES,
+    );
     if (bootRom) machine.load_rom(bootRom.rom, bootRom.ext ?? undefined);
 
     await buildAudioStack(false);
@@ -712,14 +782,14 @@ async function boot() {
     shaderMsThisSecond = 0;
     resetRenderStrideController();
 
-    // A fresh machine boots with an empty drive: DF0 holds the pending disk
-    // or nothing, never a name left over from before the reboot (a crash
-    // consumes the pending disk, and the bug report reads df0Name).
-    if (pendingDisk) {
-      machine.insert_floppy(0, pendingDisk.bytes, pendingDisk.name);
+    // A fresh machine boots with empty drives: each holds its pending disk or
+    // nothing, never a name left over from before the reboot.
+    for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
+      const disk = pendingDisks[drive];
+      if (disk) machine.insert_floppy(drive, disk.bytes, disk.name);
+      diskNames[drive] = disk?.name ?? null;
+      pendingDisks[drive] = null;
     }
-    df0Name = pendingDisk?.name ?? null;
-    pendingDisk = null;
     machine.set_volume_percent(Number($('vol').value));
     if (floppySoundsToggle) machine.set_floppy_sounds(floppySoundsToggle.checked);
     else if (configFloppySounds !== null) machine.set_floppy_sounds(configFloppySounds);
@@ -748,7 +818,7 @@ async function boot() {
       (bootRom
         ? `booted ${bootRom.label}${machineModel ? ` on the ${machineModel}` : ''}`
         : 'machine built, waiting for the state') +
-        (df0Name ? ` - DF0: ${df0Name} (write-protected)` : ''),
+        (inserted ? ` - ${inserted}` : ''),
     );
     overlay.style.display = 'none';
     showBugLink(false);
@@ -2057,16 +2127,18 @@ function touchJoyEnd(e) {
 
 // --- controls ------------------------------------------------------------
 
-$('df0').addEventListener('change', async (e) => {
-  const file = e.target.files[0];
-  e.target.value = '';
-  if (!file) return;
-  try {
-    insertDisk(new Uint8Array(await file.arrayBuffer()), file.name);
-  } catch (err) {
-    setLoadStatus(`insert failed: ${err.message ?? err}`);
-  }
-});
+for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
+  $(`df${drive}`).addEventListener('change', async (e) => {
+    const file = e.target.files[0];
+    e.target.value = '';
+    if (!file) return;
+    try {
+      insertDisk(new Uint8Array(await file.arrayBuffer()), file.name, drive);
+    } catch (err) {
+      setLoadStatus(`DF${drive} insert failed: ${err.message ?? err}`);
+    }
+  });
+}
 
 $('kick').addEventListener('change', async (e) => {
   const file = e.target.files[0];
@@ -2079,17 +2151,19 @@ $('kick').addEventListener('change', async (e) => {
   }
 });
 
-$('eject').addEventListener('click', () => {
-  if (!emu) return;
-  try {
-    emu.eject_floppy(0);
-    df0Name = null;
-    setLoadStatus('DF0 ejected');
-    updateStatusDisks();
-  } catch (err) {
-    setLoadStatus(`${err.message ?? err}`);
-  }
-});
+for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
+  $(`eject${drive || ''}`).addEventListener('click', () => {
+    if (!emu) return;
+    try {
+      emu.eject_floppy(drive);
+      diskNames[drive] = null;
+      setLoadStatus(`DF${drive} ejected`);
+      updateStatusDisks();
+    } catch (err) {
+      setLoadStatus(`${err.message ?? err}`);
+    }
+  });
+}
 
 $('reset').addEventListener('click', () => {
   if (!emu) return;
@@ -3696,7 +3770,8 @@ function stateRecord(bytes) {
     saved: new Date(),
     emulated: emu.emulated_seconds(),
     rom: bootRom?.label ?? 'unknown',
-    df0: df0Name,
+    df0: diskNames[0],
+    df1: diskNames[1],
     machine: emu.machine_model?.() ?? machineModel ?? null,
   };
 }
@@ -3705,7 +3780,11 @@ function describeState(info) {
   if (!info) return '';
   const when = info.saved instanceof Date ? info.saved.toLocaleString() : 'unknown time';
   const machine = info.machine ? `${info.machine}, ` : '';
-  return `${when} - ${info.df0 ?? 'no disk'} (${machine}${Math.round(info.emulated ?? 0)}s emulated)`;
+  const disks = [info.df0, info.df1]
+    .map((name, drive) => (name ? `DF${drive}: ${name}` : null))
+    .filter(Boolean)
+    .join(', ');
+  return `${when} - ${disks || 'no disks'} (${machine}${Math.round(info.emulated ?? 0)}s emulated)`;
 }
 
 // Enablement follows what each control can actually do right now: saving
@@ -3797,8 +3876,10 @@ function restoreState(bytes, source) {
   // A restored state carries its own idea of which keys are held, so the
   // on-screen keyboard's latches are stale: believe the machine.
   forgetVirtualKeys();
-  // The disk came back inside the state; believe the machine, not the page.
-  df0Name = emu.disk_name(0) ?? null;
+  // The disks came back inside the state; believe the machine, not the page.
+  for (let drive = 0; drive < diskNames.length; drive++) {
+    diskNames[drive] = emu.disk_name(drive) ?? null;
+  }
   lastFddTrack = null;
   updateStatusDisks();
   // So did the machine itself, model, video standard and all.
@@ -3807,9 +3888,8 @@ function restoreState(bytes, source) {
   // Paint the restored screen now: a load into a paused machine steps no
   // frames, so nothing else would.
   presentFrame();
-  setLoadStatus(
-    `state loaded from ${source}` + (df0Name ? ` - DF0: ${df0Name}` : ''),
-  );
+  const disks = insertedDiskDescription();
+  setLoadStatus(`state loaded from ${source}` + (disks ? ` - ${disks}` : ''));
   return true;
 }
 
@@ -4484,10 +4564,9 @@ machineSel.addEventListener('change', () => {
   if (!model || model === machineModel) return;
   machineModel = model;
   if (emu && running) {
-    // Carry the page's copy of the inserted disk into the new machine; a
-    // disk that only exists inside the old one (restored from a state)
-    // cannot come along.
-    if (df0Name && lastDisk?.name === df0Name) pendingDisk = lastDisk;
+    // Carry page-owned uploaded disks into the new machine; a disk that only
+    // exists inside the old one (restored from a state) cannot come along.
+    keepUploadedDisksForRebuild();
     boot();
   } else if (!emu) {
     setLoadStatus(`machine: ${model} - applies at boot`);
@@ -4574,8 +4653,8 @@ videoSel.addEventListener('change', () => {
   videoStandard = std;
   if (emu && running) {
     // The machine select's rebuild, for the same reason: the standard is
-    // soldered in. ROM and disk carry over the same way.
-    if (df0Name && lastDisk?.name === df0Name) pendingDisk = lastDisk;
+    // soldered in. ROM and disks carry over the same way.
+    keepUploadedDisksForRebuild();
     boot();
   } else if (!emu) {
     setLoadStatus(`video: ${std} - applies at boot`);
@@ -6371,7 +6450,7 @@ const KICK_LIST_EXT = /\.(rom|bin)$/i;
 // Null until the module is up, and on a bundle too old to say.
 let diskFormats = null;
 
-// Called once the wasm module is ready (load()): point the disk picker and
+// Called once the wasm module is ready (load()): point the disk pickers and
 // the optional DF0 list at the formats this build reads. A shell's
 // hand-written accept attribute is a list the wasm can outgrow, and it did
 // - which is why the glue rewrites it rather than trusting it. Only a
@@ -6393,9 +6472,11 @@ function applyDiskFormats() {
     if (diskListSelect) diskListSelect.hidden = true;
     return;
   }
-  const picker = $('df0');
-  if (picker.hasAttribute('accept')) {
-    picker.accept = diskFormats.map((ext) => `.${ext}`).join(',');
+  for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
+    const picker = $(`df${drive}`);
+    if (picker.hasAttribute('accept')) {
+      picker.accept = diskFormats.map((ext) => `.${ext}`).join(',');
+    }
   }
   if (diskListSelect) {
     const listExt = new RegExp(`\\.(${diskFormats.join('|')})$`, 'i');
@@ -6585,7 +6666,8 @@ function bugReportHref() {
       // tracks state loads); otherwise what the next boot would build.
       `machine = ${toml(emu?.machine_summary?.() ?? machineModel ?? 'A500 (default)')}`,
       `kickstart = ${toml(bootRom?.label ?? 'none')}`,
-      `df0 = ${toml(df0Name ?? 'empty')}`,
+      `df0 = ${toml(diskNames[0] ?? 'empty')}`,
+      `df1 = ${toml(diskNames[1] ?? 'empty')}`,
       `joystick = ${toml(joyMode)}`,
       // The emulated presentation and the canvas backing store; under
       // the monitor path the latter is display-resolution, so a size
@@ -6710,7 +6792,7 @@ const pageParams = new URLSearchParams(location.search);
 // Optional copperline.json next to the page: a site sets its defaults in
 // one hand-editable file instead of touching the shell or this glue. All
 // keys are optional; a missing or invalid file is simply no defaults.
-// Link parameters (?df0=, ?kick=, ?machine=, ?joy=, ?fdspeed=) override
+// Link parameters (?df0=/df1=, ?kick=, ?machine=, ?joy=, ?fdspeed=) override
 // the file, and anything the visitor changes by hand wins as usual.
 //
 //   {
@@ -6718,6 +6800,7 @@ const pageParams = new URLSearchParams(location.search);
 //     "video": "NTSC",               video standard, like ?video= (PAL|NTSC)
 //     "kick": "roms/kick31.rom",     same-origin path, like ?kick=
 //     "df0": "adf/demo.adf",         URL, like ?df0=
+//     "df1": "adf/demo-disk2.adf",   optional second-drive URL
 //     "floppy_sounds": false,        preset the drive-sounds toggle
 //     "mono_audio": true,            preset the mono-audio toggle
 //     "floppy_speed": 800,           100|200|400|800|0 (0 = turbo)
@@ -6782,9 +6865,12 @@ async function startup() {
   if (bgRunPref !== null) bgRunToggle.checked = bgRunPref === 'on';
   else if (typeof cfg.background_run === 'boolean') bgRunToggle.checked = cfg.background_run;
   const fetches = [];
-  const linkedDisk =
-    pageParams.get('df0') ?? (typeof cfg.df0 === 'string' ? cfg.df0 : null);
-  if (linkedDisk) fetches.push(insertDiskFromUrl(linkedDisk));
+  for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
+    const key = `df${drive}`;
+    const linkedDisk =
+      pageParams.get(key) ?? (typeof cfg[key] === 'string' ? cfg[key] : null);
+    if (linkedDisk) fetches.push(insertDiskFromUrl(linkedDisk, drive));
+  }
   const linkedKick =
     pageParams.get('kick') ?? (typeof cfg.kick === 'string' ? cfg.kick : null);
   if (linkedKick) fetches.push(fitRomFromUrl(linkedKick));

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -15,7 +15,7 @@ locally, and how to embed the emulator in your own page.
 AROS ROM or a loaded Kickstart. Changing it before boot just changes what
 the boot button builds, and changing it while a machine runs rebuilds the
 machine and powers it up again -- the model is the board itself, not a
-knob on it -- keeping the chosen ROM and the inserted disk. A link can
+knob on it -- keeping the chosen ROM and the inserted disks. A link can
 preset the model with `?machine=A1200`, and a
 [save state](#browser-save-states) carries its own machine, so loading
 one switches the select to whatever the state brings back. The **Video**
@@ -24,8 +24,10 @@ desktop's `[chipset] video` key) -- the standard is the Agnus crystal,
 so changing it rebuilds a running machine exactly like the model select,
 and `?video=NTSC` presets it per link. The
 page fetches the open-source AROS ROM while it loads, so the boot button
-works with no files of your own; the **Kickstart ROM** and **DF0 disk**
-pickers load local images instead. Both work before or after boot: a
+works with no files of your own; the **Kickstart ROM**, **DF0 disk** and
+**DF1 disk** pickers load local images instead. The hosted machine fits both
+floppy drives, so a multi-disk title can keep its second disk in DF1 instead
+of swapping DF0. The pickers work before or after boot: a
 pre-boot choice is stashed and applied when the machine starts (the boot
 button relabels to show which ROM it will use), and a post-boot pick swaps
 the disk live. Disk images are recognised by content -- ADF, ADZ, DMS, IPF,
@@ -111,10 +113,11 @@ restores a [save state](#browser-save-states), and anything else inserts
 into DF0 like the disk picker -- dropped before boot it queues and inserts
 when the machine starts. The same 64 MiB cap as URL fetches applies.
 
-A disk can also come from a link: `/try/?df0=<url>` fetches the image while
-the emulator loads and inserts it at boot, so a bootable demo is one
-shareable URL, and the **DF0 from URL** button does the same for a pasted
-address, inserting live when the machine is already running. The fetch
+A disk can also come from a link: `/try/?df0=<url>&df1=<url>` fetches either
+or both images while the emulator loads and inserts them at boot, so a
+multi-disk demo is one shareable URL. The **DF0 from URL** button does the
+same for a pasted boot-disk address, inserting live when the machine is
+already running. The fetch
 happens in the visitor's browser and nothing is proxied, so the image's
 host must allow cross-origin GETs (same-origin always works; archive.org
 does too). Only http(s) URLs are accepted, capped at 64 MiB (SCP flux
@@ -314,7 +317,7 @@ does not place them:
   restarts.
 - **Quick load** restores that slot. It is enabled only when the browser
   holds a quick state, and its tooltip says when the state was taken,
-  what was in DF0, and how far the machine had run.
+  what was in DF0/DF1, and how far the machine had run.
 - **Saved states...** opens the panel over everything the browser
   remembers: the stored Kickstart (with its **Forget** button), the quick
   slot, and *named* states -- type a name and **Save new** keeps the
@@ -496,6 +499,7 @@ import init, { WebEmu } from './pkg/copperline_web.js';
 const wasm = await init();
 const emu = new WebEmu();          // default A500 machine, placeholder ROM
 // ...or pick a machine model: new WebEmu('A1200')
+// ...or fit DF0 + DF1: new WebEmu('A500', 'PAL', 2)
 emu.load_rom(romBytes, extBytes);  // Kickstart or AROS bytes; cold reset
 emu.insert_floppy(0, adfBytes, 'game.adf');
 
@@ -526,7 +530,10 @@ second optional argument picks the video standard on top of the profile
 (`new WebEmu('A500', 'NTSC')`), the desktop's `[chipset] video` key;
 omitted, the profile keeps its own (PAL for every offered profile).
 `WebEmu.video_standards()` lists the accepted names and is the matching
-feature test. `machine_model()` returns the running machine's profile name
+feature test. The third optional argument fits one to four floppy drives,
+the browser equivalent of `[floppy] drives`; omitted, the chosen profile's
+default remains for backward compatibility. `machine_model()` returns the
+running machine's profile name
 (`undefined` for a shape no profile describes, such as a state saved
 from a custom desktop config) and follows `load_state`, so a page can
 re-point its machine select at what a state brought back;
@@ -662,6 +669,10 @@ elements, and pages without them are untouched:
 
 - `#df0url` / `#kickurl` (buttons): prompt for a disk / same-origin ROM
   URL, as described above.
+- `#df1` (file input) / `#eject1` (button): place the hosted page's second
+  drive controls. An older shell with only `#df0` and `#eject` gets the DF1
+  picker and eject button inserted beside them automatically; in that case
+  the original eject button is relabelled **Eject DF0** for clarity.
 - `#floppy-sounds` (checkbox): toggles the synthesized floppy drive
   sounds -- motor hum, head-step clicks, read hiss -- live and at boot, so
   a shell can also default them off by shipping the box unchecked.
@@ -865,7 +876,7 @@ elements, and pages without them are untouched:
 A site can set its defaults in one hand-editable file instead of editing
 the shell: `copperline.json`, served next to the page. Every key is
 optional, a missing or invalid file means no defaults, link parameters
-(`?df0=`, `?kick=`, `?machine=`, `?joy=`, `?fdspeed=`) override the file
+(`?df0=`, `?df1=`, `?kick=`, `?machine=`, `?joy=`, `?fdspeed=`) override the file
 per URL, and anything the visitor changes by hand wins as usual:
 
 ```json
@@ -874,6 +885,7 @@ per URL, and anything the visitor changes by hand wins as usual:
   "video": "NTSC",
   "kick": "roms/kick31.rom",
   "df0": "adf/demo.adf",
+  "df1": "adf/demo-disk2.adf",
   "floppy_sounds": false,
   "mono_audio": true,
   "floppy_speed": 800,
@@ -891,8 +903,8 @@ per URL, and anything the visitor changes by hand wins as usual:
 `machine` picks the machine model, like `?machine=`; `video` the PAL/NTSC
 standard, like `?video=`; `kick` follows the
 same-origin rule as `?kick=` (the file can only name a ROM the site
-already serves); `df0` is any URL the visitor's browser may fetch, like
-`?df0=`. `floppy_sounds`, `mono_audio`, and
+already serves); `df0` and `df1` are URLs the visitor's browser may fetch,
+like `?df0=` / `?df1=`. `floppy_sounds`, `mono_audio`, and
 `floppy_speed` reach the machine whether or not the shell has their
 controls -- the speed select inserts itself, and a configured
 `floppy_sounds` or `mono_audio` is applied at boot even with no checkbox

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -531,8 +531,9 @@ second optional argument picks the video standard on top of the profile
 omitted, the profile keeps its own (PAL for every offered profile).
 `WebEmu.video_standards()` lists the accepted names and is the matching
 feature test. The third optional argument fits one to four floppy drives,
-the browser equivalent of `[floppy] drives`; omitted, the chosen profile's
-default remains for backward compatibility. `machine_model()` returns the
+the browser equivalent of `[floppy] drives`; it must be an integer. When
+omitted, the chosen profile's default remains for backward compatibility.
+`machine_model()` returns the
 running machine's profile name
 (`undefined` for a shape no profile describes, such as a state saved
 from a custom desktop config) and follows `load_state`, so a page can


### PR DESCRIPTION
## Summary

- let WebEmu callers configure one to four connected floppy drives
- fit DF0 and DF1 on the hosted page, with independent picker/eject controls and URL loading
- carry both disks through machine rebuilds, state metadata, status text, and bug reports
- document the browser API and multi-disk workflow

## Verification

- cargo test --locked
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo fmt --check (workspace and web crate)
- cargo build --release --target wasm32-unknown-unknown --locked
- npm test
- browser smoke: legacy hosted shell auto-adds DF1; ?df1=blank.adf boots with DF1 connected and inserted

Part of #505.