### PR TITLE
video: keep HAM8 on the history-dependent resolver

### DIFF
--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -234,6 +234,10 @@ Inspection: `regs.get`, `regs.set {reg, value}`, `mem.read {addr, len,
 encoding?}` / `mem.write {addr, data, encoding?}` (hex default, base64
 for bulk; 1 MiB cap; side-effect-free RAM/ROM view, device windows are
 not touched), `disasm {addr?, count?}`, `custom.dump`,
+`palette.dump` (the live Denise/Lisa palette: all 256 AGA entries as their
+high and low nibble-plane words -- `custom.dump`'s COLORxx values are only
+the write latches, so this is the way to see what a banked or LOCT palette
+upload actually landed),
 `custom.read {reg}` (name or offset), `cia.get {cia: "a"|"b"}`,
 `beam.get`, `display.get`, `copper.list {addr?, max?}`, `pc_history`.
 

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -149,8 +149,8 @@ than per pixel. The per-pixel decisions inside a run are unchanged -- the
 chunking is a host-CPU optimisation, not a model change.
 History-independent colour modes also resolve their complete 256-entry
 Denise/Lisa index table once for each distinct control-and-palette state in
-the frame. HAM remains on the sequential path because every output depends
-on the preceding colour. Prepared planar rows similarly share a single byte
+the frame. HAM -- HAM6 and Lisa's HAM8 alike -- remains on the sequential
+path because every output depends on the preceding colour. Prepared planar rows similarly share a single byte
 lookup when the odd and even BPLCON1 taps have the same delay; the exhaustive
 prepared-pixel/word-sampler comparison covers both that common path and
 separate dual-playfield taps.

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -67,6 +67,9 @@ pub enum CoreOp {
         count: usize,
     },
     CustomDump,
+    /// Dump the live Denise palette: all 256 AGA entries as their high and
+    /// low nibble-plane words (debug aid; not part of the stable surface).
+    PaletteDump,
     CustomRead {
         off: u16,
     },
@@ -193,6 +196,7 @@ impl CoreOp {
                 | CoreOp::MemRead { .. }
                 | CoreOp::Disasm { .. }
                 | CoreOp::CustomDump
+                | CoreOp::PaletteDump
                 | CoreOp::CustomRead { .. }
                 | CoreOp::CustomWriter { .. }
                 | CoreOp::ChipsetReport
@@ -738,6 +742,7 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             count: p.usize_or("count", 16)?.clamp(1, 256),
         }),
         "custom.dump" => core(CoreOp::CustomDump),
+        "palette.dump" => core(CoreOp::PaletteDump),
         "custom.read" => core(CoreOp::CustomRead {
             off: parse_custom_reg_param(&p)?,
         }),
@@ -1614,6 +1619,18 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
                 }
             }
             Ok(json!({"regs": regs}))
