### PR TITLE
control: at_seconds for all input.* methods; disasm: 68020 full-format extension words

### DIFF
--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -528,15 +528,18 @@ pub enum InputCmd {
         middle: Option<bool>,
         dx: i32,
         dy: i32,
+        at_seconds: Option<f64>,
     },
     Joy {
         port: u8,
         state: JoyState,
+        at_seconds: Option<f64>,
     },
     Analogue {
         port: u8,
         x: u8,
         y: u8,
+        at_seconds: Option<f64>,
     },
 }
 
@@ -611,11 +614,12 @@ impl InputCmd {
                 middle,
                 dx,
                 dy,
+                at_seconds,
             } => {
                 for (index, state) in [(0u8, left), (1, right), (2, middle)] {
                     if let Some(pressed) = state {
                         emit(
-                            None,
+                            at_seconds,
                             InputAction::MouseButton {
                                 port,
                                 index,
@@ -625,11 +629,20 @@ impl InputCmd {
                     }
                 }
                 if dx != 0 || dy != 0 {
-                    emit(None, InputAction::MouseMove { port, dx, dy });
+                    emit(at_seconds, InputAction::MouseMove { port, dx, dy });
                 }
             }
-            InputCmd::Joy { port, state } => emit(None, InputAction::Joy { port, state }),
-            InputCmd::Analogue { port, x, y } => emit(None, InputAction::Pot { port, x, y }),
+            InputCmd::Joy {
+                port,
+                state,
+                at_seconds,
+            } => emit(at_seconds, InputAction::Joy { port, state }),
+            InputCmd::Analogue {
+                port,
+                x,
+                y,
+                at_seconds,
+            } => emit(at_seconds, InputAction::Pot { port, x, y }),
         }
         (now, later)
     }
@@ -637,6 +650,17 @@ impl InputCmd {
 
 // ---------------------------------------------------------------------
 // Parsing
+
+/// Parse the optional `at_seconds` param shared by the `input.*` methods:
+/// absent means "apply now", present schedules at that emulated time.
+fn parse_at_seconds(p: &ParamReader) -> Result<Option<f64>, CtlError> {
+    match p.f64_opt("at_seconds")? {
+        Some(t) if !t.is_finite() => Err(CtlError::invalid_params(
+            "at_seconds must be a finite number",
+        )),
+        other => Ok(other),
+    }
+}
 
 /// Parse the optional 1-based `port` param (1 or 2), defaulting to
 /// `default`, into the bus's 0-based port index.
@@ -893,14 +917,7 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             host(HostOp::Input(InputCmd::Key {
                 rawkey: rawkey as u8,
                 kind,
-                at_seconds: match p.f64_opt("at_seconds")? {
-                    Some(t) if !t.is_finite() => {
-                        return Err(CtlError::invalid_params(
-                            "at_seconds must be a finite number",
-                        ))
-                    }
-                    other => other,
-                },
+                at_seconds: parse_at_seconds(&p)?,
             }))
         }
         "input.mouse" => host(HostOp::Input(InputCmd::Mouse {
@@ -910,6 +927,7 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             middle: p.bool_opt("middle")?,
             dx: p.i32_or("dx", 0)?,
             dy: p.i32_or("dy", 0)?,
+            at_seconds: parse_at_seconds(&p)?,
         })),
         "input.mouse_to" => host(HostOp::MouseTo {
             port: parse_port_param(&p, 1)?,
@@ -937,6 +955,7 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
                 green: p.bool_or("green", false)?,
                 yellow: p.bool_or("yellow", false)?,
             },
+            at_seconds: parse_at_seconds(&p)?,
         })),
         "input.analogue" => {
             let (x, y) = (p.u32_req("x")?, p.u32_req("y")?);
@@ -947,6 +966,7 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
                 port: parse_port_param(&p, 2)?,
                 x: x as u8,
                 y: y as u8,
+                at_seconds: parse_at_seconds(&p)?,
             }))
         }
         "input.set_port" => {

--- a/src/control/headless.rs
+++ b/src/control/headless.rs
@@ -1451,6 +1451,62 @@ mod tests {
     }
 
     #[test]
+    fn joy_and_analogue_accept_at_seconds_scheduling() {
+        // input.joy/analogue/mouse share input.key's at_seconds semantics:
+        // a future timestamp defers the state change instead of applying it
+        // at submission time (a press/release pair scheduled while paused
+        // must not cancel itself out).
+        let emu = control_test_emulator();
+        let input = MachineInputState::default();
+        let (emu, input, _, _) = run_machine_session(emu, input, |c| {
+            c.auth();
+            let press = c.result(
+                "input.joy",
+                json!({"right": true, "red": true, "at_seconds": 0.02}),
+            );
+            assert_eq!(press["scheduled"], 1);
+            let release = c.result("input.joy", json!({"at_seconds": 0.06}));
+            assert_eq!(release["scheduled"], 1);
+            let pot = c.result(
+                "input.analogue",
+                json!({"port": 1, "x": 10, "y": 200, "at_seconds": 0.02}),
+            );
+            assert_eq!(pot["scheduled"], 1);
+        });
+        assert!(
+            !emu.bus().input.ports[1].right,
+            "a future joy state must not apply at submission time"
+        );
+        assert_eq!(
+            emu.bus().input.ports[0].device,
+            crate::bus::PortDevice::Mouse
+        );
+
+        let (emu, input, _, _) = run_machine_session(emu, input, |c| {
+            c.auth();
+            c.result("run_until", json!({"seconds": 0.04}));
+        });
+        assert!(emu.bus().input.ports[1].right);
+        assert!(emu.bus().input.ports[1].fire);
+        // The scheduled analogue event hot-plugged the paddle when it fired.
+        assert_eq!(
+            emu.bus().input.ports[0].device,
+            crate::bus::PortDevice::Analogue
+        );
+        assert!(emu.bus().input.ports[0].pot_x_ohms.is_some());
+
+        let (emu, _, _, _) = run_machine_session(emu, input, |c| {
+            c.auth();
+            c.result("run_until", json!({"seconds": 0.08}));
+        });
+        assert!(
+            !emu.bus().input.ports[1].right,
+            "the scheduled release must fire at its own timestamp"
+        );
+        assert!(!emu.bus().input.ports[1].fire);
+    }
+
+    #[test]
     fn future_input_from_a_closed_session_fires_under_continue() {
         let emu = control_test_emulator();
         let input = MachineInputState::default();

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -28,6 +28,10 @@ struct Stream<'a> {
     base: u32,
     /// Number of words consumed so far (including the opcode word).
     words: u32,
+    /// 68020+ decode: indexed extension words with bit 8 set are the full
+    /// format (base/outer displacements, memory indirection). The 68000
+    /// and 68010 ignore that bit and always use the brief format.
+    full_ext: bool,
 }
 
 impl Stream<'_> {
@@ -107,6 +111,76 @@ fn brief_index(ext: u16) -> String {
     }
 }
 
