### PR TITLE
Add Nero NRG CD image support

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -393,7 +393,7 @@ slow = "512K"
 # autoboots on Kickstart 1.3+, so it does not depend on the Kickstart IDE
 # driver (which only probes the master on stock 3.1). Drive paths accept the
 # same images as [ide]: RDB HDFs, bare partition hardfiles, gzip-compressed
-# hardfiles (.hdz), or host directories. A path ending in .cue, .iso, or .chd
+# hardfiles (.hdz), or host directories. A path ending in .cue, .iso, .nrg, or .chd
 # attaches a SCSI CD-ROM drive at that ID instead (read-only; mount it in the
 # guest with a CD filesystem pointed at the controller's scsi.device and that
 # unit number). CD audio tracks play through the machine's audio output, and
@@ -494,7 +494,7 @@ video = "PAL"
 # own RDB, which keeps its label, priorities, and filesystem recorded inside
 # it.
 #
-# A path ending in .cue, .iso, or .chd attaches an ATAPI CD-ROM drive at
+# A path ending in .cue, .iso, .nrg, or .chd attaches an ATAPI CD-ROM drive at
 # that slot instead of a hard disk (see [scsi], above, for the read-only
 # SCSI-2 command engine both share).
 # [ide]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1563,7 +1563,7 @@ appears in the status bar on IDE machines. On the `A4000` profile the same
 `$DD2020` (no Gayle involved; Kickstart's `scsi.device` drives it the same
 way).
 
-A path ending in `.cue`, `.iso`, or `.chd` attaches an **ATAPI CD-ROM
+A path ending in `.cue`, `.iso`, `.nrg`, or `.chd` attaches an **ATAPI CD-ROM
 drive** at that slot instead of a hard disk, through the PACKET (0xA0)
 command -- the same read-only SCSI-2 command engine `[scsi]` CD-ROM units
 use (see below), reached over the ATA task file instead of a WD33C93 SCSI
@@ -1579,7 +1579,7 @@ rom = "a2091-v6.6.rom"       # boot ROM (a2091 needs one; a4091 defaults to bund
 # rom_odd = "a2091-odd.rom"  # a2091 only: split even/odd EPROM dumps
 unit0 = "workbench.hdf"      # SCSI IDs 0-6
 unit1 = "data.hdf"
-unit2 = "game.cue"           # a .cue, .iso, or .chd attaches a CD-ROM drive
+unit2 = "game.cue"           # .cue/.iso/.nrg/.chd attaches a CD-ROM drive
 # unit3..unit6 = ...
 ```
 
@@ -1622,11 +1622,11 @@ form that overrides a directory mount's volume name, filesystem, and the
 synthesized partition's boot priority. The HDD activity LED covers SCSI
 traffic too.
 
-A `unitN` path ending in `.cue`, `.iso`, or `.chd` attaches a **SCSI
+A `unitN` path ending in `.cue`, `.iso`, `.nrg`, or `.chd` attaches a **SCSI
 CD-ROM drive** at that ID instead of a hard disk: a read-only removable
 SCSI-2 target (INQUIRY device type 5) serving 2048-byte blocks, with the
 full READ TOC / READ CD / mode-page surface CD filesystems expect.
-Cue sheets and CHD images may mix data and audio tracks (a cue sheet's
+Cue sheets, NRG, and CHD images may mix data and audio tracks (a cue sheet's
 audio tracks may be `WAVE` or `MP3` files, as described under `[cd]`
 below); a bare `.iso` is a single data track. The drive answers on the host adapter's `scsi.device` like any
 other unit, so mount it the way you would on real hardware: a
@@ -1640,7 +1640,7 @@ emulated time (as if the drive's analogue output were cabled to the
 machine), the sub-channel reports the live playback position, and the
 debugger's Audio tab shows the stream on its CD-DA row with the play
 state, track, and position. Discs swap at runtime like CDTV/CD32 media:
-the status bar's CD load/eject buttons, dropping a `.cue`/`.iso`/`.chd`
+the status bar's CD load/eject buttons, dropping a `.cue`/`.iso`/`.nrg`/`.chd`
 on the window, the scheduled `--insert-cd-after SECS PATH` flag, or the
 control protocol's `media.cd.insert` all eject the current disc, run the
 tray for a second of emulated time, and mount the new one with a
@@ -1660,7 +1660,7 @@ A built-in Zorro II IDE board compatible with LIV2's actively-maintained
 open-source [lide.device](https://github.com/LIV2/lide.device), giving
 autobooting IDE storage under any Kickstart including 1.3 -- unlike `[ide]`,
 which needs a Gayle or A4000 IDE port, `[lide]` works on **any machine
-model**, the same way `[scsi]`'s Zorro boards do. A `.cue`/`.iso`/`.chd`
+model**, the same way `[scsi]`'s Zorro boards do. A `.cue`/`.iso`/`.nrg`/`.chd`
 drive entry attaches an ATAPI CD-ROM drive, exactly as it does on `[ide]`.
 
 `board` picks the AutoConfig identity: `"ripple"` (the default), LIV2's
@@ -1836,11 +1836,17 @@ insert_delay = 0.0        # emulated seconds after power-on to insert
 # nvram = "cd32-nvram.bin" # CD32 save-game EEPROM backing file (default)
 ```
 
-`image` takes a cue sheet, a bare `.iso` (single data track), or a
-`.chd` -- MAME's compressed CHD CD format (v5, as chdman's `createcd`
+`image` takes a cue sheet, a bare `.iso` (single data track), a Nero
+`.nrg`, or a `.chd` -- MAME's compressed CHD CD format (v5, as chdman's `createcd`
 writes: LZMA/Deflate/FLAC-compressed hunks with data and audio tracks).
 The disc mounts on the machine's CD controller: Akiko on CD32, the DMAC on
 CDTV.
+
+NRG supports both the older `NERO`/32-bit and newer `NER5`/64-bit footer
+formats, with DAO (`CUES`/`DAOI`, `CUEX`/`DAOX`) or TAO (`ETNF`/`ETN2`)
+track layouts. MODE1/2048, MODE1/2352, and CD-DA tracks are supported;
+Mode 2, multi-session discs, and images with stored subchannel bytes are
+rejected explicitly.
 
 A cue sheet's `FILE` lines may be `BINARY` (raw sector images, single- or
 multi-file) or, for audio tracks, `WAVE` and `MP3` -- the packaged form a

--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -102,7 +102,7 @@ deterministically:
 | `--floppy-drives COUNT` | Connect `COUNT` floppy drives (`1` to `4`), so scheduled inserts can target empty external drives |
 | `--insert-disk-after SECS DFN PATH` | Insert a disk image into `df0`..`df3` |
 | `--defer-disk-insert SECS DFN` | Start with the configured drive empty, then insert its configured image |
-| `--insert-cd-after SECS PATH` | Swap the CD image (`.cue`/`.iso`/`.chd`) in the machine's CD drive (CDTV, CD32, or a SCSI CD-ROM unit) |
+| `--insert-cd-after SECS PATH` | Swap the CD image (`.cue`/`.iso`/`.nrg`/`.chd`) in the machine's CD drive (CDTV, CD32, or a SCSI CD-ROM unit) |
 | `--script FILE` | Run scripted-input directives from a file (below) |
 | `--record-input PATH` | Record all machine-bound input for the whole run; the script is written to PATH on exit |
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -128,7 +128,7 @@ Status Bar*):
   drive, and changing it is done by hand (see [](fluxbridge)).
 - **CD controls** on machines with a CD drive (CDTV, CD32, or a SCSI
   CD-ROM unit): a CD button that loads (or swaps) a CD image
-  (`.cue`/`.iso`/`.chd`) with the proper media-change notification, and a
+  (`.cue`/`.iso`/`.nrg`/`.chd`) with the proper media-change notification, and a
   CD eject button. These do not appear on machines without a CD drive.
 - **Joystick toggle** (just left of the volume control): a gamepad or
   keyboard icon showing which source drives the joystick port. Click it to
@@ -235,7 +235,7 @@ Disk images can be dropped anywhere on the emulator window:
   (`1`-`4`), or press `Esc` to cancel. Dropping several floppies at once
   queues them all as the target drive's swap playlist, exactly like a
   multi-selection in the disk dialog.
-- **CD images** (`.cue`/`.iso`/`.chd`) mount in the machine's CD drive
+- **CD images** (`.cue`/`.iso`/`.nrg`/`.chd`) mount in the machine's CD drive
   (CDTV, CD32, or a SCSI CD-ROM unit), with the media-change notification.
 - **WHDLoad packages** (`.lha`, `.zip`, or a bare `.slave`) reboot the
   machine straight into the game through the [WHDLoad booter](whdload.md),

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -57,7 +57,7 @@ src/
   filesys.rs        # host directories mounted live as AmigaDOS volumes
   a2065.rs          # A2065 Zorro II Ethernet board (Am7990 LANCE)
   net/              # loopback, userspace NAT, and host-adapter bridge backends
