### PR TITLE
Add CDXL playback support for cooked ISO images

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1863,6 +1863,13 @@ track layouts. MODE1/2048, MODE1/2352, and CD-DA tracks are supported;
 Mode 2, multi-session discs, and images with stored subchannel bytes are
 rejected explicitly.
 
+CDXL video discs need no special setting: mount the image on a `CD32`
+profile and launch it as on the console. For a bare ISO, Copperline promotes
+each cooked 2048-byte sector to a complete raw Mode 1 frame (including EDC
+and P/Q parity) when an Akiko client requests raw sectors. CD32 discs that
+use a CDTV trademark boot record for backward-compatible startup are accepted
+by the same path.
+
 A cue sheet's `FILE` lines may be `BINARY` (raw sector images, single- or
 multi-file) or, for audio tracks, `WAVE` and `MP3` -- the packaged form a
 disc's audio tracks often come in, one file per track:

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -465,6 +465,12 @@ audio mixes into the host output, and both light the blue CD LED. The
 512 KiB extended ROM sits at `$E00000`, and the CD32 pad protocol drives
 port 2.
 
+The optical sector clock and the firmware command transport are separate:
+sector payloads retain their physical 75/150 Hz cadence, while the drive's
+cached TOC is returned over the command ring at 600 packets/second. This lets
+CDStrap receive a coherent TOC during its first media probe, including on
+CD32 discs mastered with the older CDTV trademark boot layout.
+
 The drive protocol is cross-checked against both ROM drivers known to have
 run on real hardware, Kickstart's cd.device and AROS's, which pinned down
 four behaviours where the two disagree with older emulator lore: the drive
@@ -489,7 +495,11 @@ extents, like a CHD's gaps) for both machines and the SCSI/ATAPI drives,
 and lays every `FILE` out as a run of extents over a byte-addressed
 source. Nero NRG images use the same extent model after their 32- or
 64-bit CUE/DAO or ETN footer has supplied the track offsets and stored
-pregaps. A `BINARY` source is the file itself; a `WAVE` or `MP3` source
+pregaps. A raw read from a cooked MODE1/2048 source synthesizes the complete
+2352-byte frame: sync and BCD MSF header, EDC, the reserved bytes, and both
+Reed-Solomon P/Q parity fields. Akiko therefore presents the same raw-sector
+shape to CDXL players whether their video disc is a bare ISO or BIN/CUE. A
+`BINARY` source is the file itself; a `WAVE` or `MP3` source
 (`cdrom/audio.rs`) presents the decoded audio as CD-DA sectors --
 588 stereo frames per sector, the last sector zero-padded, other sample
 rates linearly interpolated in integer arithmetic -- so the layout code

--- a/src/akiko.rs
+++ b/src/akiko.rs
@@ -32,7 +32,7 @@
 //! CD-DA sectors into the host mixer ring (44.1 kHz, the mixer's native
 //! rate) and sends the drive's start/end notification packets.
 
-use crate::cdrom::{to_bcd, CdImage, DATA_SECTOR_BYTES, LEADIN_SECTORS};
+use crate::cdrom::{to_bcd, CdImage, LEADIN_SECTORS, RAW_SECTOR_BYTES};
 use crate::chipset::paula::CdAudioRing;
 
 pub const AKIKO_BASE: u32 = 0x00B8_0000;
@@ -78,6 +78,13 @@ const TOC_REPEAT: u32 = 3;
 
 /// Colour clocks per 1/75th second (one single-speed CD frame).
 const CCK_PER_CD_FRAME: u32 = crate::chipset::paula::PAULA_CLOCK_HZ / 75;