+/// Render an indexed EA (`(d8,base,Xn)` brief format, or the 68020+ full
+/// format when bit 8 of the extension word is set and the CPU honours it),
+/// consuming any base/outer displacement words from `s`. `base` is "A0".."A7"
+/// or "PC".
+fn indexed_ea(base: &str, ext: u16, s: &mut Stream) -> String {
+    if ext & 0x0100 == 0 || !s.full_ext {
+        let d = ext as i8 as i32;
+        return format!("({},{},{})", signed_hex(d), base, brief_index(ext));
+    }
+    // Full extension word format. Word order after it: base displacement,
+    // then outer displacement (matching the execution model in the CPU
+    // core's EA calculation).
+    let base_suppress = ext & 0x0080 != 0;
+    let index_suppress = ext & 0x0040 != 0;
+    let bd = match (ext >> 4) & 3 {
+        2 => Some(s.next_word() as i16 as i32),
+        3 => Some(s.next_long() as i32),
+        _ => None, // 0 reserved, 1 null displacement
+    };
+    let i_is = ext & 7;
+    let od = if i_is != 0 {
+        match i_is & 3 {
+            2 => Some(s.next_word() as i16 as i32),
+            3 => Some(s.next_long() as i32),
+            _ => None, // null outer displacement
+        }
+    } else {
+        None
+    };
+    let index = (!index_suppress).then(|| brief_index(ext));
+    let mut inner: Vec<String> = Vec::new();
+    if let Some(bd) = bd {
+        inner.push(signed_hex(bd));
+    }
+    if !base_suppress {
+        inner.push(base.to_string());
+    }
+    if i_is == 0 {
+        // No memory indirection: (bd,base,Xn).
+        if let Some(x) = index {
+            inner.push(x);
+        }
+        if inner.is_empty() {
+            inner.push("0".to_string());
+        }
+        return format!("({})", inner.join(","));
+    }
+    // Memory indirect: pre-indexed puts the index inside the brackets,
+    // post-indexed applies it after the fetch.
+    let post_indexed = i_is & 4 != 0;
+    if !post_indexed {
+        if let Some(x) = index.clone() {
+            inner.push(x);
+        }
+    }
+    if inner.is_empty() {
+        inner.push("0".to_string());
+    }
+    let mut outer = format!("[{}]", inner.join(","));
+    if post_indexed {
+        if let Some(x) = index {
+            outer = format!("{outer},{x}");
+        }
+    }
+    if let Some(od) = od {
+        outer = format!("{outer},{}", signed_hex(od));
+    }
+    format!("({outer})")
+}
+
 /// Decode the effective address with mode/reg fields and an operand size
 /// (0=byte, 1=word, 2=long), consuming any extension words from `s`.
 fn effective_address(mode: u8, reg: u8, size: u8, s: &mut Stream) -> String {
@@ -122,13 +196,7 @@ fn effective_address(mode: u8, reg: u8, size: u8, s: &mut Stream) -> String {
         }
         6 => {
             let ext = s.next_word();
-            let d = ext as i8 as i32;
-            format!(
-                "({},{},{})",
-                signed_hex(d),
-                AN[reg as usize],
-                brief_index(ext)
-            )
+            indexed_ea(AN[reg as usize], ext, s)
         }
         7 => match reg {
             0 => {
@@ -146,8 +214,7 @@ fn effective_address(mode: u8, reg: u8, size: u8, s: &mut Stream) -> String {
             }
             3 => {
                 let ext = s.next_word();
-                let d = ext as i8 as i32;
-                format!("({},PC,{})", signed_hex(d), brief_index(ext))
+                indexed_ea("PC", ext, s)
             }
             4 => match size {
                 0 => format!("#${:X}", s.next_word() & 0xFF),
@@ -167,6 +234,7 @@ pub fn disassemble(read: impl Fn(u32) -> u16, pc: u32, cpu_type: CpuType) -> (St
         read: &read,
         base: pc,
         words: 0,
+        full_ext: !matches!(cpu_type, CpuType::M68000 | CpuType::M68010),
     };
     let op = s.next_word();
     let text = decode(op, &mut s, cpu_type);
@@ -750,6 +818,54 @@ mod tests {
     fn displacement_addressing() {
         // MOVE.W $4(A0),D0 -> 3028 0004
         assert_eq!(dis(&[0x3028, 0x0004], 0).0, "MOVE.W ($4,A0),D0");
+    }
+
+    /// Disassemble as a 68020, where indexed extension words with bit 8 set
+    /// use the full format (base/outer displacements, memory indirection).
+    fn dis020(words: &[u16], pc: u32) -> (String, u32) {
+        let mem = words.to_vec();
+        disassemble(
+            move |addr| {
+                let idx = (addr.wrapping_sub(pc) / 2) as usize;
+                mem.get(idx).copied().unwrap_or(0)
+            },
+            pc,
+            CpuType::M68EC020,
+        )
+    }
+
+    #[test]
+    fn full_extension_memory_indirect() {
+        // MOVE.W ([$25DE,A4],$C),D0: index suppressed, word base
+        // displacement, memory indirect with word outer displacement.
+        let (t, n) = dis020(&[0x3034, 0x0162, 0x25DE, 0x000C], 0);
+        assert_eq!(t, "MOVE.W ([$25DE,A4],$C),D0");
+        assert_eq!(n, 8);
+        // MOVEA.L ([$25DE,A4],$10),A0: the vectored-call form of the same EA.
+        let (t, n) = dis020(&[0x2074, 0x0162, 0x25DE, 0x0010], 0);
+        assert_eq!(t, "MOVEA.L ([$25DE,A4],$10),A0");
+        assert_eq!(n, 8);
+    }
+
+    #[test]
+    fn full_extension_pre_indexed_and_plain() {
+        // Pre-indexed with a live index register and null outer displacement.
+        let (t, n) = dis020(&[0x3034, 0x0121, 0x0040], 0);
+        assert_eq!(t, "MOVE.W ([$40,A4,D0.W]),D0");
+        assert_eq!(n, 6);
+        // No memory indirection, long base displacement: (bd32,An,Xn).
+        let (t, n) = dis020(&[0x3034, 0x0130, 0x0001, 0x2345], 0);
+        assert_eq!(t, "MOVE.W ($12345,A4,D0.W),D0");
+        assert_eq!(n, 8);
+    }
+
+    #[test]
+    fn full_extension_bit_ignored_on_68000() {
+        // The 68000 has no full-format extension words: bit 8 is ignored and
+        // the word decodes as the brief format (d8 = low byte).
+        let (t, n) = dis(&[0x3034, 0x0162, 0x25DE, 0x000C], 0);
+        assert_eq!(t, "MOVE.W ($62,A4,D0.W),D0");
+        assert_eq!(n, 4);
     }
 
     #[test]


### PR DESCRIPTION
Two debugger-surface fixes found while investigating a CD32 title.

**control: honor `at_seconds` on `input.joy`, `input.mouse` and `input.analogue`**

`docs/debugger/control.md` documents `at_seconds` scheduling for every
`input.*` method, but only `input.key` implemented it. The other three
silently ignored the parameter and applied the state at submission time,
so a press/release pair scheduled while paused cancelled itself out
before the timeline advanced. `at_seconds` is now threaded through
`InputCmd::Joy/Mouse/Analogue` into the shared `expand()` path, with the
finite-number validation factored into one helper. New regression test:
`joy_and_analogue_accept_at_seconds_scheduling` (scheduled state must not
apply at submission time, fires at its own timestamp, analogue hot-plug
happens when the event fires).

**disasm: decode 68020+ full-format extension words**

Indexed extension words with bit 8 set were always decoded as the brief
format, so 68020 base displacements and memory indirection rendered as
garbage (`MOVE.W ([$25DE,A4],$C),D0` came out as a bogus
`MOVE.L (A6)+,($C,PC)` plus stray instructions). The CPU core executes
these modes correctly; only CCP `disasm`, `DBG_TRACE` and the debugger
window lied. Full-format parsing (base/index suppression, word/long base
displacements, pre/post-indexed memory indirect with word/long outer
displacements) now follows the core's EA word order, gated on 020+ CPU
types since the 68000/010 ignore bit 8 in hardware. Tests cover memory
indirect, pre-indexed, long-bd, and the 68000 brief-format gating.

Full suite: 3019 unit tests pass, clippy and rustfmt clean.