+        }
+        CoreOp::PaletteDump => {
+            let palette = &emu.bus().denise.palette;
+            let mut hi = Vec::with_capacity(256);
+            let mut lo = Vec::with_capacity(256);
+            for bank in 0..8 {
+                for idx in 0..32 {
+                    hi.push(Value::from(palette.read_banked(bank, idx, false)));
+                    lo.push(Value::from(palette.read_banked(bank, idx, true)));
+                }
+            }
+            Ok(json!({"hi": hi, "lo": lo}))
         }
         CoreOp::CustomRead { off } => match emu.bus().debug_custom_word(*off) {
             Some(value) => Ok(json!({

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -1173,8 +1173,24 @@ impl ControlState {
         self.nplanes() == 6 && self.bplcon0 & 0x0C00 == 0 && self.bplcon2 & BPLCON2_KILLEHB == 0
     }
 
+    /// HAM6: HAMEN with five or six planes, on every Denise generation.
+    /// Callers that mean "any hold-and-modify variant" (history-dependent
+    /// pixel output) must use [`Self::ham`], which also covers Lisa's HAM8.
     fn hold_and_modify(&self) -> bool {
         !self.shres() && matches!(self.nplanes(), 5 | 6) && self.bplcon0 & 0x0800 != 0
+    }
+
+    /// Lisa's HAM8: HAMEN with all eight planes, AGA only. Mirrors the
+    /// decode condition in `denise_aga_playfield_output`.
+    fn ham8(&self) -> bool {
+        self.aga() && self.nplanes() == 8 && self.bplcon0 & 0x0800 != 0
+    }
+
+    /// Any hold-and-modify variant. The pixel colour then depends on the
+    /// previous pixel's held colour, so history-free resolution (the indexed
+    /// output cache and the constant-run fast interior) must stay off.
+    fn ham(&self) -> bool {
+        self.hold_and_modify() || self.ham8()
     }
 
     fn dual_playfield(&self) -> bool {
@@ -6114,7 +6130,7 @@ fn render_planned_playfield_line_impl(
         let nplanes = sample_control.nplanes().min(plan.plane_words.len());
         let delays = std::array::from_fn(|plane| sample_control.sample_delay_for_plane(plane));
         let hold_final_fetch_sample = pixel_control.holds_final_lowres_fetch_sample_at_diwstop();
-        let ham_mode = output_control.hold_and_modify();
+        let ham_mode = output_control.ham();
         let indexed_outputs = if ham_mode {
             None
         } else {
@@ -6705,7 +6721,7 @@ fn manual_bpl_ham_seed_color(
         &control_segments[seg.line],
         sample_x,
     );
-    if !control.hold_and_modify() {
+    if !control.ham() {
         return rgb12_to_rgb24(color_rgb12(seg.palette[0]));
     }
     if seg.x <= 0 {

--- a/src/video/bitplane/output.rs
+++ b/src/video/bitplane/output.rs
@@ -32,7 +32,7 @@ impl IndexedOutputCache {
         control: ControlState,
         palette: &Palette,
     ) -> &[DenisePlayfieldOutput; 256] {
-        debug_assert!(!control.hold_and_modify());
+        debug_assert!(!control.ham());
         if let Some(idx) = self
             .entries
             .iter()

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -6702,6 +6702,84 @@ fn planned_ham_dma_advances_hold_through_edge_fetch_phase() {
 }
 
 #[test]
+fn ham8_is_hold_and_modify_but_not_ham6() {
+    let control = ControlState {
+        agnus_revision: AgnusRevision::AgaAlice,
+        bplcon0: 0x0A11, // HAMEN + BPU3 (8 planes) + COLOR + ECSENA
+        ..ControlState::default()
+    };
+    assert_eq!(control.nplanes(), 8);
+    assert!(!control.hold_and_modify());
+    assert!(control.ham8());
+    assert!(control.ham());
+
+    // The same BPLCON0 without AGA decodes no eighth plane and no HAM8.
+    let ecs = ControlState {
+        bplcon0: 0x0A11,
+        ..ControlState::default()
+    };
+    assert!(!ecs.ham8());
+}
+
+/// HAM8's held colour must carry from pixel to pixel through the planned
+/// line renderer: an 8-plane HAM screen is history-dependent, so the
+/// history-free indexed output cache has to stay off. Regression example:
+/// the Super Stardust CD32 intro (HAM8 anim) rendered every modify pixel
+/// from a black hold, collapsing the picture to saturated single-channel
+/// noise.
+#[test]
+fn planned_ham8_dma_carries_hold_across_pixels() {
+    // Native x0: set op, palette entry 5 (pv $14 -> planes 3/5).
+    // Native x1: modify blue := $2A<<2 (pv $A9 -> planes 1/4/6/8).
+    // Native x2: modify red := $3F<<2 (pv $FE -> planes 2..8).
+    let plane_bits: [u16; 8] = [
+        0x4000, 0x2000, 0xA000, 0x6000, 0xA000, 0x6000, 0x2000, 0x6000,
+    ];
+    let row_words: Vec<Vec<u16>> = plane_bits.iter().map(|&word| vec![word]).collect();
+    let line_plan = DenisePlannedPlayfieldLine::new(0, 68, 74, &row_words, 3);
+    let mut control = visible_lowres_control(0x0A11);
+    control.agnus_revision = AgnusRevision::AgaAlice;
+    let mut palette = Palette::new();
+    palette.write_banked(0, 5, false, 0x0135);
+    palette.write_banked(0, 5, true, 0x0246);
+    let mut fb = vec![0; FB_PIXELS];
+    let mut playfield_mask = vec![0; FB_PIXELS];
+    let mut collision_pixels = vec![CollisionPixel::default(); FB_PIXELS];
+    let mut clxdat = 0;
+
+    render_planned_playfield_line(
+        &line_plan,
+        &mut fb,
+        &mut playfield_mask,
+        &mut collision_pixels,
+        &mut CollisionLookup::new(),
+        &mut IndexedOutputCache::default(),
+        &mut clxdat,
+        palette,
+        &[],
+        0,
+        control,
+        &[],
+        0,
+        control.bplcon1,
+        control.bplcon0,
+        false,
+        0,
+        0,
+        &h_row_for(control),
+        PAL_VISIBLE_LINE0,
+        0.0,
+        0,
+    );
+
+    // Set: entry 5 = $123456. Modify blue: $A8 | ($56 & 3) = $AA. Modify
+    // red: $FC | ($12 & 3) = $FE, holding the accumulated green and blue.
+    assert_eq!(fb[68], rgb24_to_rgba8_alpha(0x0012_3456, true));
+    assert_eq!(fb[70], rgb24_to_rgba8_alpha(0x0012_34AA, true));
+    assert_eq!(fb[72], rgb24_to_rgba8_alpha(0x00FE_34AA, true));
+}
+
+#[test]
 fn planned_ham_dma_carries_early_ddf_history_across_diw_open() {
     // Denise's HAM accumulator advances on every shifted sample; DIW only
     // selects between border and playfield output. With DDFSTRT one fetch


### PR DESCRIPTION
## Summary

The indexed output cache (28921c37) and the constant-run fast interior gate on `hold_and_modify()`, which matches HAM6 (five or six planes) only. An 8-plane Lisa HAM8 screen therefore resolved every pixel through the history-free cached table: each modify pixel started from a black held colour instead of the previous pixel's, collapsing the picture to saturated single-channel noise (pure R/G/B dither, solid single-channel fills) while shapes survived. Before the cache landed this stale predicate was harmless, because the per-pixel path still threaded the real held colour through `denise_aga_playfield_output`.

## Fix

- New `ControlState::ham8()` (AGA, eight planes, HAMEN - mirrors the decode condition in `denise_aga_playfield_output`) and `ControlState::ham()` = HAM6 or HAM8.
- The render `ham_mode` gate, `manual_bpl_ham_seed_color`, and the cache's debug assert now use `ham()`; `hold_and_modify()` keeps its HAM6 meaning for the decode paths.
- Regression test `planned_ham8_dma_carries_hold_across_pixels` drives the planned-line renderer through a set / modify-blue / modify-red HAM8 sequence and pins the held-colour carry (fails against the old gate).

## Diagnostics

Adds a CCP `palette.dump` method returning the live Denise/Lisa palette (all 256 AGA entries as hi/lo nibble-plane words), documented in `docs/debugger/control.md`. `custom.dump`'s COLORxx values are only write latches, so this is what separates a wrong palette upload from a wrong resolver - it was how this bug was isolated to the render side.

Regression example: the Super Stardust CD32 intro (HAM8 anim), broken vs fixed on the same frame of a resumed save state:

| broken | fixed |
| --- | --- |
| green sun, R/G/B dither rings, near-black ship | correct sun/battleship scene |

## Verification

- `cargo test`: 3000 passed
- `cargo test --release --test probe_golden -- --include-ignored`: 33 passed (no golden shifts)
- `cargo clippy` and `cargo fmt --check` clean
- Resumed a Super Stardust CD32 save state on the fixed build: HAM8 hangar/Earth and sun/battleship intro scenes both render correctly; HAM6 titles unaffected (goldens include the hamprobe-select render)