+
+/// The drive firmware returns its cached TOC over the command channel,
+/// independently of the 75-sector/s optical data path. A single-track TOC
+/// is 12 packets after the mandated three copies of each point; 600 packets/s
+/// lets the controller deliver that table inside the boot ROM's first media
+/// probe. Sector data and CD-DA remain at their physical 75/150 Hz cadence.
+const CCK_PER_TOC_PACKET: u32 = crate::chipset::paula::PAULA_CLOCK_HZ / 600;
 /// TX/RX DMA restart delay: ~3 scanlines, expressed in colour clocks.
 const DMA_RESTART_DELAY_CCK: u32 = 3 * 227;
 
@@ -826,7 +833,7 @@ impl Akiko {
 
         self.frame_counter_cck -= cck as i32;
         if self.frame_counter_cck <= 0 {
-            self.frame_counter_cck += (CCK_PER_CD_FRAME / self.speed.max(1)) as i32;
+            self.frame_counter_cck += (CCK_PER_TOC_PACKET / self.speed.max(1)) as i32;
             self.frame_sync = true;
         }
 
@@ -923,7 +930,7 @@ impl Akiko {
             }
             _ => {}
         }
-        // One TOC entry per CD frame while a TOC dump is in progress.
+        // One cached-TOC packet per firmware transport interval.
         if self.toc_counter >= 0 && self.command_active == 0 && self.frame_sync {
             self.frame_sync = false;
             let len = self.return_toc_entry();
@@ -1318,28 +1325,24 @@ impl Akiko {
         if sector < 0 || !sector_in_data_track(&self.toc, sector as u32) {
             return;
         }
-        let mut data = [0u8; DATA_SECTOR_BYTES];
-        if disc.read_data_sector(sector as u32, &mut data).is_err() {
+        // Akiko's PBX path carries the complete raw Mode 1 frame. Preserve
+        // a raw BIN/CUE sector verbatim, or let the shared image backend
+        // promote a cooked ISO sector with its EDC and P/Q parity. CDXL
+        // players use this raw-sector path for sustained video streaming.
+        let mut raw = [0u8; RAW_SECTOR_BYTES];
+        if disc.read_raw_sector(sector as u32, &mut raw).is_err() {
             return;
         }
 
-        // Build the raw 2352-byte frame: sync + BCD MSF header + data.
-        // The first four bytes carry the transfer tag the ROM expects.
-        let mut raw = [0u8; 2352];
-        raw[1..11].fill(0xFF);
-        let msf = sector as u32 + LEADIN_SECTORS;
-        raw[12] = to_bcd((msf / (60 * 75)) as u8);
-        raw[13] = to_bcd(((msf / 75) % 60) as u8);
-        raw[14] = to_bcd((msf % 75) as u8);
-        raw[15] = 1; // mode 1
-        raw[16..16 + DATA_SECTOR_BYTES].copy_from_slice(&data);
+        // The first four sync bytes carry Akiko's transfer tag instead.
         raw[0] = 0;
         raw[1] = 0;
         raw[2] = 0;
         raw[3] = (self.sector_counter & 31) as u8;
 
         log::trace!(
-            "akiko: sector {sector} -> slot {slot} (tag {}, pbx {:04x})",
+            "akiko: sector {sector} -> slot {slot} at {:#010x} (tag {}, pbx {:04x})",
+            self.addressdata + slot * 4096,
             self.sector_counter & 31,
             self.pbx
         );
@@ -1593,6 +1596,7 @@ fn sector_in_data_track(toc: &[TocEntry], sector: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cdrom::DATA_SECTOR_BYTES;
     use std::io::Write;
     use std::path::PathBuf;
 
@@ -2322,20 +2326,10 @@ mod tests {
             ],
         );
         assert_eq!(response[0], 0x04);
-        assert!(akiko.toc_counter >= 0, "TOC dump should be armed");
-
-        // Re-arm RX and let the whole TOC stream (one packet per CD
-        // frame, each entry repeated three times).
-        akiko.write(
-            AKIKO_BASE + 0x1F,
-            1,
-            u32::from(akiko.cdcomrxinx.wrapping_sub(1)),
-            &mut chip,
+        assert_eq!(
+            akiko.toc_counter, -1,
+            "cached TOC should complete at the firmware transport rate"
         );
-        for _ in 0..400 {
-            akiko.tick(CCK_PER_CD_FRAME / 4, &mut chip, &mut ring);
-        }
-        assert_eq!(akiko.toc_counter, -1, "TOC dump should have completed");
 
         // Find the lead-out (A2) packet in the RX ring: packet type 6,
         // status 0x0A, point byte A2, MSF = 8 sectors + lead-in =
@@ -2376,21 +2370,13 @@ mod tests {
             ],
         );
         assert_eq!(response[0], 0x04);
-        assert!(akiko.toc_counter >= 0, "TOC dump should be armed");
+        assert_eq!(
+            akiko.toc_counter, -1,
+            "cached TOC should complete at the firmware transport rate"
+        );
         // The ring serializes responses: the 3-byte command response
         // first, then the TOC packets.
         let start = pre + 3;
-
-        akiko.write(
-            AKIKO_BASE + 0x1F,
-            1,
-            u32::from(akiko.cdcomrxinx.wrapping_sub(1)),
-            &mut chip,
-        );
-        for _ in 0..400 {
-            akiko.tick(CCK_PER_CD_FRAME / 4, &mut chip, &mut ring);
-        }
-        assert_eq!(akiko.toc_counter, -1, "TOC dump should have completed");
 
         // One data track: 4 entries x TOC_REPEAT packets of 16 bytes,
         // laid out in DMA order from the pre-dump RX index (no wrap).

--- a/src/akiko.rs
+++ b/src/akiko.rs
@@ -833,7 +833,7 @@ impl Akiko {
 
         self.frame_counter_cck -= cck as i32;
         if self.frame_counter_cck <= 0 {
-            self.frame_counter_cck += (CCK_PER_TOC_PACKET / self.speed.max(1)) as i32;
+            self.frame_counter_cck += CCK_PER_TOC_PACKET as i32;
             self.frame_sync = true;
         }
 
@@ -2345,6 +2345,36 @@ mod tests {
                 && ring[(i + 12) & 0xFF] == 0x08
         });
         assert!(found, "lead-out TOC packet not found in RX ring");
+    }
+
+    #[test]
+    fn toc_transport_rate_ignores_double_speed_bit() {
+        fn frame_phase_after_dump(speed_bit: u8) -> i32 {
+            let mut ring = CdAudioRing::default();
+            let mut chip = vec![0u8; 64 * 1024];
+            let mut akiko = Akiko::new();
+            akiko.insert_disc(test_disc());
+            akiko.tick(2048, &mut chip, &mut ring);
+            akiko.cd_initialized = 2;
+            akiko.receive_length = 0;
+
+            let response = dma_command(
+                &mut akiko,
+                &mut chip,
+                &[
+                    0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, speed_bit, 0x00, 0x00, 0x00,
+                ],
+            );
+            assert_eq!(response[0], 0x04);
+            assert_eq!(akiko.toc_counter, -1, "cached TOC should complete");
+            akiko.frame_counter_cck
+        }
+
+        assert_eq!(
+            frame_phase_after_dump(0),
+            frame_phase_after_dump(0x40),
+            "the data-speed bit must not change cached TOC pacing"
+        );
     }
 
     #[test]

--- a/src/cdrom.rs
+++ b/src/cdrom.rs
@@ -698,7 +698,8 @@ impl CdImage {
 
     /// Read one full 2352-byte raw frame at `sector`, whatever the track
     /// type: raw images are copied through; cooked (2048-byte) data
-    /// sectors get a synthesized sync + BCD MSF header (zero EDC/ECC).
+    /// sectors get a complete Mode 1 frame with sync, BCD MSF header,
+    /// EDC, and P/Q error-correction parity.
     pub fn read_raw_sector(&mut self, sector: u32, buf: &mut [u8; RAW_SECTOR_BYTES]) -> Result<()> {
         let kind = self
             .sector_kind(sector)
@@ -708,14 +709,7 @@ impl CdImage {
             TrackKind::Mode1_2048 => {
                 let mut data = [0u8; DATA_SECTOR_BYTES];
                 self.read_payload(sector, &mut data)?;
-                buf.fill(0);
-                buf[1..11].fill(0xFF);
-                let msf = sector + LEADIN_SECTORS;
-                buf[12] = to_bcd((msf / (60 * 75)) as u8);
-                buf[13] = to_bcd(((msf / 75) % 60) as u8);
-                buf[14] = to_bcd((msf % 75) as u8);
-                buf[15] = 1; // mode 1
-                buf[16..16 + DATA_SECTOR_BYTES].copy_from_slice(&data);
+                synthesize_mode1_sector(sector, &data, buf);
                 Ok(())
             }
         }
@@ -770,6 +764,112 @@ pub(crate) fn to_bcd(v: u8) -> u8 {
     ((v / 10) << 4) | (v % 10)
 }
 
+// Mode 1 sector layout after the 2048-byte user-data field. EDC is the
+// little-endian CD-ROM CRC, followed by eight reserved zero bytes and the
+// two interleaved Reed-Solomon parity fields. A bare ISO stores none of
+// these bytes, but CD controllers return them on a raw-sector read; Akiko
+// clients such as CDXL players consume the complete 2352-byte frame.
+const MODE1_EDC_OFFSET: usize = 16 + DATA_SECTOR_BYTES;
+const MODE1_ECC_P_OFFSET: usize = MODE1_EDC_OFFSET + 4 + 8;
+const MODE1_ECC_Q_OFFSET: usize = MODE1_ECC_P_OFFSET + 172;
+
+const fn build_edc_lut() -> [u32; 256] {
+    let mut lut = [0u32; 256];
+    let mut i = 0usize;
+    while i < lut.len() {
+        let mut value = i as u32;
+        let mut bit = 0;
+        while bit < 8 {
+            value = (value >> 1) ^ if value & 1 != 0 { 0xD801_8001 } else { 0 };
+            bit += 1;
+        }
+        lut[i] = value;
+        i += 1;
+    }
+    lut
+}
+
+const fn build_ecc_luts() -> ([u8; 256], [u8; 256]) {
+    let mut forward = [0u8; 256];
+    let mut backward = [0u8; 256];
+    let mut i = 0usize;
+    while i < forward.len() {
+        let doubled = (i << 1) ^ if i & 0x80 != 0 { 0x11D } else { 0 };
+        forward[i] = doubled as u8;
+        backward[i ^ doubled] = i as u8;
+        i += 1;
+    }
+    (forward, backward)
+}
+
+const EDC_LUT: [u32; 256] = build_edc_lut();
+const ECC_LUTS: ([u8; 256], [u8; 256]) = build_ecc_luts();
+
+fn mode1_edc(bytes: &[u8]) -> u32 {
+    bytes.iter().fold(0u32, |edc, &byte| {
+        (edc >> 8) ^ EDC_LUT[((edc ^ u32::from(byte)) & 0xFF) as usize]
+    })
+}
+
+/// Generate one half of the Mode 1 P/Q parity field. The geometry values
+/// are the standard CD-ROM product-code interleave: 86x24 for P, then
+/// 52x43 for Q after P has been added to the source area.
+fn mode1_ecc(
+    source: &[u8],
+    major_count: usize,
+    minor_count: usize,
+    major_mult: usize,
+    minor_inc: usize,
+    dest: &mut [u8],
+) {
+    let size = major_count * minor_count;
+    debug_assert!(source.len() >= size);
+    debug_assert!(dest.len() >= major_count * 2);
+    for major in 0..major_count {
+        let mut index = (major >> 1) * major_mult + (major & 1);
+        let mut a = 0u8;
+        let mut b = 0u8;
+        for _ in 0..minor_count {
+            let byte = source[index];
+            index += minor_inc;
+            if index >= size {
+                index -= size;
+            }
+            a ^= byte;
+            b ^= byte;
+            a = ECC_LUTS.0[usize::from(a)];
+        }
+        a = ECC_LUTS.1[usize::from(ECC_LUTS.0[usize::from(a)] ^ b)];
+        dest[major] = a;
+        dest[major + major_count] = a ^ b;
+    }
+}
+
+/// Promote a cooked ISO sector to the exact 2352-byte Mode 1 frame a CD
+/// drive places on its raw-data path.
+fn synthesize_mode1_sector(
+    sector: u32,
+    data: &[u8; DATA_SECTOR_BYTES],
+    raw: &mut [u8; RAW_SECTOR_BYTES],
+) {
+    raw.fill(0);
+    raw[1..11].fill(0xFF);
+    let msf = sector + LEADIN_SECTORS;
+    raw[12] = to_bcd((msf / (60 * SECTORS_PER_SECOND)) as u8);
+    raw[13] = to_bcd(((msf / SECTORS_PER_SECOND) % 60) as u8);
+    raw[14] = to_bcd((msf % SECTORS_PER_SECOND) as u8);
+    raw[15] = 1;
+    raw[16..MODE1_EDC_OFFSET].copy_from_slice(data);
+
+    let edc = mode1_edc(&raw[..MODE1_EDC_OFFSET]);
+    raw[MODE1_EDC_OFFSET..MODE1_EDC_OFFSET + 4].copy_from_slice(&edc.to_le_bytes());
+
+    let (prefix, parity) = raw.split_at_mut(MODE1_ECC_P_OFFSET);
+    mode1_ecc(&prefix[12..], 86, 24, 2, 86, &mut parity[..172]);
+    let (prefix, parity) = raw.split_at_mut(MODE1_ECC_Q_OFFSET);
+    mode1_ecc(&prefix[12..], 52, 43, 86, 88, &mut parity[..104]);
+}
+
 /// Parse a cue MM:SS:FF time to a sector number.
 fn parse_msf(s: &str) -> Result<u32> {
     let parts: Vec<&str> = s.split(':').collect();
@@ -816,6 +916,20 @@ mod tests {
         assert_eq!(parse_msf("62:03:74").unwrap(), (62 * 60 + 3) * 75 + 74);
         assert!(parse_msf("00:60:00").is_err());
         assert!(parse_msf("00:00:75").is_err());
+    }
+
+    #[test]
+    fn cooked_mode1_synthesis_matches_mastered_raw_sector() {
+        // Sector 0 from a mastered CD32 MODE1/2352 image has a zeroed
+        // payload. Its golden hash still covers the sync/header,
+        // little-endian EDC, reserved bytes, and both P/Q parity fields.
+        let data = [0u8; DATA_SECTOR_BYTES];
+        let mut raw = [0u8; RAW_SECTOR_BYTES];
+        synthesize_mode1_sector(0, &data, &mut raw);
+        assert_eq!(
+            crate::hash::sha256_hex(&raw),
+            "b4f18ab66709c9b3fdef2721cc323e031b6728f3ca6c57b7c435c96189222250"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- synthesize complete raw Mode 1 sectors, including EDC and P/Q parity, when a client reads from a cooked ISO
- route Akiko PBX data through the shared raw-sector path and pace cached TOC transport independently from optical sector delivery
- document CDXL playback and CDTV-trademark boot compatibility on the CD32 profile

## Verification

- cargo fmt --check
- cargo clippy
- cargo test
- cargo build --release
- booted the provided AIKa CDXL ISO with official CD32 ROMs, opened Special Trial, and captured changing video frames at 27 and 32 emulated seconds
- captured non-silent stereo 44.1 kHz audio
- repeated the headless run and obtained byte-identical screenshot hashes
- confirmed the Video Creator v1.1 CD32 regression disc still reaches its application display