-  cdrom.rs          # CD images: cue sheets (BINARY/WAVE/MP3 files), ISO, CHD
+  cdrom.rs          # CD images: cue sheets (BINARY/WAVE/MP3), ISO, NRG, CHD
   cdtv.rs           # CDTV DMAC + Matshita drive model
   akiko.rs          # CD32 Akiko (C2P, NVRAM, Chinon drive)
   rtc.rs            # MSM6242-compatible battery RTC

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -70,7 +70,7 @@ WinUAE-verified model so device scans terminate correctly. PCMCIA reports
 an empty slot (the status/config registers exist so card.resource
 behaves); credit-card device emulation is a non-goal.
 
-Either drive slot may instead be an ATAPI CD-ROM (a `.cue`/`.iso`/`.chd`
+Either drive slot may instead be an ATAPI CD-ROM (a `.cue`/`.iso`/`.nrg`/`.chd`
 image): `ata.rs`'s task-file engine drives the PACKET (0xA0) command,
 handing 12-byte CDBs to the same bus-agnostic SCSI-2 CD-ROM command engine
 (`scsi/cd.rs`'s `ScsiCdRom`) the `[scsi]` host adapters use, so the read
@@ -204,7 +204,7 @@ whole clone family). All three reuse the front-end-agnostic ATA core in
 drive backend above; the new work is entirely in the board's own address
 decode, since none of the three personalities resemble Gayle's 4-byte task
 file. Drive slots may be ATA hard disks or, since `ata.rs` gained ATAPI
-PACKET support, `.cue`/`.iso`/`.chd` CD-ROM images.
+PACKET support, `.cue`/`.iso`/`.nrg`/`.chd` CD-ROM images.
 
 **Register decode.** Each ATA channel occupies a 4K block of the board
 window, with register index `(offset >> 9) & 7` -- ATA A0-A2 are wired to
@@ -487,7 +487,9 @@ fast RAM exists -- not just chip RAM.
 MODE1/2352, and AUDIO tracks; `PREGAP`/`POSTGAP` as unstored zero-fill
 extents, like a CHD's gaps) for both machines and the SCSI/ATAPI drives,
 and lays every `FILE` out as a run of extents over a byte-addressed
-source. A `BINARY` source is the file itself; a `WAVE` or `MP3` source
+source. Nero NRG images use the same extent model after their 32- or
+64-bit CUE/DAO or ETN footer has supplied the track offsets and stored
+pregaps. A `BINARY` source is the file itself; a `WAVE` or `MP3` source
 (`cdrom/audio.rs`) presents the decoded audio as CD-DA sectors --
 588 stereo frames per sector, the last sector zero-padded, other sample
 rates linearly interpolated in integer arithmetic -- so the layout code

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -12,7 +12,7 @@ cargo install cargo-fuzz
 cd fuzz
 cargo +nightly fuzz run dms            # one target...
 cargo +nightly fuzz run floppy_image   # ADF/extADF/DMS/SCP/IPF/gzip/zip
-cargo +nightly fuzz run cd_image       # CUE/BIN, bare ISO, and CHD
+cargo +nightly fuzz run cd_image       # CUE/BIN, bare ISO, NRG, and CHD
 cargo +nightly fuzz run hardfile_classification # HDF/RDSK/bare-volume classification
 cargo +nightly fuzz run savestate      # .clstate bincode machine images
 ```

--- a/fuzz/fuzz_targets/cd_image.rs
+++ b/fuzz/fuzz_targets/cd_image.rs
@@ -1,4 +1,4 @@
-//! Fuzz the CD image loaders (CUE sheet, bare ISO, CHD) by writing the
+//! Fuzz the CD image loaders (CUE sheet, bare ISO, NRG, CHD) by writing the
 //! input to a temporary file named by its extension and loading it. The
 //! CUE parser follows BINARY file references, so the bytes are also laid
 //! down under the name a cue sheet would point at.
@@ -31,5 +31,6 @@ fn load_as(data: &[u8], extension: &str) {
 fuzz_target!(|data: &[u8]| {
     load_as(data, "cue");
     load_as(data, "iso");
+    load_as(data, "nrg");
     load_as(data, "chd");
 });

--- a/src/cdrom.rs
+++ b/src/cdrom.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-//! CD image backend: cue/bin parsing and sector access.
+//! CD image backend: cue/bin, NRG, and CHD parsing and sector access.
 //!
 //! Supports single-file and multi-file cue layouts with MODE1/2048,
 //! MODE1/2352, and AUDIO tracks, including INDEX 00 pregaps stored in
@@ -13,7 +13,9 @@
 //! sector size; the disc address space is the concatenation of all files
 //! and gaps in cue order. A bare `.iso` image (2048-byte cooked data
 //! sectors, no cue sheet) loads as a single-track data disc, and a `.chd`
-//! loads through the compressed CHD backend in the `chd` child module.
+//! loads through the compressed CHD backend in the `chd` child module. Nero
+//! `.nrg` images use their footer's CUE/DAO or ETN layout to address the same
+//! plain-file extent backend.
 
 use anyhow::{bail, Context, Result};
 use std::fs::File;
@@ -24,6 +26,7 @@ mod audio;
 mod chd;
 #[cfg(feature = "cd-mp3")]
 mod mp3;
+mod nrg;
 mod wav;
 
 pub use audio::FileFormat;
@@ -294,11 +297,13 @@ struct RawTrack {
 
 impl CdImage {
     /// Load a CD image: a cue sheet (with its BINARY/WAVE/MP3 files), a
-    /// bare `.iso` data image, or a `.chd`.
+    /// bare `.iso` data image, a Nero `.nrg`, or a `.chd`.
     pub fn load(path: &Path) -> Result<Self> {
         let ext = path.extension().and_then(|e| e.to_str());
         if ext.is_some_and(|e| e.eq_ignore_ascii_case("chd")) {
             Self::load_chd(path)
+        } else if ext.is_some_and(|e| e.eq_ignore_ascii_case("nrg")) {
+            nrg::load(path)
         } else if ext.is_some_and(|e| e.eq_ignore_ascii_case("iso")) {
             Self::load_iso(path)
         } else {

--- a/src/cdrom/nrg.rs
+++ b/src/cdrom/nrg.rs
@@ -852,6 +852,83 @@ mod tests {
         assert!(err.to_string().contains("reopening CD image"));
     }
 
+    /// One raw MODE1 sector: sync/header bytes, 2048 bytes of user data,
+    /// then the EDC/ECC tail. `read_data_sector` must expose only the user
+    /// payload whichever NRG metadata layout selected the 2352-byte geometry.
+    fn raw_mode1_sector(value: u8) -> Vec<u8> {
+        let mut sector = vec![0xEE; RAW_SECTOR_BYTES];
+        sector[16..16 + DATA_SECTOR_BYTES].fill(value);
+        sector
+    }
+
+    #[test]
+    fn mode1_2352_geometry_is_served_from_dao_and_tao_layouts() {
+        let raw = raw_mode1_sector(0x42);
+
+        let dao_path = temp_path("raw-dao.nrg");
+        let mut dao_image = raw.clone();
+        let descriptor_start = dao_image.len() as u64;
+        let mut cue = Vec::new();
+        for entry in [
+            cue_entry(0, 0, -150, false),
+            cue_entry(1, 0, 0, false),
+            cue_entry(1, 1, 0, false),
+            cue_entry(0xAA, 1, 1, false),
+        ] {
+            cue.extend_from_slice(&entry);
+        }
+        chunk(b"CUEX", &cue, &mut dao_image);
+        let mut dao = vec![0u8; DAO_HEADER_BYTES];
+        dao[20] = 1;
+        dao[21] = 1;
+        dao.extend(dao_entry(
+            RAW_SECTOR_BYTES as u16,
+            0x05,
+            [0, 0, RAW_SECTOR_BYTES as u64],
+            false,
+        ));
+        chunk(b"DAOX", &dao, &mut dao_image);
+        chunk(b"END!", &[], &mut dao_image);
+        dao_image.extend_from_slice(b"NER5");
+        dao_image.extend_from_slice(&descriptor_start.to_be_bytes());
+        File::create(&dao_path)
+            .unwrap()
+            .write_all(&dao_image)
+            .unwrap();
+
+        let tao_path = temp_path("raw-tao.nrg");
+        let mut tao_image = raw.clone();
+        let descriptor_start = tao_image.len() as u64;
+        let mut etn = Vec::new();
+        etn.extend_from_slice(&0u64.to_be_bytes());
+        etn.extend_from_slice(&(RAW_SECTOR_BYTES as u64).to_be_bytes());
+        etn.extend_from_slice(&0x05u32.to_be_bytes());
+        etn.extend_from_slice(&0u32.to_be_bytes());
+        etn.extend_from_slice(&0u64.to_be_bytes());
+        chunk(b"ETN2", &etn, &mut tao_image);
+        chunk(b"END!", &[], &mut tao_image);
+        tao_image.extend_from_slice(b"NER5");
+        tao_image.extend_from_slice(&descriptor_start.to_be_bytes());
+        File::create(&tao_path)
+            .unwrap()
+            .write_all(&tao_image)
+            .unwrap();
+
+        for path in [&dao_path, &tao_path] {
+            let mut image = CdImage::load(path).unwrap();
+            assert_eq!(image.tracks()[0].kind, TrackKind::Mode1_2352);
+            let mut data = [0u8; DATA_SECTOR_BYTES];
+            image.read_data_sector(0, &mut data).unwrap();
+            assert!(data.iter().all(|&byte| byte == 0x42));
+            let mut full = [0u8; RAW_SECTOR_BYTES];
+            image.read_raw_sector(0, &mut full).unwrap();
+            assert_eq!(full.as_slice(), raw.as_slice());
+        }
+
+        let _ = std::fs::remove_file(dao_path);
+        let _ = std::fs::remove_file(tao_path);
+    }
+
     #[test]
     fn etn2_tao_inserts_virtual_intertrack_pregap() {
         let path = temp_path("tao.nrg");

--- a/src/cdrom/nrg.rs
+++ b/src/cdrom/nrg.rs
@@ -1,0 +1,930 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Nero NRG CD image backend.
+//!
+//! NRG stores sector data first and a chunked descriptor at the end of the
+//! file. Pre-5.5 images carry a `NERO` footer with a 32-bit descriptor offset;
+//! newer images carry `NER5` and a 64-bit offset. DAO images describe track
+//! offsets through `CUES`/`DAOI` or `CUEX`/`DAOX`, while TAO images use
+//! `ETNF`/`ETN2`. Once decoded, both layouts are ordinary byte extents over
+//! the NRG file and therefore share `CdImage`'s plain-file backend.
+
+use super::{
+    BinBackend, CdImage, CdTrack, Extent, FileFormat, Source, Storage, TrackKind,
+    DATA_SECTOR_BYTES, RAW_SECTOR_BYTES,
+};
+use anyhow::{bail, Context, Result};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+const NEW_FOOTER_BYTES: u64 = 12;
+const OLD_FOOTER_BYTES: u64 = 8;
+const CHUNK_HEADER_BYTES: u64 = 8;
+const DAO_HEADER_BYTES: usize = 22;
+const MAX_TRACKS: usize = 99;
+const MAX_DISC_SECTORS: u32 = 100 * 60 * 75;
+/// CUE permits indices 00 through 99 on every track. They are uncommon past
+/// INDEX 01, but bounding for the complete addressable set avoids rejecting a
+/// valid footer while still preventing a forged chunk from driving allocation.
+const MAX_CUE_BYTES: usize = (MAX_TRACKS * 100 + 2) * 8;
+const MAX_DAO_BYTES: usize = DAO_HEADER_BYTES + MAX_TRACKS * 42;
+const MAX_ETN_BYTES: usize = MAX_TRACKS * 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Version {
+    Old,
+    New,
+}
+
+impl Version {
+    fn footer_bytes(self) -> u64 {
+        match self {
+            Version::Old => OLD_FOOTER_BYTES,
+            Version::New => NEW_FOOTER_BYTES,
+        }
+    }
+}
+
+#[derive(Default)]
+struct Chunks {
+    cue: Option<(Version, Vec<u8>)>,
+    dao: Option<(Version, Vec<u8>)>,
+    etn: Option<(Version, Vec<u8>)>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CueEntry {
+    track: u8,
+    index: u8,
+    lba: i32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DaoTrack {
+    kind: TrackKind,
+    sector_bytes: u64,
+    pregap_offset: u64,
+    start_offset: u64,
+    end_offset: u64,
+}
+
+pub(super) fn load(path: &Path) -> Result<CdImage> {
+    let mut file =
+        File::open(path).with_context(|| format!("opening NRG image {}", path.display()))?;
+    let file_len = file
+        .metadata()
+        .with_context(|| format!("stat {}", path.display()))?
+        .len();
+    let (version, descriptor_start) = read_footer(&mut file, file_len, path)?;
+    let descriptor_end = file_len - version.footer_bytes();
+    if descriptor_start >= descriptor_end {
+        bail!(
+            "{}: NRG descriptor offset {descriptor_start} is not before its footer",
+            path.display()
+        );
+    }
+
+    let chunks = read_chunks(&mut file, descriptor_start, descriptor_end, version, path)?;
+    let (tracks, extents, total_sectors) = match (chunks.cue, chunks.dao, chunks.etn) {
+        (Some((cue_version, cue)), Some((dao_version, dao)), None) => {
+            if cue_version != version || dao_version != version {
+                bail!(
+                    "{}: NRG footer and DAO chunk generations disagree",
+                    path.display()
+                );
+            }
+            parse_dao_layout(&cue, &dao, version, descriptor_start, path)?
+        }
+        (None, None, Some((etn_version, etn))) => {
+            if etn_version != version {
+                bail!(
+                    "{}: NRG footer and ETN chunk generations disagree",
+                    path.display()
+                );
+            }
+            parse_tao_layout(&etn, version, descriptor_start, path)?
+        }
+        (Some(_), None, None) | (None, Some(_), None) => bail!(
+            "{}: NRG DAO image needs both a CUE and a DAO chunk",
+            path.display()
+        ),
+        (None, None, None) => bail!("{}: NRG descriptor contains no CD tracks", path.display()),
+        _ => bail!(
+            "{}: NRG descriptor mixes DAO and TAO track layouts",
+            path.display()
+        ),
+    };
+
+    let source = Source::open(path, FileFormat::Binary)?;
+    Ok(CdImage {
+        tracks,
+        total_sectors,
+        backend: super::Backend::Bin(BinBackend {
+            sources: vec![source],
+            extents,
+        }),
+    })
+}
+
+fn read_footer(file: &mut File, file_len: u64, path: &Path) -> Result<(Version, u64)> {
+    if file_len < NEW_FOOTER_BYTES {
+        bail!(
+            "{}: file is too short to contain an NRG footer",
+            path.display()
+        );
+    }
+    file.seek(SeekFrom::End(-(NEW_FOOTER_BYTES as i64)))?;
+    let mut tail = [0u8; NEW_FOOTER_BYTES as usize];
+    file.read_exact(&mut tail)?;
+    if &tail[..4] == b"NER5" {
+        return Ok((Version::New, be_u64(&tail[4..12])));
+    }
+    if &tail[4..8] == b"NERO" {
+        return Ok((Version::Old, u64::from(be_u32(&tail[8..12]))));
+    }
+    bail!("{}: missing NERO/NER5 footer", path.display())
+}
+
+fn read_chunks(
+    file: &mut File,
+    descriptor_start: u64,
+    descriptor_end: u64,
+    footer_version: Version,
+    path: &Path,
+) -> Result<Chunks> {
+    let mut chunks = Chunks::default();
+    let mut pos = descriptor_start;
+    let mut saw_end = false;
+    while pos < descriptor_end {
+        if descriptor_end - pos < CHUNK_HEADER_BYTES {
+            bail!("{}: truncated NRG chunk header", path.display());
+        }
+        file.seek(SeekFrom::Start(pos))?;
+        let mut header = [0u8; CHUNK_HEADER_BYTES as usize];
+        file.read_exact(&mut header)?;
+        let id = &header[..4];
+        let length = u64::from(be_u32(&header[4..8]));
+        let payload_start = pos + CHUNK_HEADER_BYTES;
+        let payload_end = payload_start
+            .checked_add(length)
+            .with_context(|| format!("{}: NRG chunk length overflows", path.display()))?;
+        if payload_end > descriptor_end {
+            bail!(
+                "{}: truncated NRG {} chunk",
+                path.display(),
+                String::from_utf8_lossy(id)
+            );
+        }
+
+        match id {
+            b"CUEX" => set_chunk(
+                &mut chunks.cue,
+                Version::New,
+                read_payload(file, length, MAX_CUE_BYTES, "CUEX", path)?,
+                "CUE",
+                path,
+            )?,
+            b"CUES" => set_chunk(
+                &mut chunks.cue,
+                Version::Old,
+                read_payload(file, length, MAX_CUE_BYTES, "CUES", path)?,
+                "CUE",
+                path,
+            )?,
+            b"DAOX" => set_chunk(
+                &mut chunks.dao,
+                Version::New,
+                read_payload(file, length, MAX_DAO_BYTES, "DAOX", path)?,
+                "DAO",
+                path,
+            )?,
+            b"DAOI" => set_chunk(
+                &mut chunks.dao,
+                Version::Old,
+                read_payload(file, length, MAX_DAO_BYTES, "DAOI", path)?,
+                "DAO",
+                path,
+            )?,
+            b"ETN2" => set_chunk(
+                &mut chunks.etn,
+                Version::New,
+                read_payload(file, length, MAX_ETN_BYTES, "ETN2", path)?,
+                "ETN",
+                path,
+            )?,
+            b"ETNF" => set_chunk(
+                &mut chunks.etn,
+                Version::Old,
+                read_payload(file, length, MAX_ETN_BYTES, "ETNF", path)?,
+                "ETN",
+                path,
+            )?,
+            b"END!" => {
+                if length != 0 {
+                    bail!("{}: END! NRG chunk has a payload", path.display());
+                }
+                saw_end = true;
+                pos = payload_end;
+                break;
+            }
+            _ => file.seek(SeekFrom::Start(payload_end)).map(|_| ())?,
+        }
+        pos = payload_end;
+    }
+
+    if !saw_end {
+        bail!("{}: NRG descriptor has no END! chunk", path.display());
+    }
+    if pos != descriptor_end {
+        bail!("{}: data follows the NRG END! chunk", path.display());
+    }
+    if footer_version == Version::New
+        && (chunks.cue.as_ref().is_some_and(|(v, _)| *v == Version::Old)
+            || chunks.dao.as_ref().is_some_and(|(v, _)| *v == Version::Old)
+            || chunks.etn.as_ref().is_some_and(|(v, _)| *v == Version::Old))
+    {
+        bail!(
+            "{}: NER5 footer contains old-format track chunks",
+            path.display()
+        );
+    }
+    Ok(chunks)
+}
+
+fn read_payload(
+    file: &mut File,
+    length: u64,
+    maximum: usize,
+    name: &str,
+    path: &Path,
+) -> Result<Vec<u8>> {
+    let length = usize::try_from(length)
+        .with_context(|| format!("{}: {name} NRG chunk is too large", path.display()))?;
+    if length > maximum {
+        bail!(
+            "{}: {name} NRG chunk is too large ({length} bytes)",
+            path.display()
+        );
+    }
+    let mut payload = vec![0u8; length];
+    file.read_exact(&mut payload)?;
+    Ok(payload)
+}
+
+fn set_chunk(
+    slot: &mut Option<(Version, Vec<u8>)>,
+    version: Version,
+    payload: Vec<u8>,
+    name: &str,
+    path: &Path,
+) -> Result<()> {
+    if slot.is_some() {
+        bail!(
+            "{}: multi-session NRG images are not supported (repeated {name} chunk)",
+            path.display()
+        );
+    }
+    *slot = Some((version, payload));
+    Ok(())
+}
+
+fn parse_dao_layout(
+    cue: &[u8],
+    dao: &[u8],
+    version: Version,
+    descriptor_start: u64,
+    path: &Path,
+) -> Result<(Vec<CdTrack>, Vec<Extent>, u32)> {
+    let cue = parse_cue(cue, version, path)?;
+    let entry_bytes = match version {
+        Version::Old => 30,
+        Version::New => 42,
+    };
+    if dao.len() < DAO_HEADER_BYTES || !(dao.len() - DAO_HEADER_BYTES).is_multiple_of(entry_bytes) {
+        bail!("{}: malformed NRG DAO chunk length", path.display());
+    }
+    let count = (dao.len() - DAO_HEADER_BYTES) / entry_bytes;
+    if count == 0 || count > MAX_TRACKS {
+        bail!("{}: NRG DAO track count {count} is invalid", path.display());
+    }
+    let first_track = dao[20];
+    let last_track = dao[21];
+    let header_count = last_track
+        .checked_sub(first_track)
+        .map(|n| usize::from(n) + 1)
+        .unwrap_or(0);
+    if first_track == 0 || last_track > MAX_TRACKS as u8 || header_count != count {
+        bail!(
+            "{}: NRG DAO header track range {first_track}..{last_track} does not match {count} entries",
+            path.display()
+        );
+    }
+
+    let mut raw_tracks = Vec::with_capacity(count);
+    for i in 0..count {
+        let entry =
+            &dao[DAO_HEADER_BYTES + i * entry_bytes..DAO_HEADER_BYTES + (i + 1) * entry_bytes];
+        let sector_size = u64::from(be_u16(&entry[12..14]));
+        let mode = entry[14];
+        let kind = decode_mode(mode, sector_size, path)?;
+        let (pregap_offset, start_offset, end_offset) = match version {
+            Version::Old => (
+                u64::from(be_u32(&entry[18..22])),
+                u64::from(be_u32(&entry[22..26])),
+                u64::from(be_u32(&entry[26..30])),
+            ),
+            Version::New => (
+                be_u64(&entry[18..26]),
+                be_u64(&entry[26..34]),
+                be_u64(&entry[34..42]),
+            ),
+        };
+        if pregap_offset > start_offset || start_offset > end_offset {
+            bail!(
+                "{}: NRG track {} offsets are not monotonic",
+                path.display(),
+                first_track + i as u8
+            );
+        }
+        if end_offset > descriptor_start {
+            bail!(
+                "{}: NRG track {} runs into the descriptor",
+                path.display(),
+                first_track + i as u8
+            );
+        }
+        if !(start_offset - pregap_offset).is_multiple_of(sector_size)
+            || !(end_offset - start_offset).is_multiple_of(sector_size)
+        {
+            bail!(
+                "{}: NRG track {} does not end on a sector boundary",
+                path.display(),
+                first_track + i as u8
+            );
+        }
+        raw_tracks.push(DaoTrack {
+            kind,
+            sector_bytes: sector_size,
+            pregap_offset,
+            start_offset,
+            end_offset,
+        });
+    }
+
+    let mut tracks = Vec::with_capacity(count);
+    let mut extents = Vec::with_capacity(count + 1);
+    let mut cursor = 0u32;
+    for (i, raw) in raw_tracks.iter().enumerate() {
+        let number = first_track + i as u8;
+        let index1 = cue_lba(&cue, number, 1)
+            .with_context(|| format!("{}: NRG track {number} has no INDEX 01", path.display()))?;
+        if index1 < 0 {
+            bail!(
+                "{}: NRG track {number} INDEX 01 is negative",
+                path.display()
+            );
+        }
+        let pregap_sectors = u32::try_from(
+            (raw.start_offset - raw.pregap_offset) / raw.sector_bytes,
+        )
+        .with_context(|| format!("{}: NRG track {number} pregap is too large", path.display()))?;
+        let data_sectors = u32::try_from((raw.end_offset - raw.start_offset) / raw.sector_bytes)
+            .with_context(|| format!("{}: NRG track {number} is too large", path.display()))?;
+        if data_sectors == 0 {
+            bail!("{}: NRG track {number} is empty", path.display());
+        }
+        let pregap_sectors_i32 = i32::try_from(pregap_sectors).with_context(|| {
+            format!("{}: NRG track {number} pregap is too large", path.display())
+        })?;
+        let data_sectors_i32 = i32::try_from(data_sectors)
+            .with_context(|| format!("{}: NRG track {number} is too large", path.display()))?;
+        let derived_index0 = index1
+            .checked_sub(pregap_sectors_i32)
+            .with_context(|| format!("{}: NRG track {number} pregap underflows", path.display()))?;
+        let index0 = cue_lba(&cue, number, 0).unwrap_or(derived_index0);
+        if index0 != derived_index0 {
+            bail!(
+                "{}: NRG track {number} CUE pregap does not match its DAO offsets",
+                path.display()
+            );
+        }
+        let logical_end = index1
+            .checked_add(data_sectors_i32)
+            .with_context(|| format!("{}: NRG track {number} address overflows", path.display()))?;
+        if logical_end <= 0 || logical_end as u32 > MAX_DISC_SECTORS {
+            bail!(
+                "{}: NRG track {number} lies outside a CD address space",
+                path.display()
+            );
+        }
+
+        let extent_start = index0.max(0) as u32;
+        let clipped = u64::try_from(extent_start as i64 - index0 as i64).unwrap();
+        let source_offset = raw
+            .pregap_offset
+            .checked_add(clipped * raw.sector_bytes)
+            .with_context(|| format!("{}: NRG track {number} offset overflows", path.display()))?;
+        let extent_count = logical_end as u32 - extent_start;
+        push_source_extent(
+            &mut extents,
+            &mut cursor,
+            extent_start,
+            extent_count,
+            raw.kind,
+            source_offset,
+            path,
+        )?;
+        tracks.push(CdTrack {
+            number,
+            kind: raw.kind,
+            start_sector: index1 as u32,
+            sector_count: data_sectors,
+        });
+    }
+
+    let leadout = cue_lba(&cue, 0xAA, 1).unwrap_or(cursor as i32);
+    if leadout < cursor as i32 || leadout < 0 || leadout as u32 > MAX_DISC_SECTORS {
+        bail!("{}: NRG lead-out address is invalid", path.display());
+    }
+    if leadout as u32 > cursor {
+        let kind = tracks.last().unwrap().kind;
+        extents.push(Extent {
+            disc_start: cursor,
+            sector_count: leadout as u32 - cursor,
+            kind,
+            storage: Storage::Gap,
+        });
+    }
+    Ok((tracks, extents, leadout as u32))
+}
+
+fn parse_tao_layout(
+    etn: &[u8],
+    version: Version,
+    descriptor_start: u64,
+    path: &Path,
+) -> Result<(Vec<CdTrack>, Vec<Extent>, u32)> {
+    let entry_bytes = match version {
+        Version::Old => 20,
+        Version::New => 32,
+    };
+    if etn.is_empty() || !etn.len().is_multiple_of(entry_bytes) {
+        bail!("{}: malformed NRG ETN chunk length", path.display());
+    }
+    let count = etn.len() / entry_bytes;
+    if count > MAX_TRACKS {
+        bail!("{}: NRG ETN track count {count} is invalid", path.display());
+    }
+
+    let mut tracks = Vec::with_capacity(count);
+    let mut extents = Vec::with_capacity(count * 2);
+    let mut cursor = 0u32;
+    for i in 0..count {
+        let entry = &etn[i * entry_bytes..(i + 1) * entry_bytes];
+        let (offset, size, mode, raw_start) = match version {
+            Version::Old => (
+                u64::from(be_u32(&entry[0..4])),
+                u64::from(be_u32(&entry[4..8])),
+                be_u32(&entry[8..12]),
+                be_u32(&entry[12..16]),
+            ),
+            Version::New => (
+                be_u64(&entry[0..8]),
+                be_u64(&entry[8..16]),
+                be_u32(&entry[16..20]),
+                be_u32(&entry[20..24]),
+            ),
+        };
+        let mode = u8::try_from(mode)
+            .with_context(|| format!("{}: NRG track {} mode is invalid", path.display(), i + 1))?;
+        let (kind, sector_bytes) = tao_mode(mode, path)?;
+        if !size.is_multiple_of(sector_bytes) {
+            bail!(
+                "{}: NRG track {} does not end on a sector boundary",
+                path.display(),
+                i + 1
+            );
+        }
+        let end_offset = offset
+            .checked_add(size)
+            .with_context(|| format!("{}: NRG track {} offset overflows", path.display(), i + 1))?;
+        if end_offset > descriptor_start {
+            bail!(
+                "{}: NRG track {} runs into the descriptor",
+                path.display(),
+                i + 1
+            );
+        }
+        let sector_count = u32::try_from(size / sector_bytes)
+            .with_context(|| format!("{}: NRG track {} is too large", path.display(), i + 1))?;
+        if sector_count == 0 {
+            bail!("{}: NRG track {} is empty", path.display(), i + 1);
+        }
+        // ETN start_lsn omits the standard 150-sector pregap inserted
+        // before every track after the first.
+        let start_sector = raw_start.checked_add(i as u32 * 150).with_context(|| {
+            format!("{}: NRG track {} address overflows", path.display(), i + 1)
+        })?;
+        let end_sector = start_sector.checked_add(sector_count).with_context(|| {
+            format!("{}: NRG track {} address overflows", path.display(), i + 1)
+        })?;
+        if end_sector > MAX_DISC_SECTORS {
+            bail!(
+                "{}: NRG track {} lies outside a CD address space",
+                path.display(),
+                i + 1
+            );
+        }
+        push_source_extent(
+            &mut extents,
+            &mut cursor,
+            start_sector,
+            sector_count,
+            kind,
+            offset,
+            path,
+        )?;
+        tracks.push(CdTrack {
+            number: (i + 1) as u8,
+            kind,
+            start_sector,
+            sector_count,
+        });
+    }
+    Ok((tracks, extents, cursor))
+}
+
+fn push_source_extent(
+    extents: &mut Vec<Extent>,
+    cursor: &mut u32,
+    start: u32,
+    count: u32,
+    kind: TrackKind,
+    byte_offset: u64,
+    path: &Path,
+) -> Result<()> {
+    if start < *cursor {
+        bail!("{}: NRG track address ranges overlap", path.display());
+    }
+    if start > *cursor {
+        extents.push(Extent {
+            disc_start: *cursor,
+            sector_count: start - *cursor,
+            kind,
+            storage: Storage::Gap,
+        });
+    }
+    extents.push(Extent {
+        disc_start: start,
+        sector_count: count,
+        kind,
+        storage: Storage::Source {
+            source: 0,
+            byte_offset,
+        },
+    });
+    *cursor = start
+        .checked_add(count)
+        .with_context(|| format!("{}: NRG disc address overflows", path.display()))?;
+    Ok(())
+}
+
+fn parse_cue(data: &[u8], version: Version, path: &Path) -> Result<Vec<CueEntry>> {
+    if data.is_empty() || !data.len().is_multiple_of(8) {
+        bail!("{}: malformed NRG CUE chunk length", path.display());
+    }
+    let mut entries = Vec::with_capacity(data.len() / 8);
+    for raw in data.chunks_exact(8) {
+        let track = if raw[1] == 0xAA {
+            0xAA
+        } else {
+            from_bcd(raw[1], "track", path)?
+        };
+        let index = from_bcd(raw[2], "index", path)?;
+        let lba = match version {
+            Version::New => i32::from_be_bytes(raw[4..8].try_into().unwrap()),
+            Version::Old => {
+                let (minutes, seconds, frames) = (raw[5], raw[6], raw[7]);
+                if seconds >= 60 || frames >= 75 {
+                    bail!("{}: invalid MSF address in NRG CUES chunk", path.display());
+                }
+                let mut lba =
+                    (i32::from(minutes) * 60 + i32::from(seconds)) * 75 + i32::from(frames) - 150;
+                if minutes >= 90 {
+                    lba -= 450_000;
+                }
+                lba
+            }
+        };
+        if entries
+            .iter()
+            .any(|entry: &CueEntry| entry.track == track && entry.index == index)
+        {
+            bail!(
+                "{}: duplicate NRG CUE track {track:02X} index {index}",
+                path.display()
+            );
+        }
+        entries.push(CueEntry { track, index, lba });
+    }
+    Ok(entries)
+}
+
+fn cue_lba(entries: &[CueEntry], track: u8, index: u8) -> Option<i32> {
+    entries
+        .iter()
+        .find(|entry| entry.track == track && entry.index == index)
+        .map(|entry| entry.lba)
+}
+
+fn decode_mode(mode: u8, sector_bytes: u64, path: &Path) -> Result<TrackKind> {
+    match (mode, sector_bytes) {
+        (0x00, n) if n == DATA_SECTOR_BYTES as u64 => Ok(TrackKind::Mode1_2048),
+        (0x05, n) if n == RAW_SECTOR_BYTES as u64 => Ok(TrackKind::Mode1_2352),
+        (0x07, n) if n == RAW_SECTOR_BYTES as u64 => Ok(TrackKind::Audio),
+        (0x0F..=0x11, 2448) => bail!(
+            "{}: NRG sectors with stored subchannel data are not supported",
+            path.display()
+        ),
+        (0x02 | 0x03 | 0x06 | 0x11, _) => {
+            bail!("{}: Mode 2 NRG tracks are not supported", path.display())
+        }
+        _ => bail!(
+            "{}: unsupported NRG track mode 0x{mode:02X} with {sector_bytes}-byte sectors",
+            path.display()
+        ),
+    }
+}
+
+fn tao_mode(mode: u8, path: &Path) -> Result<(TrackKind, u64)> {
+    match mode {
+        0x00 => Ok((TrackKind::Mode1_2048, DATA_SECTOR_BYTES as u64)),
+        0x05 => Ok((TrackKind::Mode1_2352, RAW_SECTOR_BYTES as u64)),
+        0x07 => Ok((TrackKind::Audio, RAW_SECTOR_BYTES as u64)),
+        0x02 | 0x03 | 0x06 => bail!("{}: Mode 2 NRG tracks are not supported", path.display()),
+        _ => bail!(
+            "{}: unsupported NRG track mode 0x{mode:02X}",
+            path.display()
+        ),
+    }
+}
+
+fn from_bcd(value: u8, field: &str, path: &Path) -> Result<u8> {
+    let hi = value >> 4;
+    let lo = value & 0x0F;
+    if hi > 9 || lo > 9 {
+        bail!("{}: invalid BCD {field} in NRG CUE chunk", path.display());
+    }
+    Ok(hi * 10 + lo)
+}
+
+fn be_u16(bytes: &[u8]) -> u16 {
+    u16::from_be_bytes(bytes.try_into().unwrap())
+}
+
+fn be_u32(bytes: &[u8]) -> u32 {
+    u32::from_be_bytes(bytes.try_into().unwrap())
+}
+
+fn be_u64(bytes: &[u8]) -> u64 {
+    u64::from_be_bytes(bytes.try_into().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    fn temp_path(name: &str) -> PathBuf {
+        static UNIQUE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let unique = UNIQUE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "copperline-nrg-{}-{unique}-{name}",
+            std::process::id()
+        ))
+    }
+
+    fn chunk(id: &[u8; 4], data: &[u8], out: &mut Vec<u8>) {
+        out.extend_from_slice(id);
+        out.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        out.extend_from_slice(data);
+    }
+
+    fn cue_entry(track: u8, index: u8, lba: i32, old: bool) -> [u8; 8] {
+        let mut entry = [0u8; 8];
+        entry[0] = if track == 1 { 0x41 } else { 0x01 };
+        entry[1] = track;
+        entry[2] = index;
+        if old {
+            let absolute = lba + 150;
+            entry[5] = (absolute / (60 * 75)) as u8;
+            entry[6] = ((absolute / 75) % 60) as u8;
+            entry[7] = (absolute % 75) as u8;
+        } else {
+            entry[4..8].copy_from_slice(&lba.to_be_bytes());
+        }
+        entry
+    }
+
+    fn dao_entry(sector_bytes: u16, mode: u8, offsets: [u64; 3], old: bool) -> Vec<u8> {
+        let mut entry = vec![0u8; if old { 30 } else { 42 }];
+        entry[12..14].copy_from_slice(&sector_bytes.to_be_bytes());
+        entry[14] = mode;
+        entry[17] = 1;
+        if old {
+            for (i, offset) in offsets.into_iter().enumerate() {
+                entry[18 + i * 4..22 + i * 4].copy_from_slice(&(offset as u32).to_be_bytes());
+            }
+        } else {
+            for (i, offset) in offsets.into_iter().enumerate() {
+                entry[18 + i * 8..26 + i * 8].copy_from_slice(&offset.to_be_bytes());
+            }
+        }
+        entry
+    }
+
+    fn write_dao_image(path: &Path, old: bool) {
+        let mut image = Vec::new();
+        // Track 1 has a two-sector stored lead-in followed by three data
+        // sectors. Track 2 has a one-sector stored pregap and two audio
+        // sectors.
+        image.extend(vec![0xEE; 2 * DATA_SECTOR_BYTES]);
+        for value in [0x10, 0x11, 0x12] {
+            image.extend(vec![value; DATA_SECTOR_BYTES]);
+        }
+        image.extend(vec![0xA0; RAW_SECTOR_BYTES]);
+        image.extend(vec![0xA1; RAW_SECTOR_BYTES]);
+        image.extend(vec![0xA2; RAW_SECTOR_BYTES]);
+        let t1 = [
+            0,
+            2 * DATA_SECTOR_BYTES as u64,
+            5 * DATA_SECTOR_BYTES as u64,
+        ];
+        let t2 = [t1[2], t1[2] + RAW_SECTOR_BYTES as u64, image.len() as u64];
+
+        let mut descriptor = Vec::new();
+        let cue = [
+            cue_entry(0, 0, -2, old),
+            cue_entry(1, 0, -2, old),
+            cue_entry(1, 1, 0, old),
+            cue_entry(2, 0, 3, old),
+            cue_entry(2, 1, 4, old),
+            cue_entry(0xAA, 1, 6, old),
+        ]
+        .concat();
+        chunk(if old { b"CUES" } else { b"CUEX" }, &cue, &mut descriptor);
+        let mut dao = vec![0u8; DAO_HEADER_BYTES];
+        dao[20] = 1;
+        dao[21] = 2;
+        dao.extend(dao_entry(DATA_SECTOR_BYTES as u16, 0, t1, old));
+        dao.extend(dao_entry(RAW_SECTOR_BYTES as u16, 7, t2, old));
+        chunk(if old { b"DAOI" } else { b"DAOX" }, &dao, &mut descriptor);
+        chunk(b"END!", &[], &mut descriptor);
+
+        let descriptor_start = image.len() as u64;
+        image.extend(descriptor);
+        if old {
+            image.extend_from_slice(b"NERO");
+            image.extend_from_slice(&(descriptor_start as u32).to_be_bytes());
+        } else {
+            image.extend_from_slice(b"NER5");
+            image.extend_from_slice(&descriptor_start.to_be_bytes());
+        }
+        File::create(path).unwrap().write_all(&image).unwrap();
+    }
+
+    fn assert_mixed_dao(path: &Path) {
+        let mut image = CdImage::load(path).unwrap();
+        assert_eq!(image.total_sectors(), 6);
+        assert_eq!(image.tracks().len(), 2);
+        assert_eq!(image.tracks()[0].start_sector, 0);
+        assert_eq!(image.tracks()[0].sector_count, 3);
+        assert_eq!(image.tracks()[1].start_sector, 4);
+        assert_eq!(image.tracks()[1].sector_count, 2);
+
+        let mut data = [0u8; DATA_SECTOR_BYTES];
+        for (sector, value) in [(0, 0x10), (1, 0x11), (2, 0x12)] {
+            image.read_data_sector(sector, &mut data).unwrap();
+            assert!(data.iter().all(|&byte| byte == value));
+        }
+        let mut audio = [0u8; RAW_SECTOR_BYTES];
+        for (sector, value) in [(3, 0xA0), (4, 0xA1), (5, 0xA2)] {
+            image.read_audio_sector(sector, &mut audio).unwrap();
+            assert!(audio.iter().all(|&byte| byte == value));
+        }
+    }
+
+    #[test]
+    fn ner5_daox_maps_stored_pregaps_and_mixed_track_sizes() {
+        let path = temp_path("mixed-new.nrg");
+        write_dao_image(&path, false);
+        assert_mixed_dao(&path);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn nero_daoi_decodes_msf_cue_addresses_and_32_bit_offsets() {
+        let path = temp_path("mixed-old.nrg");
+        write_dao_image(&path, true);
+        assert_mixed_dao(&path);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn serde_reopens_nrg_extents_and_serves_the_same_sectors() {
+        let path = temp_path("serde.nrg");
+        write_dao_image(&path, false);
+        let mut image = CdImage::load(&path).unwrap();
+        let encoded = bincode::serialize(&image).unwrap();
+        let mut restored: CdImage = bincode::deserialize(&encoded).unwrap();
+        assert_eq!(restored.total_sectors(), image.total_sectors());
+        let mut expected = [0u8; RAW_SECTOR_BYTES];
+        let mut actual = [0u8; RAW_SECTOR_BYTES];
+        image.read_audio_sector(4, &mut expected).unwrap();
+        restored.read_audio_sector(4, &mut actual).unwrap();
+        assert_eq!(actual, expected);
+
+        let _ = std::fs::remove_file(&path);
+        let err = bincode::deserialize::<CdImage>(&encoded)
+            .expect_err("deserializing with the NRG gone must fail");
+        assert!(err.to_string().contains("reopening CD image"));
+    }
+
+    #[test]
+    fn etn2_tao_inserts_virtual_intertrack_pregap() {
+        let path = temp_path("tao.nrg");
+        let mut image = vec![0x31; 2 * DATA_SECTOR_BYTES];
+        let audio_offset = image.len() as u64;
+        image.extend(vec![0x72; 2 * RAW_SECTOR_BYTES]);
+        let descriptor_start = image.len() as u64;
+
+        let mut etn = Vec::new();
+        for (offset, size, mode, start) in [
+            (0, (2 * DATA_SECTOR_BYTES) as u64, 0u32, 0u32),
+            (audio_offset, (2 * RAW_SECTOR_BYTES) as u64, 7u32, 2u32),
+        ] {
+            etn.extend_from_slice(&offset.to_be_bytes());
+            etn.extend_from_slice(&size.to_be_bytes());
+            etn.extend_from_slice(&mode.to_be_bytes());
+            etn.extend_from_slice(&start.to_be_bytes());
+            etn.extend_from_slice(&0u64.to_be_bytes());
+        }
+        chunk(b"ETN2", &etn, &mut image);
+        chunk(b"END!", &[], &mut image);
+        image.extend_from_slice(b"NER5");
+        image.extend_from_slice(&descriptor_start.to_be_bytes());
+        File::create(&path).unwrap().write_all(&image).unwrap();
+
+        let mut image = CdImage::load(&path).unwrap();
+        assert_eq!(image.tracks()[0].start_sector, 0);
+        assert_eq!(image.tracks()[1].start_sector, 152);
+        assert_eq!(image.total_sectors(), 154);
+        let mut audio = [1u8; RAW_SECTOR_BYTES];
+        image.read_audio_sector(2, &mut audio).unwrap();
+        assert!(audio.iter().all(|&byte| byte == 0));
+        image.read_audio_sector(152, &mut audio).unwrap();
+        assert!(audio.iter().all(|&byte| byte == 0x72));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn etnf_tao_uses_32_bit_offsets() {
+        let path = temp_path("tao-old.nrg");
+        let mut image = vec![0x51; 2 * DATA_SECTOR_BYTES];
+        let descriptor_start = image.len() as u64;
+        let mut etn = Vec::new();
+        etn.extend_from_slice(&0u32.to_be_bytes());
+        etn.extend_from_slice(&(2 * DATA_SECTOR_BYTES as u32).to_be_bytes());
+        etn.extend_from_slice(&0u32.to_be_bytes());
+        etn.extend_from_slice(&0u32.to_be_bytes());
+        etn.extend_from_slice(&0u32.to_be_bytes());
+        chunk(b"ETNF", &etn, &mut image);
+        chunk(b"END!", &[], &mut image);
+        image.extend_from_slice(b"NERO");
+        image.extend_from_slice(&(descriptor_start as u32).to_be_bytes());
+        File::create(&path).unwrap().write_all(&image).unwrap();
+
+        let mut image = CdImage::load(&path).unwrap();
+        assert_eq!(image.total_sectors(), 2);
+        let mut data = [0u8; DATA_SECTOR_BYTES];
+        image.read_data_sector(1, &mut data).unwrap();
+        assert!(data.iter().all(|&byte| byte == 0x51));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn descriptor_chunk_cannot_run_into_the_footer() {
+        let path = temp_path("truncated.nrg");
+        let mut image = Vec::new();
+        image.extend_from_slice(b"CUEX");
+        image.extend_from_slice(&100u32.to_be_bytes());
+        image.extend_from_slice(b"NER5");
+        image.extend_from_slice(&0u64.to_be_bytes());
+        File::create(&path).unwrap().write_all(&image).unwrap();
+        let err = CdImage::load(&path).unwrap_err();
+        assert!(err.to_string().contains("truncated NRG CUEX"), "{err:#}");
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1417,7 +1417,7 @@ fn print_help() {
          \x20                            insert PATH into DFN after SECS seconds\n  \
          --defer-disk-insert SECS DFN   start with configured DFN empty, then insert\n  \
          \x20                            its configured disk image after SECS seconds\n  \
-         --insert-cd-after SECS PATH    swap the CD image (cue/iso/chd) in the machine's CD\n  \
+         --insert-cd-after SECS PATH    swap the CD image (cue/iso/nrg/chd) in the machine's CD\n  \
          \x20                            drive (CDTV, CD32, or a SCSI CD-ROM unit) after\n  \
          \x20                            SECS seconds\n  \
          --audio                        enable real-time stereo audio output via cpal (default)\n  \

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1086,13 +1086,14 @@ pub const HARDFILE_DEFAULT_BOOT_PRI: i8 = 0;
 pub const BOOT_PRI_NEVER: i8 = -128;
 
 /// Whether a drive-image path names a CD image (a cue sheet, a bare ISO,
-/// or a CHD). On the SCSI bus such an entry attaches a CD-ROM drive
+/// a Nero NRG, or a CHD). On the SCSI bus such an entry attaches a CD-ROM drive
 /// instead of a hard disk; the file extension is the format signal,
 /// exactly as it is for the hard-drive back ends (HDF vs. directory).
 pub fn is_cd_image_path(path: &std::path::Path) -> bool {
     path.extension().and_then(|e| e.to_str()).is_some_and(|e| {
         e.eq_ignore_ascii_case("cue")
             || e.eq_ignore_ascii_case("iso")
+            || e.eq_ignore_ascii_case("nrg")
             || e.eq_ignore_ascii_case("chd")
     })
 }

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -940,7 +940,7 @@ pub(crate) struct RawRtg {
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawCd {
-    /// Path to a CUE/BIN, bare ISO, or CHD CD image.
+    /// Path to a CUE/BIN, bare ISO, Nero NRG, or CHD CD image.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) image: Option<String>,
     /// Insert the disc this many emulated seconds after power-on

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2452,13 +2452,14 @@ fn lide_section_parses_board_rom_and_drives() -> Result<()> {
     Ok(())
 }
 
-/// CD images (CUE/BIN, bare ISO, and CHD) are recognised by extension:
+/// CD images (CUE/BIN, bare ISO, NRG, and CHD) are recognised by extension:
 /// they attach as SCSI CD-ROM drives on [scsi], and as ATAPI drives on
 /// [ide]/[lide].
 #[test]
 fn cd_images_fit_scsi_units_and_the_ide_port() -> Result<()> {
     assert!(is_cd_image_path(Path::new("games/Disc.CUE")));
     assert!(is_cd_image_path(Path::new("cd32.iso")));
+    assert!(is_cd_image_path(Path::new("compilation.NRG")));
     assert!(!is_cd_image_path(Path::new("workbench.hdf")));
     assert!(!is_cd_image_path(Path::new("directory/")));
 

--- a/src/ide_zorro.rs
+++ b/src/ide_zorro.rs
@@ -6,7 +6,7 @@
 //! sharing RIPPLE's ROM image and register layout, one channel), and
 //! **AT-Bus 2008** (the register model shared by that board's whole clone
 //! family, one channel). Drives may be hard disks or ATAPI CD-ROMs, either a
-//! `.cue`/`.iso`/`.chd` image on any `[lide] drives` slot or a real host
+//! `.cue`/`.iso`/`.nrg`/`.chd` image on any `[lide] drives` slot or a real host
 //! block device attached via `[[host_disk]] attach = "lide0-master"` (etc).
 //! The boot ROM is always user-supplied (a `lide.rom` / `lide-atbus.rom`
 //! release image from <https://github.com/LIV2/lide.device>) -- nothing is

--- a/src/scsi/cd.rs
+++ b/src/scsi/cd.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 //! SCSI-2 CD-ROM target: a read-only removable-medium device (peripheral
-//! type 5) backed by a CUE/BIN, bare ISO, or CHD image.
+//! type 5) backed by a CUE/BIN, bare ISO, Nero NRG, or CHD image.
 //!
 //! The command set covers what Amiga CD filesystems (CDFileSystem,
 //! CacheCDFS, AsimCDFS and friends) drive through a host adapter's
@@ -64,7 +64,7 @@ struct PendingDisc {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct ScsiCdRom {
     image: CdImage,
-    /// Path the drive was opened from (CUE, ISO, or CHD), for logs.
+    /// Path the drive was opened from (CUE, ISO, NRG, or CHD), for logs.
     path: PathBuf,
     /// Tray closed with the medium in place. START STOP UNIT's eject and
     /// load strobes toggle it; reloading raises a unit attention.
@@ -87,7 +87,7 @@ pub struct ScsiCdRom {
 }
 
 impl ScsiCdRom {
-    /// Open a CD-ROM unit from a CUE/BIN, bare ISO, or CHD image.
+    /// Open a CD-ROM unit from a CUE/BIN, bare ISO, Nero NRG, or CHD image.
     pub fn open(path: &Path) -> anyhow::Result<Self> {
         let image = CdImage::load(path)?;
         Ok(Self {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4889,7 +4889,7 @@ enum DroppedMediaKind {
     /// unknown extensions): FloppyImage::from_bytes sniffs the content and
     /// rejects what it cannot read, surfacing a clean OSD failure.
     Floppy,
-    /// A CD image (cue sheet, bare ISO, or CHD) for the CD drive.
+    /// A CD image (cue sheet, bare ISO, Nero NRG, or CHD) for the CD drive.
     Cd,
     /// Hard disk images cannot be hot-attached; point at the config screen.
     HardDisk,
@@ -4905,7 +4905,7 @@ fn classify_dropped_media(path: &std::path::Path) -> DroppedMediaKind {
         .extension()
         .map(|e| e.to_string_lossy().to_ascii_lowercase());
     match ext.as_deref() {
-        Some("cue") | Some("iso") | Some("chd") => DroppedMediaKind::Cd,
+        Some("cue") | Some("iso") | Some("nrg") | Some("chd") => DroppedMediaKind::Cd,
         Some("hdf") | Some("hdz") | Some("img") => DroppedMediaKind::HardDisk,
         Some("rom") => DroppedMediaKind::Rom,
         // Every shape `package` accepts, or a dropped zip would be taken

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -126,9 +126,9 @@ impl App {
                 dialog.add_filter("Floppy images", crate::floppy::IMAGE_EXTENSIONS)
             }
             // Only formats CdImage::load takes: a cue sheet, a bare ISO,
-            // or a CHD (a raw .bin is a cue sheet's payload, not loadable
+            // an NRG, or a CHD (a raw .bin is a cue sheet's payload, not loadable
             // alone).
-            LauncherField::CdImage => dialog.add_filter("CD images", &["cue", "iso", "chd"]),
+            LauncherField::CdImage => dialog.add_filter("CD images", &["cue", "iso", "nrg", "chd"]),
             // A WHDLoad package however it arrived: as distributed
             // (`.lha`), zipped, or as a bare `.slave` picked inside an
             // already-extracted one (stored as its directory, which is
@@ -146,7 +146,7 @@ impl App {
                 dialog.add_filter("SoundFonts", &["sf2", "SF2", "zip", "ZIP"])
             }
             // SCSI, IDE, and lide drive slots all take hard disks or CD
-            // images (a cue/iso/chd attaches a CD-ROM drive at that slot,
+            // images (a cue/iso/nrg/chd attaches a CD-ROM drive at that slot,
             // over SCSI or ATAPI as appropriate).
             LauncherField::ScsiUnit0
             | LauncherField::ScsiUnit1
@@ -162,7 +162,7 @@ impl App {
             | LauncherField::LideDrive2
             | LauncherField::LideDrive3 => dialog
                 .add_filter("Hard disk images", &["hdf", "hdz", "img", "bin"])
-                .add_filter("CD images", &["cue", "iso", "chd"]),
+                .add_filter("CD images", &["cue", "iso", "nrg", "chd"]),
             _ => dialog.add_filter("Hard disk images", &["hdf", "hdz", "img", "bin"]),
         };
         if let Some(dir) = start_dir {

--- a/src/video/window/app_media.rs
+++ b/src/video/window/app_media.rs
@@ -103,7 +103,7 @@ impl App {
         self.suspend_live_audio_for_host_io();
         let picked = rfd::FileDialog::new()
             .set_title("Load CD image")
-            .add_filter("CD images", &["cue", "iso", "chd"])
+            .add_filter("CD images", &["cue", "iso", "nrg", "chd"])
             .pick_file();
 
         // Re-baseline pacing after the modal dialog, as for floppies.
@@ -143,7 +143,7 @@ impl App {
 
     /// Route files dropped on the window: floppy images to a drive
     /// (directly, or via the chooser panel when several drives could take
-    /// them), a CD image (cue/iso/chd) to the CD drive, and everything else to
+    /// them), a CD image (cue/iso/nrg/chd) to the CD drive, and everything else to
     /// an explanatory notice. winit reports drops with no cursor position,
     /// so the target drive can only be picked after the fact.
     pub(super) fn handle_dropped_files(&mut self, files: Vec<PathBuf>) {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -7074,6 +7074,7 @@ fn dropped_media_classifies_by_extension() {
     assert_eq!(kind("mystery"), DroppedMediaKind::Floppy);
     assert_eq!(kind("game.CUE"), DroppedMediaKind::Cd);
     assert_eq!(kind("game.iso"), DroppedMediaKind::Cd);
+    assert_eq!(kind("game.NRG"), DroppedMediaKind::Cd);
     assert_eq!(kind("disk.hdf"), DroppedMediaKind::HardDisk);
     assert_eq!(kind("disk.HDZ"), DroppedMediaKind::HardDisk);
     assert_eq!(kind("disk.img"), DroppedMediaKind::HardDisk);

--- a/tests/README.md
+++ b/tests/README.md
@@ -178,6 +178,7 @@ baselines to maintain.
 | `picasso2_p96cts_reports_all_modes_clean` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-picasso2-cts.hdf` (startup runs p96cts at 8/16/24 bpp and writes `P96OUT:p96cts.result`) |
 | `graffity_z2_workbench_opens_640x480x8` / `graffity_z3_workbench_opens_640x480x8` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-graffity.hdf` (WB + Picasso96 with `Graffity.card`, default 640x480x8 screen) |
 | `chd_cd32_disc_serves_iso9660_data_and_smooth_audio` | `Pinball Fantasies (EU).chd` (a chdman v5 CD32 disc with a MODE1_RAW data track and CD audio tracks) |
+| `nrg_cd32_disc_serves_iso9660_data_and_smooth_audio` | `30 Games Compilation CD (2005)(Stuermer, A.).nrg` (a Nero 5 DAO CD32 disc with one MODE1/2048 data track and nine CD audio tracks) |
 | `toccata_ahi_driver_recognizes_the_board` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `toccata-ahi.hdf` (WB3.1 + AHI 4.18 with `toccata.audio` staged into `Devs/AHI` and Unit 0 set to Toccata) |
 | `zz9k_sdk_tools_pass_on_zorro_ii` / `zz9k_sdk_tools_pass_on_zorro_iii` | `zz9k/C/zz9k-{info,hash,chacha,aead,irqtest}` -- the unmodified ZZ9000 SDK m68k tools, built from the zz9000-sdk revision pinned in `docs/internals/zz9k.md` (build recipe in `tests/zz9k_sdk_tools.rs`'s module comment) |
 

--- a/tests/nrg_cd.rs
+++ b/tests/nrg_cd.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Asset-gated checks of the NRG CD backend against a real Nero 5 DAO image
+//! with one MODE1/2048 data track and CD audio tracks. The synthetic unit
+//! tests cover both footer generations and DAO/TAO layout mechanics; this
+//! regression proves the real CD32 image's footer offsets, ISO data, and
+//! CD-DA byte order.
+
+use copperline::cdrom::{CdImage, DATA_SECTOR_BYTES, RAW_SECTOR_BYTES};
+
+fn asset(name: &str) -> Option<std::path::PathBuf> {
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let dir = match std::env::var_os("COPPERLINE_TEST_ASSETS") {
+        Some(dir) => std::path::PathBuf::from(dir),
+        None => {
+            let dir = root.join("test-assets");
+            if dir.is_dir() {
+                dir
+            } else {
+                root
+            }
+        }
+    };
+    let path = dir.join(name);
+    path.is_file().then_some(path)
+}
+
+fn lag1_autocorrelation(sectors: &[[u8; RAW_SECTOR_BYTES]]) -> f64 {
+    let samples: Vec<f64> = sectors
+        .iter()
+        .flat_map(|sector| sector.chunks_exact(4))
+        .map(|frame| f64::from(i16::from_le_bytes([frame[0], frame[1]])))
+        .collect();
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+    let numerator: f64 = samples
+        .windows(2)
+        .map(|window| (window[0] - mean) * (window[1] - mean))
+        .sum();
+    let denominator: f64 = samples
+        .iter()
+        .map(|sample| (sample - mean) * (sample - mean))
+        .sum();
+    numerator / denominator
+}
+
+#[test]
+#[ignore = "needs the local CD32 NRG image (see tests/README.md)"]
+fn nrg_cd32_disc_serves_iso9660_data_and_smooth_audio() {
+    let Some(path) = asset("30 Games Compilation CD (2005)(Stuermer, A.).nrg") else {
+        eprintln!("skipping: CD32 NRG not in the asset directory");
+        return;
+    };
+    let mut image = CdImage::load(&path).expect("NRG loads");
+    assert_eq!(image.tracks().len(), 10);
+    assert!(image.tracks()[0].kind.is_data());
+    let audio_start = image
+        .tracks()
+        .iter()
+        .find(|track| !track.kind.is_data())
+        .expect("disc has an audio track")
+        .start_sector;
+
+    let mut pvd = [0u8; DATA_SECTOR_BYTES];
+    image.read_data_sector(16, &mut pvd).expect("PVD reads");
+    assert_eq!(&pvd[1..6], b"CD001", "ISO9660 identifier at LBA 16");
+
+    let mut sectors = vec![[0u8; RAW_SECTOR_BYTES]; 75];
+    let mut peak = 0i16;
+    for (index, sector) in sectors.iter_mut().enumerate() {
+        image
+            .read_audio_sector(audio_start + 300 + index as u32, sector)
+            .expect("audio sector reads");
+        for sample in sector.chunks_exact(2) {
+            peak = peak.max(i16::from_le_bytes([sample[0], sample[1]]).saturating_abs());
+        }
+    }
+    assert!(peak > 1000, "audio window is not silence (peak {peak})");
+    let correlation = lag1_autocorrelation(&sectors);
+    assert!(
+        correlation > 0.5,
+        "CD-DA is not smooth little-endian PCM (lag-1 autocorrelation {correlation:.3})"
+    );
+}


### PR DESCRIPTION
## Summary

- parse legacy `NERO`/32-bit and modern `NER5`/64-bit CD images
- support DAO (`CUES`/`DAOI`, `CUEX`/`DAOX`) and TAO (`ETNF`/`ETN2`) layouts for MODE1/2048, MODE1/2352, and CD-DA tracks
- recognize `.nrg` media throughout configuration, runtime insertion, drag-and-drop, file dialogs, docs, and fuzzing
- add synthetic parser/save-state coverage and an asset-gated real CD32 NRG regression

## Verification

- `cargo test --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `cargo build --release --locked`
- `COPPERLINE_TEST_ASSETS=/Users/linuxjedi/Downloads cargo test --release --test nrg_cd -- --ignored --nocapture`
- deterministic CD32 headless boot of the supplied 10-track NRG to its game selector at 35 emulated seconds