### PR TITLE
lide: make every drive slot configurable, and put each boot priority under its drive

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -441,11 +441,16 @@ slow = "512K"
 # uses to test in-development driver builds). rom_bank2 optionally supplies
 # a second flash bank (e.g. cdfs.rom, LIV2's CD filesystem); it needs rom
 # and does not apply to atbus2008, which has no banking.
+# One drive key per slot, in (channel, master/slave) order: drive0/drive1 are
+# channel 0's master/slave, drive2/drive3 are channel 1's (ripple only). Each
+# is independent, so a slot can be left empty without ending the list -- the
+# same shape as [ide]'s master/slave and [scsi]'s unit0..unit6. The older
+# positional `drives = [...]` array is still read for existing configs.
 # [lide]
 # board = "ripple"
 # rom = "lide.rom"
-# drives = ["workbench.hdf", "data.hdf"]
-# drives = [{ path = "workbench.hdf", bootpri = 6 }]   # table form, as for [ide]
+# drive0 = "workbench.hdf"
+# drive1 = { path = "data.hdf", bootpri = 6 }   # table form, as for [ide]
 
 
 [chipset]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1616,12 +1616,27 @@ CDTV-RAM-IDE, Zorro-LAN-IDE), one register model covering the whole family,
 one channel, no ROM banking. None of the three wire an interrupt line --
 `lide.device` is a purely polling driver.
 
