### PR TITLE
cd32: add Full Motion Video module support

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -30,6 +30,11 @@ Thank you to:
 
 ## Bundled third-party code
 
+- **[plmpeg](https://github.com/CopperlineHQ/plmpeg-rs)** provides the safe,
+  pure-Rust incremental MPEG-1 video decoder used by the CD32 Full Motion
+  Video module. Its reconstruction core descends from Native32Emu's
+  BSD-3-Clause Rust port of Dominic Szablewski's MIT-licensed PL_MPEG; exact
+  source revisions and both license notices are recorded in that repository.
 - **[A4091 software](https://github.com/A4091/a4091-software)** provides the
   v42.39 autoboot ROM bundled as Copperline's default for an A4091. Thanks to
   Stefan Reinauer, Chris Hooper, Toni Wilen, Matt Harlum, and the upstream

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "pcap",
  "pixels",
+ "plmpeg",
  "png",
  "rfd",
  "ringbuf",
@@ -2921,6 +2922,15 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plmpeg"
+version = "0.1.0"
+source = "git+https://github.com/CopperlineHQ/plmpeg-rs?rev=d020ba1015b48c0c646d32b16a27157623fff915#d020ba1015b48c0c646d32b16a27157623fff915"
+dependencies = [
+ "serde",
+ "serde-big-array",
+]
 
 [[package]]
 name = "png"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ default = [
     "game-library",
     "mhi",
     "cd-mp3",
+    "cd32-fmv",
     "gdb",
 ]
 # MT-32 emulation through CopperlineHQ/mt32-rs, reachable as a MIDI-Out
@@ -63,6 +64,16 @@ mhi = ["dep:symphonia-bundle-mp3", "dep:symphonia-core"]
 # have either without the other; default-on for the same reason `mhi` is,
 # and off in the browser build.
 cd-mp3 = ["dep:symphonia-bundle-mp3", "dep:symphonia-core"]
+# Commodore's CD32 Full Motion Video module: the L64111 MPEG Layer II path
+# reuses Symphonia, while the CL450's MPEG-1 video path uses CopperlineHQ's
+# safe pure-Rust plmpeg decoder. Native-only by construction: browser builds
+# use `default-features = false` and do not fit this physical Zorro II module.
+cd32-fmv = [
+    "dep:plmpeg",
+    "dep:symphonia-bundle-mp3",
+    "dep:symphonia-core",
+    "symphonia-bundle-mp3/mp2",
+]
 display-plan-trace = []
 # Detailed host-cost counters used by native diagnostics. The browser crate
 # builds the core with `default-features = false`, so its release hot paths do
@@ -173,6 +184,10 @@ serde-big-array = "0.5"
 # a track file, rather than going through a format reader.
 symphonia-bundle-mp3 = { version = "0.6.1", default-features = false, features = ["mp3"], optional = true }
 symphonia-core = { version = "0.6.1", default-features = false, optional = true }
+# Safe incremental MPEG-1 video decoder used by the CD32 FMV module. The
+# serde feature snapshots prediction frames and partial bitstream state rather
+# than retaining and replaying the compressed stream on every save-state load.
+plmpeg = { git = "https://github.com/CopperlineHQ/plmpeg-rs", rev = "d020ba1015b48c0c646d32b16a27157623fff915", features = ["serde"], optional = true }
 # Save-state and snapshot serialization (src/savestate.rs and friends).
 # Held on the 1.x serde API on purpose: bincode 2 replaces the API and its
 # defaults use a different wire format, while bincode 3 is an intentionally

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ against real hardware.
   (ADF / ADZ / ZIP / DMS, read-only IPF and SCP, or a real 3.5" drive over
   a Greaseweazle via the pure-Rust FluxBridge library,
   `docs/guide/fluxbridge.md`), Gayle and A4000 IDE, SCSI (A2091,
-  A4091, or the A3000's onboard Super DMAC), CDTV/CD32 CD, A2065 Ethernet,
+  A4091, or the A3000's onboard Super DMAC), CDTV/CD32 CD, the CD32 Full
+  Motion Video module with pure-Rust MPEG-1 video decoding, A2065 Ethernet,
   a bundled host-backed `bsdsocket.library` (socket networking for guest
   applications with no guest TCP/IP stack to boot),
   Z3660 and Picasso II/II+ RTG cards (high-colour Picasso96 screens), the serial
@@ -336,6 +337,7 @@ steps for every channel are in
 | Fast RAM | Optional Zorro II autoconfig RAM at $00200000 and Zorro III autoconfig RAM (`[memory] z3`); runs at the CPU clock. |
 | Slow RAM | Optional A500 trapdoor/fake-fast RAM at $00C00000; arbitrated on the chip bus through Agnus like chip RAM. |
 | ROM | Kickstart at $F80000 (512 KiB); optional extended ROM for CD32 ($E00000) and CDTV ($F00000). |
+| CD32 FMV | Optional Commodore Full Motion Video cartridge: Zorro II autoconfig ROM/RAM, CL450 MPEG-1 video, L64111 MPEG Layer II audio, and analogue-keyed presentation. |
 | Battery RTC | Oki MSM6242 or Ricoh RP5C01 at $DC0000 (`rtc_chip`; Ricoh is the A3000/A4000 default), read-only wall clock -- guest writes drive latch/bank/control state and the RP5C01's battery RAM, which persists to a WinUAE/Amiberry-compatible `.nvram` file (`battmem`). A `rtc_time` seed ticks in emulated time for reproducible runs; `rtc_frozen` pins it. |
 | CIA-A / CIA-B | I/O ports, /OVL, timers, TOD, keyboard SDR/ICR, disk control/status lines, CIA-B FLAG disk index pulses, and the Centronics parallel port (data/strobe/ACK on CIA-A, BUSY/POUT/SEL on CIA-B). |
 | Paula serial | SERDAT through a one-word transmit buffer and timed shift register, out to stdout, a TCP port, a pseudo-terminal, or -- with the default `midi` feature -- bridged to host MIDI in/out; SERDATR reports TBE/TSRE/RBF, and serial receive is fed from the selected input. |

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -203,9 +203,15 @@ model = "68000"
 # main rom.
 # extended_rom = "cdtv-extended.rom"
 
+# CD32 Full Motion Video module ROM. A 256 KiB v40.30 image fits the physical
+# Commodore MPEG cartridge as the first Zorro II board in a CD32. Omit it for
+# a stock CD32 without the FMV module.
+# fmv_rom = "cd32fmv.rom"
+
 
 # CD image (a cue sheet, single- or multi-file, with MODE1/2048, MODE1/2352,
-# and AUDIO tracks -- audio tracks may be BINARY, WAVE, or MP3 files, with
+# MODE2/2336, MODE2/2352, and AUDIO tracks -- audio tracks may be BINARY,
+# WAVE, or MP3 files, with
 # PREGAP/POSTGAP lines honoured; a bare .iso; or a chdman v5 .chd), mounted on
 # the machine's CD controller (CD32 Akiko or CDTV DMAC). insert_delay inserts the disc that many
 # emulated seconds after power-on instead of at boot: some CDTV discs

--- a/deny.toml
+++ b/deny.toml
@@ -68,10 +68,12 @@ deny = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# Project-owned sources: mt32-rs and Coppersynth are revision-pinned in the
-# manifest; FluxBridge currently follows its maintained main branch.
+# Project-owned sources: mt32-rs, Coppersynth, and plmpeg-rs are
+# revision-pinned in the manifest; FluxBridge currently follows its
+# maintained main branch.
 allow-git = [
     "https://github.com/CopperlineHQ/mt32-rs",
     "https://github.com/CopperlineHQ/Coppersynth",
+    "https://github.com/CopperlineHQ/plmpeg-rs",
     "https://github.com/CopperlineHQ/FluxBridge",
 ]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -99,6 +99,7 @@ described with their `[audio]`, `[serial]`, `[parallel]`, `[a2065]`, and
 rom = "KICK13.ROM"            # Kickstart image, 512 KiB (or a 256 KiB 1.x part)
 extended_rom = "cd32ext.rom"  # optional: CDTV (256K at $F00000) or
                               # CD32 (512K at $E00000) extended ROM
+fmv_rom = "cd32fmv.rom"       # optional: 256K CD32 FMV module ROM
 # identify = false            # drop the Copperline identification board
                               # from the Zorro chain (default: present)
 ```
@@ -120,7 +121,8 @@ menu's **Load Kickstart ROM...** item, which hard-resets the machine. Machine
 profiles that need an extended ROM (CDTV, CD32) will tell you if it is
 missing.
 
-Both ROM keys accept images in either byte order. Alongside plain CPU-order
+The Kickstart and extended-ROM keys accept images in either byte order.
+Alongside plain CPU-order
 dumps, the byte-swapped images prepared for EPROM programmers -- the
 single-chip `.bin` ROM files in Hyperion's Kickstart 3.1.4/3.2 releases, such
 as `kick.a500a600a2000.46.143.bin`, store every 16-bit word with its bytes
@@ -129,6 +131,14 @@ file boots identically. A 256 KiB Kickstart 1.x part is mirrored across the
 512 KiB ROM window, as it decodes on real hardware. The split `hi`/`lo` chip
 pairs for the 32-bit machines are not accepted; use the matching single-file
 image instead.
+
+`fmv_rom` fits the Commodore CD32 Full Motion Video module and is valid only
+with the `CD32` machine profile. It must be the 256 KiB module ROM (v40.30 is
+the released ROM). The cartridge autoconfigures ahead of the normal Zorro
+chain, and its CL450 video and L64111 MPEG Layer II audio decoders are fed by
+the original module software; no per-title setting or replacement player is
+used. Leave the key out for a stock CD32. The launcher's **ROM** tab exposes
+the same setting as **FMV module ROM**.
 
 Copperline also names the ROM it is given. A ROM file's name is whatever its
 dumper called it, so the image is identified by checksum against a table of
@@ -1846,7 +1856,8 @@ it. It is CLI-only by design (no config section) and is covered in
 profile = "CD32"
 
 [cd]
-image = "disc.cue"        # cue sheet (BINARY/WAVE/MP3 files; MODE1/2048, MODE1/2352, AUDIO)
+image = "disc.cue"        # cue sheet (MODE1/2048, MODE1/2352,
+                          # MODE2/2336, MODE2/2352, AUDIO)
 insert_delay = 0.0        # emulated seconds after power-on to insert
 # nvram = "cd32-nvram.bin" # CD32 save-game EEPROM backing file (default)
 ```
@@ -1859,9 +1870,9 @@ CDTV.
 
 NRG supports both the older `NERO`/32-bit and newer `NER5`/64-bit footer
 formats, with DAO (`CUES`/`DAOI`, `CUEX`/`DAOX`) or TAO (`ETNF`/`ETN2`)
-track layouts. MODE1/2048, MODE1/2352, and CD-DA tracks are supported;
-Mode 2, multi-session discs, and images with stored subchannel bytes are
-rejected explicitly.
+track layouts. MODE1/2048, MODE1/2352, MODE2/2336, MODE2/2352, and CD-DA
+tracks are supported; multi-session discs and images with stored subchannel
+bytes are rejected explicitly.
 
 CDXL video discs need no special setting: mount the image on a `CD32`
 profile and launch it as on the console. For a bare ISO, Copperline promotes
@@ -1869,6 +1880,10 @@ each cooked 2048-byte sector to a complete raw Mode 1 frame (including EDC
 and P/Q parity) when an Akiko client requests raw sectors. CD32 discs that
 use a CDTV trademark boot record for backward-compatible startup are accepted
 by the same path.
+
+MPEG Video CD and CD32 FMV-enhanced titles use the same Akiko media path. Fit
+the FMV module with top-level `fmv_rom`; the module ROM then detects and feeds
+the MPEG cartridge exactly as it does on the console.
 
 A cue sheet's `FILE` lines may be `BINARY` (raw sector images, single- or
 multi-file) or, for audio tracks, `WAVE` and `MP3` -- the packaged form a

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -569,12 +569,13 @@ The layout is:
   *Memory* (cold power-on fill -- zero, deterministic random, or a typed fixed
   16-bit word -- plus chip/fast/slow/motherboard/accelerator/Zorro III RAM),
   *ROM*
-  (Kickstart and
-  extended ROM; the Kickstart row carries **Name**, **Version** and
+  (Kickstart, extended ROM, and the CD32-only **FMV module ROM**; the
+  Kickstart row carries **Name**, **Version** and
   **Revision** lines naming what the chosen image is, identified by
   checksum rather than by file name -- blank for an image Copperline does
-  not know, and read from the image itself for the bundled AROS;
-  see [](configuration)),
+  not know, and read from the image itself for the bundled AROS. The FMV row
+  fits the physical Commodore MPEG cartridge when a 256 KiB module ROM is
+  selected and is greyed on non-CD32 profiles; see [](configuration)),
   *Floppy* (drive count and speed, then each wired drive as a
   greyed **DFn:** heading with its indented disk image and write-protect;
   drives that are not enabled are hidden rather than greyed. Each drive also

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -60,6 +60,7 @@ src/
   cdrom.rs          # CD images: cue sheets (BINARY/WAVE/MP3), ISO, NRG, CHD
   cdtv.rs           # CDTV DMAC + Matshita drive model
   akiko.rs          # CD32 Akiko (C2P, NVRAM, Chinon drive)
+  cd32_fmv.rs       # CD32 FMV cartridge (CL450 video + L64111 MPEG audio)
   rtc.rs            # MSM6242-compatible battery RTC
   serial.rs         # Paula serial sinks (stdout, TCP, pty)
   midi/             # host MIDI serial bridge (CoreMIDI / ALSA / WinMM)

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -465,11 +465,39 @@ audio mixes into the host output, and both light the blue CD LED. The
 512 KiB extended ROM sits at `$E00000`, and the CD32 pad protocol drives
 port 2.
 
+### CD32 Full Motion Video module (`cd32_fmv.rs`)
+
+Setting top-level `fmv_rom` fits Commodore's 1 MiB Zorro II FMV cartridge as
+the first autoconfig board, normally at `$200000` (manufacturer 514, product
+`$6A`, serial `$0028001E`). Its window follows the physical decode: 256 KiB ROM at
+`+$000000`, board status/control at `+$040000`, LSI L64111 MPEG Layer II audio
+at `+$050000`, the C-Cube CL450 bitstream port at `+$060000`, CL450 registers
+at `+$070000`, and 512 KiB module RAM at `+$080000`.
+
+The guest module ROM remains responsible for reading sectors through Akiko
+and programming both chips. Copperline implements their register, command,
+FIFO, interrupt, SCR/PTS, presentation, and audio-buffer contracts; MPEG-1
+video is decoded through CopperlineHQ's safe pure-Rust `plmpeg` core and
+MPEG-1 Layer II audio through Symphonia. The production player never programs
+Denise/Lisa's digital genlock controls: the cartridge keys the dark native RGB
+level in its analogue output path, which the renderer models alongside
+explicit chipset genlock transparency while preserving the module's border
+and blanking controls. The decoder's partial bitstream, prediction frames,
+and presentation state are serialized directly, so a resumed headless run
+produces the same frames without retaining the already-decoded program stream.
+
 The optical sector clock and the firmware command transport are separate:
 sector payloads retain their physical 75/150 Hz cadence, while the drive's
 cached TOC is returned over the command ring at 600 packets/second. This lets
 CDStrap receive a coherent TOC during its first media probe, including on
 CD32 discs mastered with the older CDTV trademark boot layout.
+
+READ DATA's end MSF is exclusive. At that boundary the PBX path retains one
+final position-bearing raw frame, matching the sector already buffered by a
+continuous physical read. The ROM driver uses its on-disc MSF to detect when
+the next filesystem request is outside the current stream, stop it, and seek
+to the new LSN; dropping the buffered boundary frame instead would leave the
+driver asleep waiting for a PBX interrupt that can never arrive.
 
 The drive protocol is cross-checked against both ROM drivers known to have
 run on real hardware, Kickstart's cd.device and AROS's, which pinned down
@@ -490,14 +518,17 @@ included, which is where AROS places its `MEMF_24BITDMA` allocations when
 fast RAM exists -- not just chip RAM.
 
 `cdrom.rs` parses cue sheets (single- or multi-file; MODE1/2048,
-MODE1/2352, and AUDIO tracks; `PREGAP`/`POSTGAP` as unstored zero-fill
+MODE1/2352, MODE2/2336, MODE2/2352, and AUDIO tracks;
+`PREGAP`/`POSTGAP` as unstored zero-fill
 extents, like a CHD's gaps) for both machines and the SCSI/ATAPI drives,
 and lays every `FILE` out as a run of extents over a byte-addressed
 source. Nero NRG images use the same extent model after their 32- or
 64-bit CUE/DAO or ETN footer has supplied the track offsets and stored
 pregaps. A raw read from a cooked MODE1/2048 source synthesizes the complete
 2352-byte frame: sync and BCD MSF header, EDC, the reserved bytes, and both
-Reed-Solomon P/Q parity fields. Akiko therefore presents the same raw-sector
+Reed-Solomon P/Q parity fields. MODE2/2336 similarly gains its omitted sync,
+BCD MSF, and mode header without disturbing the stored XA subheader, payload,
+EDC, or parity. Akiko therefore presents the same raw-sector
 shape to CDXL players whether their video disc is a bare ISO or BIN/CUE. A
 `BINARY` source is the file itself; a `WAVE` or `MP3` source
 (`cdrom/audio.rs`) presents the decoded audio as CD-DA sectors --

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -482,9 +482,13 @@ MPEG-1 Layer II audio through Symphonia. The production player never programs
 Denise/Lisa's digital genlock controls: the cartridge keys the dark native RGB
 level in its analogue output path, which the renderer models alongside
 explicit chipset genlock transparency while preserving the module's border
-and blanking controls. The decoder's partial bitstream, prediction frames,
-and presentation state are serialized directly, so a resumed headless run
-produces the same frames without retaining the already-decoded program stream.
+and blanking controls. The CL450's interpolated 704-pixel output line maps to
+the captured TV aperture rather than the deeper native overscan framebuffer;
+the later TV presentation therefore retains both edges of the 352-pixel MPEG
+source instead of applying a second, one-sided crop. The decoder's partial
+bitstream, prediction frames, and presentation state are serialized directly,
+so a resumed headless run produces the same frames without retaining the
+already-decoded program stream.
 
 The optical sector clock and the firmware command transport are separate:
 sector payloads retain their physical 75/150 Hz cadence, while the drive's
@@ -504,7 +508,9 @@ run on real hardware, Kickstart's cd.device and AROS's, which pinned down
 four behaviours where the two disagree with older emulator lore: the drive
 microcontroller answers a command about a millisecond after its last byte
 rather than inside the guest's register write (drivers arm their
-completion interrupt in that window); the TOC dump streams the track
+completion interrupt in that window), and an enabled TX-DMA completion is
+presented before the corresponding RX completion on the half-duplex drive
+link; the TOC dump streams the track
 entries before the A0/A1/A2 session entries, since a parser may treat the
 lead-out entry as end-of-TOC; the CDINTREQ status read exposes only
 enabled sources (`intreq & intena`), because INT2 servers read it on every
@@ -515,7 +521,13 @@ satisfies both). Akiko's DMA engines drive a full 24-bit address bus (the
 address registers mask to `$00FFF000`), so the rings and sector buffers
 resolve through every RAM bank in the low 16 MB -- Zorro II fast RAM
 included, which is where AROS places its `MEMF_24BITDMA` allocations when
