### PR TITLE
WASM: add writable in-memory floppy images

### DIFF
--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -97,6 +97,12 @@ jobs:
           if (emu.floppy_write_protected(1) !== false || emu.export_floppy(1).length !== 901120) {
             throw new Error('browser writable floppy did not round-trip in memory');
           }
+          const writableState = emu.save_state();
+          emu.eject_floppy(1);
+          emu.load_state(writableState);
+          if (emu.floppy_write_protected(1) !== false || emu.export_floppy(1).length !== 901120) {
+            throw new Error('browser writable floppy did not survive a save-state round trip');
+          }
           for (const invalid of [0, 5, 2.5, 257, NaN, Infinity]) {
             try {
               new WebEmu('A500', 'PAL', invalid);

--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -93,6 +93,10 @@ jobs:
           if (!emu.drive_connected(0) || !emu.drive_connected(1) || emu.drive_connected(2)) {
             throw new Error('browser floppy drive count was not applied');
           }
+          emu.insert_floppy_writable(1, new Uint8Array(901120), 'blank.adf');
+          if (emu.floppy_write_protected(1) !== false || emu.export_floppy(1).length !== 901120) {
+            throw new Error('browser writable floppy did not round-trip in memory');
+          }
           if (emu.presentation_revision() !== 0) {
             throw new Error('fresh presentation revision is not zero');
           }

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -880,13 +880,41 @@ impl WebEmu {
 
     /// Insert a floppy image from bytes: every format the core reads
     /// (ADF/ADZ, extended ADF, DMS, IPF, SCP, optionally gzip/zip-packed),
-    /// recognised by signature rather than by name. Always write-protected:
-    /// the browser has nowhere to write changes back to.
+    /// recognised by signature rather than by name. Always write-protected;
+    /// use `insert_floppy_writable` when the page will offer an export.
     pub fn insert_floppy(&mut self, drive: u8, bytes: Vec<u8>, name: &str) -> Result<(), JsValue> {
         self.emu
             .bus_mut()
             .floppy
             .insert_disk_image_bytes(drive as usize, bytes, PathBuf::from(name), true)
+            .map_err(js_err)
+    }
+
+    /// Insert an uncompressed standard or UAE extended ADF with a writable,
+    /// in-memory backing. Guest writes stay in the machine (and its save
+    /// states) until the page calls `export_floppy`; no browser filesystem is
+    /// involved. Compressed containers, DMS, IPF and SCP throw because their
+    /// decoded representation cannot be written back in the original format.
+    pub fn insert_floppy_writable(
+        &mut self,
+        drive: u8,
+        bytes: Vec<u8>,
+        name: &str,
+    ) -> Result<(), JsValue> {
+        self.emu
+            .bus_mut()
+            .floppy
+            .insert_memory_disk_image_bytes(drive as usize, bytes, PathBuf::from(name), false)
+            .map_err(js_err)
+    }
+
+    /// Snapshot DFn's current image bytes. Standard disks export as ADF and
+    /// track images as UAE extended ADF; compressed inputs export decoded.
+    pub fn export_floppy(&self, drive: u8) -> Result<Vec<u8>, JsValue> {
+        self.emu
+            .bus()
+            .floppy
+            .export_disk_image(drive as usize)
             .map_err(js_err)
     }
 
@@ -939,6 +967,15 @@ impl WebEmu {
     /// empty (so this doubles as the inserted check).
     pub fn disk_name(&self, drive: u8) -> Option<String> {
         self.emu.bus().floppy.inserted_disk_name(drive as usize)
+    }
+
+    /// Whether DFn's inserted image is write-protected, or undefined when
+    /// empty. A writable browser image remains in memory until exported.
+    pub fn floppy_write_protected(&self, drive: u8) -> Option<bool> {
+        self.emu
+            .bus()
+            .floppy
+            .disk_image_write_protected(drive as usize)
     }
 
     /// Queue received bytes for Paula's serial receiver (the page's
@@ -1008,6 +1045,10 @@ impl WebEmu {
     /// speed choices should re-apply them after a load.
     pub fn load_state(&mut self, blob: &[u8]) -> Result<(), JsValue> {
         self.emu.load_state_bytes(blob).map_err(js_err)?;
+        // A desktop state can name writable host files. The browser has no
+        // such paths, so adopt every restored image into serialized memory
+        // before the guest gets another chance to write it.
+        self.emu.bus_mut().floppy.make_disk_images_memory_backed();
         // Emulated time jumps to the state's timeline, so the pacer must
         // start over from now rather than chase the gap, and motion buffered
         // against the pre-load machine must not replay into it.

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -1276,7 +1276,8 @@ fn elapsed_fields_for_immediate_render(deferred_fields: &mut u32) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use super::elapsed_fields_for_immediate_render;
+    use super::{elapsed_fields_for_immediate_render, WebEmu};
+    use std::path::PathBuf;
 
     #[test]
     fn immediate_render_consumes_deferred_fields_without_double_aging() {
@@ -1284,5 +1285,31 @@ mod tests {
         assert_eq!(elapsed_fields_for_immediate_render(&mut deferred), 3);
         assert_eq!(deferred, 0);
         assert_eq!(elapsed_fields_for_immediate_render(&mut deferred), 1);
+    }
+
+    #[test]
+    fn state_load_adopts_desktop_writable_disk_into_memory() {
+        let mut web = WebEmu::new(Some("A500".into()), Some("PAL".into()), Some(1.0)).unwrap();
+        web.emu
+            .bus_mut()
+            .floppy
+            .insert_disk_image_bytes(
+                0,
+                vec![0xA5; 901_120],
+                PathBuf::from("desktop-writable.adf"),
+                false,
+            )
+            .unwrap();
+        assert_eq!(
+            web.emu.bus().floppy.runahead_block_reason(),
+            Some("writable floppy image")
+        );
+
+        let state = web.save_state().unwrap();
+        web.load_state(&state).unwrap();
+
+        assert_eq!(web.emu.bus().floppy.runahead_block_reason(), None);
+        assert_eq!(web.floppy_write_protected(0), Some(false));
+        assert_eq!(web.export_floppy(0).unwrap(), vec![0xA5; 901_120]);
     }
 }

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -221,9 +221,9 @@ let bootRom = null; // { rom, ext, label } - what the boot button will fit
 // uploaded bytes stay available so a model/video rebuild can re-insert them
 // into the replacement machine. A disk restored only from a save state has
 // no page-side bytes and therefore cannot cross such a rebuild.
-const pendingDisks = Array(4).fill(null); // { bytes, name }, inserted at boot
+const pendingDisks = Array(4).fill(null); // { bytes, name, writable }, inserted at boot
 const diskNames = Array(4).fill(null); // page's view, for reports and captions
-const lastDisks = Array(4).fill(null); // last uploaded { bytes, name }
+const lastDisks = Array(4).fill(null); // last uploaded { bytes, name, writable }
 
 function refreshBootButton() {
   bootBtn.disabled = !(wasm && bootRom);
@@ -342,26 +342,35 @@ async function forgetStoredRom() {
 
 // Route disk bytes from any source (picker, URL, drop): insert into a
 // running machine, or stash them for the boot button to insert after boot.
-function insertDisk(bytes, name, drive = 0) {
+function insertDisk(bytes, name, drive = 0, writable = writableFloppyToggle.checked) {
   if (drive < 0 || drive >= PAGE_FLOPPY_DRIVES) {
     throw new Error(`DF${drive} is not fitted`);
   }
-  lastDisks[drive] = { bytes, name };
+  const disk = { bytes, name, writable };
   if (emu) {
-    emu.insert_floppy(drive, bytes, name);
-    setLoadStatus(`DF${drive}: ${name} (write-protected)`);
+    if (writable) emu.insert_floppy_writable(drive, bytes, name);
+    else emu.insert_floppy(drive, bytes, name);
+    setLoadStatus(
+      `DF${drive}: ${name} (${writable ? 'writable in memory; download to keep changes' : 'write-protected'})`,
+    );
     lastFddTrack = null; // desktop clears its track latch on insert too
     updateStatusDisks();
+    updateFloppyImageControls();
   } else {
-    pendingDisks[drive] = { bytes, name };
-    setLoadStatus(`DF${drive}: ${name} (inserts at boot)`);
+    pendingDisks[drive] = disk;
+    setLoadStatus(
+      `DF${drive}: ${name} (${writable ? 'writable; ' : ''}inserts at boot)`,
+    );
   }
+  lastDisks[drive] = disk;
   diskNames[drive] = name;
 }
 
 function queuedDiskDescription() {
   return pendingDisks
-    .map((disk, drive) => (disk ? `DF${drive}: ${disk.name}` : null))
+    .map((disk, drive) =>
+      disk ? `DF${drive}: ${disk.name}${disk.writable ? ' (writable)' : ''}` : null,
+    )
     .filter(Boolean)
     .join(', ');
 }
@@ -373,8 +382,29 @@ function insertedDiskDescription(suffix = '') {
     .join(', ');
 }
 
+function insertedDiskStatusDescription() {
+  return diskNames
+    .map((name, drive) => {
+      if (!name) return null;
+      const writable = emu?.floppy_write_protected?.(drive) === false;
+      return `DF${drive}: ${name} (${writable ? 'writable in memory' : 'write-protected'})`;
+    })
+    .filter(Boolean)
+    .join(', ');
+}
+
 function keepUploadedDisksForRebuild() {
   for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
+    // A writable disk's page-side upload is stale as soon as the guest writes
+    // it. Snapshot the controller before replacing the machine so model/video
+    // changes keep the current platter, not the original upload.
+    if (diskNames[drive] && emu?.floppy_write_protected?.(drive) === false) {
+      lastDisks[drive] = {
+        bytes: emu.export_floppy(drive),
+        name: diskNames[drive],
+        writable: true,
+      };
+    }
     if (diskNames[drive] && lastDisks[drive]?.name === diskNames[drive]) {
       pendingDisks[drive] = lastDisks[drive];
     }
@@ -557,7 +587,6 @@ async function load() {
       );
     }
   } catch (e) {
-    const inserted = insertedDiskDescription(' (write-protected)');
     setLoadStatus(
       `AROS ROMs failed to load (${e.message ?? e}) - load your own Kickstart to boot`,
     );
@@ -786,10 +815,15 @@ async function boot() {
     // nothing, never a name left over from before the reboot.
     for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
       const disk = pendingDisks[drive];
-      if (disk) machine.insert_floppy(drive, disk.bytes, disk.name);
-      diskNames[drive] = disk?.name ?? null;
-      pendingDisks[drive] = null;
+      if (disk) {
+        if (disk.writable) machine.insert_floppy_writable(drive, disk.bytes, disk.name);
+        else machine.insert_floppy(drive, disk.bytes, disk.name);
+      }
     }
+    for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
+      diskNames[drive] = pendingDisks[drive]?.name ?? null;
+    }
+    pendingDisks.fill(null);
     machine.set_volume_percent(Number($('vol').value));
     if (floppySoundsToggle) machine.set_floppy_sounds(floppySoundsToggle.checked);
     else if (configFloppySounds !== null) machine.set_floppy_sounds(configFloppySounds);
@@ -808,10 +842,12 @@ async function boot() {
     // on-screen keyboard forgets rather than sending release codes into it.
     forgetVirtualKeys();
     updateStatusDisks();
+    updateFloppyImageControls();
 
     // Leave a fresh status behind: the old line ("inserts at boot", an
     // earlier failure) would otherwise go stale into any bug report filed
     // while the machine runs.
+    const inserted = insertedDiskStatusDescription();
     setLoadStatus(
       // A ROM-less boot is only ever a landing place for a state load,
       // which overwrites this line the moment it lands.
@@ -2159,6 +2195,7 @@ for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
       diskNames[drive] = null;
       setLoadStatus(`DF${drive} ejected`);
       updateStatusDisks();
+      updateFloppyImageControls();
     } catch (err) {
       setLoadStatus(`${err.message ?? err}`);
     }
@@ -2185,6 +2222,120 @@ $('reset').addEventListener('click', () => {
 // toggle and Exit.
 
 const shell = $('shell');
+
+// Writable browser floppies live in the WASM machine rather than a host file.
+// Keep opening read-only by default, then make the choice explicit and put
+// the only persistence operation -- downloading the current image -- beside
+// it. Older page shells acquire the controls from this glue automatically.
+const BLANK_ADF_BYTES = 901120;
+
+function buildFloppyImageControls() {
+  const eject = $('eject');
+  const host = eject?.closest('.try-side-section') ?? eject?.parentElement ?? shell.parentElement;
+  const buttonClass = eject?.className ?? '';
+
+  let writable = $('writable-floppies');
+  if (!writable) {
+    const label = document.createElement('label');
+    label.className = 'try-check';
+    label.title = 'New disk inserts stay read-only unless this is checked';
+    writable = document.createElement('input');
+    writable.type = 'checkbox';
+    writable.id = 'writable-floppies';
+    label.appendChild(writable);
+    label.append(' Open disks writable');
+    host.appendChild(label);
+  }
+
+  for (const [prefix, text] of [
+    ['blank', 'Blank'],
+    ['download', 'Download'],
+  ]) {
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;gap:0.45rem;flex-wrap:wrap;';
+    for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
+      let button = $(`${prefix}-df${drive}`);
+      if (!button) {
+        button = document.createElement('button');
+        button.id = `${prefix}-df${drive}`;
+        button.className = buttonClass;
+        button.textContent = `${text} DF${drive}`;
+        row.appendChild(button);
+      }
+    }
+    if (row.childElementCount) host.appendChild(row);
+  }
+  return { writable };
+}
+
+const { writable: writableFloppyToggle } = buildFloppyImageControls();
+const blankFloppyButtons = Array.from(
+  { length: PAGE_FLOPPY_DRIVES },
+  (_, drive) => $(`blank-df${drive}`),
+);
+const downloadFloppyButtons = Array.from(
+  { length: PAGE_FLOPPY_DRIVES },
+  (_, drive) => $(`download-df${drive}`),
+);
+
+function updateFloppyImageControls() {
+  for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
+    const button = downloadFloppyButtons[drive];
+    if (!button) continue;
+    const name = emu?.disk_name(drive);
+    button.disabled = !name;
+    const writable = name && emu?.floppy_write_protected?.(drive) === false;
+    button.title = name
+      ? `Download ${name}${writable ? ' with its current guest changes' : ''}`
+      : `DF${drive} is empty`;
+  }
+}
+
+function floppyDownloadName(name, bytes) {
+  const clean = (name || 'disk').replace(/[^\w.()+ -]+/g, '_');
+  if (/\.adf$/i.test(clean)) return clean;
+  const stem = clean.replace(/\.(adz|dms|ipf|scp|gz|zip)$/i, '');
+  return bytes.length === BLANK_ADF_BYTES ? `${stem}.adf` : `${stem}.extended.adf`;
+}
+
+function downloadFloppy(drive) {
+  if (!emu) return;
+  try {
+    const name = emu.disk_name(drive);
+    if (!name) throw new Error(`DF${drive} is empty`);
+    const bytes = emu.export_floppy(drive);
+    const blob = new Blob([bytes], { type: 'application/octet-stream' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = floppyDownloadName(name, bytes);
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+    setLoadStatus(
+      `DF${drive}: ${name} downloaded - guest software must flush its own buffers first`,
+    );
+  } catch (err) {
+    setLoadStatus(`DF${drive} download failed: ${err.message ?? err}`);
+  }
+}
+
+for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
+  blankFloppyButtons[drive]?.addEventListener('click', () => {
+    try {
+      insertDisk(
+        new Uint8Array(BLANK_ADF_BYTES),
+        `blank-df${drive}.adf`,
+        drive,
+        true,
+      );
+    } catch (err) {
+      setLoadStatus(`DF${drive} blank disk failed: ${err.message ?? err}`);
+    }
+  });
+  downloadFloppyButtons[drive]?.addEventListener('click', () => downloadFloppy(drive));
+}
+updateFloppyImageControls();
+
 let cssFullscreen = false;
 let fsUi = null; // { bar, joy } - built lazily, like the touch-joystick UI
 
@@ -3882,6 +4033,7 @@ function restoreState(bytes, source) {
   }
   lastFddTrack = null;
   updateStatusDisks();
+  updateFloppyImageControls();
   // So did the machine itself, model, video standard and all.
   syncMachineSelect();
   syncVideoSelect();
@@ -6413,7 +6565,9 @@ function updateStatusDisks() {
   const parts = [];
   for (let drive = 0; drive < 4; drive++) {
     if (!emu.drive_connected(drive)) continue;
-    parts.push(`DF${drive}: ${emu.disk_name(drive) ?? '-'}`);
+    const name = emu.disk_name(drive);
+    const writable = name && emu.floppy_write_protected?.(drive) === false;
+    parts.push(`DF${drive}: ${name ?? '-'}${writable ? ' [writable]' : ''}`);
   }
   const text = parts.join('  ');
   if (text !== sb.disksText) {

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -31,8 +31,16 @@ of swapping DF0. The pickers work before or after boot: a
 pre-boot choice is stashed and applied when the machine starts (the boot
 button relabels to show which ROM it will use), and a post-boot pick swaps
 the disk live. Disk images are recognised by content -- ADF, ADZ, DMS, IPF,
-and SCP, plain or gzip/zip packed -- and are always write-protected, since
-the browser has no filesystem to write changes back to. A file picker
+and SCP, plain or gzip/zip packed. They open write-protected by default.
+Check **Open disks writable** before picking one to give an uncompressed
+standard or UAE extended ADF an in-memory writable backing; compressed
+containers, DMS, IPF and SCP have no write-back representation and are
+refused in that mode. **Blank DF0/DF1** creates a writable 880 KiB disk for
+the guest to format. The browser never alters the file that was picked:
+**Download DF0/DF1** saves a snapshot of the current image, and guest
+software must flush or close the disk before that snapshot is taken. Writable
+images and their changes also travel in save states and survive machine/video
+rebuilds. A file picker
 cannot sniff content, though: it filters by extension and hides whatever
 the filter leaves out, which is how an `.ipf` stayed greyed out in a
 bundle that decodes IPF perfectly well. So the glue rewrites the disk
@@ -339,7 +347,10 @@ state of this build's format version is refused with the running machine
 untouched -- including a state from an older Copperline whose format
 version has moved on. If that refusal follows a boot the load itself
 asked for, the page returns to its pre-boot screen rather than leaving a
-machine running that nothing was restored into.
+machine running that nothing was restored into. A writable disk restored
+from a desktop state is adopted into browser memory before the guest resumes,
+so its old host path is never treated as a browser path; use **Download DFn**
+to keep later changes as an image file.
 
 There are no keyboard shortcuts for these (the desktop's
 Cmd/Alt+Shift+S and +L): every key on the page belongs to the guest, so a
@@ -454,10 +465,11 @@ through wasm-bindgen; the page's JavaScript drives everything from
 
 The guest sees a stock machine: ROMs arrive as bytes
 (`Emulator::reload_rom`), floppies as bytes
-(`FloppyController::insert_disk_image_bytes`, which sniffs the same image
-formats by content as the desktop file paths), and disks are always
-write-protected because the browser has no filesystem to write changes back
-to.
+(`FloppyController::insert_disk_image_bytes` or its memory-backed writable
+counterpart, which sniff the same image formats by content as the desktop
+file paths). A writable browser image updates the controller's serialized
+image data; it never treats the display label as a filesystem path. Exporting
+encodes that current data as a standard or UAE extended ADF.
 
 ## Building it locally
 
@@ -502,6 +514,8 @@ const emu = new WebEmu();          // default A500 machine, placeholder ROM
 // ...or fit DF0 + DF1: new WebEmu('A500', 'PAL', 2)
 emu.load_rom(romBytes, extBytes);  // Kickstart or AROS bytes; cold reset
 emu.insert_floppy(0, adfBytes, 'game.adf');
+emu.insert_floppy_writable(1, workBytes, 'work.adf');
+const changedDisk = emu.export_floppy(1); // download/store these current bytes
 
 function tick(nowMs) {
   emu.run(nowMs, 5);               // step to the wall clock, max 5 frames
@@ -545,7 +559,14 @@ and diagnostics.
 
 `insert_floppy(drive, bytes, name)` takes any format the core reads --
 ADF/ADZ, extended ADF, DMS, IPF, SCP, plain or gzip/zip packed -- decided
-by signature, so the name it is given is only a label. The static
+by signature, so the name it is given is only a label, and presents it
+write-protected. `insert_floppy_writable(drive, bytes, name)` instead keeps
+an uncompressed standard or UAE extended ADF writable in serialized memory;
+formats that cannot be faithfully written back throw. `export_floppy(drive)`
+returns the current bytes (standard ADF, or the matching UAE extended ADF
+variant), including completed guest writes; `floppy_write_protected(drive)`
+reports the inserted image's current protection or `undefined` for an empty
+drive. The host still decides where exported bytes live. The static
 `WebEmu.floppy_formats()` lists the extensions those formats conventionally
 carry (`["adf", "adz", ...]`, no dots) for the one thing a page cannot
 decide by content: a file input's `accept` filter, and any list it scrapes
@@ -673,6 +694,11 @@ elements, and pages without them are untouched:
   drive controls. An older shell with only `#df0` and `#eject` gets the DF1
   picker and eject button inserted beside them automatically; in that case
   the original eject button is relabelled **Eject DF0** for clarity.
+- `#writable-floppies` (checkbox), `#blank-df0` / `#blank-df1` and
+  `#download-df0` / `#download-df1` (buttons): place the writable-disk
+  workflow. Without them the glue adds the opt-in checkbox and both drives'
+  blank/download buttons to the storage controls. Opening remains read-only
+  by default.
 - `#floppy-sounds` (checkbox): toggles the synthesized floppy drive
   sounds -- motor hum, head-step clicks, read hiss -- live and at boot, so
   a shell can also default them off by shipping the box unchecked.

--- a/src/floppy/formats.rs
+++ b/src/floppy/formats.rs
@@ -19,6 +19,13 @@ pub(super) struct FloppyImage {
     pub(super) data: FloppyImageData,
     pub(super) write_protected: bool,
     pub(super) legacy_extended_adf: bool,
+    pub(super) backing: FloppyImageBacking,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub(super) enum FloppyImageBacking {
+    File,
+    Memory,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -44,18 +51,38 @@ impl FloppyImage {
     pub(super) fn load(config: &FloppyDriveConfig) -> Result<Self> {
         let packed = std::fs::read(&config.path)
             .with_context(|| format!("reading floppy image {}", config.path.display()))?;
-        Self::from_bytes(packed, config.path.clone(), config.write_protected)
+        Self::from_bytes_with_backing(
+            packed,
+            config.path.clone(),
+            config.write_protected,
+            FloppyImageBacking::File,
+        )
     }
 
     /// Decode an already-loaded image (the byte-for-byte file contents:
     /// ADF/extended ADF/DMS/SCP/IPF, optionally gzip- or zip-packed) without
-    /// touching the filesystem. `path` is the display/write-back label; hosts
-    /// with no filesystem (the browser build) must insert write-protected so
-    /// the extended-ADF write-back path never fires.
+    /// touching the filesystem. `path` is the display/write-back label.
     pub(crate) fn from_bytes(
         packed: Vec<u8>,
         path: PathBuf,
         write_protected: bool,
+    ) -> Result<Self> {
+        Self::from_bytes_with_backing(packed, path, write_protected, FloppyImageBacking::File)
+    }
+
+    pub(super) fn from_memory_bytes(
+        packed: Vec<u8>,
+        path: PathBuf,
+        write_protected: bool,
+    ) -> Result<Self> {
+        Self::from_bytes_with_backing(packed, path, write_protected, FloppyImageBacking::Memory)
+    }
+
+    fn from_bytes_with_backing(
+        packed: Vec<u8>,
+        path: PathBuf,
+        write_protected: bool,
+        backing: FloppyImageBacking,
     ) -> Result<Self> {
         let (data, write_protected, legacy_extended_adf) = if packed.starts_with(GZIP_SIGNATURE) {
             let unpacked = decode_gzip_floppy_image(&packed)?;
@@ -72,6 +99,7 @@ impl FloppyImage {
             data,
             write_protected,
             legacy_extended_adf,
+            backing,
         })
     }
 

--- a/src/floppy/mod.rs
+++ b/src/floppy/mod.rs
@@ -11,7 +11,7 @@ use crate::chipset::paula::PAULA_CLOCK_HZ;
 use crate::config::{FloppyConfig, FloppyDriveConfig};
 use crate::gzip;
 use anyhow::{bail, ensure, Context, Result};
-use formats::{FloppyImage, FloppyImageData, FloppyTrackImage};
+use formats::{FloppyImage, FloppyImageBacking, FloppyImageData, FloppyTrackImage};
 use log::{debug, warn};
 // The bridge's retry path traces, and its media reporting is worth an info
 // line; both are compiled out with the feature.
@@ -549,6 +549,45 @@ impl FloppyController {
         )
     }
 
+    /// Whether the image in DFn presents a closed write-protect tab.
+    pub fn disk_image_write_protected(&self, drive_idx: usize) -> Option<bool> {
+        Some(self.drives.get(drive_idx)?.image.as_ref()?.write_protected)
+    }
+
+    /// Encode the current in-memory image as a standalone ADF. Standard ADFs
+    /// stay byte-for-byte standard; track images become the same UAE extended
+    /// ADF variant they were loaded as. Container formats such as ADZ and DMS
+    /// deliberately export their decoded disk rather than recompressing it.
+    pub fn export_disk_image(&self, drive_idx: usize) -> Result<Vec<u8>> {
+        let image = self
+            .drives
+            .get(drive_idx)
+            .with_context(|| format!("invalid floppy drive df{drive_idx}"))?
+            .image
+            .as_ref()
+            .with_context(|| format!("floppy.df{drive_idx} is empty"))?;
+        match &image.data {
+            FloppyImageData::StandardAdf(data) => Ok(data.clone()),
+            FloppyImageData::Tracks(tracks) if image.legacy_extended_adf => {
+                encode_uae_legacy_extended_adf(tracks)
+            }
+            FloppyImageData::Tracks(tracks) => encode_uae_extended_adf(tracks),
+        }
+    }
+
+    /// A host without a writable filesystem adopts every restored image into
+    /// memory. This is intentionally called after browser save-state loads:
+    /// desktop states may name writable host files which do not exist there.
+    pub fn make_disk_images_memory_backed(&mut self) {
+        for image in self
+            .drives
+            .iter_mut()
+            .filter_map(|drive| drive.image.as_mut())
+        {
+            image.backing = FloppyImageBacking::Memory;
+        }
+    }
+
     pub fn insert_disk_image(
         &mut self,
         drive_idx: usize,
@@ -586,10 +625,9 @@ impl FloppyController {
         Ok(())
     }
 
-    /// Insert a disk from in-memory image bytes (any format
-    /// [`FloppyImage::from_bytes`] accepts). `label` stands in for the file
-    /// path in logs and the UI; hosts without a filesystem should pass
-    /// `write_protected = true` (see `from_bytes`).
+    /// Insert a disk from already-loaded image bytes while retaining ordinary
+    /// host-file write-through semantics. `label` is both its UI name and the
+    /// path updated by a writable image.
     pub fn insert_disk_image_bytes(
         &mut self,
         drive_idx: usize,
@@ -616,6 +654,45 @@ impl FloppyController {
         );
         let image = FloppyImage::from_bytes(bytes, label, write_protected)
             .with_context(|| format!("loading floppy.df{} image", drive_idx))?;
+        self.idle_cache = false;
+        self.drives[drive_idx].insert_image(image);
+        if self.selected_drive() == Some(drive_idx) {
+            self.ensure_track(drive_idx, self.track_for_drive(drive_idx));
+        }
+        Ok(())
+    }
+
+    /// Insert a disk whose writable backing lives entirely in this controller.
+    /// Guest writes update the serialized image data and never touch `label`;
+    /// [`Self::export_disk_image`] snapshots the current bytes for its host.
+    /// Formats without a writable representation (compressed containers,
+    /// DMS, IPF and SCP) reject a writable request instead of silently
+    /// presenting a write-protected disk.
+    pub fn insert_memory_disk_image_bytes(
+        &mut self,
+        drive_idx: usize,
+        bytes: Vec<u8>,
+        label: PathBuf,
+        write_protected: bool,
+    ) -> Result<()> {
+        ensure!(
+            drive_idx < self.drives.len(),
+            "invalid floppy drive df{}",
+            drive_idx
+        );
+        #[cfg(feature = "fluxbridge")]
+        ensure!(
+            !self.drives[drive_idx].is_bridged(),
+            "floppy.df{drive_idx} is a physical drive; take the drive off the bay before \
+             using a disk image in it"
+        );
+        let image = FloppyImage::from_memory_bytes(bytes, label, write_protected)
+            .with_context(|| format!("loading floppy.df{} image", drive_idx))?;
+        ensure!(
+            write_protected || !image.write_protected,
+            "floppy image {} uses a read-only format; use an uncompressed ADF or UAE extended ADF for writable media",
+            image.path.display()
+        );
         self.idle_cache = false;
         self.drives[drive_idx].insert_image(image);
         if self.selected_drive() == Some(drive_idx) {
@@ -689,18 +766,18 @@ impl FloppyController {
     }
 
     /// Why this controller cannot be replayed speculatively. A physical
-    /// mechanism cannot rewind, and a writable image flushes completed guest
-    /// writes to its host file. Read-only image media is fully serialized.
+    /// mechanism cannot rewind, and a file-backed writable image flushes
+    /// completed guest writes to its host file. Read-only and memory-backed
+    /// image media are fully serialized.
     pub fn runahead_block_reason(&self) -> Option<&'static str> {
         #[cfg(feature = "fluxbridge")]
         if self.drives.iter().any(FloppyDrive::is_bridged) {
             return Some("physical floppy drive");
         }
         if self.drives.iter().any(|drive| {
-            drive
-                .image
-                .as_ref()
-                .is_some_and(|image| !image.write_protected)
+            drive.image.as_ref().is_some_and(|image| {
+                !image.write_protected && image.backing == FloppyImageBacking::File
+            })
         }) {
             return Some("writable floppy image");
         }
@@ -2047,11 +2124,17 @@ impl FloppyController {
         }
         let path = image.path.clone();
         let legacy_extended_adf = image.legacy_extended_adf;
+        let backing = image.backing;
         let write_result: Result<()> = match &mut image.data {
             FloppyImageData::StandardAdf(image_data) => {
                 decode_non_empty_track_write(track, write_words).and_then(|sectors| {
                     apply_standard_adf_sectors(image_data, track, &sectors);
-                    write_standard_adf_sectors_to_disk(&path, track, &sectors)
+                    match backing {
+                        FloppyImageBacking::File => {
+                            write_standard_adf_sectors_to_disk(&path, track, &sectors)
+                        }
+                        FloppyImageBacking::Memory => Ok(()),
+                    }
                 })
             }
             FloppyImageData::Tracks(tracks) => apply_extended_adf_write(
@@ -2063,16 +2146,19 @@ impl FloppyController {
                 legacy_extended_adf,
                 lose_tail_bits,
             )
-            .and_then(|encoded| {
-                std::fs::write(&path, encoded).context("writing extended ADF image")
+            .and_then(|encoded| match backing {
+                FloppyImageBacking::File => {
+                    std::fs::write(&path, encoded).context("writing extended ADF image")
+                }
+                FloppyImageBacking::Memory => Ok(()),
             }),
         };
         match write_result {
             Ok(()) => {
                 drive.cached_track = None;
-                debug!("floppy.df{} write-through complete", drive_idx);
+                debug!("floppy.df{} image write complete", drive_idx);
             }
-            Err(e) => warn!("floppy.df{} write-through failed: {e:#}", drive_idx),
+            Err(e) => warn!("floppy.df{} image write failed: {e:#}", drive_idx),
         }
     }
 

--- a/src/floppy/mod.rs
+++ b/src/floppy/mod.rs
@@ -2146,8 +2146,13 @@ impl FloppyController {
                 legacy_extended_adf,
                 lose_tail_bits,
             )
-            .and_then(|encoded| match backing {
+            .and_then(|()| match backing {
                 FloppyImageBacking::File => {
+                    let encoded = if legacy_extended_adf {
+                        encode_uae_legacy_extended_adf(tracks)
+                    } else {
+                        encode_uae_extended_adf(tracks)
+                    }?;
                     std::fs::write(&path, encoded).context("writing extended ADF image")
                 }
                 FloppyImageBacking::Memory => Ok(()),
@@ -3380,7 +3385,7 @@ fn apply_extended_adf_write(
     write_start_bit: u8,
     legacy_extended_adf: bool,
     lose_tail_bits: bool,
-) -> Result<Vec<u8>> {
+) -> Result<()> {
     let Some(Some(image_track)) = tracks.get_mut(track) else {
         bail!("target track {track} is empty");
     };
@@ -3388,11 +3393,6 @@ fn apply_extended_adf_write(
         FloppyTrackImage::AmigaDos(track_data) => {
             let sectors = decode_non_empty_track_write(track, write_words)?;
             apply_amigados_track_sectors(track_data, track, &sectors)?;
-            if legacy_extended_adf {
-                encode_uae_legacy_extended_adf(tracks)
-            } else {
-                encode_uae_extended_adf(tracks)
-            }
         }
         FloppyTrackImage::RawMfm {
             words,
@@ -3415,7 +3415,6 @@ fn apply_extended_adf_write(
                     write_start_bit,
                     lose_tail_bits,
                 )?;
-                encode_uae_legacy_extended_adf(tracks)
             } else {
                 apply_raw_mfm_write(
                     words,
@@ -3427,10 +3426,10 @@ fn apply_extended_adf_write(
                     write_start_bit,
                     lose_tail_bits,
                 )?;
-                encode_uae_extended_adf(tracks)
             }
         }
     }
+    Ok(())
 }
 
 fn decode_non_empty_track_write(

--- a/src/floppy/tests.rs
+++ b/src/floppy/tests.rs
@@ -25,6 +25,10 @@ fn runahead_gate_tracks_the_inserted_images_write_protection() -> Result<()> {
 
     ctrl.make_disk_images_memory_backed();
     assert_eq!(ctrl.runahead_block_reason(), None);
+    assert_eq!(
+        ctrl.drives[0].image.as_ref().unwrap().backing,
+        FloppyImageBacking::Memory
+    );
     Ok(())
 }
 
@@ -3926,6 +3930,44 @@ fn writable_extended_adf_amigados_track_persists_sector_updates() -> Result<()> 
 }
 
 #[test]
+fn memory_backed_extended_adf_write_exports_updated_track() -> Result<()> {
+    let label = temp_path("browser.ext.adf");
+    let track_data = vec![0u8; SECTORS_PER_TRACK * BYTES_PER_SECTOR];
+    let image = ext2_track_image(0, (track_data.len() * 8) as u32, 1, &track_data);
+    let mut ctrl = FloppyController::default();
+    ctrl.insert_memory_disk_image_bytes(0, image, label.clone(), false)?;
+
+    let mut source = vec![0u8; SECTORS_PER_TRACK * BYTES_PER_SECTOR];
+    source[0..BYTES_PER_SECTOR].fill(0xA5);
+    let words = encode_amigados_track(0, &source);
+    let mut chip_ram = vec![0u8; words.len() * 2 + 2];
+    for (i, word) in words.iter().copied().enumerate() {
+        let [hi, lo] = word.to_be_bytes();
+        chip_ram[i * 2] = hi;
+        chip_ram[i * 2 + 1] = lo;
+    }
+
+    ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
+    ctrl.tick(MOTOR_READY_CCK, 0, &mut chip_ram);
+    ctrl.set_dskpt_low(0);
+    let len = DSKLEN_DMAEN | DSKLEN_WRITE | (words.len() as u16 & DSKLEN_MASK);
+    assert!(!ctrl.write_dsklen(len, 0));
+    assert!(!ctrl.write_dsklen(len, 0));
+    let dmacon = DMACON_DMAEN | DMACON_DISK;
+    while !ctrl.tick(ctrl.word_cck(), dmacon, &mut chip_ram) {}
+
+    assert!(!label.exists());
+    let exported = ctrl.export_disk_image(0)?;
+    assert_eq!(&exported[0..8], UAE_EXT2_SIGNATURE);
+    let payload_off = 8 + 4 + 12;
+    assert_eq!(
+        &exported[payload_off..payload_off + BYTES_PER_SECTOR],
+        &[0xA5; BYTES_PER_SECTOR]
+    );
+    Ok(())
+}
+
+#[test]
 fn writable_extended_adf_preserves_multi_revolution_raw_track_payload() -> Result<()> {
     let raw_words: [u16; 4] = [0x1111, 0x2222, 0x3333, 0x4444];
     let raw_payload: Vec<u8> = raw_words
@@ -4722,7 +4764,7 @@ fn write_dma_decodes_and_persists_track() -> Result<()> {
 }
 
 #[test]
-fn memory_backed_write_dma_exports_without_touching_the_label_path() -> Result<()> {
+fn memory_backed_write_and_state_round_trip_preserve_bytes_without_host_io() -> Result<()> {
     let label = temp_path("browser.adf");
     let mut ctrl = FloppyController::default();
     ctrl.insert_memory_disk_image_bytes(0, vec![0u8; ADF_SIZE], label.clone(), false)?;
@@ -4750,6 +4792,21 @@ fn memory_backed_write_dma_exports_without_touching_the_label_path() -> Result<(
 
     let exported = ctrl.export_disk_image(0)?;
     assert_eq!(&exported[0..BYTES_PER_SECTOR], &[0xA5; BYTES_PER_SECTOR]);
+    assert!(!label.exists());
+
+    let state = bincode::serialize(&ctrl)?;
+    let restored: FloppyController = bincode::deserialize(&state)?;
+    assert_eq!(
+        restored.drives[0].image.as_ref().unwrap().backing,
+        FloppyImageBacking::Memory
+    );
+    assert_eq!(restored.disk_image_write_protected(0), Some(false));
+    assert_eq!(restored.runahead_block_reason(), None);
+    let restored_export = restored.export_disk_image(0)?;
+    assert_eq!(
+        &restored_export[0..BYTES_PER_SECTOR],
+        &[0xA5; BYTES_PER_SECTOR]
+    );
     assert!(!label.exists());
     Ok(())
 }

--- a/src/floppy/tests.rs
+++ b/src/floppy/tests.rs
@@ -22,6 +22,25 @@ fn runahead_gate_tracks_the_inserted_images_write_protection() -> Result<()> {
 
     ctrl.insert_disk_image_bytes(0, vec![0; ADF_SIZE], PathBuf::from("writable.adf"), false)?;
     assert_eq!(ctrl.runahead_block_reason(), Some("writable floppy image"));
+
+    ctrl.make_disk_images_memory_backed();
+    assert_eq!(ctrl.runahead_block_reason(), None);
+    Ok(())
+}
+
+#[test]
+fn compressed_image_rejects_a_writable_memory_backing() -> Result<()> {
+    let mut packed = GzEncoder::new(Vec::new(), Compression::default());
+    packed.write_all(&vec![0; ADF_SIZE])?;
+    let packed = packed.finish()?;
+    let mut ctrl = FloppyController::default();
+
+    let err = ctrl
+        .insert_memory_disk_image_bytes(0, packed, PathBuf::from("disk.adz"), false)
+        .unwrap_err();
+
+    assert!(err.to_string().contains("read-only format"));
+    assert!(!ctrl.disk_inserted(0));
     Ok(())
 }
 
@@ -4699,6 +4718,39 @@ fn write_dma_decodes_and_persists_track() -> Result<()> {
     let persisted = fs::read(&path)?;
     assert_eq!(&persisted[0..BYTES_PER_SECTOR], &[0xA5; BYTES_PER_SECTOR]);
     let _ = fs::remove_file(path);
+    Ok(())
+}
+
+#[test]
+fn memory_backed_write_dma_exports_without_touching_the_label_path() -> Result<()> {
+    let label = temp_path("browser.adf");
+    let mut ctrl = FloppyController::default();
+    ctrl.insert_memory_disk_image_bytes(0, vec![0u8; ADF_SIZE], label.clone(), false)?;
+    assert_eq!(ctrl.disk_image_write_protected(0), Some(false));
+    assert_eq!(ctrl.runahead_block_reason(), None);
+
+    let mut source = vec![0u8; ADF_SIZE];
+    source[0..BYTES_PER_SECTOR].fill(0xA5);
+    let words = encode_adf_track(0, &source);
+    let mut chip_ram = vec![0u8; words.len() * 2 + 2];
+    for (i, word) in words.iter().copied().enumerate() {
+        let [hi, lo] = word.to_be_bytes();
+        chip_ram[i * 2] = hi;
+        chip_ram[i * 2 + 1] = lo;
+    }
+
+    ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
+    ctrl.tick(MOTOR_READY_CCK, 0, &mut chip_ram);
+    ctrl.set_dskpt_low(0);
+    let len = DSKLEN_DMAEN | DSKLEN_WRITE | (words.len() as u16 & DSKLEN_MASK);
+    assert!(!ctrl.write_dsklen(len, 0));
+    assert!(!ctrl.write_dsklen(len, 0));
+    let dmacon = DMACON_DMAEN | DMACON_DISK;
+    while !ctrl.tick(ctrl.word_cck(), dmacon, &mut chip_ram) {}
+
+    let exported = ctrl.export_disk_image(0)?;
+    assert_eq!(&exported[0..BYTES_PER_SECTOR], &[0xA5; BYTES_PER_SECTOR]);
+    assert!(!label.exists());
     Ok(())
 }
 

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -315,7 +315,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      linear memory, whose internal layout is replayed against the current
 //      module on load; reject old snapshots rather than interpret that memory
 //      with the new dependency's layout.
-pub const STATE_VERSION: u32 = 64;
+//  65: floppy images record whether writable changes go to a host file or
+//      remain in serialized memory for filesystem-free hosts such as WASM.
+pub const STATE_VERSION: u32 = 65;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {


### PR DESCRIPTION
## Summary

- distinguish file-backed floppy images from serialized, memory-backed images in the core
- let standard and UAE extended ADF guest writes remain in memory, export their current bytes, and survive save states without filesystem access
- keep memory-backed writable media runahead-safe; adopt desktop-state floppy paths into memory when loaded in WASM
- expose writable insert, protection status, and export through WebEmu
- add read-only-by-default hosted controls for writable opens, blank DF0/DF1 disks, and per-drive downloads
- preserve current writable bytes across quick saves and machine/video rebuilds
- reject compressed containers, DMS, IPF, and SCP when writable mode is requested
- bump the save-state format to version 65 for the new backing field

## Verification

- cargo test --locked (2,839 passed; 33 ignored)
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo fmt --check (workspace and web crate)
- cargo check --target wasm32-unknown-unknown --locked
- cargo build --release --target wasm32-unknown-unknown --locked
- npm test
- focused DMA test verifies an in-memory guest write changes exported ADF bytes without creating the label path
- browser smoke: create writable DF1, quick-save/eject/restore, rebuild as A1200, and download the current image

Depends on #555. Closes #505.