-`drives` takes the same bare-path/table form as `[ide]`/`[scsi]` (RDB images,
-bare partition hardfiles, `.hdz`, host directories, and the `{ path = "...",
-name = "...", bootpri = N, filesystem = "..." }` table), in (channel,
-master/slave) order:
-entries 0 and 1 are channel 0's master and slave, entries 2 and 3 are channel
-1's (`"ripple"` only -- `"ride"` and `"atbus2008"` have one channel).
+`drive0`..`drive3` take the same bare-path/table form as `[ide]`/`[scsi]`
+(RDB images, bare partition hardfiles, `.hdz`, host directories, and the
+`{ path = "...", name = "...", bootpri = N, filesystem = "..." }` table), one
+key per slot in (channel, master/slave) order: `drive0` and `drive1` are
+channel 0's master and slave, `drive2` and `drive3` are channel 1's
+(`"ripple"` only -- `"ride"` and `"atbus2008"` have one channel). Each is
+independent, so any slot can be filled or left empty on its own, the same way
+`[ide]`'s `master`/`slave` and `[scsi]`'s `unit0`..`unit6` are:
+
+```toml
+[lide]
+board = "ripple"
+rom = "lide.rom"
+drive1 = "ch0-slave.hdf"   # channel 0 slave, with no master fitted
+```
+
+An older `drives = [...]` array is still read, so configs written before the
+named keys existed keep working. It is positional and cannot express a gap
+(the first empty entry ends the list), which is why the named keys replaced
+it; a named key wins over the same slot in the array, and saving from the
+launcher rewrites a config to the named form.
 
 `rom` is **always user-supplied**, never bundled: fetch a release from
 [lide.device's GitHub releases page](https://github.com/LIV2/lide.device/releases)

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -814,23 +814,22 @@ impl RawLide {
     /// `drives` array filled in underneath: a named key always wins, so a
     /// config carrying both is unambiguous rather than order-dependent.
     pub(crate) fn drive_slots(&self) -> [Option<RawDrive>; 4] {
-        let named = [
+        let named = self.named_drive_slots();
+        std::array::from_fn(|i| named[i].clone().or_else(|| self.drives.get(i).cloned()))
+    }
+
+    /// Just the named `driveN` keys, without the deprecated array
+    /// underneath. Validation checks these per slot so it can name the key
+    /// at fault; a slot filled from the legacy array is covered by that
+    /// array's own length rule instead, since reporting it as `driveN`
+    /// would name a key the config never wrote.
+    pub(crate) fn named_drive_slots(&self) -> [Option<RawDrive>; 4] {
+        [
             self.drive0.clone(),
             self.drive1.clone(),
             self.drive2.clone(),
             self.drive3.clone(),
-        ];
-        std::array::from_fn(|i| named[i].clone().or_else(|| self.drives.get(i).cloned()))
-    }
-
-    /// Whether any named `driveN` key was given, so validation can tell a
-    /// legacy `drives` config apart from a modern one and only apply the
-    /// positional array's own length rule to the former.
-    pub(crate) fn has_named_drives(&self) -> bool {
-        self.drive0.is_some()
-            || self.drive1.is_some()
-            || self.drive2.is_some()
-            || self.drive3.is_some()
+        ]
     }
 }
 

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -784,8 +784,54 @@ pub(crate) struct RawLide {
     pub(crate) rom_bank2: Option<String>,
     /// Drive images, in (channel, master/slave) order: index 0-1 are
     /// channel 0's master/slave, index 2-3 are channel 1's (RIPPLE only).
+    ///
+    /// Deprecated in favour of the `drive0`..`drive3` keys below, which can
+    /// leave a slot empty -- a positional array cannot express "channel 0
+    /// slave only", so this form forced the launcher to hide any slot past
+    /// the first empty one. Still read, so configs written before the named
+    /// keys existed keep working; never written back out.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) drives: Vec<RawDrive>,
+    /// Channel 0 master. Named per slot, like `[ide]`'s `master`/`slave`
+    /// and `[scsi]`'s `unit0`..`unit6`, so any slot can be filled or left
+    /// empty independently of the others.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) drive0: Option<RawDrive>,
+    /// Channel 0 slave.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) drive1: Option<RawDrive>,
+    /// Channel 1 master (RIPPLE only -- RIDE and AT-Bus 2008 have one
+    /// channel).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) drive2: Option<RawDrive>,
+    /// Channel 1 slave (RIPPLE only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) drive3: Option<RawDrive>,
+}
+
+impl RawLide {
+    /// The four drive slots as named keys, with the deprecated positional
+    /// `drives` array filled in underneath: a named key always wins, so a
+    /// config carrying both is unambiguous rather than order-dependent.
+    pub(crate) fn drive_slots(&self) -> [Option<RawDrive>; 4] {
+        let named = [
+            self.drive0.clone(),
+            self.drive1.clone(),
+            self.drive2.clone(),
+            self.drive3.clone(),
+        ];
+        std::array::from_fn(|i| named[i].clone().or_else(|| self.drives.get(i).cloned()))
+    }
+
+    /// Whether any named `driveN` key was given, so validation can tell a
+    /// legacy `drives` config apart from a modern one and only apply the
+    /// positional array's own length rule to the former.
+    pub(crate) fn has_named_drives(&self) -> bool {
+        self.drive0.is_some()
+            || self.drive1.is_some()
+            || self.drive2.is_some()
+            || self.drive3.is_some()
+    }
 }
 
 /// `[a2065]` Ethernet board. Fitting the board enables host networking, which

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2420,6 +2420,37 @@ fn lide_named_drive_keys_allow_holes_and_beat_the_legacy_array() -> Result<()> {
     )
     .unwrap_err();
     assert!(err.to_string().contains("drive2"), "{err:#}");
+
+    // A named key must not buy an over-long legacy array a free pass:
+    // `drive_slots` only reads the first four entries, so a fifth would
+    // otherwise be dropped without a word.
+    let err = parse_config(
+        r#"
+            [lide]
+            board = "ripple"
+            drives = ["a.hdf", "b.hdf", "c.hdf", "d.hdf", "e.hdf"]
+            drive0 = "named.hdf"
+            "#,
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("5 entries"), "{err:#}");
+
+    // ...and a legacy-array overflow with no named key still reports once,
+    // by length, not as a `driveN` key the config never wrote.
+    let err = parse_config(
+        r#"
+            [lide]
+            board = "ride"
+            drives = ["a.hdf", "b.hdf", "c.hdf"]
+            "#,
+    )
+    .unwrap_err();
+    let text = err.to_string();
+    assert!(text.contains("3 entries"), "{err:#}");
+    assert!(
+        !text.contains("drive2"),
+        "should not name an unwritten key: {err:#}"
+    );
     Ok(())
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2353,6 +2353,77 @@ fn scsi_section_parses_units_and_requires_the_boot_rom() -> Result<()> {
 }
 
 #[test]
+fn lide_named_drive_keys_allow_holes_and_beat_the_legacy_array() -> Result<()> {
+    // A slot filled with the one before it empty -- the whole point of the
+    // named keys, and impossible to express with the positional `drives`
+    // array that predates them.
+    let cfg = parse_config(
+        r#"
+            [lide]
+            board = "ripple"
+            drive1 = "ch0-slave.hdf"
+            drive3 = "ch1-slave.hdf"
+            "#,
+    )?;
+    assert!(cfg.lide.drives[0].is_none());
+    assert_eq!(
+        cfg.lide.drives[1].as_ref().map(|d| d.path.as_path()),
+        Some(Path::new("ch0-slave.hdf"))
+    );
+    assert!(cfg.lide.drives[2].is_none());
+    assert_eq!(
+        cfg.lide.drives[3].as_ref().map(|d| d.path.as_path()),
+        Some(Path::new("ch1-slave.hdf"))
+    );
+
+    // The deprecated array still loads, so configs written before the named
+    // keys existed keep working unchanged.
+    let cfg = parse_config(
+        r#"
+            [lide]
+            board = "ripple"
+            drives = ["dh0.hdf", "dh1.hdf"]
+            "#,
+    )?;
+    assert_eq!(
+        cfg.lide.drives[0].as_ref().map(|d| d.path.as_path()),
+        Some(Path::new("dh0.hdf"))
+    );
+    assert_eq!(
+        cfg.lide.drives[1].as_ref().map(|d| d.path.as_path()),
+        Some(Path::new("dh1.hdf"))
+    );
+
+    // A named key wins over the same slot in the legacy array, so a config
+    // carrying both is unambiguous rather than order-dependent.
+    let cfg = parse_config(
+        r#"
+            [lide]
+            board = "ripple"
+            drives = ["from-array.hdf"]
+            drive0 = "from-named.hdf"
+            "#,
+    )?;
+    assert_eq!(
+        cfg.lide.drives[0].as_ref().map(|d| d.path.as_path()),
+        Some(Path::new("from-named.hdf"))
+    );
+
+    // A named key naming a channel the board does not have is an error, and
+    // says which slot rather than just counting entries.
+    let err = parse_config(
+        r#"
+            [lide]
+            board = "ride"
+            drive2 = "ch1-master.hdf"
+            "#,
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("drive2"), "{err:#}");
+    Ok(())
+}
+
+#[test]
 fn lide_section_parses_board_rom_and_drives() -> Result<()> {
     let cfg = parse_config(
         r#"

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -613,28 +613,31 @@ impl TryFrom<RawConfig> for Config {
         // "rom_bank2 needs rom" instead of the whole table being silently
         // accepted as a no-op.
         let max_drives = lide_board.max_drives();
-        if raw.lide.has_named_drives() {
-            // Named keys are checked per slot rather than by count: with
-            // holes now expressible, "how many are set" no longer says
-            // which ones, and `drive2` on a one-channel board is the error
-            // worth naming.
-            for (slot, raw_drive) in raw_lide_slots.iter().enumerate() {
-                if raw_drive.is_some() && slot >= max_drives {
-                    errors.push(anyhow!(
-                        "[lide] drive{slot} is on channel {}; {} only has {max_drives} drive(s)",
-                        slot / 2,
-                        lide_board.name()
-                    ));
-                }
-            }
-        } else if raw.lide.drives.len() > max_drives {
-            // The deprecated positional array keeps its own length message,
-            // which names the real problem for a config written that way.
+        // The deprecated positional array's length is checked whatever else
+        // the section sets: a named key must not buy an over-long array a
+        // free pass, and `drive_slots` only reads the first four entries,
+        // so an unchecked fifth would be dropped without a word.
+        if raw.lide.drives.len() > max_drives {
             errors.push(anyhow!(
                 "[lide] drives has {} entries; {} only has {max_drives} drive(s)",
                 raw.lide.drives.len(),
                 lide_board.name()
             ));
+        }
+        // Named keys are checked per slot rather than by count: with holes
+        // expressible, "how many are set" no longer says which ones, and
+        // `drive2` on a one-channel board is the error worth naming. Only
+        // the named ones -- a slot filled from the legacy array is already
+        // covered above, and calling it `driveN` would name a key the
+        // config never wrote.
+        for (slot, named) in raw.lide.named_drive_slots().iter().enumerate() {
+            if named.is_some() && slot >= max_drives {
+                errors.push(anyhow!(
+                    "[lide] drive{slot} is on channel {}; {} only has {max_drives} drive(s)",
+                    slot / 2,
+                    lide_board.name()
+                ));
+            }
         }
         if lide.rom_bank2.is_some() && lide.rom.is_none() {
             errors.push(anyhow!(

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -591,9 +591,12 @@ impl TryFrom<RawConfig> for Config {
                 }
             },
         };
+        let raw_lide_slots = raw.lide.drive_slots();
         let mut lide_drives: [Option<DriveImage>; 4] = Default::default();
-        for (slot, raw_drive) in raw.lide.drives.iter().enumerate().take(4) {
-            lide_drives[slot] = Some(drive_image(raw_drive.clone())?);
+        for (slot, raw_drive) in raw_lide_slots.iter().enumerate() {
+            if let Some(raw_drive) = raw_drive {
+                lide_drives[slot] = Some(drive_image(raw_drive.clone())?);
+            }
         }
         let lide = LideConfig {
             board: lide_board,
@@ -610,7 +613,23 @@ impl TryFrom<RawConfig> for Config {
         // "rom_bank2 needs rom" instead of the whole table being silently
         // accepted as a no-op.
         let max_drives = lide_board.max_drives();
-        if raw.lide.drives.len() > max_drives {
+        if raw.lide.has_named_drives() {
+            // Named keys are checked per slot rather than by count: with
+            // holes now expressible, "how many are set" no longer says
+            // which ones, and `drive2` on a one-channel board is the error
+            // worth naming.
+            for (slot, raw_drive) in raw_lide_slots.iter().enumerate() {
+                if raw_drive.is_some() && slot >= max_drives {
+                    errors.push(anyhow!(
+                        "[lide] drive{slot} is on channel {}; {} only has {max_drives} drive(s)",
+                        slot / 2,
+                        lide_board.name()
+                    ));
+                }
+            }
+        } else if raw.lide.drives.len() > max_drives {
+            // The deprecated positional array keeps its own length message,
+            // which names the real problem for a config written that way.
             errors.push(anyhow!(
                 "[lide] drives has {} entries; {} only has {max_drives} drive(s)",
                 raw.lide.drives.len(),

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -2307,6 +2307,11 @@ impl MachineSetup {
     /// "no boot ROM = AROS" distinction, and the `[[zorro]]` board paths.
     pub fn from_raw(raw: &RawConfig) -> Result<Self> {
         let cfg: Config = raw.clone().try_into()?;
+        // Boot priority is read from the raw form (the validated
+        // `DriveImage` resolves it to a number, losing "unset"), so this
+        // needs the same named-key-over-legacy-array merge validation used
+        // rather than the positional array alone.
+        let lide_raw_slots = raw.lide.drive_slots();
         // One tick box governs both kinds of bay, so read it from whichever
         // of the two a bay actually has.
         let df_write_protected = std::array::from_fn(|i| {
@@ -2437,10 +2442,10 @@ impl MachineSetup {
                 cfg.lide.drives[i].as_ref().is_some_and(|d| d.path.is_dir())
             }),
             lide_drive_bootpri: std::array::from_fn(|i| {
-                boot_priority_of(raw.lide.drives.get(i).and_then(|d| d.bootpri))
+                boot_priority_of(lide_raw_slots[i].as_ref().and_then(|d| d.bootpri))
             }),
             lide_drive_boot_off: std::array::from_fn(|i| {
-                boot_is_off(raw.lide.drives.get(i).and_then(|d| d.bootpri))
+                boot_is_off(lide_raw_slots[i].as_ref().and_then(|d| d.bootpri))
             }),
             filesys_dirs: std::array::from_fn(|i| {
                 raw.filesys.get(i).map(|m| PathBuf::from(&m.path))
@@ -2882,26 +2887,34 @@ impl MachineSetup {
             raw.lide.rom_bank2 = (board != LidePersonality::AtBus2008)
                 .then(|| self.lide_rom_bank2.as_deref().map(path_string))
                 .flatten();
-            // `[lide] drives` is a positional list in the config file -- a hole
-            // cannot be represented -- so this stops at the first empty slot
-            // rather than filtering, trusting `clear_path`'s cascade to keep
-            // the array itself always gap-free.
+            // One named `driveN` key per slot, so an empty slot before a
+            // filled one round-trips: each is emitted independently rather
+            // than as a positional array that could not express the hole.
+            // The deprecated `drives` array is never written back -- reading
+            // one and saving migrates the config to the named form.
             const LIDE_DRIVE_BOOT_FIELDS: [LauncherField; 4] = [
                 F::LideDrive0Boot,
                 F::LideDrive1Boot,
                 F::LideDrive2Boot,
                 F::LideDrive3Boot,
             ];
-            raw.lide.drives = (0..board.max_drives())
-                .map_while(|i| {
-                    drive_raw(
-                        self.lide_drives[i].as_deref(),
-                        self.lide_drive_names[i].as_deref(),
-                        self.effective_bootpri(LIDE_DRIVE_BOOT_FIELDS[i]),
-                        self.lide_drive_fs[i],
-                    )
-                })
-                .collect();
+            let slot_raw = |i: usize| {
+                (i < board.max_drives())
+                    .then(|| {
+                        drive_raw(
+                            self.lide_drives[i].as_deref(),
+                            self.lide_drive_names[i].as_deref(),
+                            self.effective_bootpri(LIDE_DRIVE_BOOT_FIELDS[i]),
+                            self.lide_drive_fs[i],
+                        )
+                    })
+                    .flatten()
+            };
+            raw.lide.drives = Vec::new();
+            raw.lide.drive0 = slot_raw(0);
+            raw.lide.drive1 = slot_raw(1);
+            raw.lide.drive2 = slot_raw(2);
+            raw.lide.drive3 = slot_raw(3);
         }
         // Host FS mounts: the edited slots (empty ones drop out), then any
         // hand-written extras beyond what the GUI shows.
@@ -3435,16 +3448,15 @@ impl MachineSetup {
             F::LideRomBank2 => self
                 .lide_board
                 .is_none_or(|b| b == LidePersonality::AtBus2008),
-            // `[lide] drives` is a positional list in the config file -- a
-            // hole cannot be represented -- so a slot beyond the board's
-            // channel count (RIDE/AT-Bus 2008 have one; RIPPLE has two) or
-            // beyond the first empty slot stays hidden: it is not just
-            // inapplicable, filling it would be unrepresentable.
+            // Only a slot the fitted board does not have stays hidden
+            // (RIDE/AT-Bus 2008 have one channel, RIPPLE two). Every slot
+            // the board *does* have is always editable, the same way
+            // `[ide]`'s master/slave and `[scsi]`'s units are: each is its
+            // own `driveN` key, so filling one without the one before it is
+            // representable.
             F::LideDrive0 | F::LideDrive1 | F::LideDrive2 | F::LideDrive3 => {
-                lide_drive_index(field).is_some_and(|i| {
-                    self.lide_board.is_none_or(|b| b.max_drives() <= i)
-                        || (i > 0 && self.lide_drives[i - 1].is_none())
-                })
+                lide_drive_index(field)
+                    .is_some_and(|i| self.lide_board.is_none_or(|b| b.max_drives() <= i))
             }
             _ => false,
         }
@@ -5095,17 +5107,6 @@ impl MachineSetup {
             self.clear_drive_bootpri(field);
             self.refresh_drive_is_dir(field);
         }
-        // `[lide] drives` is a positional list in the config file -- a hole
-        // cannot be represented -- so clearing a slot also clears every slot
-        // after it, keeping the array always representable as a config.
-        if let Some(i) = lide_drive_index(field) {
-            for slot in i + 1..self.lide_drives.len() {
-                self.lide_drives[slot] = None;
-                self.lide_drive_names[slot] = None;
-                self.lide_drive_bootpri[slot] = None;
-                self.lide_drive_boot_off[slot] = false;
-            }
-        }
     }
 
     /// Reset a hard-disk drive's boot priority to unset (shown as 0) and its
@@ -5750,18 +5751,6 @@ impl MachineSetup {
                 }
                 if let Some(name) = self.lide_drive_names.get_mut(idx) {
                     *name = None;
-                }
-                // `[lide] drives` is a positional list -- a hole cannot be
-                // represented -- so a host disk taking over this slot must
-                // cascade-clear every later slot too, exactly like
-                // `clear_path` does for the image case, or `to_raw`'s
-                // `map_while` would silently stop emitting at this slot and
-                // drop any image still sitting in a later one.
-                for slot in idx + 1..self.lide_drives.len() {
-                    self.lide_drives[slot] = None;
-                    self.lide_drive_names[slot] = None;
-                    self.lide_drive_bootpri[slot] = None;
-                    self.lide_drive_boot_off[slot] = false;
                 }
             }
             crate::config::HostDiskAttach::Scsi(unit) => {

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1070,12 +1070,12 @@ const LIDE_ROWS: [Row; 11] = [
     row(F::LideRom, "Boot ROM", PathRow),
     row(F::LideRomBank2, "Boot ROM bank 2", PathRow),
     row(F::LideDrive0, "Drive 0", Drive),
-    row(F::LideDrive1, "Drive 1", Drive),
-    row(F::LideDrive2, "Drive 2", Drive),
-    row(F::LideDrive3, "Drive 3", Drive),
     row(F::LideDrive0Boot, "  Boot priority", Bootpri),
+    row(F::LideDrive1, "Drive 1", Drive),
     row(F::LideDrive1Boot, "  Boot priority", Bootpri),
+    row(F::LideDrive2, "Drive 2", Drive),
     row(F::LideDrive2Boot, "  Boot priority", Bootpri),
+    row(F::LideDrive3, "Drive 3", Drive),
     row(F::LideDrive3Boot, "  Boot priority", Bootpri),
 ];
 // The WHDLoad Settings page: the game to launch, then what staging
@@ -3436,11 +3436,16 @@ impl MachineSetup {
                         .and_then(|drive| self.drive_holds(drive))
                         .is_none()
             }
+            // Each sits directly under the drive it belongs to, and stays
+            // on the page when that drive is empty -- greyed with "No
+            // drive" (see `disabled_reason`) rather than vanishing, so the
+            // rows do not reshuffle under the cursor as slots are filled
+            // and the indented label always has its own drive above it.
+            // Only a slot the board does not have goes, along with the
+            // drive row itself.
             F::LideDrive0Boot | F::LideDrive1Boot | F::LideDrive2Boot | F::LideDrive3Boot => {
-                self.lide_board.is_none()
-                    || Self::boot_field_drive(field)
-                        .and_then(|drive| self.drive_holds(drive))
-                        .is_none()
+                lide_drive_index(field)
+                    .is_some_and(|i| self.lide_board.is_none_or(|b| b.max_drives() <= i))
             }
             // Nothing to configure without a board fitted.
             F::LideRom => self.lide_board.is_none(),

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -3423,23 +3423,19 @@ fn lide_rows_are_hidden_without_a_board_and_rom_bank2_hidden_on_atbus2008() {
     s.cycle(F::LideBoard, true); // RIPPLE: two channels, four drives
     assert!(!s.row_hidden(F::LideRom));
     assert!(!s.row_hidden(F::LideRomBank2));
+    // Every slot the fitted board has is configurable straight away, the
+    // same as `[ide]`'s master/slave and `[scsi]`'s units: each is its own
+    // `driveN` key, so a hole is representable and nothing is gated on the
+    // slot before it holding an image.
     assert!(!s.row_hidden(F::LideDrive0));
-    // Drive 1 is gated on drive 0 holding an image: `[lide] drives` is a
-    // positional list, so a hole cannot be represented in the config.
-    assert!(s.row_hidden(F::LideDrive1));
-    s.set_path(F::LideDrive0, PathBuf::from("a.hdf"));
     assert!(!s.row_hidden(F::LideDrive1));
-    assert!(s.row_hidden(F::LideDrive2), "drive 1 is still empty");
-    s.set_path(F::LideDrive1, PathBuf::from("b.hdf"));
-    s.set_path(F::LideDrive2, PathBuf::from("c.hdf"));
+    assert!(!s.row_hidden(F::LideDrive2));
     assert!(!s.row_hidden(F::LideDrive3));
 
     s.cycle(F::LideBoard, true); // RIDE: one channel, two drives, four banks
     assert!(!s.row_hidden(F::LideRomBank2), "RIDE has flash banking too");
     assert!(s.row_hidden(F::LideDrive2), "RIDE has only one channel");
     assert!(s.row_hidden(F::LideDrive3));
-    // Cycling the board dropped the drives beyond RIDE's channel count.
-    assert!(s.to_raw().lide.drives.len() <= 2);
 
     s.cycle(F::LideBoard, true); // AT-Bus 2008: one channel, no banking
     assert!(s.row_hidden(F::LideRomBank2));
@@ -3463,15 +3459,17 @@ fn lide_drives_round_trip_in_channel_order_with_boot_priority() {
     assert_eq!(s.disabled_reason(F::LideDrive1Boot), None);
     assert!(
         s.row_hidden(F::LideDrive2Boot),
-        "empty slot stays off the page"
+        "an empty slot has nothing to prioritise, so its boot row stays off"
     );
 
     let raw = s.to_raw();
     assert_eq!(raw.lide.board.as_deref(), Some("ripple"));
-    assert_eq!(raw.lide.drives.len(), 2);
-    assert_eq!(raw.lide.drives[0].path, "ch0-master.hdf");
-    assert_eq!(raw.lide.drives[0].bootpri, Some(5));
-    assert_eq!(raw.lide.drives[1].path, "ch0-slave.hdf");
+    // Named per-slot keys, never the deprecated positional array.
+    assert!(raw.lide.drives.is_empty());
+    assert_eq!(raw.lide.drive0.as_ref().unwrap().path, "ch0-master.hdf");
+    assert_eq!(raw.lide.drive0.as_ref().unwrap().bootpri, Some(5));
+    assert_eq!(raw.lide.drive1.as_ref().unwrap().path, "ch0-slave.hdf");
+    assert!(raw.lide.drive2.is_none());
 
     let back = MachineSetup::from_raw(&raw).unwrap();
     assert_eq!(back.path(F::LideDrive0), Some(Path::new("ch0-master.hdf")));
@@ -3539,22 +3537,32 @@ fn drive_filesystem_toggle_applies_only_to_disk_backed_fields_and_tracks_path_sh
     std::fs::remove_dir_all(&dir).ok();
 }
 
+/// Clearing a slot is just that one slot: with a named `driveN` key each,
+/// a gap is representable, so emptying channel 0's master no longer drags
+/// everything after it out too.
 #[test]
-fn lide_clearing_a_drive_cascades_to_later_slots() {
+fn lide_clearing_a_drive_leaves_later_slots_alone() {
     use LauncherField as F;
     let mut s = MachineSetup::default();
     s.cycle(F::LideBoard, true); // RIPPLE
     s.set_path(F::LideDrive0, PathBuf::from("a.hdf"));
     s.set_path(F::LideDrive1, PathBuf::from("b.hdf"));
     s.set_path(F::LideDrive2, PathBuf::from("c.hdf"));
-    assert_eq!(s.to_raw().lide.drives.len(), 3);
 
-    // Clearing an earlier slot cannot leave a later one dangling: the
-    // config format has no way to represent the resulting gap.
     s.clear_path(F::LideDrive0);
-    assert_eq!(s.path(F::LideDrive1), None);
-    assert_eq!(s.path(F::LideDrive2), None);
-    assert!(s.to_raw().lide.drives.is_empty());
+    assert_eq!(s.path(F::LideDrive0), None);
+    assert_eq!(s.path(F::LideDrive1), Some(Path::new("b.hdf")));
+    assert_eq!(s.path(F::LideDrive2), Some(Path::new("c.hdf")));
+
+    // ...and the hole survives a round trip through the config.
+    let raw = s.to_raw();
+    assert!(raw.lide.drive0.is_none(), "the emptied slot stays empty");
+    assert_eq!(raw.lide.drive1.as_ref().unwrap().path, "b.hdf");
+    assert_eq!(raw.lide.drive2.as_ref().unwrap().path, "c.hdf");
+    let back = MachineSetup::from_raw(&raw).unwrap();
+    assert_eq!(back.path(F::LideDrive0), None);
+    assert_eq!(back.path(F::LideDrive1), Some(Path::new("b.hdf")));
+    assert_eq!(back.path(F::LideDrive2), Some(Path::new("c.hdf")));
 }
 
 /// Lide host-disk attachment points are only fitted for a channel the
@@ -3599,19 +3607,17 @@ fn lide_host_disk_attach_points_are_fitted_by_board_channel_count() {
     );
 }
 
-/// Mounting a host disk on an earlier lide slot must cascade-clear later
-/// slots exactly like `clear_path` does for the image case -- otherwise
-/// `[lide] drives` (a positional array) would go on carrying images the
-/// UI, and a saved config, no longer have any way to show.
+/// Mounting a host disk takes over exactly the slot it attaches to: the
+/// images on the other slots keep their own `driveN` keys, so there is no
+/// gap to avoid and nothing else to clear.
 #[test]
-fn lide_host_disk_on_an_earlier_slot_cascades_to_later_slots() {
+fn lide_host_disk_takes_only_the_slot_it_attaches_to() {
     use LauncherField as F;
     let mut s = MachineSetup::default();
     s.cycle(F::LideBoard, true); // RIPPLE
     s.set_path(F::LideDrive0, PathBuf::from("ch0-master.hdf"));
     s.set_path(F::LideDrive1, PathBuf::from("ch0-slave.hdf"));
     s.set_path(F::LideDrive2, PathBuf::from("ch1-master.hdf"));
-    assert_eq!(s.to_raw().lide.drives.len(), 3);
 
     s.set_host_disks_for_test(vec![HostDiskRow {
         id: "disk4".to_string(),
@@ -3626,11 +3632,14 @@ fn lide_host_disk_on_an_earlier_slot_cascades_to_later_slots() {
     let mounted = s.mount_host_disks().expect("channel 0 master is fitted");
     assert_eq!(mounted.len(), 1);
 
-    // The host disk took slot 0; slots 1 and 2's images must not be left
-    // dangling as invisible ghosts behind it.
-    assert_eq!(s.path(F::LideDrive1), None);
-    assert_eq!(s.path(F::LideDrive2), None);
-    assert!(s.to_raw().lide.drives.is_empty());
+    // The host disk took slot 0 and only slot 0.
+    assert_eq!(s.path(F::LideDrive0), None, "the host disk owns this slot");
+    assert_eq!(s.path(F::LideDrive1), Some(Path::new("ch0-slave.hdf")));
+    assert_eq!(s.path(F::LideDrive2), Some(Path::new("ch1-master.hdf")));
+    let raw = s.to_raw();
+    assert!(raw.lide.drive0.is_none());
+    assert_eq!(raw.lide.drive1.as_ref().unwrap().path, "ch0-slave.hdf");
+    assert_eq!(raw.lide.drive2.as_ref().unwrap().path, "ch1-master.hdf");
 }
 
 /// Cycling the lide board to a personality with fewer channels must drop

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -3457,10 +3457,18 @@ fn lide_drives_round_trip_in_channel_order_with_boot_priority() {
     assert!(!s.has_boot_priority_rows());
     assert_eq!(s.value_label(F::LideDrive0Boot), "5");
     assert_eq!(s.disabled_reason(F::LideDrive1Boot), None);
-    assert!(
-        s.row_hidden(F::LideDrive2Boot),
-        "an empty slot has nothing to prioritise, so its boot row stays off"
-    );
+    // An empty slot keeps its boot row, greyed rather than hidden, so the
+    // page does not reshuffle as slots are filled.
+    assert!(!s.row_hidden(F::LideDrive2Boot));
+    assert_eq!(s.disabled_reason(F::LideDrive2Boot), Some("No drive"));
+    // A slot the fitted board does not have goes entirely, drive row and
+    // boot row together.
+    s.cycle(F::LideBoard, true); // RIDE: one channel
+    assert!(s.row_hidden(F::LideDrive2));
+    assert!(s.row_hidden(F::LideDrive2Boot));
+    s.cycle(F::LideBoard, true); // AT-Bus 2008
+    s.cycle(F::LideBoard, true); // None
+    s.cycle(F::LideBoard, true); // back to RIPPLE for the round trip below
 
     let raw = s.to_raw();
     assert_eq!(raw.lide.board.as_deref(), Some("ripple"));


### PR DESCRIPTION
Two related fixes to the launcher's LIDE page, which behaved unlike the Storage page next to it.

## Every drive slot is configurable straight away

The page hid every drive slot past the first empty one, and cascade-cleared later slots when one was emptied. That wasn't a UI choice: `[lide] drives` was a **positional TOML array**, so "channel 0 slave, no master" simply could not be written to a config file. `[ide]`'s `master`/`slave` and `[scsi]`'s `unit0`..`unit6` are named keys, which is why those pages have never had this problem.

Adds `[lide] drive0`..`drive3`, one per slot in the same (channel, master/slave) order, so a gap is representable and every slot the fitted board has is editable immediately. With that, both cascades go — the one in `clear_path`, and one in the host-disk attach path that had the same positional-array reason and would silently wipe later slots when a host disk was mounted on channel 0 master. That branch now behaves like the SCSI branch beside it: a host disk claims only the slot it attaches to.

**Existing configs keep working.** The deprecated `drives` array is still read; a named key wins over the same slot in it, and the launcher never writes the array back, so saving migrates a config to the named form. Validation follows suit: named keys are checked per slot (naming `drive2` on a one-channel board rather than counting entries), with the array's own length message kept for configs written that way.

## Each boot priority sits under its drive

The four priority rows sat in a block after the four drive rows, so each was detached from the drive it belongs to — and since they all read `"  Boot priority"` identically, nothing on screen said which drive each was for. They also vanished when their slot was empty, so the page reshuffled under the cursor as slots were filled.

Interleaved instead — drive, its priority, next drive — which is the shape the HostFS page already uses (`HOSTFS0` / Boot priority / Access, then `HOSTFS1`...). Same eleven rows, just reordered, so the page still fits. An empty slot now keeps its priority row, greyed with the `"No drive"` reason `disabled_reason` already returned for it. Only a slot the fitted board does not have is hidden, and then the drive row and its priority row go together.

Resulting page (RIPPLE, only Drive 1 filled), verified against the real row-rendering path:

```
Board
Boot ROM
Boot ROM bank 2
Drive 0
  Boot priority        [greyed: No drive]
Drive 1
  Boot priority
Drive 2
  Boot priority        [greyed: No drive]
Drive 3
  Boot priority        [greyed: No drive]
```

## Testing

`cargo test --lib` (2838 pass), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the MyST docs build are all clean. Four launcher tests that encoded the old cascade behaviour are inverted to assert holes survive a round trip; new config tests cover holes, the legacy array, named-beats-array precedence, and the per-slot channel error. Also confirmed end to end against a release build: a RIDE board configured with only `drive1` set now attaches (`lide: ride controller on the Zorro chain`), a configuration that was previously unrepresentable.

Docs and `copperline.example.toml` updated for the named keys.

## Not included

Moving the priority rows to the shared Boot Priority page was considered and left out: it overflows that page (13 rows, row 13 lands at 498px against a 482px limit, caught by `every_launcher_tab_row_fits_inside_the_panel`). Interleaving addresses the same readability problem without needing the space.