-fast RAM exists -- not just chip RAM.
+fast RAM exists -- not just chip RAM. The command/status comparator indices
+are eight-bit, but the physical DMA byte counter retains its page carry for
+the remainder of a packet. Kickstart relies on this when it copies a packet
+contiguously across index `$FF`; folding the physical address at the same point
+reads stale bytes from the start of the page. The next parsed packet rebases
+the counter to its visible index, even if the producer queued several packets
+under one comparator value.
 
 `cdrom.rs` parses cue sheets (single- or multi-file; MODE1/2048,
 MODE1/2352, MODE2/2336, MODE2/2352, and AUDIO tracks;

--- a/docs/zorro.md
+++ b/docs/zorro.md
@@ -587,6 +587,12 @@ ways:
 On CDTV machines the DMAC occupies the config window first; the Zorro chain
 follows once it is configured, matching real-machine autoconfig order.
 
+On a CD32 with `fmv_rom`, the Commodore Full Motion Video cartridge instead
+occupies the first Zorro II slot, as its module ROM expects: manufacturer 514,
+product `$6A`, serial `$0028001E`, 1 MiB memory-space board with DiagArea vector
+`$80` and the no-shut-up flag. Its hardware model and address map are documented in
+[](internals/peripherals).
+
 ## The Copperline manufacturer ID
 
 Copperline's built-in virtual boards autoconfig under manufacturer ID

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "pcap",
  "pixels",
+ "plmpeg",
  "png",
  "rfd",
  "ringbuf",
@@ -2939,6 +2940,15 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plmpeg"
+version = "0.1.0"
+source = "git+https://github.com/CopperlineHQ/plmpeg-rs?rev=d020ba1015b48c0c646d32b16a27157623fff915#d020ba1015b48c0c646d32b16a27157623fff915"
+dependencies = [
+ "serde",
+ "serde-big-array",
+]
 
 [[package]]
 name = "png"

--- a/packaging/flatpak/cargo-sources.json
+++ b/packaging/flatpak/cargo-sources.json
@@ -18,6 +18,12 @@
         "dest": "flatpak-cargo/git/mt32-rs-ac00f81"
     },
     {
+        "type": "git",
+        "url": "https://github.com/copperlinehq/plmpeg-rs",
+        "commit": "d020ba1015b48c0c646d32b16a27157623fff915",
+        "dest": "flatpak-cargo/git/plmpeg-rs-d020ba1"
+    },
+    {
         "type": "archive",
         "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ab_glyph/ab_glyph-0.2.32.crate",
@@ -3881,6 +3887,24 @@
         "dest-filename": ".cargo-checksum.json"
     },
     {
+        "type": "shell",
+        "commands": [
+            "cp -r --reflink=auto \"flatpak-cargo/git/plmpeg-rs-d020ba1/.\" \"cargo/vendor/plmpeg\""
+        ]
+    },
+    {
+        "type": "inline",
+        "contents": "[package]\nname = \"plmpeg\"\nversion = \"0.1.0\"\nedition = \"2021\"\nrust-version = \"1.85\"\nlicense = \"BSD-3-Clause\"\ndescription = \"Safe pure-Rust incremental MPEG-1 video decoder\"\nreadme = \"README.md\"\nrepository = \"https://github.com/CopperlineHQ/plmpeg-rs\"\nkeywords = [\"mpeg\", \"mpeg1\", \"video\", \"decoder\", \"streaming\"]\ncategories = [\"multimedia::video\", \"multimedia::encoding\"]\n\n[features]\ndefault = []\nserde = [\"dep:serde\", \"dep:serde-big-array\"]\n\n[dependencies.serde]\nversion = \"1\"\ndefault-features = false\nfeatures = [\"alloc\", \"derive\"]\noptional = true\n\n[dependencies.serde-big-array]\nversion = \"0.5\"\noptional = true\n\n[lints.rust]\nunsafe_code = \"forbid\"\n\n[lints.clippy]\nall = \"warn\"\npedantic = \"warn\"\n",
+        "dest": "cargo/vendor/plmpeg",
+        "dest-filename": "Cargo.toml"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": null, \"files\": {}}",
+        "dest": "cargo/vendor/plmpeg",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
         "type": "archive",
         "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/png/png-0.18.1.crate",
@@ -6950,7 +6974,7 @@
     },
     {
         "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"38873e283aa9f2e6d2574d6c71e9a2cf9d0b42a2\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/copperlinehq/coppersynth\"]\ngit = \"https://github.com/copperlinehq/coppersynth\"\nreplace-with = \"vendored-sources\"\nrev = \"38873e283aa9f2e6d2574d6c71e9a2cf9d0b42a2\"\n\n[source.\"https://github.com/copperlinehq/fluxbridge\"]\ngit = \"https://github.com/copperlinehq/fluxbridge\"\nreplace-with = \"vendored-sources\"\nbranch = \"main\"\n\n[source.\"https://github.com/copperlinehq/mt32-rs\"]\ngit = \"https://github.com/copperlinehq/mt32-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"ac00f818629a549a2712747660091e4f84d55599\"\n\n[source.\"https://github.com/copperlinehq/plmpeg-rs\"]\ngit = \"https://github.com/copperlinehq/plmpeg-rs\"\nreplace-with = \"vendored-sources\"\nrev = \"d020ba1015b48c0c646d32b16a27157623fff915\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/src/akiko.rs
+++ b/src/akiko.rs
@@ -422,6 +422,8 @@ pub struct Akiko {
     door: u8,
     toc_counter: i32,
     data_offset: i64,
+    /// Exclusive end sector supplied by the drive's READ DATA command.
+    data_end: i64,
     sector_counter: u32,
     current_sector: i64,
     seek_delay: u32,
@@ -488,6 +490,7 @@ impl Default for Akiko {
             door: 1,
             toc_counter: -1,
             data_offset: -1,
+            data_end: -1,
             sector_counter: 0,
             current_sector: -1,
             seek_delay: 0,
@@ -568,6 +571,7 @@ impl Akiko {
         self.audio_notify = 0;
         self.toc_counter = -1;
         self.data_offset = -1;
+        self.data_end = -1;
         self.media_notify = self.cd_initialized != 0;
         log::info!("akiko: disc ejected");
     }
@@ -1071,6 +1075,8 @@ impl Akiko {
         }
         self.result_buffer[1] = 0;
         self.stop_audio();
+        self.data_offset = -1;
+        self.data_end = -1;
         2
     }
 
@@ -1122,6 +1128,7 @@ impl Akiko {
         if self.command_buffer[7] & 0x80 != 0 {
             // Data read from seekpos to endpos.
             self.data_offset = seekpos;
+            self.data_end = endpos;
             let distance = (self.current_sector - seekpos).unsigned_abs();
             self.seek_delay = if distance < 100 {
                 1
@@ -1322,7 +1329,30 @@ impl Akiko {
         };
         let sector = self.data_offset + i64::from(self.sector_counter);
         self.current_sector = sector;
-        if sector < 0 || !sector_in_data_track(&self.toc, sector as u32) {
+        if self.data_end >= 0 && sector > self.data_end {
+            self.data_offset = -1;
+            self.data_end = -1;
+            return;
+        }
+
+        // The READ DATA end MSF is exclusive, but the CD32 driver keeps a
+        // continuous hardware read open across filesystem requests. When a
+        // request seeks backwards after that stream reaches lead-out, the
+        // driver needs one final position-bearing PBX frame to notice that
+        // the buffered stream is nowhere near the requested sector; it then
+        // sends STOP and starts a new read at the requested LSN. Re-present
+        // the final valid raw sector as that boundary probe. Its payload is
+        // never returned to the caller because its on-disc MSF mismatches the
+        // requested LSN, while retaining the real frame also preserves valid
+        // Mode 1/2 EDC and ECC bytes for the ROM's sector validator.
+        let at_end = self.data_end >= 0 && sector == self.data_end;
+        let read_sector = if at_end { sector - 1 } else { sector };
+        if read_sector < 0 || !sector_in_data_track(&self.toc, read_sector as u32) {
+            if at_end {
+                self.data_offset = -1;
+                self.data_end = -1;
+                self.intreq |= CDINT_PBX;
+            }
             return;
         }
         // Akiko's PBX path carries the complete raw Mode 1 frame. Preserve
@@ -1330,7 +1360,7 @@ impl Akiko {
         // promote a cooked ISO sector with its EDC and P/Q parity. CDXL
         // players use this raw-sector path for sustained video streaming.
         let mut raw = [0u8; RAW_SECTOR_BYTES];
-        if disc.read_raw_sector(sector as u32, &mut raw).is_err() {
+        if disc.read_raw_sector(read_sector as u32, &mut raw).is_err() {
             return;
         }
 
@@ -1371,6 +1401,13 @@ impl Akiko {
         }
 
         self.sector_counter += 1;
+        if at_end {
+            log::debug!(
+                "akiko: READ DATA reached exclusive end {sector}; delivered final-sector boundary probe"
+            );
+            self.data_offset = -1;
+            self.data_end = -1;
+        }
     }
 
     // ----- C2P -------------------------------------------------------------
@@ -2091,6 +2128,39 @@ mod tests {
                                             // Both slots consumed, PBX interrupt raised.
         assert_eq!(akiko.pbx, 0);
         assert_ne!(akiko.intreq & CDINT_PBX, 0);
+    }
+
+    #[test]
+    fn data_read_end_delivers_a_position_probe_for_the_next_seek() {
+        let mut chip = vec![0u8; 256 * 1024];
+        let mut akiko = Akiko::new();
+        akiko.insert_disc(test_disc());
+        akiko.addressdata = 0x0001_0000;
+        akiko.flags = CDFLAG_ENABLE | CDFLAG_PBX | CDFLAG_CAS;
+        akiko.data_offset = 0;
+        akiko.data_end = 2;
+        akiko.pbx = 0x0007;
+
+        // Sectors 0 and 1 consume the two highest armed buffers.
+        akiko.run_sector_read(&mut chip);
+        akiko.run_sector_read(&mut chip);
+        assert_eq!(akiko.sector_counter, 2);
+        assert_eq!(akiko.pbx, 0x0001);
+
+        // Reaching the exclusive end re-presents the final valid sector. The
+        // ROM uses its MSF to detect that a later backwards request needs a
+        // STOP/reseek, rather than sleeping forever on an empty PBX ring.
+        akiko.intreq = 0;
+        akiko.run_sector_read(&mut chip);
+        assert_eq!(akiko.data_offset, -1);
+        assert_eq!(akiko.data_end, -1);
+        assert_eq!(akiko.pbx, 0);
+        assert_eq!(akiko.sector_counter, 3);
+        let slot0 = 0x0001_0000;
+        assert_eq!(chip[slot0 + 3], 2);
+        assert_eq!(chip[slot0 + 16], 1);
+        assert_ne!(akiko.intreq & CDINT_PBX, 0);
+        assert!(!akiko.activity_led_on());
     }
 
     #[test]

--- a/src/akiko.rs
+++ b/src/akiko.rs
@@ -399,6 +399,11 @@ pub struct Akiko {
     cdcomrxinx: u8,
     cdcomtxcmp: u8,
     cdcomrxcmp: u8,
+    /// Physical byte offsets within the misc-DMA allocation. The comparator
+    /// registers expose only the low eight bits, but the DMA address counters
+    /// carry into the following page for the remainder of the current packet.
+    tx_dma_offset: u16,
+    rx_dma_offset: u16,
     tx_dma_delay_cck: u32,
     rx_dma_delay_cck: u32,
 
@@ -473,6 +478,8 @@ impl Default for Akiko {
             cdcomrxinx: 0,
             cdcomtxcmp: 0,
             cdcomrxcmp: 0,
+            tx_dma_offset: 0,
+            rx_dma_offset: 0,
             tx_dma_delay_cck: 0,
             rx_dma_delay_cck: 0,
             command_buffer: [0; 32],
@@ -723,11 +730,25 @@ impl Akiko {
             0x18 => self.intreq &= !CDINT_SUBCODE,
             0x1D => {
                 self.intreq &= !CDINT_TXDMADONE;
+                if self.cdcomtxinx == self.cdcomtxcmp
+                    && (self.command_active != 0 || self.command_length == 0)
+                {
+                    // A fresh DMA window starts at base + the visible index.
+                    // If a comparator stopped in the middle of a command,
+                    // retain the carried address when the guest extends it.
+                    self.tx_dma_offset = u16::from(self.cdcomtxinx);
+                }
                 self.cdcomtxcmp = value;
                 self.tx_dma_delay_cck = DMA_RESTART_DELAY_CCK;
             }
             0x1F => {
                 self.intreq &= !CDINT_RXDMADONE;
+                if self.cdcomrxinx == self.cdcomrxcmp && self.receive_offset == 0 {
+                    // New response packet/window: restart at base + index.
+                    // An extension after a partial response instead preserves
+                    // the page carry in rx_dma_offset.
+                    self.rx_dma_offset = u16::from(self.cdcomrxinx);
+                }
                 self.cdcomrxcmp = value;
                 self.rx_dma_delay_cck = DMA_RESTART_DELAY_CCK;
             }
@@ -818,6 +839,15 @@ impl Akiko {
                     // it in result_buffer. Hold the command until the
                     // ring drains; the host cannot send another one
                     // meanwhile (can_send_command gates on both).
+                    self.command_active = 1;
+                } else if self.intreq & self.intena & CDINT_TXDMADONE != 0 {
+                    // The three-wire drive link is half duplex. Akiko may
+                    // already have the drive's reply buffered, but it does
+                    // not expose RX completion while an enabled TX-DMA
+                    // completion is still awaiting service. Keeping those
+                    // edges distinct matters to the ROM driver: it uses one
+                    // shared INT2 server for both channels and advances the
+                    // response ring according to the completion it observed.
                     self.command_active = 1;
                 } else {
                     self.execute_command();
@@ -978,8 +1008,9 @@ impl Akiko {
         if !self.can_send_command() {
             return;
         }
-        let byte = mem.dma_get(self.cdtx_address + u32::from(self.cdcomtxinx));
+        let byte = mem.dma_get(self.cdtx_address + u32::from(self.tx_dma_offset));
         self.add_command_byte(byte);
+        self.tx_dma_offset = self.tx_dma_offset.wrapping_add(1);
         self.cdcomtxinx = self.cdcomtxinx.wrapping_add(1);
         if self.cdcomtxinx == self.cdcomtxcmp {
             self.intreq |= CDINT_TXDMADONE;
@@ -1025,6 +1056,10 @@ impl Akiko {
             self.unknown_command
         );
         self.command_length = 0;
+        // The page carry belongs to the packet just parsed. A later command
+        // queued under the same comparator starts at base + the visible index,
+        // exactly where the ROM's producer copied it.
+        self.tx_dma_offset = u16::from(self.cdcomtxinx);
         self.result_buffer = [0; 32];
 
         if self.checksum_error || self.unknown_command {
@@ -1275,7 +1310,11 @@ impl Akiko {
         }
         while self.receive_offset < self.receive_length {
             self.last_rx = self.result_buffer[self.receive_offset];
-            mem.dma_put(self.cdrx_address + u32::from(self.cdcomrxinx), self.last_rx);
+            mem.dma_put(
+                self.cdrx_address + u32::from(self.rx_dma_offset),
+                self.last_rx,
+            );
+            self.rx_dma_offset = self.rx_dma_offset.wrapping_add(1);
             self.cdcomrxinx = self.cdcomrxinx.wrapping_add(1);
             self.receive_offset += 1;
             if self.cdcomrxinx == self.cdcomrxcmp {
@@ -1286,6 +1325,9 @@ impl Akiko {
         if self.receive_offset == self.receive_length {
             self.receive_length = 0;
             self.receive_offset = 0;
+            // Like TX, the next packet begins at base + the visible index even
+            // if this response crossed into the following physical page.
+            self.rx_dma_offset = u16::from(self.cdcomrxinx);
             self.intreq &= !CDINT_DRIVERECV;
             self.intreq |= CDINT_DRIVEXMIT;
         }
@@ -2375,6 +2417,162 @@ mod tests {
             akiko.tick(CMD_EXEC_DELAY_CCK / 4, &mut chip, &mut ring);
         }
         assert_ne!(akiko.cdcomrxinx, rx_before, "response after the delay");
+    }
+
+    #[test]
+    fn command_dma_keeps_the_physical_page_carry_through_a_packet_wrap() {
+        // Kickstart copies each command linearly from base + its software
+        // producer index, even when the visible eight-bit index wraps. Akiko's
+        // physical DMA counter carries into the following page for the rest of
+        // that packet; wrapping the address itself reads stale data
+        // from the start of the TX page.
+        let mut ring = CdAudioRing::default();
+        let mut chip = vec![0u8; 128 * 1024];
+        let mut akiko = Akiko::new();
+        akiko.insert_disc(test_disc());
+        akiko.cd_initialized = 2;
+
+        const MISC: u32 = 0x0000_1000;
+        akiko.write(AKIKO_BASE + 0x14, 4, MISC, &mut chip);
+        akiko.write(AKIKO_BASE + 0x24, 4, CDFLAG_TXD | CDFLAG_RXD, &mut chip);
+        akiko.cdcomtxinx = 0xF8;
+        akiko.cdcomtxcmp = 0xF8;
+
+        let command = [
+            0x04, 0x00, 0x02, 0x00, 0x00, 0x02, 0x04, 0x80, 0x40, 0x00, 0x00, 0x00,
+        ];
+        let tx_base = (MISC | 0x200) as usize;
+        let mut checksum = 0xFFu8;
+        for (i, byte) in command.iter().copied().enumerate() {
+            chip[tx_base + 0xF8 + i] = byte;
+            checksum = checksum.wrapping_sub(byte);
+        }
+        chip[tx_base + 0xF8 + command.len()] = checksum;
+        let end = 0xF8u8.wrapping_add(command.len() as u8 + 1);
+        akiko.write(AKIKO_BASE + 0x1D, 1, u32::from(end), &mut chip);
+
+        for _ in 0..24 {
+            akiko.tick(2048, &mut chip, &mut ring);
+        }
+        assert_eq!(akiko.cdcomtxinx, end);
+        assert!(!akiko.checksum_error);
+        assert_eq!(akiko.data_offset, 0, "the READ command executed");
+
+        // A later packet starts from base + the visible index again; the page
+        // carry belongs only to the completed packet.
+        akiko.receive_length = 0;
+        akiko.receive_offset = 0;
+        akiko.command_active = 0;
+        let next = [0x15, 0x00, 0xEA];
+        chip[tx_base + end as usize..tx_base + end as usize + next.len()].copy_from_slice(&next);
+        let next_end = end.wrapping_add(next.len() as u8);
+        akiko.write(AKIKO_BASE + 0x1D, 1, u32::from(next_end), &mut chip);
+        for _ in 0..8 {
+            akiko.tick(2048, &mut chip, &mut ring);
+        }
+        assert_eq!(akiko.cdcomtxinx, next_end);
+        assert!(!akiko.checksum_error);
+    }
+
+    #[test]
+    fn response_dma_keeps_the_physical_page_carry_when_extended() {
+        let mut ring = CdAudioRing::default();
+        let mut chip = vec![0u8; 64 * 1024];
+        let mut akiko = Akiko::new();
+        akiko.cd_initialized = 2;
+
+        const MISC: u32 = 0x0000_1000;
+        akiko.write(AKIKO_BASE + 0x14, 4, MISC, &mut chip);
+        akiko.write(AKIKO_BASE + 0x24, 4, CDFLAG_RXD, &mut chip);
+        akiko.cdcomrxinx = 0xFE;
+        akiko.cdcomrxcmp = 0xFE;
+        chip[MISC as usize] = 0xCC;
+
+        akiko.result_buffer[0] = 0x42;
+        akiko.result_buffer[1] = 0x01;
+        assert!(akiko.start_return_data(2));
+
+        // Deliver one byte to the old page, then extend the same response
+        // across $FF. The comparator extension must not discard the carry.
+        akiko.write(AKIKO_BASE + 0x1F, 1, 0xFF, &mut chip);
+        akiko.tick(DMA_RESTART_DELAY_CCK, &mut chip, &mut ring);
+        assert_eq!(akiko.receive_offset, 1);
+        akiko.write(AKIKO_BASE + 0x1F, 1, 0x01, &mut chip);
+        akiko.tick(DMA_RESTART_DELAY_CCK, &mut chip, &mut ring);
+
+        let checksum = 0xFFu8.wrapping_sub(0x42).wrapping_sub(0x01);
+        assert_eq!(
+            &chip[MISC as usize + 0xFE..MISC as usize + 0x101],
+            &[0x42, 0x01, checksum]
+        );
+        assert_eq!(chip[MISC as usize], 0xCC, "physical address did not fold");
+        assert_eq!(akiko.cdcomrxinx, 0x01);
+    }
+
+    #[test]
+    fn command_dma_rebases_between_packets_queued_in_one_window() {
+        let mut ring = CdAudioRing::default();
+        let mut chip = vec![0u8; 64 * 1024];
+        let mut akiko = Akiko::new();
+        akiko.cd_initialized = 2;
+
+        const MISC: u32 = 0x0000_1000;
+        akiko.write(AKIKO_BASE + 0x14, 4, MISC, &mut chip);
+        akiko.write(AKIKO_BASE + 0x24, 4, CDFLAG_TXD, &mut chip);
+        akiko.cdcomtxinx = 0xFE;
+        akiko.cdcomtxcmp = 0xFE;
+        let tx_base = (MISC | 0x200) as usize;
+
+        // The first LED packet crosses the physical page; the second is
+        // already queued at base + its wrapped software index. One comparator
+        // window covers both packets, so only the parser boundary can rebase
+        // the physical DMA address for the second one.
+        chip[tx_base + 0xFE..tx_base + 0x101].copy_from_slice(&[0x15, 0x00, 0xEA]);
+        chip[tx_base + 0x01..tx_base + 0x04].copy_from_slice(&[0x25, 0x01, 0xD9]);
+        akiko.write(AKIKO_BASE + 0x1D, 1, 0x04, &mut chip);
+
+        for _ in 0..16 {
+            akiko.tick(2048, &mut chip, &mut ring);
+        }
+        assert_eq!(akiko.cdcomtxinx, 0x04);
+        assert_eq!(akiko.command, 0x25);
+        assert!(!akiko.checksum_error);
+    }
+
+    #[test]
+    fn response_waits_for_an_enabled_tx_completion_to_be_acknowledged() {
+        // TX and RX completion share one interrupt server in the ROM driver.
+        // A response becoming visible while the enabled TX completion is
+        // still pending makes that server account the RX ring against the
+        // wrong event and can leave it stopped at its comparator indefinitely.
+        let mut ring = CdAudioRing::default();
+        let mut chip = vec![0u8; 64 * 1024];
+        let mut akiko = Akiko::new();
+        akiko.cd_initialized = 2;
+
+        const MISC: u32 = 0x0000_1000;
+        akiko.write(AKIKO_BASE + 0x14, 4, MISC, &mut chip);
+        akiko.write(AKIKO_BASE + 0x24, 4, CDFLAG_RXD, &mut chip);
+        akiko.write(AKIKO_BASE + 0x1F, 1, 3, &mut chip);
+        akiko.command = 0x12; // PAUSE, sequence 1
+        akiko.command_buffer[0] = 0x12;
+        akiko.command_length = 1;
+        akiko.command_active = 1;
+        akiko.intreq = CDINT_TXDMADONE;
+        akiko.intena = CDINT_TXDMADONE | CDINT_RXDMADONE;
+
+        akiko.tick(DMA_RESTART_DELAY_CCK, &mut chip, &mut ring);
+        assert_eq!(akiko.command_active, 1, "command remains deferred");
+        assert_eq!(akiko.receive_length, 0, "no response exposed yet");
+        assert_eq!(akiko.cdcomrxinx, 0);
+
+        // Writing TXCMP acknowledges TXDMADONE. The next controller tick may
+        // execute the command and deliver the response through RX DMA.
+        akiko.write(AKIKO_BASE + 0x1D, 1, 0, &mut chip);
+        akiko.tick(1, &mut chip, &mut ring);
+        assert_eq!(akiko.intreq & CDINT_TXDMADONE, 0);
+        assert_ne!(akiko.intreq & CDINT_RXDMADONE, 0);
+        assert_eq!(akiko.cdcomrxinx, 3);
     }
 
     #[test]

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -4224,6 +4224,17 @@ impl Bus {
         })
     }
 
+    /// Immutable CD32 FMV genlock/video snapshot for the native renderer.
+    /// The decoded pixel storage is shared, so taking one for the render
+    /// worker is constant-time.
+    #[cfg(feature = "cd32-fmv")]
+    pub fn fmv_presentation(&self) -> Option<crate::cd32_fmv::FmvPresentation> {
+        self.devices.iter().find_map(|dev| match dev {
+            crate::zorro_device::BoardDevice::Cd32Fmv(board) => Some(board.presentation()),
+            _ => None,
+        })
+    }
+
     /// Whether the machine has a hard-disk controller, which is what gives it
     /// an HDD LED: a Zorro board, or the A3000's motherboard SCSI.
     fn has_hard_disk_controller(&self) -> bool {

--- a/src/cd32_fmv.rs
+++ b/src/cd32_fmv.rs
@@ -9,6 +9,7 @@
 //! this module therefore models the cartridge rather than recognizing any
 //! particular disc or title.
 
+use crate::audio::resample::Resampler;
 use crate::audio::MIX_SAMPLE_RATE;
 use crate::chipset::paula::{CdAudioRing, PAULA_CLOCK_HZ};
 use crate::zorro_device::{DeviceHost, ZorroDevice};
@@ -536,6 +537,8 @@ pub struct Cd32Fmv {
     audio_pcm: VecDeque<AudioPcmFrame>,
     audio_sample_acc: u64,
     audio_rate: u32,
+    audio_resampler_rate: u32,
+    audio_resampler: Resampler,
 }
 
 impl Cd32Fmv {
@@ -587,6 +590,8 @@ impl Cd32Fmv {
             audio_pcm: VecDeque::new(),
             audio_sample_acc: 0,
             audio_rate: MIX_SAMPLE_RATE,
+            audio_resampler_rate: MIX_SAMPLE_RATE,
+            audio_resampler: Resampler::new(MIX_SAMPLE_RATE, MIX_SAMPLE_RATE),
         };
         board.reset_all();
         Ok(board)
@@ -666,6 +671,8 @@ impl Cd32Fmv {
         self.audio_pcm.clear();
         self.audio_sample_acc = 0;
         self.audio_rate = MIX_SAMPLE_RATE;
+        self.audio_resampler_rate = MIX_SAMPLE_RATE;
+        self.audio_resampler = Resampler::new(MIX_SAMPLE_RATE, MIX_SAMPLE_RATE);
         self.audio_decoder = Mp2Decoder::new();
     }
 
@@ -802,6 +809,10 @@ impl Cd32Fmv {
                         self.audio_regs[A_CB_READ] = 0;
                         self.audio_regs[A_CB_STATUS] = 0;
                         self.audio_pcm.clear();
+                        self.audio_sample_acc = 0;
+                        self.audio_resampler_rate = self.audio_rate.max(1);
+                        self.audio_resampler =
+                            Resampler::new(self.audio_resampler_rate, MIX_SAMPLE_RATE);
                     }
                 }
                 self.audio_regs[A_CONTROL1] = value;
@@ -1276,35 +1287,51 @@ impl Cd32Fmv {
         if self.audio_regs[A_CONTROL1] & 1 == 0 {
             return;
         }
-        // VCD audio is 44.1 kHz.  The L64111 also accepts 32/48 kHz Layer II;
-        // those uncommon modes are paced at their declared native rate while
-        // the hardware's ordinary VCD path remains exactly mixer-rate.
-        self.audio_sample_acc += u64::from(cck) * u64::from(self.audio_rate.max(1));
+        let native_rate = self.audio_rate.max(1);
+        if self.audio_resampler_rate != native_rate {
+            self.audio_resampler_rate = native_rate;
+            self.audio_resampler = Resampler::new(native_rate, MIX_SAMPLE_RATE);
+        }
+        // The L64111 accepts 32/44.1/48 kHz Layer II streams, while the
+        // analogue CD input is sampled on Copperline's fixed mixer grid.
+        self.audio_sample_acc += u64::from(cck) * u64::from(MIX_SAMPLE_RATE);
+        let muted =
+            self.audio_regs[A_CONTROL2] & (1 << 5) != 0 || self.io_reg & IO_L64111_MUTE != 0;
         while self.audio_sample_acc >= u64::from(PAULA_CLOCK_HZ) {
             self.audio_sample_acc -= u64::from(PAULA_CLOCK_HZ);
-            let mut finished = false;
-            let sample = if let Some(frame) = self.audio_pcm.front_mut() {
-                let sample = frame
-                    .samples
-                    .get(frame.index)
-                    .copied()
-                    .unwrap_or((0.0, 0.0));
-                frame.index += 1;
-                finished = frame.index >= frame.samples.len();
-                sample
-            } else {
-                (0.0, 0.0)
+            let sample = {
+                let Self {
+                    audio_resampler,
+                    audio_pcm,
+                    audio_regs,
+                    ..
+                } = self;
+                audio_resampler.next(|| Self::pop_native_audio_sample(audio_pcm, audio_regs))
             };
-            let muted =
-                self.audio_regs[A_CONTROL2] & (1 << 5) != 0 || self.io_reg & IO_L64111_MUTE != 0;
             let sample = if muted { (0.0, 0.0) } else { sample };
             let _ = ring.push_frame(sample.0, sample.1);
-            if finished {
-                self.audio_pcm.pop_front();
-                self.audio_regs[A_CB_READ] = (self.audio_regs[A_CB_READ] + 1) & 63;
-                self.audio_regs[A_CB_STATUS] = self.audio_regs[A_CB_STATUS].saturating_sub(1);
-            }
         }
+    }
+
+    fn pop_native_audio_sample(
+        audio_pcm: &mut VecDeque<AudioPcmFrame>,
+        audio_regs: &mut [u16; 32],
+    ) -> (f32, f32) {
+        let Some(frame) = audio_pcm.front_mut() else {
+            return (0.0, 0.0);
+        };
+        let sample = frame
+            .samples
+            .get(frame.index)
+            .copied()
+            .unwrap_or((0.0, 0.0));
+        frame.index += 1;
+        if frame.index >= frame.samples.len() {
+            audio_pcm.pop_front();
+            audio_regs[A_CB_READ] = (audio_regs[A_CB_READ] + 1) & 63;
+            audio_regs[A_CB_STATUS] = audio_regs[A_CB_STATUS].saturating_sub(1);
+        }
+        sample
     }
 }
 
@@ -1509,6 +1536,26 @@ mod tests {
         assert_eq!(header.rate, 44_100);
         assert_eq!(header.len, 731);
         assert!(!header.mono);
+    }
+
+    #[test]
+    fn non_vcd_audio_rates_are_resampled_to_mixer_cadence() {
+        for (rate, expected_native_frames) in [(32_000, 32_064), (48_000, 48_064)] {
+            let mut board = Cd32Fmv::new(rom()).unwrap();
+            board.audio_regs[A_CONTROL1] = 1;
+            board.audio_rate = rate;
+            board.audio_pcm.push_back(AudioPcmFrame {
+                samples: vec![(0.25, -0.25); 50_000],
+                index: 0,
+            });
+            let mut ring = CdAudioRing::default();
+            board.advance_audio(PAULA_CLOCK_HZ, Some(&mut ring));
+            assert_eq!(
+                board.audio_pcm.front().unwrap().index,
+                expected_native_frames,
+                "native rate {rate}"
+            );
+        }
     }
 
     #[test]

--- a/src/cd32_fmv.rs
+++ b/src/cd32_fmv.rs
@@ -1,0 +1,1554 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Commodore CD32 Full Motion Video module.
+//!
+//! The cartridge is a 1 MiB Zorro II board normally autoconfigured at
+//! $200000: 256 KiB ROM, a small control window, an LSI L64111 MPEG audio
+//! decoder, a C-Cube CL450 MPEG video decoder, and 512 KiB RAM.  The guest
+//! ROM owns CD sector reads through Akiko and feeds the two decoder ports;
+//! this module therefore models the cartridge rather than recognizing any
+//! particular disc or title.
+
+use crate::audio::MIX_SAMPLE_RATE;
+use crate::chipset::paula::{CdAudioRing, PAULA_CLOCK_HZ};
+use crate::zorro_device::{DeviceHost, ZorroDevice};
+use anyhow::{bail, Result};
+use plmpeg::{
+    DecodeStatus, Decoder as Mpeg1Decoder, Frame as Mpeg1Frame, Sequence as Mpeg1Sequence,
+};
+use std::collections::VecDeque;
+use std::sync::Arc;
+use symphonia_bundle_mp3::MpaDecoder;
+use symphonia_core::audio::{Audio, GenericAudioBufferRef};
+use symphonia_core::codecs::audio::well_known::CODEC_ID_MP2;
+use symphonia_core::codecs::audio::{AudioCodecParameters, AudioDecoder, AudioDecoderOptions};
+use symphonia_core::packet::Packet;
+use symphonia_core::units::{Duration, Timestamp};
+
+pub const ROM_BYTES: usize = 0x4_0000;
+const RAM_BYTES: usize = 0x8_0000;
+const ROM_BASE: u32 = 0x000000;
+const IO_BASE: u32 = 0x040000;
+const L64111_BASE: u32 = 0x050000;
+const CL450_DATA: u32 = 0x060000;
+const CL450_BASE: u32 = 0x070000;
+const RAM_BASE: u32 = 0x080000;
+const BANK_MASK: u32 = 0x0F0000;
+
+// Cartridge I/O/status bits.
+const IO_CL450_IRQ: u16 = 0x8000;
+const IO_L64111_IRQ: u16 = 0x4000;
+const IO_CL450_VIDEO: u16 = 0x4000;
+const IO_CL450_FIFO_STATUS: u16 = 0x0800;
+const IO_L64111_MUTE: u16 = 0x0200;
+
+// L64111 register indices.
+const A_DATA: usize = 0;
+const A_CONTROL1: usize = 1;
+const A_CONTROL2: usize = 2;
+const A_CONTROL3: usize = 3;
+const A_INT1: usize = 4;
+const A_INT2: usize = 5;
+const A_PARAM1: usize = 9;
+const A_PARAM2: usize = 10;
+const A_PARAM3: usize = 11;
+const A_PRESENT1: usize = 12;
+const A_PRESENT2: usize = 13;
+const A_PRESENT3: usize = 14;
+const A_PRESENT4: usize = 15;
+const A_PRESENT5: usize = 16;
+const A_CB_STATUS: usize = 18;
+const A_CB_WRITE: usize = 19;
+const A_CB_READ: usize = 20;
+
+const AUDIO_FRAME_DETECT: u16 = 0x04;
+const AUDIO_PTS_AVAILABLE: u16 = 0x20;
+const AUDIO_SYNC: u16 = 0x10;
+const SYSTEM_SYNC: u16 = 0x08;
+const AUDIO_NEW_FRAME: u16 = 0x01;
+
+// CL450 direct-access registers (byte offsets).
+const CMEM_DATA: usize = 0x02;
+const CPU_CONTROL: usize = 0x20;
+const CPU_PC: usize = 0x22;
+const CPU_IADDR: usize = 0x3E;
+const CPU_IMEM: usize = 0x42;
+const CPU_TMEM: usize = 0x46;
+const CPU_INT: usize = 0x54;
+const HOST_NEWCMD: usize = 0x56;
+const CPU_INTENB: usize = 0x26;
+const CPU_TADDR: usize = 0x38;
+const CMEM_CONTROL: usize = 0x80;
+const CMEM_STATUS: usize = 0x82;
+const CMEM_DMACTRL: usize = 0x84;
+const HOST_RADDR: usize = 0x88;
+const HOST_RDATA: usize = 0x8C;
+const HOST_CONTROL: usize = 0x90;
+const HOST_SCR0: usize = 0x92;
+const HOST_SCR1: usize = 0x94;
+const HOST_SCR2: usize = 0x96;
+const HOST_INTVECW: usize = 0x98;
+const HOST_INTVECR: usize = 0x9C;
+const DRAM_REFCNT: usize = 0xAC;
+const VID_CONTROL: usize = 0xEC;
+const VID_REGDATA: usize = 0xEE;
+
+const CL_SET_BLANK: u16 = 0x030F;
+const CL_SET_BORDER: u16 = 0x0407;
+const CL_SET_COLOR_MODE: u16 = 0x0111;
+const CL_SET_INTERRUPT_MASK: u16 = 0x0104;
+const CL_SET_THRESHOLD: u16 = 0x0103;
+const CL_SET_VIDEO_FORMAT: u16 = 0x0105;
+const CL_SET_WINDOW: u16 = 0x0406;
+const CL_DISPLAY_STILL: u16 = 0x000C;
+const CL_PAUSE: u16 = 0x000E;
+const CL_PLAY: u16 = 0x000D;
+const CL_SCAN: u16 = 0x000A;
+const CL_SINGLE_STEP: u16 = 0x000B;
+const CL_SLOW_MOTION: u16 = 0x0109;
+const CL_ACCESS_SCR: u16 = 0x8312;
+const CL_FLUSH_BITSTREAM: u16 = 0x8102;
+const CL_INQUIRE_BUFFER_FULLNESS: u16 = 0x8001;
+const CL_NEW_PACKET: u16 = 0x0408;
+const CL_RESET: u16 = 0x8000;
+
+const CL_INT_RDY: u16 = 1 << 10;
+const CL_INT_PIC_D: u16 = 1 << 6;
+const CL_INT_SEQ_V: u16 = 1 << 3;
+const CL_INT_UND: u16 = 1 << 8;
+const CL_HMEM_INT_STATUS: usize = 0x0A;
+
+const CL_DRAM_H_SIZE: usize = 0x12;
+const CL_DRAM_V_SIZE: usize = 0x13;
+const CL_DRAM_PICTURE_RATE: usize = 0x14;
+const CL_DRAM_TIME_CODE_0: usize = 0x17;
+const CL_DRAM_TIME_CODE_1: usize = 0x18;
+const CL_DRAM_VER: usize = 0xA0;
+const CL_DRAM_PID: usize = 0xA1;
+
+const CL450_MPEG_BUFFER_SIZE: usize = 65_536;
+const CL450_VIDEO_BUFFERS: usize = 8;
+const CL450_IMEM_WORDS: usize = 1024;
+const CL450_TMEM_WORDS: usize = 128;
+const CL450_HMEM_WORDS: usize = 16;
+const CL450_VID_REGS: usize = 16;
+const CL450_NEWPACKET_BUFFER_SIZE: usize = 32;
+const MAX_AUDIO_STREAM_BYTES: usize = 1024 * 1024;
+const MAX_PENDING_GOPS: usize = 64;
+
+/// A decoded frame in Copperline's packed little-endian RGBA layout.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FmvFrame {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Arc<Vec<u32>>,
+}
+
+/// Cheap immutable frame snapshot carried to the render worker.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct FmvPresentation {
+    pub enabled: bool,
+    pub blank: bool,
+    /// Packed 0x00RRGGBB CL450 border latch.
+    pub border: u32,
+    pub generation: u64,
+    pub frame: Option<FmvFrame>,
+}
+
+impl PartialEq for FmvPresentation {
+    fn eq(&self, other: &Self) -> bool {
+        self.enabled == other.enabled
+            && self.blank == other.blank
+            && self.border == other.border
+            && self.generation == other.generation
+            && self.frame.as_ref().map(|f| (f.width, f.height))
+                == other.frame.as_ref().map(|f| (f.width, f.height))
+    }
+}
+
+impl Eq for FmvPresentation {}
+
+#[derive(Clone, Copy, serde::Serialize, serde::Deserialize)]
+struct GopMarker {
+    offset: u64,
+    hours: u8,
+    minutes: u8,
+    seconds: u8,
+    pictures: u8,
+}
+
+enum VideoEvent {
+    NeedInput,
+    Sequence {
+        width: u32,
+        height: u32,
+        frame_period: u32,
+    },
+    Gop {
+        hours: u8,
+        minutes: u8,
+        seconds: u8,
+        pictures: u8,
+    },
+    Frame(FmvFrame),
+}
+
+/// The CL450-facing MPEG-1 decoder. The decoder's reference pictures and
+/// partial bit buffer serialize directly, so save-state restore neither
+/// retains nor replays the compressed program stream.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct VideoDecoder {
+    decoder: Mpeg1Decoder,
+    observed_sequence: Option<Mpeg1Sequence>,
+    gop_scan_tail: Vec<u8>,
+    stream_bytes: u64,
+    pending_gops: VecDeque<GopMarker>,
+    pending_frame: Option<FmvFrame>,
+}
+
+impl VideoDecoder {
+    fn new() -> Self {
+        Self {
+            decoder: Mpeg1Decoder::new(),
+            observed_sequence: None,
+            gop_scan_tail: Vec::new(),
+            stream_bytes: 0,
+            pending_gops: VecDeque::new(),
+            pending_frame: None,
+        }
+    }
+
+    fn reset(&mut self) {
+        *self = Self::new();
+    }
+
+    fn offer(&mut self, bytes: Vec<u8>) {
+        if let Err(error) = self.decoder.push(&bytes) {
+            log::warn!("CD32 FMV: resetting MPEG-1 decoder after input error: {error}");
+            self.reset();
+            if let Err(error) = self.decoder.push(&bytes) {
+                log::warn!("CD32 FMV: MPEG-1 decoder rejected fresh input: {error}");
+                return;
+            }
+        }
+        self.scan_gops(&bytes);
+    }
+
+    fn scan_gops(&mut self, bytes: &[u8]) {
+        let old_tail = self.gop_scan_tail.len();
+        let base = self.stream_bytes.saturating_sub(old_tail as u64);
+        let mut scan = std::mem::take(&mut self.gop_scan_tail);
+        scan.extend_from_slice(bytes);
+        for (at, code) in start_codes(&scan) {
+            if code != 0xB8 || at + 8 > scan.len() || at + 8 <= old_tail {
+                continue;
+            }
+            let bits = u32::from_be_bytes(scan[at + 4..at + 8].try_into().unwrap());
+            if self.pending_gops.len() == MAX_PENDING_GOPS {
+                self.pending_gops.pop_front();
+            }
+            self.pending_gops.push_back(GopMarker {
+                offset: base + at as u64,
+                hours: ((bits >> 26) & 0x1F) as u8,
+                minutes: ((bits >> 20) & 0x3F) as u8,
+                seconds: ((bits >> 13) & 0x3F) as u8,
+                pictures: ((bits >> 7) & 0x3F) as u8,
+            });
+        }
+        self.stream_bytes = self.stream_bytes.saturating_add(bytes.len() as u64);
+        let tail = scan.len().saturating_sub(7);
+        self.gop_scan_tail.extend_from_slice(&scan[tail..]);
+    }
+
+    fn metadata_event(&mut self) -> Option<VideoEvent> {
+        if let Some(sequence) = self.decoder.sequence() {
+            if self.observed_sequence != Some(sequence) {
+                self.observed_sequence = Some(sequence);
+                return Some(VideoEvent::Sequence {
+                    width: sequence.width as u32,
+                    height: sequence.height as u32,
+                    frame_period: sequence.frame_rate.period_27mhz(),
+                });
+            }
+        }
+        let stream_position = self.decoder.stream_position();
+        if let Some(gop) = self
+            .pending_gops
+            .pop_front_if(|gop| gop.offset <= stream_position)
+        {
+            return Some(VideoEvent::Gop {
+                hours: gop.hours,
+                minutes: gop.minutes,
+                seconds: gop.seconds,
+                pictures: gop.pictures,
+            });
+        }
+        None
+    }
+
+    fn parse(&mut self) -> VideoEvent {
+        if let Some(frame) = self.pending_frame.take() {
+            return VideoEvent::Frame(frame);
+        }
+        if let Some(event) = self.metadata_event() {
+            return event;
+        }
+
+        let status = match self.decoder.decode() {
+            Ok(status) => status,
+            Err(error) => {
+                log::warn!("CD32 FMV: resetting malformed MPEG-1 stream: {error}");
+                self.reset();
+                return VideoEvent::NeedInput;
+            }
+        };
+        if status == DecodeStatus::FrameReady {
+            self.pending_frame = self.decoder.frame().and_then(Self::copy_display_frame);
+        }
+        if let Some(event) = self.metadata_event() {
+            return event;
+        }
+        self.pending_frame
+            .take()
+            .map_or(VideoEvent::NeedInput, VideoEvent::Frame)
+    }
+
+    fn copy_display_frame(frame: &Mpeg1Frame) -> Option<FmvFrame> {
+        let width = frame.width;
+        let height = frame.height;
+        if width == 0 || height == 0 || width > 1920 || height > 1080 {
+            return None;
+        }
+        let y_stride = frame.y.width;
+        let c_stride = frame.cb.width;
+        let c_height = frame.cb.height;
+        if frame.y.data.len() < y_stride.saturating_mul(frame.y.height)
+            || frame.cb.data.len() < c_stride.saturating_mul(c_height)
+            || frame.cr.data.len() < c_stride.saturating_mul(c_height)
+            || frame.cr.width != c_stride
+            || frame.cr.height != c_height
+        {
+            return None;
+        }
+        let mut pixels = Vec::with_capacity(width * height);
+        for py in 0..height {
+            let cy = (py / 2).min(c_height.saturating_sub(1));
+            for px in 0..width {
+                let cx = (px / 2).min(c_stride.saturating_sub(1));
+                pixels.push(ycbcr_to_rgba(
+                    frame.y.data[py * y_stride + px],
+                    frame.cb.data[cy * c_stride + cx],
+                    frame.cr.data[cy * c_stride + cx],
+                ));
+            }
+        }
+        Some(FmvFrame {
+            width: width as u32,
+            height: height as u32,
+            pixels: Arc::new(pixels),
+        })
+    }
+}
+
+fn ycbcr_to_rgba(y: u8, cb: u8, cr: u8) -> u32 {
+    let c = i32::from(y).saturating_sub(16);
+    let d = i32::from(cb) - 128;
+    let e = i32::from(cr) - 128;
+    let r = ((298 * c + 409 * e + 128) >> 8).clamp(0, 255) as u8;
+    let g = ((298 * c - 100 * d - 208 * e + 128) >> 8).clamp(0, 255) as u8;
+    let b = ((298 * c + 516 * d + 128) >> 8).clamp(0, 255) as u8;
+    u32::from_le_bytes([r, g, b, 0xFF])
+}
+
+fn start_codes(data: &[u8]) -> impl DoubleEndedIterator<Item = (usize, u8)> + '_ {
+    data.windows(4)
+        .enumerate()
+        .filter_map(|(i, w)| (w[..3] == [0, 0, 1]).then_some((i, w[3])))
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Mp2DecoderSnapshot {
+    history: Vec<Vec<u8>>,
+}
+
+struct Mp2Decoder {
+    decoder: MpaDecoder,
+    history: VecDeque<Vec<u8>>,
+}
+
+fn new_mp2_decoder() -> MpaDecoder {
+    let mut params = AudioCodecParameters::new();
+    params.for_codec(CODEC_ID_MP2);
+    MpaDecoder::try_new(&params, &AudioDecoderOptions::default())
+        .expect("symphonia-bundle-mp3 is built with its mp2 feature")
+}
+
+impl Mp2Decoder {
+    fn new() -> Self {
+        Self {
+            decoder: new_mp2_decoder(),
+            history: VecDeque::new(),
+        }
+    }
+
+    fn decode(&mut self, frame: &[u8]) -> Option<Vec<(f32, f32)>> {
+        let packet = Packet::new(0, Timestamp::ZERO, Duration::ZERO, frame);
+        let result = match self.decoder.decode_ref(&packet.as_packet_ref()) {
+            Ok(GenericAudioBufferRef::F32(buf)) => {
+                if buf.num_planes() == 1 {
+                    buf.plane(0)
+                        .map(|p| p.iter().map(|&v| (v, v)).collect::<Vec<_>>())
+                } else {
+                    buf.plane_pair(0, 1)
+                        .map(|(l, r)| l.iter().zip(r).map(|(&l, &r)| (l, r)).collect())
+                }
+            }
+            _ => None,
+        };
+        self.history.push_back(frame.to_vec());
+        while self.history.len() > 4 {
+            self.history.pop_front();
+        }
+        result.filter(|samples| !samples.is_empty())
+    }
+
+    fn restore(snapshot: Mp2DecoderSnapshot) -> Self {
+        let mut decoder = Self::new();
+        for frame in snapshot.history {
+            let _ = decoder.decode(&frame);
+        }
+        decoder
+    }
+}
+
+impl serde::Serialize for Mp2Decoder {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        Mp2DecoderSnapshot {
+            history: self.history.iter().cloned().collect(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Mp2Decoder {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        Ok(Self::restore(Mp2DecoderSnapshot::deserialize(
+            deserializer,
+        )?))
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Mp2Header {
+    len: usize,
+    rate: u32,
+    mono: bool,
+    raw: [u8; 4],
+}
+
+fn parse_mp2_header(raw: [u8; 4]) -> Option<Mp2Header> {
+    let h = u32::from_be_bytes(raw);
+    if h & 0xFFE0_0000 != 0xFFE0_0000 {
+        return None;
+    }
+    let version = (h >> 19) & 3;
+    let layer = (h >> 17) & 3;
+    let bitrate_index = ((h >> 12) & 15) as usize;
+    let rate_index = ((h >> 10) & 3) as usize;
+    if version != 3 || layer != 2 || bitrate_index == 0 || bitrate_index == 15 || rate_index == 3 {
+        return None;
+    }
+    const KBPS: [u32; 15] = [
+        0, 32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384,
+    ];
+    const RATES: [u32; 3] = [44_100, 48_000, 32_000];
+    let rate = RATES[rate_index];
+    let padding = (h >> 9) & 1;
+    let len = (144 * KBPS[bitrate_index] * 1000 / rate + padding) as usize;
+    Some(Mp2Header {
+        len,
+        rate,
+        mono: (h >> 6) & 3 == 3,
+        raw,
+    })
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct AudioPcmFrame {
+    samples: Vec<(f32, f32)>,
+    index: usize,
+}
+
+#[derive(Clone, Copy, serde::Serialize, serde::Deserialize)]
+struct NewPacket {
+    remaining: u16,
+    pts: u64,
+    pts_valid: bool,
+}
+
+/// Complete CD32 FMV cartridge state.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Cd32Fmv {
+    rom: Vec<u8>,
+    ram: Vec<u8>,
+    io_reg: u16,
+
+    cl_regs: Vec<u16>,
+    cl_imem: Vec<u16>,
+    cl_tmem: Vec<u16>,
+    cl_hmem: [u16; CL450_HMEM_WORDS],
+    cl_vid: [u16; CL450_VID_REGS],
+    cl_play: i8,
+    cl_blank: bool,
+    cl_border: u32,
+    cl_interrupt_mask: u16,
+    cl_pending_interrupts: u16,
+    cl_threshold: u16,
+    cl_buffer_empty_count: u8,
+    cl_buffer_empty_acc: u64,
+    cl_newpacket_mode: bool,
+    cl_newpackets: VecDeque<NewPacket>,
+    video_input: Vec<u8>,
+    video_decoder: VideoDecoder,
+    video_frames: VecDeque<FmvFrame>,
+    current_frame: Option<FmvFrame>,
+    frame_width: u32,
+    frame_height: u32,
+    frame_period: u32,
+    video_present_acc: u64,
+    presentation_generation: u64,
+    scr: u64,
+    scr_acc: u64,
+
+    audio_regs: [u16; 32],
+    audio_int_mask: [u16; 2],
+    audio_int_status: [u16; 2],
+    audio_fifo: Vec<u8>,
+    audio_es: Vec<u8>,
+    audio_frame_detect: u8,
+    audio_head_detect: u8,
+    audio_decoder: Mp2Decoder,
+    audio_pcm: VecDeque<AudioPcmFrame>,
+    audio_sample_acc: u64,
+    audio_rate: u32,
+}
+
+impl Cd32Fmv {
+    pub fn new(rom: Vec<u8>) -> Result<Self> {
+        if rom.len() != ROM_BYTES {
+            bail!(
+                "CD32 FMV ROM must be exactly {ROM_BYTES} bytes (256 KiB), got {}",
+                rom.len()
+            );
+        }
+        let mut board = Self {
+            rom,
+            ram: vec![0; RAM_BYTES],
+            io_reg: 0,
+            cl_regs: vec![0; 256],
+            cl_imem: vec![0; CL450_IMEM_WORDS],
+            cl_tmem: vec![0; CL450_TMEM_WORDS],
+            cl_hmem: [0; CL450_HMEM_WORDS],
+            cl_vid: [0; CL450_VID_REGS],
+            cl_play: 0,
+            cl_blank: false,
+            cl_border: 0,
+            cl_interrupt_mask: 0,
+            cl_pending_interrupts: 0,
+            cl_threshold: 4096,
+            cl_buffer_empty_count: 0,
+            cl_buffer_empty_acc: 0,
+            cl_newpacket_mode: false,
+            cl_newpackets: VecDeque::new(),
+            video_input: Vec::with_capacity(CL450_MPEG_BUFFER_SIZE),
+            video_decoder: VideoDecoder::new(),
+            video_frames: VecDeque::new(),
+            current_frame: None,
+            frame_width: 0,
+            frame_height: 0,
+            frame_period: 1_080_000,
+            video_present_acc: 0,
+            presentation_generation: 0,
+            scr: 0,
+            scr_acc: 0,
+            audio_regs: [0; 32],
+            audio_int_mask: [0; 2],
+            audio_int_status: [0; 2],
+            audio_fifo: Vec::new(),
+            audio_es: Vec::new(),
+            audio_frame_detect: 0,
+            audio_head_detect: 0,
+            audio_decoder: Mp2Decoder::new(),
+            audio_pcm: VecDeque::new(),
+            audio_sample_acc: 0,
+            audio_rate: MIX_SAMPLE_RATE,
+        };
+        board.reset_all();
+        Ok(board)
+    }
+
+    pub fn presentation(&self) -> FmvPresentation {
+        FmvPresentation {
+            enabled: self.io_reg & IO_CL450_VIDEO != 0,
+            blank: self.cl_blank,
+            border: self.cl_border,
+            generation: self.presentation_generation,
+            frame: self.current_frame.clone(),
+        }
+    }
+
+    fn reset_all(&mut self) {
+        self.ram.fill(0);
+        self.io_reg = 0;
+        self.reset_cl450();
+        self.reset_l64111();
+        self.presentation_generation = self.presentation_generation.wrapping_add(1);
+    }
+
+    fn reset_cl450(&mut self) {
+        self.cl_play = 0;
+        self.cl_pending_interrupts = 0;
+        self.cl_interrupt_mask = 0;
+        self.cl_blank = false;
+        self.cl_border = 0;
+        self.cl_threshold = 4096;
+        self.cl_buffer_empty_count = 0;
+        self.cl_buffer_empty_acc = 0;
+        self.cl_newpacket_mode = false;
+        self.cl_newpackets.clear();
+        self.video_input.clear();
+        self.video_frames.clear();
+        self.current_frame = None;
+        self.frame_width = 0;
+        self.frame_height = 0;
+        self.frame_period = 1_080_000;
+        self.video_present_acc = 0;
+        self.scr = 0;
+        self.scr_acc = 0;
+        self.cl_regs.fill(0);
+        self.cl_imem.fill(0);
+        self.cl_tmem.fill(0);
+        self.cl_hmem.fill(0);
+        self.cl_vid.fill(0);
+        self.video_decoder.reset();
+        self.write_dram(CL_DRAM_VER, 0x0200);
+        self.write_dram(CL_DRAM_PID, 0x0002);
+    }
+
+    fn init_cl450_cpu(&mut self) {
+        log::debug!("CD32 FMV: CL450 CPU enabled");
+        self.cl_hmem[15] = 0;
+        self.cl_regs[HOST_NEWCMD] = 0;
+        self.cl_regs[CMEM_CONTROL] = 2;
+        self.cl_regs[HOST_CONTROL] = 0x0081;
+        self.cl_vid[0] = 0xA8C6;
+        self.cl_vid[1] = 0x4967;
+        self.cl_regs[HOST_SCR2] = 0x1DE0;
+        self.cl_regs[HOST_SCR1] = 0;
+        self.cl_regs[HOST_SCR0] = 0;
+        self.scr = 0;
+        self.write_dram(CL_DRAM_VER, 0x0200);
+        self.write_dram(CL_DRAM_PID, 0x0002);
+        self.ram[0x10..0x100].fill(0);
+    }
+
+    fn reset_l64111(&mut self) {
+        self.audio_regs.fill(0);
+        self.audio_int_mask = [0; 2];
+        self.audio_int_status = [0; 2];
+        self.audio_regs[A_CONTROL3] = 0x80;
+        self.reset_audio_parser();
+        self.audio_pcm.clear();
+        self.audio_sample_acc = 0;
+        self.audio_rate = MIX_SAMPLE_RATE;
+        self.audio_decoder = Mp2Decoder::new();
+    }
+
+    fn reset_audio_parser(&mut self) {
+        self.audio_fifo.clear();
+        self.audio_es.clear();
+        self.audio_frame_detect = 0;
+        self.audio_head_detect = 0;
+    }
+
+    fn write_dram(&mut self, word: usize, value: u16) {
+        let at = word * 2;
+        if at + 1 < self.ram.len() {
+            self.ram[at..at + 2].copy_from_slice(&value.to_be_bytes());
+        }
+    }
+
+    fn cl450_irq(&self) -> bool {
+        self.cl_regs[CPU_CONTROL] & 1 != 0 && self.cl_regs[HOST_CONTROL] & 0x80 == 0
+    }
+
+    fn l64111_irq(&self) -> bool {
+        self.audio_int_status[0] & self.audio_int_mask[0] != 0
+            || (((self.audio_int_status[1] << 1) | (self.audio_int_status[1] >> 7))
+                & self.audio_int_mask[1]
+                != 0)
+    }
+
+    fn cl450_set_status(&mut self, mask: u16) {
+        self.cl_pending_interrupts |= mask & self.cl_interrupt_mask;
+        if self.cl_hmem[CL_HMEM_INT_STATUS] == 0 && self.cl_pending_interrupts != 0 {
+            self.cl_hmem[CL_HMEM_INT_STATUS] = self.cl_pending_interrupts;
+            self.cl_pending_interrupts = 0;
+            self.cl_regs[HOST_CONTROL] &= !0x80;
+        }
+    }
+
+    fn audio_set_status(&mut self, bank: usize, mask: u16) {
+        self.audio_int_status[bank] |= mask;
+    }
+
+    fn read_be(data: &[u8], at: usize, size: usize) -> u32 {
+        match size {
+            1 => data.get(at).copied().unwrap_or(0xFF).into(),
+            2 => u16::from_be_bytes([
+                data.get(at).copied().unwrap_or(0xFF),
+                data.get(at + 1).copied().unwrap_or(0xFF),
+            ])
+            .into(),
+            4 => u32::from_be_bytes([
+                data.get(at).copied().unwrap_or(0xFF),
+                data.get(at + 1).copied().unwrap_or(0xFF),
+                data.get(at + 2).copied().unwrap_or(0xFF),
+                data.get(at + 3).copied().unwrap_or(0xFF),
+            ]),
+            _ => 0,
+        }
+    }
+
+    fn write_be(data: &mut [u8], at: usize, size: usize, value: u32) {
+        match size {
+            1 => {
+                if let Some(byte) = data.get_mut(at) {
+                    *byte = value as u8;
+                }
+            }
+            2 => {
+                if let Some(dst) = data.get_mut(at..at + 2) {
+                    dst.copy_from_slice(&(value as u16).to_be_bytes());
+                }
+            }
+            4 => {
+                if let Some(dst) = data.get_mut(at..at + 4) {
+                    dst.copy_from_slice(&value.to_be_bytes());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn io_read(&self, off: u32) -> u16 {
+        if off & 0xFFFF != 0 {
+            return 0;
+        }
+        let mut value = IO_CL450_IRQ | IO_L64111_IRQ | IO_CL450_FIFO_STATUS;
+        if self.cl450_irq() {
+            value &= !IO_CL450_IRQ;
+        }
+        if self.l64111_irq() {
+            value &= !IO_L64111_IRQ;
+        }
+        value
+    }
+
+    fn io_write(&mut self, off: u32, value: u16) {
+        if off & 0xFFFF == 0 {
+            let changed = self.io_reg ^ value;
+            self.io_reg = value;
+            if changed & IO_CL450_VIDEO != 0 {
+                self.presentation_generation = self.presentation_generation.wrapping_add(1);
+            }
+        }
+    }
+
+    fn l64111_read(&mut self, off: u32) -> u16 {
+        let reg = ((off >> 1) & 31) as usize;
+        match reg {
+            A_INT1 => {
+                let value = self.audio_int_status[0];
+                self.audio_int_status[0] = 0;
+                value
+            }
+            A_INT2 => {
+                let value = self.audio_int_status[1] & 0x7F;
+                self.audio_int_status[1] = 0;
+                value
+            }
+            _ => self.audio_regs[reg],
+        }
+    }
+
+    fn l64111_write(&mut self, off: u32, value: u16) {
+        let reg = ((off >> 1) & 31) as usize;
+        match reg {
+            A_CONTROL1 => {
+                if value & 2 != 0 {
+                    self.reset_l64111();
+                } else {
+                    if (value ^ self.audio_regs[A_CONTROL1]) & 1 != 0 {
+                        self.reset_audio_parser();
+                    }
+                    if value & 4 != 0 {
+                        self.audio_regs[A_CB_WRITE] = 0;
+                        self.audio_regs[A_CB_READ] = 0;
+                        self.audio_regs[A_CB_STATUS] = 0;
+                        self.audio_pcm.clear();
+                    }
+                }
+                self.audio_regs[A_CONTROL1] = value;
+            }
+            A_DATA => {
+                self.audio_regs[A_DATA] = value;
+                if self.audio_fifo.len() + 2 <= MAX_AUDIO_STREAM_BYTES {
+                    self.audio_fifo.extend_from_slice(&value.to_be_bytes());
+                    self.parse_audio_stream();
+                }
+            }
+            A_INT1 => self.audio_int_mask[0] = value,
+            A_INT2 => self.audio_int_mask[1] = value,
+            _ => self.audio_regs[reg] = value,
+        }
+    }
+
+    fn parse_audio_stream(&mut self) {
+        if self.audio_regs[A_CONTROL1] & 1 == 0 {
+            self.audio_fifo.clear();
+            return;
+        }
+        if self.audio_regs[A_CONTROL2] & 0x08 != 0 {
+            self.audio_es.append(&mut self.audio_fifo);
+            self.parse_audio_elementary();
+            return;
+        }
+        loop {
+            let Some(prefix) = self.audio_fifo.windows(3).position(|w| w == [0, 0, 1]) else {
+                if self.audio_fifo.len() > 2 {
+                    let keep = self.audio_fifo.split_off(self.audio_fifo.len() - 2);
+                    self.audio_fifo = keep;
+                }
+                break;
+            };
+            if prefix != 0 {
+                self.audio_fifo.drain(..prefix);
+            }
+            if self.audio_fifo.len() < 4 {
+                break;
+            }
+            let code = self.audio_fifo[3];
+            if code == 0xBA {
+                let Some(total) = pack_header_len(&self.audio_fifo) else {
+                    break;
+                };
+                if self.audio_fifo.len() < total {
+                    break;
+                }
+                self.audio_fifo.drain(..total);
+                continue;
+            }
+            if self.audio_fifo.len() < 6 {
+                break;
+            }
+            let packet_len =
+                usize::from(u16::from_be_bytes([self.audio_fifo[4], self.audio_fifo[5]]));
+            let total = 6 + packet_len;
+            if self.audio_fifo.len() < total {
+                break;
+            }
+            let packet: Vec<u8> = self.audio_fifo.drain(..total).collect();
+            if (0xC0..=0xDF).contains(&code)
+                && (self.audio_regs[A_CONTROL3] & 0x80 != 0
+                    || usize::from(code - 0xC0) == usize::from(self.audio_regs[A_CONTROL3] & 31))
+            {
+                self.audio_head_detect = self.audio_head_detect.saturating_add(1);
+                if self.audio_head_detect == 3 {
+                    self.audio_set_status(1, SYSTEM_SYNC);
+                }
+                let (payload, pts) = pes_audio_payload(&packet);
+                if let Some(pts) = pts {
+                    self.audio_regs[A_PRESENT1] = pts as u16;
+                    self.audio_regs[A_PRESENT2] = (pts >> 8) as u16;
+                    self.audio_regs[A_PRESENT3] = (pts >> 16) as u16;
+                    self.audio_regs[A_PRESENT4] = (pts >> 24) as u16;
+                    self.audio_regs[A_PRESENT5] = (pts >> 32) as u16;
+                    if self.audio_head_detect >= 3 {
+                        self.audio_set_status(1, AUDIO_PTS_AVAILABLE);
+                    }
+                }
+                self.audio_es.extend_from_slice(payload);
+                self.parse_audio_elementary();
+            }
+        }
+    }
+
+    fn parse_audio_elementary(&mut self) {
+        loop {
+            if self.audio_es.len() < 4 {
+                break;
+            }
+            let Some((at, header)) = (0..=self.audio_es.len() - 4).find_map(|at| {
+                parse_mp2_header([
+                    self.audio_es[at],
+                    self.audio_es[at + 1],
+                    self.audio_es[at + 2],
+                    self.audio_es[at + 3],
+                ])
+                .map(|header| (at, header))
+            }) else {
+                self.audio_es.drain(..self.audio_es.len() - 3);
+                break;
+            };
+            if at != 0 {
+                self.audio_es.drain(..at);
+            }
+            if self.audio_es.len() < header.len {
+                break;
+            }
+            let frame: Vec<u8> = self.audio_es.drain(..header.len).collect();
+            self.audio_frame_detect = self.audio_frame_detect.saturating_add(1);
+            self.audio_regs[A_PARAM1] =
+                ((u16::from(header.raw[1]) << 4) | u16::from(header.raw[2] >> 4)) & 0xFF;
+            self.audio_regs[A_PARAM2] =
+                ((u16::from(header.raw[2]) << 4) | u16::from(header.raw[3] >> 4)) & 0xFF;
+            self.audio_regs[A_PARAM3] = u16::from(header.raw[3]) << 4 & 0xFF;
+            self.audio_set_status(
+                1,
+                AUDIO_FRAME_DETECT
+                    | if self.audio_frame_detect == 3 {
+                        AUDIO_SYNC
+                    } else {
+                        0
+                    },
+            );
+            self.audio_rate = header.rate;
+            if let Some(samples) = self.audio_decoder.decode(&frame) {
+                if self.audio_pcm.len() < 64 {
+                    self.audio_pcm
+                        .push_back(AudioPcmFrame { samples, index: 0 });
+                    self.audio_regs[A_CB_WRITE] = (self.audio_regs[A_CB_WRITE] + 1) & 63;
+                    self.audio_regs[A_CB_STATUS] = self.audio_regs[A_CB_STATUS].saturating_add(1);
+                    self.audio_set_status(1, AUDIO_NEW_FRAME);
+                }
+            }
+            let _ = header.mono;
+        }
+    }
+
+    fn cl450_read(&self, off: u32) -> u16 {
+        let reg = (off as usize) & 0xFE;
+        match reg {
+            HOST_INTVECR | HOST_CONTROL | HOST_RADDR | HOST_NEWCMD | CPU_IADDR | CPU_TADDR
+            | CPU_PC | CPU_CONTROL | VID_CONTROL => self.cl_regs[reg],
+            HOST_RDATA => self.cl_hmem[usize::from(self.cl_regs[HOST_RADDR] & 15)],
+            VID_REGDATA => self.cl_vid[usize::from((self.cl_regs[VID_CONTROL] >> 1) & 15)],
+            CMEM_DMACTRL | CMEM_STATUS | CPU_INT | CPU_INTENB => self.cl_regs[reg],
+            _ => 0,
+        }
+    }
+
+    fn cl450_write(&mut self, off: u32, value: u16) {
+        let reg = (off as usize) & 0xFE;
+        match reg {
+            CMEM_DATA => self.cl450_data_write(value),
+            CMEM_CONTROL => {
+                self.cl_regs[CMEM_CONTROL] = value;
+                if value & 0x40 != 0 {
+                    self.reset_cl450();
+                }
+            }
+            CMEM_DMACTRL | DRAM_REFCNT | CPU_PC | HOST_SCR0 | HOST_SCR1 | HOST_SCR2 => {
+                self.cl_regs[reg] = value
+            }
+            HOST_INTVECW => self.cl_regs[HOST_INTVECR] = value,
+            HOST_CONTROL => self.cl_regs[HOST_CONTROL] = value,
+            HOST_RADDR => self.cl_regs[HOST_RADDR] = value & 15,
+            HOST_RDATA => {
+                let at = usize::from(self.cl_regs[HOST_RADDR] & 15);
+                self.cl_hmem[at] = value;
+                self.cl_regs[HOST_RADDR] = (self.cl_regs[HOST_RADDR] + 1) & 15;
+            }
+            HOST_NEWCMD => {
+                self.cl_regs[HOST_NEWCMD] = value;
+                self.cl450_command();
+            }
+            CPU_CONTROL => {
+                if self.cl_regs[CPU_CONTROL] & 1 == 0 && value & 1 != 0 {
+                    self.init_cl450_cpu();
+                }
+                self.cl_regs[CPU_CONTROL] = value & 1;
+            }
+            CPU_IADDR => self.cl_regs[CPU_IADDR] = value & (CL450_IMEM_WORDS as u16 - 1),
+            CPU_IMEM => {
+                let at = usize::from(self.cl_regs[CPU_IADDR]) & (CL450_IMEM_WORDS - 1);
+                self.cl_imem[at] = value;
+                self.cl_regs[CPU_IADDR] =
+                    (self.cl_regs[CPU_IADDR] + 1) & (CL450_IMEM_WORDS as u16 - 1);
+            }
+            CPU_TADDR => self.cl_regs[CPU_TADDR] = value & (CL450_TMEM_WORDS as u16 - 1),
+            CPU_TMEM => {
+                let at = usize::from(self.cl_regs[CPU_TADDR]) & (CL450_TMEM_WORDS - 1);
+                self.cl_tmem[at] = value;
+                self.cl_regs[CPU_TADDR] =
+                    (self.cl_regs[CPU_TADDR] + 1) & (CL450_TMEM_WORDS as u16 - 1);
+            }
+            VID_CONTROL => self.cl_regs[VID_CONTROL] = value & ((CL450_VID_REGS as u16 - 1) << 1),
+            VID_REGDATA => {
+                let at = usize::from((self.cl_regs[VID_CONTROL] >> 1) & 15);
+                self.cl_vid[at] = value;
+            }
+            _ => {}
+        }
+    }
+
+    fn cl450_data_write(&mut self, value: u16) {
+        if self.video_input.len() <= CL450_MPEG_BUFFER_SIZE - 2 {
+            self.video_input.extend_from_slice(&value.to_be_bytes());
+        }
+    }
+
+    fn cl450_command(&mut self) {
+        if matches!(self.cl_hmem[0], CL_NEW_PACKET | CL_INQUIRE_BUFFER_FULLNESS) {
+            log::trace!(
+                "CD32 FMV: CL450 NewPacket size={} flags={:#06X}",
+                self.cl_hmem[1],
+                self.cl_hmem[2]
+            );
+        } else {
+            log::debug!(
+                "CD32 FMV: CL450 command {:#06X} args={:04X},{:04X},{:04X},{:04X}",
+                self.cl_hmem[0],
+                self.cl_hmem[1],
+                self.cl_hmem[2],
+                self.cl_hmem[3],
+                self.cl_hmem[4]
+            );
+        }
+        match self.cl_hmem[0] {
+            CL_PLAY => self.cl_play = 1,
+            CL_PAUSE => {
+                if self.cl_play > 0 {
+                    self.scr = 0;
+                    self.scr_to_regs();
+                }
+                self.cl_play = -self.cl_play;
+            }
+            CL_NEW_PACKET => self.cl450_new_packet(),
+            CL_INQUIRE_BUFFER_FULLNESS => self.cl_hmem[0x0B] = self.video_input.len() as u16,
+            CL_SET_BLANK => {
+                let blank = self.cl_hmem[1] & 1 != 0;
+                if self.cl_blank != blank {
+                    self.cl_blank = blank;
+                    self.presentation_generation = self.presentation_generation.wrapping_add(1);
+                }
+            }
+            CL_SET_BORDER => {
+                let border = (u32::from(self.cl_hmem[3] & 0xFF) << 16) | u32::from(self.cl_hmem[4]);
+                if self.cl_border != border {
+                    self.cl_border = border;
+                    self.presentation_generation = self.presentation_generation.wrapping_add(1);
+                }
+            }
+            CL_SET_INTERRUPT_MASK => self.cl_interrupt_mask = self.cl_hmem[1],
+            CL_SET_THRESHOLD => self.cl_threshold = self.cl_hmem[1],
+            CL_ACCESS_SCR => {
+                if self.cl_hmem[1] & 0x8000 != 0 {
+                    self.scr_to_regs();
+                    self.cl_hmem[1] = 0x8000 | (self.cl_regs[HOST_SCR0] & 7);
+                    self.cl_hmem[2] = self.cl_regs[HOST_SCR1] & 0x7FFF;
+                    self.cl_hmem[3] = self.cl_regs[HOST_SCR2] & 0x7FFF;
+                } else {
+                    self.cl_regs[HOST_SCR0] = self.cl_hmem[1] & 7;
+                    self.cl_regs[HOST_SCR1] = self.cl_hmem[2] & 0x7FFF;
+                    self.cl_regs[HOST_SCR2] = self.cl_hmem[3] & 0x7FFF;
+                    self.regs_to_scr();
+                }
+            }
+            CL_RESET => {
+                self.cl_blank = true;
+                self.cl_play = 0;
+                self.cl_newpackets.clear();
+                self.cl_newpacket_mode = false;
+                self.cl_interrupt_mask = 0;
+                self.video_input.clear();
+                self.cl_buffer_empty_count = 0;
+                self.video_decoder.reset();
+                self.video_frames.clear();
+                self.presentation_generation = self.presentation_generation.wrapping_add(1);
+            }
+            CL_FLUSH_BITSTREAM => {
+                self.video_input.clear();
+                self.cl_newpackets.clear();
+            }
+            CL_SET_COLOR_MODE | CL_SET_VIDEO_FORMAT | CL_SET_WINDOW | CL_DISPLAY_STILL
+            | CL_SCAN | CL_SINGLE_STEP | CL_SLOW_MOTION => {}
+            _ => log::debug!(
+                "CD32 FMV: unsupported CL450 command {:#06X}",
+                self.cl_hmem[0]
+            ),
+        }
+        self.cl_regs[HOST_NEWCMD] = 0;
+    }
+
+    fn cl450_new_packet(&mut self) {
+        self.cl_newpacket_mode = true;
+        if self.cl_newpackets.len() == CL450_NEWPACKET_BUFFER_SIZE {
+            self.cl_newpackets.pop_front();
+        }
+        let pts_valid = self.cl_hmem[2] & 0x8000 != 0;
+        let pts = (u64::from(self.cl_regs[HOST_SCR0] & 7) << 30)
+            | (u64::from(self.cl_regs[HOST_SCR1] & 0x7FFF) << 15)
+            | u64::from(self.cl_regs[HOST_SCR2] & 0x7FFF);
+        self.cl_newpackets.push_back(NewPacket {
+            remaining: self.cl_hmem[1],
+            pts,
+            pts_valid,
+        });
+    }
+
+    fn consume_newpacket_bytes(&mut self, mut count: usize) {
+        while count != 0 {
+            let Some(front) = self.cl_newpackets.front_mut() else {
+                break;
+            };
+            let used = count.min(usize::from(front.remaining));
+            front.remaining -= used as u16;
+            count -= used;
+            if front.remaining == 0 {
+                self.cl_newpackets.pop_front();
+            }
+        }
+    }
+
+    fn scr_to_regs(&mut self) {
+        self.cl_regs[HOST_SCR0] = (self.cl_regs[HOST_SCR0] & !7) | ((self.scr >> 30) as u16 & 7);
+        self.cl_regs[HOST_SCR1] = (self.scr >> 15) as u16 & 0x7FFF;
+        self.cl_regs[HOST_SCR2] = self.scr as u16 & 0x7FFF;
+    }
+
+    fn regs_to_scr(&mut self) {
+        self.scr = (u64::from(self.cl_regs[HOST_SCR0] & 7) << 30)
+            | (u64::from(self.cl_regs[HOST_SCR1] & 0x7FFF) << 15)
+            | u64::from(self.cl_regs[HOST_SCR2] & 0x7FFF);
+    }
+
+    fn service_video_decoder(&mut self) {
+        if self.cl_play <= 0 || self.video_frames.len() >= CL450_VIDEO_BUFFERS - 1 {
+            return;
+        }
+        let mut offered = false;
+        for _ in 0..256 {
+            match self.video_decoder.parse() {
+                VideoEvent::NeedInput => {
+                    if offered || self.video_input.len() < 512 {
+                        break;
+                    }
+                    let input = std::mem::take(&mut self.video_input);
+                    if self.video_decoder.stream_bytes == 0 {
+                        log::debug!(
+                            "CD32 FMV: first CL450 bitstream buffer: {} bytes, prefix {:02X?}",
+                            input.len(),
+                            &input[..input.len().min(16)]
+                        );
+                    }
+                    self.consume_newpacket_bytes(input.len());
+                    self.video_decoder.offer(input);
+                    offered = true;
+                }
+                VideoEvent::Sequence {
+                    width,
+                    height,
+                    frame_period,
+                } => {
+                    if self.frame_width != width
+                        || self.frame_height != height
+                        || self.frame_period != frame_period
+                    {
+                        log::debug!(
+                            "CD32 FMV: MPEG sequence {}x{}, frame period {}",
+                            width,
+                            height,
+                            frame_period
+                        );
+                    }
+                    self.frame_width = width;
+                    self.frame_height = height;
+                    self.frame_period = frame_period.max(1);
+                    let rate = 27_000_000 / self.frame_period;
+                    self.write_dram(CL_DRAM_PICTURE_RATE, rate as u16);
+                    self.write_dram(CL_DRAM_H_SIZE, width as u16);
+                    self.write_dram(CL_DRAM_V_SIZE, height as u16);
+                    self.cl450_set_status(CL_INT_SEQ_V);
+                }
+                VideoEvent::Gop {
+                    hours,
+                    minutes,
+                    seconds,
+                    pictures,
+                } => {
+                    self.write_dram(
+                        CL_DRAM_TIME_CODE_0,
+                        (u16::from(hours) << 6) | u16::from(minutes),
+                    );
+                    self.write_dram(
+                        CL_DRAM_TIME_CODE_1,
+                        (u16::from(seconds) << 6) | u16::from(pictures),
+                    );
+                }
+                VideoEvent::Frame(frame) => {
+                    log::trace!(
+                        "CD32 FMV: decoded MPEG frame {}x{}",
+                        frame.width,
+                        frame.height
+                    );
+                    self.video_frames.push_back(frame);
+                    break;
+                }
+            }
+        }
+    }
+
+    fn advance_video(&mut self, cck: u32) {
+        if self.cl_play > 0 {
+            self.scr_acc += u64::from(cck) * 90_000;
+            self.scr += self.scr_acc / u64::from(PAULA_CLOCK_HZ);
+            self.scr_acc %= u64::from(PAULA_CLOCK_HZ);
+
+            self.video_present_acc += u64::from(cck) * 27_000_000;
+            let period = u64::from(PAULA_CLOCK_HZ) * u64::from(self.frame_period.max(1));
+            while self.video_present_acc >= period {
+                self.video_present_acc -= period;
+                self.cl450_set_status(CL_INT_PIC_D);
+                if let Some(frame) = self.video_frames.pop_front() {
+                    if self.current_frame.is_none() {
+                        log::debug!(
+                            "CD32 FMV: presenting first MPEG frame {}x{}",
+                            frame.width,
+                            frame.height
+                        );
+                    }
+                    self.current_frame = Some(frame);
+                    self.presentation_generation = self.presentation_generation.wrapping_add(1);
+                }
+            }
+        }
+
+        self.cl_buffer_empty_acc += u64::from(cck);
+        let check_period = u64::from(PAULA_CLOCK_HZ) / 250;
+        while self.cl_buffer_empty_acc >= check_period {
+            self.cl_buffer_empty_acc -= check_period;
+            if self.video_input.is_empty() {
+                if self.cl_buffer_empty_count >= 2 {
+                    self.cl450_set_status(CL_INT_UND);
+                } else {
+                    self.cl_buffer_empty_count += 1;
+                }
+            } else {
+                self.cl_buffer_empty_count = 0;
+            }
+        }
+
+        if self.cl_play > 0
+            && self.cl_newpacket_mode
+            && self.video_input.len() < usize::from(self.cl_threshold)
+        {
+            let pending: usize = self
+                .cl_newpackets
+                .iter()
+                .map(|p| usize::from(p.remaining))
+                .sum();
+            if self.video_input.len() >= pending.saturating_sub(6) {
+                self.cl450_set_status(CL_INT_RDY);
+            }
+        }
+        self.service_video_decoder();
+    }
+
+    fn advance_audio(&mut self, cck: u32, ring: Option<&mut CdAudioRing>) {
+        let Some(ring) = ring else { return };
+        if self.audio_regs[A_CONTROL1] & 1 == 0 {
+            return;
+        }
+        // VCD audio is 44.1 kHz.  The L64111 also accepts 32/48 kHz Layer II;
+        // those uncommon modes are paced at their declared native rate while
+        // the hardware's ordinary VCD path remains exactly mixer-rate.
+        self.audio_sample_acc += u64::from(cck) * u64::from(self.audio_rate.max(1));
+        while self.audio_sample_acc >= u64::from(PAULA_CLOCK_HZ) {
+            self.audio_sample_acc -= u64::from(PAULA_CLOCK_HZ);
+            let mut finished = false;
+            let sample = if let Some(frame) = self.audio_pcm.front_mut() {
+                let sample = frame
+                    .samples
+                    .get(frame.index)
+                    .copied()
+                    .unwrap_or((0.0, 0.0));
+                frame.index += 1;
+                finished = frame.index >= frame.samples.len();
+                sample
+            } else {
+                (0.0, 0.0)
+            };
+            let muted =
+                self.audio_regs[A_CONTROL2] & (1 << 5) != 0 || self.io_reg & IO_L64111_MUTE != 0;
+            let sample = if muted { (0.0, 0.0) } else { sample };
+            let _ = ring.push_frame(sample.0, sample.1);
+            if finished {
+                self.audio_pcm.pop_front();
+                self.audio_regs[A_CB_READ] = (self.audio_regs[A_CB_READ] + 1) & 63;
+                self.audio_regs[A_CB_STATUS] = self.audio_regs[A_CB_STATUS].saturating_sub(1);
+            }
+        }
+    }
+}
+
+impl ZorroDevice for Cd32Fmv {
+    fn read(&mut self, off: u32, size: usize, _host: &mut DeviceHost) -> u32 {
+        let bank = off & BANK_MASK;
+        if off < IO_BASE {
+            return Self::read_be(&self.rom, (off - ROM_BASE) as usize, size);
+        }
+        if off >= RAM_BASE {
+            return Self::read_be(&self.ram, (off - RAM_BASE) as usize, size);
+        }
+        if size == 4 {
+            return (self.read(off, 2, _host) << 16) | self.read(off + 2, 2, _host);
+        }
+        let word = match bank {
+            IO_BASE => self.io_read(off),
+            L64111_BASE => self.l64111_read(off),
+            CL450_BASE => self.cl450_read(off),
+            _ => 0,
+        };
+        if size == 1 {
+            u32::from(word as u8)
+        } else {
+            u32::from(word)
+        }
+    }
+
+    fn write(&mut self, off: u32, size: usize, value: u32, _host: &mut DeviceHost) {
+        if off >= RAM_BASE {
+            Self::write_be(&mut self.ram, (off - RAM_BASE) as usize, size, value);
+            return;
+        }
+        if off < IO_BASE {
+            return;
+        }
+        if size == 4 {
+            self.write(off, 2, value >> 16, _host);
+            self.write(off + 2, 2, value, _host);
+            return;
+        }
+        let bank = off & BANK_MASK;
+        if size == 1 {
+            match bank {
+                L64111_BASE => self.l64111_write(off, value as u16),
+                CL450_BASE => self.cl450_write(off, value as u16),
+                _ => {}
+            }
+            return;
+        }
+        match bank {
+            IO_BASE => {
+                log::debug!("CD32 FMV: I/O control <- {:#06X}", value as u16);
+                self.io_write(off, value as u16);
+            }
+            L64111_BASE => self.l64111_write(off, value as u16),
+            CL450_DATA => self.cl450_data_write(value as u16),
+            CL450_BASE => self.cl450_write(off, value as u16),
+            _ => {}
+        }
+    }
+
+    fn peek_word(&self, off: u32) -> Option<u16> {
+        if off < IO_BASE {
+            return Some(Self::read_be(&self.rom, off as usize, 2) as u16);
+        }
+        if off >= RAM_BASE {
+            return Some(Self::read_be(&self.ram, (off - RAM_BASE) as usize, 2) as u16);
+        }
+        None
+    }
+
+    fn tick(&mut self, cck: u32, host: &mut DeviceHost) {
+        self.advance_video(cck);
+        self.advance_audio(cck, host.cd_audio_opt());
+    }
+
+    fn int2_line(&self) -> bool {
+        self.cl450_irq() || self.l64111_irq()
+    }
+
+    fn is_idle(&self) -> bool {
+        false
+    }
+
+    fn reset(&mut self) {
+        self.reset_all();
+    }
+
+    fn kind(&self) -> &'static str {
+        "cd32-fmv"
+    }
+}
+
+fn pack_header_len(data: &[u8]) -> Option<usize> {
+    let version = *data.get(4)?;
+    if version & 0xF0 == 0x20 {
+        Some(12)
+    } else if version & 0xC0 == 0x40 {
+        Some(14 + usize::from(*data.get(13)? & 7))
+    } else {
+        Some(4)
+    }
+}
+
+fn pes_audio_payload(packet: &[u8]) -> (&[u8], Option<u64>) {
+    if packet.len() <= 6 {
+        return (&[], None);
+    }
+    let mut at = 6;
+    let mut pts = None;
+    if packet.get(at).is_some_and(|b| b & 0xC0 == 0x80) {
+        let flags = packet.get(at + 1).copied().unwrap_or(0);
+        let header_len = usize::from(packet.get(at + 2).copied().unwrap_or(0));
+        if flags & 0x80 != 0 {
+            pts = parse_pts(packet.get(at + 3..at + 8).unwrap_or(&[]));
+        }
+        at = (at + 3 + header_len).min(packet.len());
+    } else {
+        while packet.get(at) == Some(&0xFF) {
+            at += 1;
+        }
+        if packet.get(at).is_some_and(|b| b & 0xC0 == 0x40) {
+            at += 2;
+        }
+        match packet.get(at).map(|b| b & 0xF0) {
+            Some(0x20) => {
+                pts = parse_pts(packet.get(at..at + 5).unwrap_or(&[]));
+                at += 5;
+            }
+            Some(0x30) => {
+                pts = parse_pts(packet.get(at..at + 5).unwrap_or(&[]));
+                at += 10;
+            }
+            _ if packet.get(at) == Some(&0x0F) => at += 1,
+            _ => {}
+        }
+        at = at.min(packet.len());
+    }
+    (&packet[at..], pts)
+}
+
+fn parse_pts(data: &[u8]) -> Option<u64> {
+    if data.len() < 5 {
+        return None;
+    }
+    Some(
+        (u64::from((data[0] >> 1) & 7) << 30)
+            | (u64::from(data[1]) << 22)
+            | (u64::from(data[2] >> 1) << 15)
+            | (u64::from(data[3]) << 7)
+            | u64::from(data[4] >> 1),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rom() -> Vec<u8> {
+        (0..ROM_BYTES).map(|i| i as u8).collect()
+    }
+
+    #[test]
+    fn board_map_exposes_rom_ram_and_active_low_irq_status() {
+        let mut board = Cd32Fmv::new(rom()).unwrap();
+        let mut mem = crate::memory::Memory::placeholder(0x20_0000, 0, Default::default());
+        let mut host = DeviceHost::new(&mut mem);
+        assert_eq!(board.read(0, 4, &mut host), 0x0001_0203);
+        board.write(RAM_BASE + 2, 4, 0x1234_5678, &mut host);
+        assert_eq!(board.read(RAM_BASE + 2, 4, &mut host), 0x1234_5678);
+        assert_eq!(board.read(IO_BASE, 2, &mut host), 0xC800);
+        board.cl_regs[CPU_CONTROL] = 1;
+        board.cl_regs[HOST_CONTROL] = 0;
+        assert_eq!(
+            board.read(IO_BASE, 2, &mut host) & u32::from(IO_CL450_IRQ),
+            0
+        );
+        assert!(board.int2_line());
+    }
+
+    #[test]
+    fn cl450_host_memory_and_command_protocol() {
+        let mut board = Cd32Fmv::new(rom()).unwrap();
+        board.cl450_write(CPU_CONTROL as u32, 1);
+        assert_eq!(board.cl_regs[HOST_CONTROL], 0x0081);
+        board.cl450_write(HOST_RADDR as u32, 0);
+        board.cl450_write(HOST_RDATA as u32, CL_SET_BORDER);
+        board.cl450_write(HOST_RDATA as u32, 0);
+        board.cl450_write(HOST_RDATA as u32, 0);
+        board.cl450_write(HOST_RDATA as u32, 0x12);
+        board.cl450_write(HOST_RDATA as u32, 0x3456);
+        board.cl450_write(HOST_NEWCMD as u32, 1);
+        assert_eq!(board.cl_border, 0x123456);
+        assert_eq!(board.cl_regs[HOST_NEWCMD], 0);
+    }
+
+    #[test]
+    fn mpeg_layer_two_header_has_vcd_frame_size() {
+        // MPEG-1 Layer II, 224 kbps, 44.1 kHz, stereo.
+        let header = parse_mp2_header([0xFF, 0xFD, 0xB0, 0x00]).unwrap();
+        assert_eq!(header.rate, 44_100);
+        assert_eq!(header.len, 731);
+        assert!(!header.mono);
+    }
+
+    #[test]
+    fn gop_time_code_survives_fragmented_input() {
+        let mut decoder = VideoDecoder::new();
+        let header = [0x00, 0x00, 0x01, 0xB8, 0x48, 0xD5, 0x2A, 0x80];
+        decoder.offer(header[..3].to_vec());
+        decoder.offer(header[3..7].to_vec());
+        decoder.offer(header[7..].to_vec());
+        assert_eq!(decoder.pending_gops.len(), 1);
+        let gop = decoder.pending_gops.front().unwrap();
+        assert_eq!(
+            (gop.hours, gop.minutes, gop.seconds, gop.pictures),
+            (18, 13, 41, 21)
+        );
+    }
+
+    #[test]
+    fn video_decoder_snapshot_restores_exact_rust_state() {
+        // A valid PAL VCD sequence header followed by a GOP/end code exercises
+        // both the incremental bit reader and Copperline's metadata scanner.
+        let bytes = vec![
+            0x00, 0x00, 0x01, 0xB3, 0x16, 0x01, 0x20, 0x83, 0x02, 0xE1, 0xA0, 0xA4, 0x00, 0x00,
+            0x01, 0xB8, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x01, 0xB7,
+        ];
+        let mut decoder = VideoDecoder::new();
+        decoder.offer(bytes);
+
+        let encoded = bincode::serialize(&decoder).unwrap();
+        let restored: VideoDecoder = bincode::deserialize(&encoded).unwrap();
+        assert_eq!(
+            restored.decoder.stream_position(),
+            decoder.decoder.stream_position()
+        );
+        assert_eq!(
+            restored.decoder.buffered_bytes(),
+            decoder.decoder.buffered_bytes()
+        );
+        assert_eq!(restored.gop_scan_tail, decoder.gop_scan_tail);
+        assert_eq!(restored.stream_bytes, decoder.stream_bytes);
+        assert_eq!(restored.pending_gops.len(), decoder.pending_gops.len());
+    }
+}

--- a/src/cdrom.rs
+++ b/src/cdrom.rs
@@ -3,7 +3,7 @@
 //! CD image backend: cue/bin, NRG, and CHD parsing and sector access.
 //!
 //! Supports single-file and multi-file cue layouts with MODE1/2048,
-//! MODE1/2352, and AUDIO tracks, including INDEX 00 pregaps stored in
+//! MODE1/2352, MODE2/2336, MODE2/2352, and AUDIO tracks, including INDEX 00 pregaps stored in
 //! the files and PREGAP/POSTGAP gaps that are not (they read as zero
 //! fill, like a CHD's unstored gaps). A `FILE` is `BINARY` (raw sector
 //! bytes) or, for audio tracks, `WAVE` or `MP3` -- the packaged form a
@@ -33,6 +33,7 @@ pub use audio::FileFormat;
 
 pub const SECTORS_PER_SECOND: u32 = 75;
 pub const DATA_SECTOR_BYTES: usize = 2048;
+pub const MODE2_SECTOR_BYTES: usize = 2336;
 pub const RAW_SECTOR_BYTES: usize = 2352;
 /// Standard lead-in offset: LBA 0 is MSF 00:02:00 on a real disc.
 pub const LEADIN_SECTORS: u32 = 150;
@@ -45,13 +46,18 @@ pub enum TrackKind {
     Mode1_2352,
     /// 2352-byte CD-DA sectors.
     Audio,
+    /// 2336-byte Mode 2 sectors, stored without sync and address header.
+    Mode2_2336,
+    /// Complete 2352-byte raw Mode 2 sectors.
+    Mode2_2352,
 }
 
 impl TrackKind {
     pub fn sector_bytes(self) -> usize {
         match self {
             TrackKind::Mode1_2048 => DATA_SECTOR_BYTES,
-            TrackKind::Mode1_2352 | TrackKind::Audio => RAW_SECTOR_BYTES,
+            TrackKind::Mode2_2336 => MODE2_SECTOR_BYTES,
+            TrackKind::Mode1_2352 | TrackKind::Mode2_2352 | TrackKind::Audio => RAW_SECTOR_BYTES,
         }
     }
 
@@ -397,10 +403,12 @@ impl CdImage {
                     let kind = match words.next() {
                         Some("MODE1/2048") => TrackKind::Mode1_2048,
                         Some("MODE1/2352") => TrackKind::Mode1_2352,
+                        Some("MODE2/2336") => TrackKind::Mode2_2336,
+                        Some("MODE2/2352") => TrackKind::Mode2_2352,
                         Some("AUDIO") => TrackKind::Audio,
                         other => bail!(
                             "{}: track {} type {:?} is not supported (MODE1/2048, \
-                             MODE1/2352, AUDIO)",
+                             MODE1/2352, MODE2/2336, MODE2/2352, AUDIO)",
                             cue_path.display(),
                             number,
                             other
@@ -677,6 +685,21 @@ impl CdImage {
                 buf.copy_from_slice(&raw[16..16 + DATA_SECTOR_BYTES]);
                 Ok(())
             }
+            TrackKind::Mode2_2336 => {
+                let mut mode2 = [0u8; MODE2_SECTOR_BYTES];
+                self.read_payload(sector, &mut mode2)?;
+                // CD-ROM XA repeats an eight-byte subheader before the
+                // Form 1/2 user-data field. Cooked callers always request
+                // 2048 bytes; sustained Form 2 streams use read_raw_sector.
+                buf.copy_from_slice(&mode2[8..8 + DATA_SECTOR_BYTES]);
+                Ok(())
+            }
+            TrackKind::Mode2_2352 => {
+                let mut raw = [0u8; RAW_SECTOR_BYTES];
+                self.read_payload(sector, &mut raw)?;
+                buf.copy_from_slice(&raw[24..24 + DATA_SECTOR_BYTES]);
+                Ok(())
+            }
             TrackKind::Audio => bail!("sector {sector} is in an audio track"),
         }
     }
@@ -705,11 +728,19 @@ impl CdImage {
             .sector_kind(sector)
             .with_context(|| format!("sector {sector} beyond end of disc"))?;
         match kind {
-            TrackKind::Mode1_2352 | TrackKind::Audio => self.read_payload(sector, buf),
+            TrackKind::Mode1_2352 | TrackKind::Mode2_2352 | TrackKind::Audio => {
+                self.read_payload(sector, buf)
+            }
             TrackKind::Mode1_2048 => {
                 let mut data = [0u8; DATA_SECTOR_BYTES];
                 self.read_payload(sector, &mut data)?;
                 synthesize_mode1_sector(sector, &data, buf);
+                Ok(())
+            }
+            TrackKind::Mode2_2336 => {
+                let mut data = [0u8; MODE2_SECTOR_BYTES];
+                self.read_payload(sector, &mut data)?;
+                synthesize_mode2_sector(sector, &data, buf);
                 Ok(())
             }
         }
@@ -868,6 +899,24 @@ fn synthesize_mode1_sector(
     mode1_ecc(&prefix[12..], 86, 24, 2, 86, &mut parity[..172]);
     let (prefix, parity) = raw.split_at_mut(MODE1_ECC_Q_OFFSET);
     mode1_ecc(&prefix[12..], 52, 43, 86, 88, &mut parity[..104]);
+}
+
+/// Add the sync/address header omitted by a MODE2/2336 image. The stored
+/// bytes already contain the duplicated XA subheader, user data, EDC and
+/// (for Form 1) ECC, so no payload bytes are regenerated here.
+fn synthesize_mode2_sector(
+    sector: u32,
+    data: &[u8; MODE2_SECTOR_BYTES],
+    raw: &mut [u8; RAW_SECTOR_BYTES],
+) {
+    raw.fill(0);
+    raw[1..11].fill(0xFF);
+    let msf = sector + LEADIN_SECTORS;
+    raw[12] = to_bcd((msf / (60 * SECTORS_PER_SECOND)) as u8);
+    raw[13] = to_bcd(((msf / SECTORS_PER_SECOND) % 60) as u8);
+    raw[14] = to_bcd((msf % SECTORS_PER_SECOND) as u8);
+    raw[15] = 2;
+    raw[16..].copy_from_slice(data);
 }
 
 /// Parse a cue MM:SS:FF time to a sector number.
@@ -1035,6 +1084,72 @@ mod tests {
         let mut data = [0u8; DATA_SECTOR_BYTES];
         image.read_data_sector(0, &mut data).unwrap();
         assert!(data.iter().all(|&b| b == 0x42));
+        let _ = std::fs::remove_file(&cue);
+        let _ = std::fs::remove_file(&bin);
+    }
+
+    #[test]
+    fn mode2_2336_is_promoted_to_a_complete_raw_sector() {
+        let cue = temp_path("mode2-2336.cue");
+        let bin = temp_path("mode2-2336.bin");
+        let mut stored = [0u8; MODE2_SECTOR_BYTES];
+        stored[..8].copy_from_slice(&[1, 2, 0x20, 4, 1, 2, 0x20, 4]);
+        stored[8..8 + DATA_SECTOR_BYTES].fill(0x5A);
+        write_file(&bin, &stored);
+        std::fs::write(
+            &cue,
+            format!(
+                "FILE \"{}\" BINARY\n  TRACK 01 MODE2/2336\n    INDEX 01 00:00:00\n",
+                bin.file_name().unwrap().to_string_lossy()
+            ),
+        )
+        .unwrap();
+
+        let mut image = CdImage::load(&cue).unwrap();
+        assert_eq!(image.tracks()[0].kind, TrackKind::Mode2_2336);
+        let mut data = [0u8; DATA_SECTOR_BYTES];
+        image.read_data_sector(0, &mut data).unwrap();
+        assert!(data.iter().all(|&byte| byte == 0x5A));
+
+        let mut raw = [0u8; RAW_SECTOR_BYTES];
+        image.read_raw_sector(0, &mut raw).unwrap();
+        assert_eq!(
+            &raw[..16],
+            &[0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 2, 0, 2]
+        );
+        assert_eq!(&raw[16..], &stored);
+
+        let _ = std::fs::remove_file(&cue);
+        let _ = std::fs::remove_file(&bin);
+    }
+
+    #[test]
+    fn mode2_2352_exposes_xa_user_data_and_preserves_raw_frame() {
+        let cue = temp_path("mode2-2352.cue");
+        let bin = temp_path("mode2-2352.bin");
+        let mut raw = [0xEE; RAW_SECTOR_BYTES];
+        raw[15] = 2;
+        raw[16..24].copy_from_slice(&[1, 2, 0x20, 4, 1, 2, 0x20, 4]);
+        raw[24..24 + DATA_SECTOR_BYTES].fill(0xA6);
+        write_file(&bin, &raw);
+        std::fs::write(
+            &cue,
+            format!(
+                "FILE \"{}\" BINARY\n  TRACK 01 MODE2/2352\n    INDEX 01 00:00:00\n",
+                bin.file_name().unwrap().to_string_lossy()
+            ),
+        )
+        .unwrap();
+
+        let mut image = CdImage::load(&cue).unwrap();
+        assert_eq!(image.tracks()[0].kind, TrackKind::Mode2_2352);
+        let mut data = [0u8; DATA_SECTOR_BYTES];
+        image.read_data_sector(0, &mut data).unwrap();
+        assert!(data.iter().all(|&byte| byte == 0xA6));
+        let mut actual = [0u8; RAW_SECTOR_BYTES];
+        image.read_raw_sector(0, &mut actual).unwrap();
+        assert_eq!(actual, raw);
+
         let _ = std::fs::remove_file(&cue);
         let _ = std::fs::remove_file(&bin);
     }

--- a/src/cdrom/chd.rs
+++ b/src/cdrom/chd.rs
@@ -419,8 +419,15 @@ fn track_kind(name: &str, number: u8) -> Result<TrackKind> {
     match name {
         "MODE1" | "MODE1/2048" => Ok(TrackKind::Mode1_2048),
         "MODE1_RAW" | "MODE1/2352" => Ok(TrackKind::Mode1_2352),
+        // CHD CD hunks always expose complete 2352-byte frames even when
+        // the source image used a cooked Mode 2 geometry.
+        "MODE2" | "MODE2_RAW" | "MODE2/2336" | "MODE2/2352" | "MODE2_FORM1" | "MODE2_FORM2"
+        | "MODE2_FORM_MIX" => Ok(TrackKind::Mode2_2352),
         "AUDIO" => Ok(TrackKind::Audio),
-        other => bail!("track {number} type {other:?} is not supported (MODE1, MODE1_RAW, AUDIO)"),
+        other => bail!(
+            "track {number} type {other:?} is not supported \
+             (MODE1, MODE1_RAW, MODE2, MODE2_RAW, AUDIO)"
+        ),
     }
 }
 
@@ -840,9 +847,12 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_track_type_is_rejected() {
+    fn mode2_raw_track_is_served_as_a_raw_sector() {
         let path = temp_path("mode2.chd");
-        let data = track_frames(&[frame(&[0u8; RAW_SECTOR_BYTES])]);
+        let mut raw = [0u8; RAW_SECTOR_BYTES];
+        raw[15] = 2;
+        raw[24..24 + DATA_SECTOR_BYTES].fill(0x6B);
+        let data = track_frames(&[frame(&raw)]);
         write_chd_v5(
             &path,
             HUNK_BYTES,
@@ -853,8 +863,11 @@ mod tests {
                  PGSUB:NONE POSTGAP:0",
             )],
         );
-        let err = CdImage::load(&path).unwrap_err();
-        assert!(format!("{err:#}").contains("not supported"), "{err:#}");
+        let mut image = CdImage::load(&path).unwrap();
+        assert_eq!(image.tracks()[0].kind, TrackKind::Mode2_2352);
+        let mut actual = [0u8; RAW_SECTOR_BYTES];
+        image.read_raw_sector(0, &mut actual).unwrap();
+        assert_eq!(actual, raw);
         let _ = std::fs::remove_file(&path);
     }
 

--- a/src/cdrom/chd.rs
+++ b/src/cdrom/chd.rs
@@ -13,7 +13,7 @@
 //! disc out. CD-DA frames are stored with big-endian samples and are
 //! swapped back to the little-endian disc byte order on read.
 
-use super::{CdTrack, TrackKind, DATA_SECTOR_BYTES, RAW_SECTOR_BYTES};
+use super::{CdTrack, TrackKind, DATA_SECTOR_BYTES, MODE2_SECTOR_BYTES, RAW_SECTOR_BYTES};
 use anyhow::{anyhow, bail, Context, Result};
 use chd::metadata::{KnownMetadata, Metadata};
 use chd::Chd;
@@ -386,7 +386,10 @@ impl ChdImage {
                 Some(first) => (first + (sector - region.disc_start), region.kind),
             }
         };
-        debug_assert!(matches!(buf.len(), DATA_SECTOR_BYTES | RAW_SECTOR_BYTES));
+        debug_assert!(matches!(
+            buf.len(),
+            DATA_SECTOR_BYTES | MODE2_SECTOR_BYTES | RAW_SECTOR_BYTES
+        ));
         self.load_hunk(frame / self.frames_per_hunk)?;
         let offset = (frame % self.frames_per_hunk) as usize * FRAME_BYTES;
         buf.copy_from_slice(&self.hunk_buf[offset..offset + buf.len()]);
@@ -419,10 +422,11 @@ fn track_kind(name: &str, number: u8) -> Result<TrackKind> {
     match name {
         "MODE1" | "MODE1/2048" => Ok(TrackKind::Mode1_2048),
         "MODE1_RAW" | "MODE1/2352" => Ok(TrackKind::Mode1_2352),
-        // CHD CD hunks always expose complete 2352-byte frames even when
-        // the source image used a cooked Mode 2 geometry.
-        "MODE2" | "MODE2_RAW" | "MODE2/2336" | "MODE2/2352" | "MODE2_FORM1" | "MODE2_FORM2"
-        | "MODE2_FORM_MIX" => Ok(TrackKind::Mode2_2352),
+        "MODE2" | "MODE2/2336" | "MODE2_FORM_MIX" => Ok(TrackKind::Mode2_2336),
+        "MODE2_RAW" | "MODE2/2352" => Ok(TrackKind::Mode2_2352),
+        "MODE2_FORM1" | "MODE2_FORM2" => {
+            bail!("track {number} type {name:?} uses an unsupported cooked Mode 2 sector width")
+        }
         "AUDIO" => Ok(TrackKind::Audio),
         other => bail!(
             "track {number} type {other:?} is not supported \
@@ -869,6 +873,40 @@ mod tests {
         image.read_raw_sector(0, &mut actual).unwrap();
         assert_eq!(actual, raw);
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn mode2_2336_track_preserves_its_stored_geometry() {
+        let path = temp_path("mode2-2336.chd");
+        let mut stored = [0u8; MODE2_SECTOR_BYTES];
+        stored[..8].copy_from_slice(&[0, 0, 0, 1, 0, 0, 0, 1]);
+        stored[8..8 + DATA_SECTOR_BYTES].fill(0x6B);
+        let data = track_frames(&[frame(&stored)]);
+        write_chd_v5(
+            &path,
+            HUNK_BYTES,
+            FRAME_BYTES as u32,
+            &data,
+            &[cht2(
+                "TRACK:1 TYPE:MODE2/2336 SUBTYPE:NONE FRAMES:1 PREGAP:0 PGTYPE:MODE1 \
+                 PGSUB:NONE POSTGAP:0",
+            )],
+        );
+        let mut image = CdImage::load(&path).unwrap();
+        assert_eq!(image.tracks()[0].kind, TrackKind::Mode2_2336);
+        let mut raw = [0u8; RAW_SECTOR_BYTES];
+        image.read_raw_sector(0, &mut raw).unwrap();
+        assert_eq!(raw[15], 2);
+        assert_eq!(&raw[16..], &stored);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn unsupported_cooked_mode2_forms_are_rejected() {
+        for kind in ["MODE2_FORM1", "MODE2_FORM2"] {
+            let error = track_kind(kind, 1).unwrap_err();
+            assert!(error.to_string().contains("unsupported cooked Mode 2"));
+        }
     }
 
     #[test]

--- a/src/cdrom/nrg.rs
+++ b/src/cdrom/nrg.rs
@@ -641,15 +641,14 @@ fn cue_lba(entries: &[CueEntry], track: u8, index: u8) -> Option<i32> {
 fn decode_mode(mode: u8, sector_bytes: u64, path: &Path) -> Result<TrackKind> {
     match (mode, sector_bytes) {
         (0x00, n) if n == DATA_SECTOR_BYTES as u64 => Ok(TrackKind::Mode1_2048),
+        (0x02 | 0x03, n) if n == super::MODE2_SECTOR_BYTES as u64 => Ok(TrackKind::Mode2_2336),
         (0x05, n) if n == RAW_SECTOR_BYTES as u64 => Ok(TrackKind::Mode1_2352),
+        (0x06, n) if n == RAW_SECTOR_BYTES as u64 => Ok(TrackKind::Mode2_2352),
         (0x07, n) if n == RAW_SECTOR_BYTES as u64 => Ok(TrackKind::Audio),
         (0x0F..=0x11, 2448) => bail!(
             "{}: NRG sectors with stored subchannel data are not supported",
             path.display()
         ),
-        (0x02 | 0x03 | 0x06 | 0x11, _) => {
-            bail!("{}: Mode 2 NRG tracks are not supported", path.display())
-        }
         _ => bail!(
             "{}: unsupported NRG track mode 0x{mode:02X} with {sector_bytes}-byte sectors",
             path.display()
@@ -660,9 +659,10 @@ fn decode_mode(mode: u8, sector_bytes: u64, path: &Path) -> Result<TrackKind> {
 fn tao_mode(mode: u8, path: &Path) -> Result<(TrackKind, u64)> {
     match mode {
         0x00 => Ok((TrackKind::Mode1_2048, DATA_SECTOR_BYTES as u64)),
+        0x02 | 0x03 => Ok((TrackKind::Mode2_2336, super::MODE2_SECTOR_BYTES as u64)),
         0x05 => Ok((TrackKind::Mode1_2352, RAW_SECTOR_BYTES as u64)),
+        0x06 => Ok((TrackKind::Mode2_2352, RAW_SECTOR_BYTES as u64)),
         0x07 => Ok((TrackKind::Audio, RAW_SECTOR_BYTES as u64)),
-        0x02 | 0x03 | 0x06 => bail!("{}: Mode 2 NRG tracks are not supported", path.display()),
         _ => bail!(
             "{}: unsupported NRG track mode 0x{mode:02X}",
             path.display()

--- a/src/cdrom/nrg.rs
+++ b/src/cdrom/nrg.rs
@@ -641,7 +641,7 @@ fn cue_lba(entries: &[CueEntry], track: u8, index: u8) -> Option<i32> {
 fn decode_mode(mode: u8, sector_bytes: u64, path: &Path) -> Result<TrackKind> {
     match (mode, sector_bytes) {
         (0x00, n) if n == DATA_SECTOR_BYTES as u64 => Ok(TrackKind::Mode1_2048),
-        (0x02 | 0x03, n) if n == super::MODE2_SECTOR_BYTES as u64 => Ok(TrackKind::Mode2_2336),
+        (0x03, n) if n == super::MODE2_SECTOR_BYTES as u64 => Ok(TrackKind::Mode2_2336),
         (0x05, n) if n == RAW_SECTOR_BYTES as u64 => Ok(TrackKind::Mode1_2352),
         (0x06, n) if n == RAW_SECTOR_BYTES as u64 => Ok(TrackKind::Mode2_2352),
         (0x07, n) if n == RAW_SECTOR_BYTES as u64 => Ok(TrackKind::Audio),
@@ -659,7 +659,7 @@ fn decode_mode(mode: u8, sector_bytes: u64, path: &Path) -> Result<TrackKind> {
 fn tao_mode(mode: u8, path: &Path) -> Result<(TrackKind, u64)> {
     match mode {
         0x00 => Ok((TrackKind::Mode1_2048, DATA_SECTOR_BYTES as u64)),
-        0x02 | 0x03 => Ok((TrackKind::Mode2_2336, super::MODE2_SECTOR_BYTES as u64)),
+        0x03 => Ok((TrackKind::Mode2_2336, super::MODE2_SECTOR_BYTES as u64)),
         0x05 => Ok((TrackKind::Mode1_2352, RAW_SECTOR_BYTES as u64)),
         0x06 => Ok((TrackKind::Mode2_2352, RAW_SECTOR_BYTES as u64)),
         0x07 => Ok((TrackKind::Audio, RAW_SECTOR_BYTES as u64)),
@@ -704,6 +704,17 @@ mod tests {
             "copperline-nrg-{}-{unique}-{name}",
             std::process::id()
         ))
+    }
+
+    #[test]
+    fn cooked_mode2_form1_is_not_misclassified_as_2336_bytes() {
+        let path = Path::new("mode2-form1.nrg");
+        assert!(decode_mode(0x02, DATA_SECTOR_BYTES as u64, path).is_err());
+        assert!(tao_mode(0x02, path).is_err());
+        assert_eq!(
+            decode_mode(0x03, super::super::MODE2_SECTOR_BYTES as u64, path).unwrap(),
+            TrackKind::Mode2_2336
+        );
     }
 
     fn chunk(id: &[u8; 4], data: &[u8], out: &mut Vec<u8>) {

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -306,6 +306,18 @@ impl CdAudioRing {
         self.samples.len() + 588 <= CD_AUDIO_RING_LIMIT
     }
 
+    /// Push one already-decoded stereo frame.  The CD32 FMV cartridge's
+    /// L64111 output joins the same analogue CD input of the CD32 mixer as
+    /// CD-DA, but arrives one MPEG-audio sample at a time rather than in
+    /// 2352-byte sectors.
+    pub fn push_frame(&mut self, left: f32, right: f32) -> bool {
+        if self.samples.len() >= CD_AUDIO_RING_LIMIT {
+            return false;
+        }
+        self.samples.push_back((left, right));
+        true
+    }
+
     pub fn next_sample(&mut self) -> (f32, f32) {
         self.samples.pop_front().unwrap_or((0.0, 0.0))
     }

--- a/src/config/about.rs
+++ b/src/config/about.rs
@@ -108,6 +108,11 @@ pub fn about_machine_lines(cfg: &Config) -> Vec<String> {
             ));
         }
     }
+    if let Some(fmv) = cfg.fmv_rom_path.as_deref() {
+        if let Some(name) = fmv.file_name() {
+            lines.push(format!("CD32 FMV ROM: {}", name.to_string_lossy()));
+        }
+    }
     let drives = cfg
         .floppy_connected
         .iter()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -174,6 +174,9 @@ pub struct Config {
     /// Extended ROM image (`extended_rom = "path"`): 512 KiB maps at
     /// $E00000 (CD32), 256 KiB at $F00000 (CDTV).
     pub extended_rom_path: Option<PathBuf>,
+    /// CD32 Full Motion Video cartridge ROM (`fmv_rom = "path"`).  Naming
+    /// one fits the physical 1 MiB autoconfig module; absent means no module.
+    pub fmv_rom_path: Option<PathBuf>,
     /// CD image (`[cd] image = "disc.cue"`), mounted on the machine's CD
     /// controller (CD32 Akiko or CDTV DMAC).
     pub cd_image_path: Option<PathBuf>,
@@ -2290,6 +2293,7 @@ impl Default for Config {
             akiko: false,
             cdtv_cd: false,
             extended_rom_path: None,
+            fmv_rom_path: None,
             cd_image_path: None,
             cd_insert_delay_secs: 0.0,
             cd32_nvram_path: None,

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -32,7 +32,7 @@ pub(crate) fn raw_from_path(path: &Path) -> Result<RawConfig> {
 // the output minimal -- only fields and sections the user actually set are
 // emitted, matching the style of the hand-written `*.example.toml`. The
 // `toml` serializer requires every top-level scalar key to be emitted before
-// any `[table]`, so the three top-level scalars (`rom`, `extended_rom`,
+// any `[table]`, so the top-level scalars (`rom`, `extended_rom`, `fmv_rom`,
 // `identify`) are declared first, ahead of the section tables and the `zorro`
 // array of tables. Field declaration order otherwise mirrors deserialization,
 // which is order-independent.
@@ -44,6 +44,9 @@ pub struct RawConfig {
     /// Extended ROM image (CD32 512K at $E00000, CDTV 256K at $F00000).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) extended_rom: Option<String>,
+    /// CD32 Full Motion Video cartridge ROM (256 KiB v40.30 image).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) fmv_rom: Option<String>,
     /// `identify = false` drops the Copperline identification board from the
     /// autoconfig chain (default: present).
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1506,6 +1506,29 @@ fn machine_profile_defaults_match_bare_profile_configs() -> Result<()> {
 }
 
 #[test]
+fn fmv_rom_is_cd32_only() -> Result<()> {
+    let cfg = parse_config(
+        r#"
+            fmv_rom = "cd32fmv.rom"
+            [machine]
+            profile = "CD32"
+            "#,
+    )?;
+    assert_eq!(cfg.fmv_rom_path.as_deref(), Some(Path::new("cd32fmv.rom")));
+
+    let err = parse_config(
+        r#"
+            fmv_rom = "cd32fmv.rom"
+            [machine]
+            profile = "A1200"
+            "#,
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("only valid for a CD32"), "{err:#}");
+    Ok(())
+}
+
+#[test]
 fn machine_profiles_supply_defaults_and_keep_overrides() -> Result<()> {
     // No [machine] section: the default machine is the A500 Rev 6A
     // (ECS 8372A Agnus + OCS 8362 Denise), no gate array, no RTC (the base
@@ -4875,6 +4898,7 @@ fn the_about_rom_line_names_the_image_it_can_identify() {
     // An unknown extended ROM gets a line of its own, named the same
     // way; without one fitted no such line appears.
     cfg.extended_rom_path = Some(unknown.clone());
+    cfg.fmv_rom_path = Some(unknown.clone());
     let name = unknown.file_name().unwrap().to_string_lossy().into_owned();
     let lines = about_machine_lines(&cfg);
     assert!(
@@ -4885,7 +4909,12 @@ fn the_about_rom_line_names_the_image_it_can_identify() {
         lines.iter().any(|l| *l == format!("Extended ROM: {name}")),
         "{lines:?}"
     );
+    assert!(
+        lines.iter().any(|l| *l == format!("CD32 FMV ROM: {name}")),
+        "{lines:?}"
+    );
     cfg.extended_rom_path = None;
+    cfg.fmv_rom_path = None;
     assert!(!about_machine_lines(&cfg)
         .iter()
         .any(|l| l.starts_with("Extended ROM: ")),);

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -1101,6 +1101,9 @@ impl TryFrom<RawConfig> for Config {
         // perfectly and is then never looked at.
         let host_disk_on_ide = host_disks.iter().any(|disk| !disk.attach.is_scsi());
         let host_disk_on_scsi = host_disks.iter().any(|disk| disk.attach.is_scsi());
+        if raw.fmv_rom.is_some() && !defaults.akiko {
+            anyhow::bail!("fmv_rom is only valid for a CD32 machine profile");
+        }
         Ok(Config {
             host_disks,
             rom_path: raw.rom.map(PathBuf::from).unwrap_or(defaults.rom_path),
@@ -1163,6 +1166,7 @@ impl TryFrom<RawConfig> for Config {
                 .extended_rom
                 .map(PathBuf::from)
                 .or(defaults.extended_rom_path),
+            fmv_rom_path: raw.fmv_rom.map(PathBuf::from).or(defaults.fmv_rom_path),
             cd_image_path: raw.cd.image.map(PathBuf::from),
             cd_insert_delay_secs,
             cd32_nvram_path: raw

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -13,6 +13,8 @@ use crate::floppy::FloppyController;
 use crate::memory::Memory;
 use crate::serial::StdoutSink;
 use crate::timebase::{Duration, Instant};
+#[cfg(feature = "cd32-fmv")]
+use anyhow::Context;
 use anyhow::{anyhow, Result};
 use log::{info, warn};
 
@@ -2513,6 +2515,37 @@ pub fn build_machine(
     // the chain (mapping its window to a device slot) while the device object
     // is attached to the bus after it is built; the slot index ties them.
     let mut devices: Vec<crate::zorro_device::BoardDevice> = Vec::new();
+    // The CD32 FMV cartridge must be first in the chain: its production ROM
+    // and driver expect expansion.library's first 1 MiB Zorro II placement,
+    // $200000.  Prepending keeps that physical address even when the config
+    // also names fast RAM or other expansion boards.
+    #[cfg(feature = "cd32-fmv")]
+    if let Some(rom_path) = &cfg.fmv_rom_path {
+        let slot = devices.len();
+        let rom = if rom_optional && !rom_path.is_file() {
+            info!(
+                "--load-state: CD32 FMV ROM {} is unavailable; building with a \
+                 placeholder the save state will replace",
+                rom_path.display()
+            );
+            vec![0u8; crate::cd32_fmv::ROM_BYTES]
+        } else {
+            std::fs::read(rom_path)
+                .with_context(|| format!("reading CD32 FMV ROM {}", rom_path.display()))?
+        };
+        let board = crate::cd32_fmv::Cd32Fmv::new(rom)?;
+        zorro.prepend_board(crate::zorro::BoardSpec::cd32_fmv(slot))?;
+        info!(
+            "cd32-fmv: Full Motion Video cartridge first on the Zorro chain \
+             (slot {slot}), ROM {}",
+            rom_path.display()
+        );
+        devices.push(crate::zorro_device::BoardDevice::Cd32Fmv(Box::new(board)));
+    }
+    #[cfg(not(feature = "cd32-fmv"))]
+    if cfg.fmv_rom_path.is_some() {
+        anyhow::bail!("fmv_rom needs a build with the cd32-fmv feature");
+    }
     // The A3000's motherboard SCSI is not a Zorro board: its drives are fitted
     // to the Super DMAC further down, once the bus exists.
     if cfg.scsi.enabled() && cfg.scsi.controller.is_zorro_board() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod audio;
 pub mod blockdev;
 pub mod bus;
 pub mod cache;
+#[cfg(feature = "cd32-fmv")]
+pub mod cd32_fmv;
 pub mod cdrom;
 pub mod cdtv;
 pub mod chipset;

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -322,7 +322,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      genlock presentation latch; Akiko also records READ DATA's end LSN.
 //  67: CD32 FMV audio gained native-rate resampler state and BoardSpec records
 //      whether an autoconfig board ignores ec_Shutup.
-pub const STATE_VERSION: u32 = 67;
+//  68: Akiko gained carried physical byte offsets for command/response packets
+//      whose visible eight-bit indices cross a page boundary.
+pub const STATE_VERSION: u32 = 68;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -320,7 +320,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //  66: BoardDevice gained the CD32 FMV variant, including the cartridge ROM,
 //      CL450/L64111 state, decoder warm-up histories, queued PCM/video, and
 //      genlock presentation latch; Akiko also records READ DATA's end LSN.
-pub const STATE_VERSION: u32 = 66;
+//  67: CD32 FMV audio gained native-rate resampler state and BoardSpec records
+//      whether an autoconfig board ignores ec_Shutup.
+pub const STATE_VERSION: u32 = 67;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -317,7 +317,10 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      with the new dependency's layout.
 //  65: floppy images record whether writable changes go to a host file or
 //      remain in serialized memory for filesystem-free hosts such as WASM.
-pub const STATE_VERSION: u32 = 65;
+//  66: BoardDevice gained the CD32 FMV variant, including the cartridge ROM,
+//      CL450/L64111 state, decoder warm-up histories, queued PCM/video, and
+//      genlock presentation latch; Akiko also records READ DATA's end LSN.
+pub const STATE_VERSION: u32 = 66;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -5517,10 +5517,11 @@ fn render_from_input_with_scratch(
 /// cartridge instead keys low-level RGB from the analogue output path. Keep
 /// explicit chipset transparency too, for software that does use those bits.
 /// MPEG-1 VCD video is 352 pixels wide. The module's video DAC stretches that
-/// active line across the native capture aperture; mapping it to a fixed 704
-/// pixels leaves the remaining raster visible as a one-sided strip whenever
-/// the Amiga key signal is not symmetric. Its field-height rows already match
-/// PAL's 288-line MPEG frame one-for-one.
+/// active line to 704 display pixels within the TV capture aperture. Mapping
+/// it across Copperline's entire deep-overscan framebuffer makes the later TV
+/// sampler crop only the MPEG picture's left edge, visibly pushing any encoded
+/// matte to the right. Its field-height rows already match PAL's 288-line MPEG
+/// frame one-for-one.
 #[cfg(feature = "cd32-fmv")]
 fn compose_cd32_fmv(
     presentation: &crate::cd32_fmv::FmvPresentation,
@@ -5539,9 +5540,11 @@ fn compose_cd32_fmv(
         .then_some(presentation.frame.as_ref())
         .flatten();
     let (target_w, target_h, x0, y0) = frame.map_or((0, 0, 0, 0), |frame| {
-        let width = out_w;
+        let x = crate::video::present_common::TV_CAPTURED_SOURCE_X * canvas_scale;
+        let width = (crate::video::present_common::TV_CAPTURED_WIDTH * canvas_scale)
+            .min(out_w.saturating_sub(x));
         let height = (frame.height as usize).min(rows);
-        (width, height, (out_w - width) / 2, (rows - height) / 2)
+        (width, height, x, (rows - height) / 2)
     });
     for y in 0..rows {
         for x in 0..out_w {

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -3888,6 +3888,9 @@ pub struct RenderInput {
     /// its input. Applied to colour resolution only, never collisions.
     debug_plane_mask: u8,
     debug_sprite_mask: u8,
+    /// CD32 FMV signal behind Denise/Lisa's genlock-transparent pixels.
+    #[cfg(feature = "cd32-fmv")]
+    fmv: Option<crate::cd32_fmv::FmvPresentation>,
 }
 
 /// Exact, compact ownership of every frame-snapshot field that can affect
@@ -3920,6 +3923,8 @@ struct RenderContentPrefix {
     programmable_horizontal_blank: Option<(u32, u32)>,
     debug_plane_mask: u8,
     debug_sprite_mask: u8,
+    #[cfg(feature = "cd32-fmv")]
+    fmv: Option<crate::cd32_fmv::FmvPresentation>,
 }
 
 impl RenderContentPrefix {
@@ -3943,6 +3948,8 @@ impl RenderContentPrefix {
             programmable_horizontal_blank: input.programmable_horizontal_blank,
             debug_plane_mask: input.debug_plane_mask,
             debug_sprite_mask: input.debug_sprite_mask,
+            #[cfg(feature = "cd32-fmv")]
+            fmv: input.fmv.clone(),
         }
     }
 
@@ -3974,6 +3981,8 @@ impl RenderContentPrefix {
         different!(programmable_horizontal_blank);
         different!(debug_plane_mask);
         different!(debug_sprite_mask);
+        #[cfg(feature = "cd32-fmv")]
+        different!(fmv);
         None
     }
 }
@@ -4138,6 +4147,8 @@ impl RenderInput {
             emulated_frames: bus.emulated_frames(),
             debug_plane_mask: bus.ui_layer_masks().planes,
             debug_sprite_mask: bus.ui_layer_masks().sprites,
+            #[cfg(feature = "cd32-fmv")]
+            fmv: bus.fmv_presentation(),
         }
     }
 
@@ -4184,6 +4195,10 @@ impl RenderInput {
         self.emulated_frames = bus.emulated_frames();
         self.debug_plane_mask = bus.ui_layer_masks().planes;
         self.debug_sprite_mask = bus.ui_layer_masks().sprites;
+        #[cfg(feature = "cd32-fmv")]
+        {
+            self.fmv = bus.fmv_presentation();
+        }
     }
 
     /// Override the layer-isolation masks on an existing snapshot (tests
@@ -5452,6 +5467,10 @@ fn render_from_input_with_scratch(
         visible_line0,
         rows,
     );
+    #[cfg(feature = "cd32-fmv")]
+    if let Some(fmv) = input.fmv.as_ref().filter(|fmv| fmv.enabled) {
+        compose_cd32_fmv(fmv, fb, rows, canvas_scale);
+    }
     apply_programmable_blanking(
         input.programmable_vertical_blank,
         input.programmable_horizontal_blank,
@@ -5490,6 +5509,61 @@ fn render_from_input_with_scratch(
         timing: render_timing,
         clxdat,
         chip_ram_reads,
+    }
+}
+
+/// Key the FMV module's signal into the native output. The production module
+/// software does not program Denise/Lisa's digital genlock controls; the
+/// cartridge instead keys low-level RGB from the analogue output path. Keep
+/// explicit chipset transparency too, for software that does use those bits.
+/// MPEG-1 VCD video is 352 pixels wide. The module's video DAC stretches that
+/// active line across the native capture aperture; mapping it to a fixed 704
+/// pixels leaves the remaining raster visible as a one-sided strip whenever
+/// the Amiga key signal is not symmetric. Its field-height rows already match
+/// PAL's 288-line MPEG frame one-for-one.
+#[cfg(feature = "cd32-fmv")]
+fn compose_cd32_fmv(
+    presentation: &crate::cd32_fmv::FmvPresentation,
+    fb: &mut [u32],
+    rows: usize,
+    canvas_scale: usize,
+) {
+    let out_w = FB_WIDTH * canvas_scale;
+    let border = {
+        let r = ((presentation.border >> 16) & 0xFF) as u8;
+        let g = ((presentation.border >> 8) & 0xFF) as u8;
+        let b = (presentation.border & 0xFF) as u8;
+        u32::from_le_bytes([r, g, b, 0xFF])
+    };
+    let frame = (!presentation.blank)
+        .then_some(presentation.frame.as_ref())
+        .flatten();
+    let (target_w, target_h, x0, y0) = frame.map_or((0, 0, 0, 0), |frame| {
+        let width = out_w;
+        let height = (frame.height as usize).min(rows);
+        (width, height, (out_w - width) / 2, (rows - height) / 2)
+    });
+    for y in 0..rows {
+        for x in 0..out_w {
+            let pixel = &mut fb[y * out_w + x];
+            let [r, g, b, alpha] = pixel.to_le_bytes();
+            let dark_key = r.max(g).max(b) < 0x20;
+            if alpha != 0 && !dark_key {
+                continue;
+            }
+            *pixel = if let Some(frame) = frame {
+                if x >= x0 && x < x0 + target_w && y >= y0 && y < y0 + target_h {
+                    let sx =
+                        ((x - x0) * frame.width as usize / target_w).min(frame.width as usize - 1);
+                    let sy = (y - y0).min(frame.height as usize - 1);
+                    frame.pixels[sy * frame.width as usize + sx]
+                } else {
+                    border
+                }
+            } else {
+                border
+            };
+        }
     }
 }
 

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -50,6 +50,8 @@ fn repeated_frame_test_input() -> RenderInput {
         emulated_frames: 50,
         debug_plane_mask: 0xFF,
         debug_sprite_mask: 0xFF,
+        #[cfg(feature = "cd32-fmv")]
+        fmv: None,
     }
 }
 
@@ -8793,4 +8795,57 @@ fn fast_playfield_interior_engages_for_standard_screens() {
         "interior {fast_lo}..{fast_hi} should cover most of {x0}..{}",
         plan.x_stop
     );
+}
+
+#[cfg(feature = "cd32-fmv")]
+#[test]
+fn cd32_fmv_keys_dark_native_video_without_digital_genlock_bits() {
+    let mpeg = u32::from_le_bytes([0xC8, 0x10, 0x20, 0xFF]);
+    let presentation = crate::cd32_fmv::FmvPresentation {
+        enabled: true,
+        blank: false,
+        border: 0,
+        generation: 1,
+        frame: Some(crate::cd32_fmv::FmvFrame {
+            width: 1,
+            height: 1,
+            pixels: std::sync::Arc::new(vec![mpeg]),
+        }),
+    };
+    let bright_native = u32::from_le_bytes([0x40, 0x40, 0x40, 0xFF]);
+    let mut fb = vec![bright_native; FB_WIDTH];
+    fb[0] = u32::from_le_bytes([0x1F, 0x10, 0x08, 0xFF]);
+    fb[1] = 0;
+
+    compose_cd32_fmv(&presentation, &mut fb, 1, 1);
+
+    assert_eq!(fb[0], mpeg, "dark analogue key must reveal FMV");
+    assert_eq!(fb[1], mpeg, "digital genlock transparency still works");
+    assert_eq!(fb[2], bright_native, "bright native overlay remains");
+}
+
+#[cfg(feature = "cd32-fmv")]
+#[test]
+fn cd32_fmv_stretches_the_active_line_to_both_capture_edges() {
+    let left = u32::from_le_bytes([0x20, 0x40, 0x60, 0xFF]);
+    let right = u32::from_le_bytes([0x80, 0xA0, 0xC0, 0xFF]);
+    let presentation = crate::cd32_fmv::FmvPresentation {
+        enabled: true,
+        blank: false,
+        border: 0,
+        generation: 1,
+        frame: Some(crate::cd32_fmv::FmvFrame {
+            width: 2,
+            height: 1,
+            pixels: std::sync::Arc::new(vec![left, right]),
+        }),
+    };
+    let mut fb = vec![0; FB_WIDTH];
+
+    compose_cd32_fmv(&presentation, &mut fb, 1, 1);
+
+    assert_eq!(fb[0], left);
+    assert_eq!(fb[FB_WIDTH / 2 - 1], left);
+    assert_eq!(fb[FB_WIDTH / 2], right);
+    assert_eq!(fb[FB_WIDTH - 1], right);
 }

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -8814,19 +8814,20 @@ fn cd32_fmv_keys_dark_native_video_without_digital_genlock_bits() {
     };
     let bright_native = u32::from_le_bytes([0x40, 0x40, 0x40, 0xFF]);
     let mut fb = vec![bright_native; FB_WIDTH];
-    fb[0] = u32::from_le_bytes([0x1F, 0x10, 0x08, 0xFF]);
-    fb[1] = 0;
+    let x0 = crate::video::present_common::TV_CAPTURED_SOURCE_X;
+    fb[x0] = u32::from_le_bytes([0x1F, 0x10, 0x08, 0xFF]);
+    fb[x0 + 1] = 0;
 
     compose_cd32_fmv(&presentation, &mut fb, 1, 1);
 
-    assert_eq!(fb[0], mpeg, "dark analogue key must reveal FMV");
-    assert_eq!(fb[1], mpeg, "digital genlock transparency still works");
-    assert_eq!(fb[2], bright_native, "bright native overlay remains");
+    assert_eq!(fb[x0], mpeg, "dark analogue key must reveal FMV");
+    assert_eq!(fb[x0 + 1], mpeg, "digital genlock transparency still works");
+    assert_eq!(fb[x0 + 2], bright_native, "bright native overlay remains");
 }
 
 #[cfg(feature = "cd32-fmv")]
 #[test]
-fn cd32_fmv_stretches_the_active_line_to_both_capture_edges() {
+fn cd32_fmv_maps_the_active_line_to_both_tv_capture_edges() {
     let left = u32::from_le_bytes([0x20, 0x40, 0x60, 0xFF]);
     let right = u32::from_le_bytes([0x80, 0xA0, 0xC0, 0xFF]);
     let presentation = crate::cd32_fmv::FmvPresentation {
@@ -8844,8 +8845,19 @@ fn cd32_fmv_stretches_the_active_line_to_both_capture_edges() {
 
     compose_cd32_fmv(&presentation, &mut fb, 1, 1);
 
-    assert_eq!(fb[0], left);
-    assert_eq!(fb[FB_WIDTH / 2 - 1], left);
-    assert_eq!(fb[FB_WIDTH / 2], right);
-    assert_eq!(fb[FB_WIDTH - 1], right);
+    let x0 = crate::video::present_common::TV_CAPTURED_SOURCE_X;
+    let width = crate::video::present_common::TV_CAPTURED_WIDTH;
+    assert_eq!(fb[x0], left);
+    assert_eq!(fb[x0 + width / 2 - 1], left);
+    assert_eq!(fb[x0 + width / 2], right);
+    assert_eq!(fb[x0 + width - 1], right);
+    assert_ne!(
+        crate::video::present_common::tv_glass_sample(&fb, 0, 0),
+        0,
+        "left MPEG edge contributes through the sampler's half-texel blend"
+    );
+    assert_eq!(
+        crate::video::present_common::tv_glass_sample(&fb, FB_WIDTH - 1, 0),
+        right
+    );
 }

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -522,6 +522,7 @@ pub enum LauncherField {
     // ROM
     Rom,
     ExtendedRom,
+    FmvRom,
     // Floppy
     FloppyDrives,
     FloppySpeed,
@@ -969,7 +970,7 @@ const MEMORY_ROWS: [Row; 8] = [
 // ("Kickstart", "3.1", "40.68"), since a ROM file's name says only what
 // its dumper called it. The lines stand whether or not an image is
 // loaded; a blank value means an empty (or unrecognised) slot.
-const ROM_ROWS: [Row; 7] = [
+const ROM_ROWS: [Row; 9] = [
     section_header("Primary ROM:"),
     row(F::Rom, "  Kickstart ROM", PathRow),
     // The label picks which fact the line carries.
@@ -978,6 +979,8 @@ const ROM_ROWS: [Row; 7] = [
     row(F::Rom, "Revision", RowKind::RomInfo),
     section_header("Extended ROM:"),
     row(F::ExtendedRom, "  Extended ROM", PathRow),
+    section_header("CD32 Full Motion Video:"),
+    row(F::FmvRom, "  FMV module ROM", PathRow),
 ];
 // Each drive is a greyed "DFn:" heading with its settings indented under it. The
 // heading is keyed on the drive's image field so `row_hidden` drops it along
@@ -2003,6 +2006,7 @@ pub struct MachineSetup {
     // ROM (None = bundled AROS for the boot ROM, none for extended)
     rom: Option<PathBuf>,
     extended_rom: Option<PathBuf>,
+    fmv_rom: Option<PathBuf>,
     // Floppy
     floppy_drives: u8,
     /// `[floppy] speed`: a percentage (100/200/400/800) or 0 for turbo.
@@ -2373,6 +2377,7 @@ impl MachineSetup {
             z3_ram: cfg.z3_ram_bytes,
             rom: raw.rom.as_deref().map(PathBuf::from),
             extended_rom: raw.extended_rom.as_deref().map(PathBuf::from),
+            fmv_rom: raw.fmv_rom.as_deref().map(PathBuf::from),
             floppy_drives: raw.floppy.drives.unwrap_or(connected).clamp(1, 4),
             floppy_speed: cfg.floppy.speed,
             df_playlists: cfg.floppy_playlists.clone(),
@@ -2799,6 +2804,7 @@ impl MachineSetup {
         // ROM
         raw.rom = self.rom.as_deref().map(path_string);
         raw.extended_rom = self.extended_rom.as_deref().map(path_string);
+        raw.fmv_rom = self.fmv_rom.as_deref().map(path_string);
         // Floppy: cover any drive carrying media so the count never orphans it.
         let media_max = self
             .df_playlists
@@ -3385,6 +3391,7 @@ impl MachineSetup {
         }
         if model != Some(MachineModel::Cd32) {
             self.cd32_nvram = None;
+            self.fmv_rom = None;
         }
         // The motherboard SCSI leaves with the motherboard; the drives stay and
         // land on the default Zorro board instead.
@@ -3564,6 +3571,7 @@ impl MachineSetup {
                 reason(self.has_cd(), "needs CDTV/CD32 (or SCSI/IDE/Lide)")
             }
             F::Cd32Nvram => reason(self.model == Some(MachineModel::Cd32), "CD32 only"),
+            F::FmvRom => reason(self.model == Some(MachineModel::Cd32), "CD32 only"),
             F::Df0Image | F::Df0WriteProtect => reason(self.floppy_drives >= 1, "drive off"),
             F::Df1Image | F::Df1WriteProtect => reason(self.floppy_drives >= 2, "drive off"),
             F::Df2Image | F::Df2WriteProtect => reason(self.floppy_drives >= 3, "drive off"),
@@ -3731,6 +3739,7 @@ impl MachineSetup {
             F::CsynthSoundfont => self.csynth_soundfont.as_deref(),
             F::Mt32PcmRom => self.mt32_pcm_rom.as_deref(),
             F::ExtendedRom => self.extended_rom.as_deref(),
+            F::FmvRom => self.fmv_rom.as_deref(),
             F::Df0Image => self.df_playlists[0].first().map(PathBuf::as_path),
             F::Df1Image => self.df_playlists[1].first().map(PathBuf::as_path),
             F::Df2Image => self.df_playlists[2].first().map(PathBuf::as_path),
@@ -5030,6 +5039,7 @@ impl MachineSetup {
             F::CsynthSoundfont => self.csynth_soundfont = Some(path),
             F::Mt32PcmRom => self.mt32_pcm_rom = Some(path),
             F::ExtendedRom => self.extended_rom = Some(path),
+            F::FmvRom => self.fmv_rom = Some(path),
             F::Df0Image => self.set_floppy(0, path),
             F::Df1Image => self.set_floppy(1, path),
             F::Df2Image => self.set_floppy(2, path),
@@ -5095,6 +5105,7 @@ impl MachineSetup {
         match field {
             F::Rom => self.rom = None,
             F::ExtendedRom => self.extended_rom = None,
+            F::FmvRom => self.fmv_rom = None,
             F::Mt32ControlRom => self.mt32_control_rom = None,
             #[cfg(feature = "coppersynth")]
             F::CsynthSoundfont => self.csynth_soundfont = None,

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -1089,6 +1089,12 @@ fn the_rom_tab_carries_an_identification_line_under_each_path_row() {
             ("Revision", RowKind::RomInfo, F::Rom),
             ("Extended ROM:", RowKind::SectionHeader, F::SectionHeader),
             ("  Extended ROM", RowKind::Path, F::ExtendedRom),
+            (
+                "CD32 Full Motion Video:",
+                RowKind::SectionHeader,
+                F::SectionHeader,
+            ),
+            ("  FMV module ROM", RowKind::Path, F::FmvRom),
         ]
     );
 
@@ -1176,6 +1182,24 @@ fn the_rom_tab_carries_an_identification_line_under_each_path_row() {
     );
     // Only the ROM rows have one.
     assert_eq!(state.rom_note(F::Df0Image), None);
+}
+
+#[test]
+fn fmv_rom_path_round_trips_through_the_launcher() {
+    let mut setup = MachineSetup::default();
+    setup.select_model(Some(MachineModel::Cd32));
+    let path = PathBuf::from("/roms/cd32fmv.rom");
+    setup.set_path(F::FmvRom, path.clone());
+    assert_eq!(setup.path(F::FmvRom), Some(path.as_path()));
+    assert_eq!(setup.to_raw().fmv_rom.as_deref(), Some("/roms/cd32fmv.rom"));
+
+    setup.clear_path(F::FmvRom);
+    assert_eq!(setup.path(F::FmvRom), None);
+    assert_eq!(setup.to_raw().fmv_rom, None);
+
+    setup.set_path(F::FmvRom, path);
+    setup.select_model(Some(MachineModel::A1200));
+    assert_eq!(setup.path(F::FmvRom), None, "non-CD32 profile drops module");
 }
 
 #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -803,8 +803,8 @@ fn repeated_main_key_should_drop(
     }
 }
 
-fn ui_needs_continuous_redraw(running: bool, active: bool) -> bool {
-    running && active
+fn animated_focus_needs_continuous_redraw(running: bool, showing: bool) -> bool {
+    running && showing
 }
 
 fn raw_device_qualifier_rawkey(code: KeyCode) -> Option<u8> {
@@ -4848,7 +4848,12 @@ impl ApplicationHandler for App {
             let chrome_changed = self.last_main_redraw_state != Some(redraw_state);
             if self.main_presentation_dirty
                 || chrome_changed
-                || ui_needs_continuous_redraw(running, self.ui.active())
+                // Opening a static menu/panel is not itself a reason to
+                // upload and present the whole framebuffer every scheduler
+                // pass. New emulated pictures and UI interactions already
+                // dirty it. Only the keyboard/pad focus needs clock-driven
+                // frames for its breathing highlight.
+                || animated_focus_needs_continuous_redraw(running, self.nav.showing())
                 || self.drop_hover
                 || osd_active
                 || calibrating

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -109,6 +109,7 @@ impl App {
         dialog = match field {
             LauncherField::Rom
             | LauncherField::ExtendedRom
+            | LauncherField::FmvRom
             | LauncherField::ScsiRom
             | LauncherField::ScsiRomOdd
             | LauncherField::LideRom

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -93,10 +93,10 @@ fn host_mapping_includes_amiga_modifiers() {
 }
 
 #[test]
-fn ui_needs_continuous_redraw_only_when_running_and_active() {
-    assert!(!super::ui_needs_continuous_redraw(false, true));
-    assert!(super::ui_needs_continuous_redraw(true, true));
-    assert!(!super::ui_needs_continuous_redraw(true, false));
+fn only_an_animated_focus_needs_continuous_ui_redraws() {
+    assert!(!super::animated_focus_needs_continuous_redraw(false, true));
+    assert!(super::animated_focus_needs_continuous_redraw(true, true));
+    assert!(!super::animated_focus_needs_continuous_redraw(true, false));
 }
 
 #[test]

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -159,6 +159,9 @@ pub struct BoardSpec {
     pub memory_space: bool,
     /// Another autoconfig identity belonging to this physical board follows.
     pub chained: bool,
+    /// The board cannot be removed from the autoconfig chain by writing
+    /// `ec_Shutup` (ERFF_NOSHUTUP).
+    pub no_shutup: bool,
     /// Logical aperture number passed to a shared device in offset bits 31:28.
     pub window: u8,
     /// Autoboot: ERTF_DIAGVALID with er_InitDiagVec pointing at the
@@ -184,6 +187,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: true,
             chained: false,
+            no_shutup: true,
             window: 0,
             diag_vec: Some(0x0080),
         }
@@ -202,6 +206,7 @@ impl BoardSpec {
             memlist: true,
             memory_space: true,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: None,
         }
@@ -220,6 +225,7 @@ impl BoardSpec {
             memlist: true,
             memory_space: true,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: None,
         }
@@ -246,6 +252,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: true,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: None,
         }
@@ -266,6 +273,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: None,
         }
@@ -288,6 +296,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: None,
         }
@@ -312,6 +321,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: None,
         }
@@ -341,6 +351,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: None,
         }
@@ -363,6 +374,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: Some(0x2000),
         }
@@ -386,6 +398,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: Some(0x0200),
         }
@@ -412,6 +425,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: Some(crate::filesys::DIAG_OFFSET),
         }
@@ -436,6 +450,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: Some(crate::hostsocket::DIAG_OFFSET),
         }
@@ -470,6 +485,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: has_rom.then_some(diag_vec),
         }
@@ -492,6 +508,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: None,
         }
@@ -522,6 +539,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: true,
             chained: true,
+            no_shutup: false,
             window: 1,
             diag_vec: None,
         }
@@ -549,6 +567,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: None,
         }
@@ -569,6 +588,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: true,
             chained: true,
+            no_shutup: false,
             window: 1,
             diag_vec: None,
         }
@@ -587,6 +607,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: None,
         }
@@ -608,6 +629,7 @@ impl BoardSpec {
             memlist: false,
             memory_space: false,
             chained: false,
+            no_shutup: false,
             window: 0,
             diag_vec: None,
         }
@@ -949,6 +971,9 @@ impl ZorroChain {
                 // accepting it keeps the register sequence faithful.
             }
             EC_SHUTUP_PHYS => {
+                if board.spec.no_shutup {
+                    return;
+                }
                 board.state = BoardState::ShutUp;
                 log::debug!("zorro board {:?} shut up", board.spec.name);
                 self.rebuild_regions();
@@ -982,14 +1007,7 @@ impl ZorroChain {
         let memlist = if spec.memlist { ERTF_MEMLIST } else { 0 };
         let chained = if spec.chained { ERTF_CHAINEDCONFIG } else { 0 };
         let memspace = if spec.memory_space { ERFF_MEMSPACE } else { 0 };
-        // The CD32 FMV cartridge's production autoconfig ROM sets
-        // ERFF_NOSHUTUP. Its identity is fixed physical hardware rather than
-        // a user-authored BoardSpec, so preserve that extra flag here.
-        let no_shutup = if spec.manufacturer == 514 && spec.product == 0x6A {
-            ERFF_NOSHUTUP
-        } else {
-            0
-        };
+        let no_shutup = if spec.no_shutup { ERFF_NOSHUTUP } else { 0 };
         match spec.version {
             ZorroVersion::II => {
                 rom[0] = ERT_ZORROII | memlist | chained | zorro_ii_size_code(spec.size_bytes)?;
@@ -1243,6 +1261,7 @@ pub fn load_board_metadata(path: &Path) -> Result<LoadedZorroBoard> {
                 memlist: raw.memlist.unwrap_or(true),
                 memory_space: true,
                 chained: false,
+                no_shutup: false,
                 window: 0,
                 diag_vec: None,
             };
@@ -1293,6 +1312,7 @@ pub fn load_board_metadata(path: &Path) -> Result<LoadedZorroBoard> {
                 memlist: raw.memlist.unwrap_or(false),
                 memory_space: false,
                 chained: false,
+                no_shutup: false,
                 window: 0,
                 diag_vec: raw.diag_vec,
             };
@@ -1502,6 +1522,24 @@ mod tests {
             logical,
             [0xD5, 0x6A, 0xC0, 0x00, 0x02, 0x02, 0x00, 0x28, 0x00, 0x1E, 0x00, 0x80,]
         );
+    }
+
+    #[cfg(feature = "cd32-fmv")]
+    #[test]
+    fn no_shutup_board_ignores_the_shutup_register() {
+        let mut chain = chain_with(vec![BoardSpec::cd32_fmv(0)]);
+        chain.config_write(AUTOCONFIG_BASE + EC_SHUTUP_PHYS, 1, 0);
+        assert_eq!(chain.config_logical_byte(0, 2), Some(0xC0));
+        assert_ne!(chain.config_read(AUTOCONFIG_BASE, 1), 0xFF);
+    }
+
+    #[test]
+    fn autoconfig_identity_does_not_imply_no_shutup() {
+        let mut spec = BoardSpec::fast_ram(512 * 1024);
+        spec.manufacturer = 514;
+        spec.product = 0x6A;
+        let chain = chain_with(vec![spec]);
+        assert_eq!(chain.config_logical_byte(0, 2), Some(ERFF_MEMSPACE));
     }
 
     #[test]

--- a/src/zorro.rs
+++ b/src/zorro.rs
@@ -39,6 +39,7 @@ const ERTF_CHAINEDCONFIG: u8 = 1 << 3;
 
 // er_Flags fields.
 const ERFF_MEMSPACE: u8 = 1 << 7;
+const ERFF_NOSHUTUP: u8 = 1 << 6;
 const ERFF_EXTENDED: u8 = 1 << 5;
 const ERFF_ZORRO_III: u8 = 1 << 4;
 
@@ -166,6 +167,28 @@ pub struct BoardSpec {
 }
 
 impl BoardSpec {
+    /// Commodore's CD32 Full Motion Video cartridge: a 1 MiB Zorro II
+    /// memory-space board containing its 256 KiB diagnostic/autoboot ROM,
+    /// CL450/L64111 register windows, and 512 KiB local RAM.  Product and
+    /// serial values come from the production v40.30 ROM's autoconfig data.
+    #[cfg(feature = "cd32-fmv")]
+    pub fn cd32_fmv(slot: usize) -> Self {
+        Self {
+            name: "CD32 Full Motion Video".into(),
+            version: ZorroVersion::II,
+            manufacturer: 514,
+            product: 0x6A,
+            serial: 0x0028_001E,
+            size_bytes: 0x10_0000,
+            backing: BoardBacking::Device(slot),
+            memlist: false,
+            memory_space: true,
+            chained: false,
+            window: 0,
+            diag_vec: Some(0x0080),
+        }
+    }
+
     /// The built-in Zorro II fast RAM board (`[memory] fast`).
     pub fn fast_ram(size_bytes: usize) -> Self {
         Self {
@@ -683,6 +706,29 @@ impl ZorroChain {
         Ok(())
     }
 
+    /// Put a board at the front of the autoconfig chain.  The CD32 FMV
+    /// cartridge is physically expected at $200000 and its ROM assumes that
+    /// first legal Zorro II placement, so it must precede optional fast RAM
+    /// and other expansion boards already assembled from the configuration.
+    #[cfg(feature = "cd32-fmv")]
+    pub fn prepend_board(&mut self, spec: BoardSpec) -> Result<()> {
+        spec.validate()?;
+        let ram = match spec.backing {
+            BoardBacking::Ram => vec![0u8; spec.size_bytes],
+            BoardBacking::Device(_) => Vec::new(),
+        };
+        self.boards.insert(
+            0,
+            Board {
+                spec,
+                state: BoardState::Unconfigured,
+                ram,
+            },
+        );
+        self.rebuild_regions();
+        Ok(())
+    }
+
     /// Add a RAM-backed board with its window pre-seeded from `rom` (copied at
     /// offset 0, the remainder left zero). Used for the filesys rtarea,
     /// whose handler ROM must be present in the window from power-on. The
@@ -936,10 +982,18 @@ impl ZorroChain {
         let memlist = if spec.memlist { ERTF_MEMLIST } else { 0 };
         let chained = if spec.chained { ERTF_CHAINEDCONFIG } else { 0 };
         let memspace = if spec.memory_space { ERFF_MEMSPACE } else { 0 };
+        // The CD32 FMV cartridge's production autoconfig ROM sets
+        // ERFF_NOSHUTUP. Its identity is fixed physical hardware rather than
+        // a user-authored BoardSpec, so preserve that extra flag here.
+        let no_shutup = if spec.manufacturer == 514 && spec.product == 0x6A {
+            ERFF_NOSHUTUP
+        } else {
+            0
+        };
         match spec.version {
             ZorroVersion::II => {
                 rom[0] = ERT_ZORROII | memlist | chained | zorro_ii_size_code(spec.size_bytes)?;
-                rom[2] = memspace;
+                rom[2] = memspace | no_shutup;
             }
             ZorroVersion::III => {
                 let (code, extended) = zorro_iii_size_bits(spec.size_bytes)?;
@@ -1435,6 +1489,19 @@ mod tests {
         // nibbles: product 0x03 appears as 0xFC.
         assert_eq!(chain.config_read(AUTOCONFIG_BASE + 4, 1), 0xF0);
         assert_eq!(chain.config_read(AUTOCONFIG_BASE + 6, 1), 0xC0);
+    }
+
+    #[cfg(feature = "cd32-fmv")]
+    #[test]
+    fn cd32_fmv_autoconfig_identity_matches_the_production_rom() {
+        let chain = chain_with(vec![BoardSpec::cd32_fmv(0)]);
+        let logical: Vec<u8> = (0..12)
+            .map(|byte| chain.config_logical_byte(0, byte).unwrap())
+            .collect();
+        assert_eq!(
+            logical,
+            [0xD5, 0x6A, 0xC0, 0x00, 0x02, 0x02, 0x00, 0x28, 0x00, 0x1E, 0x00, 0x80,]
+        );
     }
 
     #[test]

--- a/src/zorro_device.rs
+++ b/src/zorro_device.rs
@@ -425,6 +425,8 @@ pub enum BoardDevice {
     Toccata(Box<crate::toccata::Toccata>),
     #[cfg(feature = "mhi")]
     Mhi(Box<crate::mhi::Mhi>),
+    #[cfg(feature = "cd32-fmv")]
+    Cd32Fmv(Box<crate::cd32_fmv::Cd32Fmv>),
 }
 
 impl ZorroDevice for BoardDevice {
@@ -444,6 +446,8 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Toccata(d) => ZorroDevice::read(d.as_mut(), off, size, host),
             #[cfg(feature = "mhi")]
             BoardDevice::Mhi(d) => ZorroDevice::read(d.as_mut(), off, size, host),
+            #[cfg(feature = "cd32-fmv")]
+            BoardDevice::Cd32Fmv(d) => ZorroDevice::read(d.as_mut(), off, size, host),
         }
     }
 
@@ -463,6 +467,8 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Toccata(d) => ZorroDevice::write(d.as_mut(), off, size, value, host),
             #[cfg(feature = "mhi")]
             BoardDevice::Mhi(d) => ZorroDevice::write(d.as_mut(), off, size, value, host),
+            #[cfg(feature = "cd32-fmv")]
+            BoardDevice::Cd32Fmv(d) => ZorroDevice::write(d.as_mut(), off, size, value, host),
         }
     }
 
@@ -482,6 +488,8 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Toccata(d) => ZorroDevice::peek_word(d.as_ref(), off),
             #[cfg(feature = "mhi")]
             BoardDevice::Mhi(d) => ZorroDevice::peek_word(d.as_ref(), off),
+            #[cfg(feature = "cd32-fmv")]
+            BoardDevice::Cd32Fmv(d) => ZorroDevice::peek_word(d.as_ref(), off),
         }
     }
 
@@ -501,6 +509,8 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Toccata(d) => ZorroDevice::tick(d.as_mut(), cck, host),
             #[cfg(feature = "mhi")]
             BoardDevice::Mhi(d) => ZorroDevice::tick(d.as_mut(), cck, host),
+            #[cfg(feature = "cd32-fmv")]
+            BoardDevice::Cd32Fmv(d) => ZorroDevice::tick(d.as_mut(), cck, host),
         }
     }
 
@@ -520,6 +530,8 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Toccata(d) => ZorroDevice::int2_line(d.as_ref()),
             #[cfg(feature = "mhi")]
             BoardDevice::Mhi(d) => ZorroDevice::int2_line(d.as_ref()),
+            #[cfg(feature = "cd32-fmv")]
+            BoardDevice::Cd32Fmv(d) => ZorroDevice::int2_line(d.as_ref()),
         }
     }
 
@@ -539,6 +551,8 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Toccata(d) => ZorroDevice::int6_line(d.as_ref()),
             #[cfg(feature = "mhi")]
             BoardDevice::Mhi(d) => ZorroDevice::int6_line(d.as_ref()),
+            #[cfg(feature = "cd32-fmv")]
+            BoardDevice::Cd32Fmv(d) => ZorroDevice::int6_line(d.as_ref()),
         }
     }
 
@@ -558,6 +572,8 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Toccata(d) => ZorroDevice::is_idle(d.as_ref()),
             #[cfg(feature = "mhi")]
             BoardDevice::Mhi(d) => ZorroDevice::is_idle(d.as_ref()),
+            #[cfg(feature = "cd32-fmv")]
+            BoardDevice::Cd32Fmv(d) => ZorroDevice::is_idle(d.as_ref()),
         }
     }
 
@@ -577,6 +593,8 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Toccata(d) => ZorroDevice::next_event_cck(d.as_ref()),
             #[cfg(feature = "mhi")]
             BoardDevice::Mhi(d) => ZorroDevice::next_event_cck(d.as_ref()),
+            #[cfg(feature = "cd32-fmv")]
+            BoardDevice::Cd32Fmv(d) => ZorroDevice::next_event_cck(d.as_ref()),
         }
     }
 
@@ -596,6 +614,8 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Toccata(d) => ZorroDevice::take_activity(d.as_mut()),
             #[cfg(feature = "mhi")]
             BoardDevice::Mhi(d) => ZorroDevice::take_activity(d.as_mut()),
+            #[cfg(feature = "cd32-fmv")]
+            BoardDevice::Cd32Fmv(d) => ZorroDevice::take_activity(d.as_mut()),
         }
     }
 
@@ -615,6 +635,8 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Toccata(d) => ZorroDevice::reset(d.as_mut()),
             #[cfg(feature = "mhi")]
             BoardDevice::Mhi(d) => ZorroDevice::reset(d.as_mut()),
+            #[cfg(feature = "cd32-fmv")]
+            BoardDevice::Cd32Fmv(d) => ZorroDevice::reset(d.as_mut()),
         }
     }
 
@@ -634,6 +656,8 @@ impl ZorroDevice for BoardDevice {
             BoardDevice::Toccata(d) => ZorroDevice::kind(d.as_ref()),
             #[cfg(feature = "mhi")]
             BoardDevice::Mhi(d) => ZorroDevice::kind(d.as_ref()),
+            #[cfg(feature = "cd32-fmv")]
+            BoardDevice::Cd32Fmv(d) => ZorroDevice::kind(d.as_ref()),
         }
     }
 }


### PR DESCRIPTION
## Summary

- add the Commodore CD32 FMV cartridge as the first Zorro II autoconfig device, including its ROM, module RAM, CL450 video and L64111 audio interfaces
- decode MPEG-1 video with the safe pure-Rust CopperlineHQ/plmpeg-rs core and MPEG Layer II audio with Symphonia
- add `fmv_rom` configuration and a CD32-only FMV module ROM chooser to the launcher
- support MODE2/2336 and MODE2/2352 tracks through CUE, NRG, CHD, and Akiko raw-sector paths
- model the module analogue keying path and scale VCD video across the full capture aperture
- preserve the position-bearing PBX boundary frame at READ DATA lead-out so the ROM can stop and reseek into game data
- serialize the complete FMV decoder/device state and bump the save-state format version

## Playback fixes

The plmpeg buffer now caches partial start-code probes and resumes at newly appended input instead of rescanning retained picture data. On the Cannon Fodder stream this reduced the worst decoder service step from about 132 ms to under 5 ms, eliminating the random playback pauses that starved CPAL.

At the end of the MPEG stream, Akiko now provides the final buffered raw frame needed by cd.device to observe the current stream position. The driver then issues STOP and a new read at the requested track-1 LSN instead of sleeping indefinitely on an empty PBX ring.

An open mouse-driven menu no longer forces a complete framebuffer upload and present on every running scheduler pass when neither the emulated picture nor the UI changed. Clock-driven redraws remain for the keyboard/gamepad focus animation. This removes a pre-existing presentation load that was especially noticeable beside FMV decoding.

## Validation

- `cargo test --release`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --check`
- `cargo check --no-default-features`
- paced windowed Cannon Fodder/FMV audio soak for two minutes: stable roughly 8k-frame live queue, zero CPAL underruns, overruns, or stale-frame skips
- deterministic Cannon Fodder runs with and without the FMV module: the module clears its video-enable bit after the MPEG sequence; the stock path contains the same long title-controlled black interval; the FMV-enabled path continues through loading and reaches gameplay by 600 emulated seconds without input
- deterministic CD32 red-button run during the post-FMV black interval: the title skips to loading and reaches gameplay
- focused redraw regression confirming a static open UI is not itself a continuous-redraw reason

The plmpeg incremental scanning fix is published in CopperlineHQ/plmpeg-rs at d020ba1015b48c0c646d32b16a27157623fff915.
