### PR TITLE
picasso2: fix transposed NOR and NAND BitBLT ROP encodings

### DIFF
--- a/src/picasso2/gd5426.rs
+++ b/src/picasso2/gd5426.rs
@@ -1155,6 +1155,9 @@ fn open_bus(size: usize) -> u32 {
 /// The CL-GD5426/5428 implement the 16 two-operand Boolean functions using this
 /// sparse set of ROP encodings. Pattern operations feed their pattern byte as
 /// `source`, so the same table covers the S and P rows in the data book.
+///
+/// `0x90` and `0xda` are easy to transpose: `0x90` is NOR (`~src & ~dst`) and
+/// `0xda` is NAND (`~src | ~dst`), not the other way round.
 fn apply_rop(rop: u8, source: u8, dest: u8) -> u8 {
     match rop {
         0x00 => 0,
@@ -1167,12 +1170,12 @@ fn apply_rop(rop: u8, source: u8, dest: u8) -> u8 {
         0x50 => !source & dest,
         0x59 => source ^ dest,
         0x6d => source | dest,
-        0x90 => !source | !dest,
+        0x90 => !source & !dest,
         0x95 => !(source ^ dest),
         0xad => source | !dest,
         0xd0 => !source,
         0xd6 => !source | dest,
-        0xda => !source & !dest,
+        0xda => !source | !dest,
         _ => source,
     }
 }
@@ -1516,7 +1519,10 @@ mod tests {
                 for dest in [0x00, 0x53, 0xaa, 0xff] {
                     // The Cirrus encoding is sparse rather than a compact
                     // four-bit truth table, so spell the documented Boolean
-                    // operation out independently of `apply_rop`.
+                    // operation out independently of `apply_rop`. NOR and NAND
+                    // are written as the negated OR and AND the data book names
+                    // them by, since transposing the two is the mistake this
+                    // whole test exists to catch.
                     let expect = match rop {
                         0x00 => 0,
                         0x05 => source & dest,
@@ -1528,12 +1534,12 @@ mod tests {
                         0x50 => !source & dest,
                         0x59 => source ^ dest,
                         0x6d => source | dest,
-                        0x90 => !source | !dest,
+                        0x90 => !(source | dest),
                         0x95 => !(source ^ dest),
                         0xad => source | !dest,
                         0xd0 => !source,
                         0xd6 => !source | dest,
-                        0xda => !source & !dest,
+                        0xda => !(source & dest),
                         _ => unreachable!(),
                     };
                     assert_eq!(apply_rop(rop, source, dest), expect, "rop {rop:#04x}");


### PR DESCRIPTION
Fixes #568.

`apply_rop()` had the CL-GD542x BitBLT encodings for NOR and NAND
exchanged, so each of those two raster ops produced the other one's
result:

```rust
0x90 => !source | !dest,   // NAND
0xda => !source & !dest,   // NOR
```

Per the CL-GD5426/5428 data book, `0x90` is `~src & ~dst` -- `NOT (src OR
dst)`, NOR -- and `0xda` is `~src | ~dst` -- `NOT (src AND dst)`, NAND.
QEMU's `cirrus_vga.c` names the same two encodings `ROP_NOTSRC_AND_NOTDST`
and `ROP_NOTSRC_OR_NOTDST`.

`every_documented_rop_matches_boolean_reference` did not catch it because
its reference table restated the same two expressions, so it compared
`apply_rop` against itself for those encodings. This rewrites them as the
negated OR and AND the data book names them by, which is the form that
does not transpose.

## Testing

Found by [p96cts](https://github.com/codewiz/p96cts) on a `picasso2plus`
board: `BltBitMap-friend` sweeps all sixteen `BltBitMap()` minterms with a
source bitmap in the screen's own pixel format, so the blits take the
accelerated path. Exactly two of the sixteen rows were wrong -- minterm
`0x10` (NOR) and minterm `0x70` (NAND) -- and each rendered as the other
one's result. The remaining fourteen were pixel-exact.

Before, at 320x200x8:

```
FAIL    9.040ms BltBitMap-friend         1872 of 64000 pixels differ
       at   4, 33 golden 168, got 189
```

Amiberry, on the same guest software stack (AmigaOS 3.2, Picasso96API
2.495, PicassoII.card 43.36, rtg.library 43.787), rendered all sixteen
minterms correctly.
