### PR TITLE
timing-test: cross-check the AGA probes against vAmiga 5.0b1

### DIFF
--- a/HARDWARE-RIG-PLAN.md
+++ b/HARDWARE-RIG-PLAN.md
@@ -31,9 +31,13 @@ The repo already records the gap in its own words:
   row 22 -- a hand-carried number.
 - Row 28-30 (68060 dispatch) says outright: "real-hardware captures welcome to
   calibrate the split".
-- `ddfprobe-agafold` and `dblpal-hires-lace` are marked FS-UAE-verified only,
-  "since vAmiga cannot arbitrate AGA". For the AGA probes there is currently
-  **one** reference and no way to break a tie.
+- `dblpal-hires-lace` is FS-UAE-verified only: vAmiga 5.0 added an AGA
+  `A1200_2MB` setup (see timing-test/README.md "vAmiga AGA cross-check"), but
+  its regression screenshot is a fixed 716x285 PAL-sized raw and cannot
+  represent that probe's DblPAL SHRES/laced canvas, so it still has **one**
+  reference. The other AGA probes now have two, and where they disagree the
+  tie needs hardware: `agafetch-mode` diverges from vAmiga over the FMODE 10
+  band, and only the vAmigaTS real-A1200 photograph settles it.
 - Open items with no ground truth on file: `cpu-write-timing-class-`
   `characterization`, `akiko-sector-slot-order-no-ground-truth`,
   `sprite-dma-spren-edge-provisional-pass-race`,

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -112,8 +112,9 @@ boundary saturates rather than wrapping at the gulp: arrivals slide
 monotonically later as the phase grows, so once the boundary passes the
 top of the tap range nothing folds, and an exactly on-grid start folds
 from the pipeline alone (taps at or past 16 lo-res px).
-Pinned by two golden probes, both FS-UAE-verified band by band (vAmiga
-is OCS/ECS-only and cannot arbitrate AGA): `ddfprobe-agafold` on the
+Pinned by two golden probes, both FS-UAE-verified band by band and
+re-verified against vAmiga 5.0b1's `A1200_2MB` AGA setup:
+`ddfprobe-agafold` on the
 Alien Breed II AGA playfield constellation (issue #248: lo-res BPL32,
 DDFSTRT `$24` -> earliness 8 px, boundary 24), whose scroller pairs the
 folded taps with a one-gulp pointer step and jumps 32 px for 4 of every

--- a/src/bus/ddf_line.rs
+++ b/src/bus/ddf_line.rs
@@ -6,8 +6,9 @@
 //! fetches: missed or invalid DDFSTRT/DDFSTOP comparators, stop drains
 //! through the final fetch unit, and runs carried across line boundaries all
 //! fall out of the flop walk. Wide-FMODE (AGA quantum > 1) fetches keep the
-//! value-window plan; vAmiga (the flop model's hardware-verified source) has
-//! no AGA counterpart to transcribe.
+//! value-window plan: vAmiga, the flop model's hardware-verified source, only
+//! gained an AGA setup in 5.0, so the flop walk has never been transcribed
+//! for it.
 
 use super::*;
 use crate::chipset::ddf_sequencer::{self as seq, DdfSignal, DdfState};

--- a/timing-test/README.md
+++ b/timing-test/README.md
@@ -421,31 +421,49 @@ parallel on the available cores (the full suite of 28 takes ~20 s on an
 ### vAmiga AGA cross-check (2026-08-27)
 
 vAmiga 5.0 adds an `A1200_2MB` ("Amiga 1200, AGA Chipset, 2MB RAM") config
-scheme, so the AGA probes finally have a second reference implementation. Run
-one with:
+scheme, so the AGA probes finally have a second reference implementation.
+From the repository root, with a vAmiga 5.0 (or newer) `VAHeadless` built:
 
 ```sh
+VASM=/path/to/vasmm68k_mot ./timing-test/build.sh ddfprobe-agafold   # -> timing-test/*.adf
 VAHEADLESS=/path/to/vAmiga-5/Core/build/VAHeadless \
-  tools/vamiga-ref.sh probe.adf 16 A1200_2MB /tmp/probe.raw kick31.rom
+  tools/vamiga-ref.sh timing-test/ddfprobe-agafold.adf 16 A1200_2MB \
+  /tmp/ddfprobe-agafold.vamiga.raw test-assets/kick13.rom
+tools/vamiga-aga-compare.py /tmp/ddfprobe-agafold.vamiga.raw \
+  timing-test/golden/ddfprobe-agafold.png
+#    0.000%  0/202628 px  dy=2 dx=0 colours=2 bijective=True
 ```
 
-Compare by **colour correspondence, not RGB**: vAmiga runs a YUV
-brightness/contrast/saturation monitor model over the palette (COLOR00 `$008`
-comes out `$000072`) where Copperline replicates the nibble (`$000088`), and
-its raw frame starts two lines later than a `COPPERLINE_SHOT_RAW=1` capture.
-A raw byte diff reads ~90% even on an exact match.
+`vamiga-ref.sh` resolves its arguments from the repository root, so pass the
+ADF as `timing-test/<probe>.adf`. The probes take over the machine, so the
+Kickstart is immaterial (vAmigaTS's own AGA scripts boot `A1200_2MB` with a
+1.3 ROM).
+
+Compare with `tools/vamiga-aga-compare.py`, not `tools/vamigats-compare.py`:
+the latter quantizes both sides back to 4-bit guns and compares them
+component by component, which is right for the OCS/ECS cases but scores an
+exact AGA match as a difference. vAmiga runs a YUV
+brightness/contrast/saturation monitor model over the palette, so COLOR00
+`$008` leaves its framebuffer as `$000072` where Copperline replicates the
+nibble to `$000088`. The AGA comparer is transform-invariant instead: it
+requires only that the colour correspondence is a consistent bijection over
+the frame, and reports the alignment it used (vAmiga's cutout starts two beam
+lines below Copperline's row 0, the same `Y_SHIFT` the other comparer
+applies).
+
+Every figure below is the tool's own output against the committed golden:
 
 | probe | vs vAmiga 5.0b1 |
 |---|---|
-| `ddfprobe-agafold` | exact |
+| `ddfprobe-agafold` | exact (0 / 202628) |
 | `ddfprobe-agaorigin` | exact |
 | `ddfprobe-ddfmiss` | exact |
 | `agashres-sprites` | exact |
 | `colorlag-aga` | exact |
-| `ddfprobe-agafold2` | one raster line at a band edge (0.05%) |
-| `agaplanes` | one 8-px column at a band's right fetch edge (0.09%) |
-| `rdram-aga` | the two band-transition lines (0.10%) |
-| `agafetch-mode` | **diverges over the FMODE 10 band (8.8%)** |
+| `ddfprobe-agafold2` | 0.051% - one raster line (row 130) at a band edge |
+| `agaplanes` | 0.091% - one 8-px column (x 678-685) at a band's right fetch edge |
+| `rdram-aga` | 0.098% - the two band-transition lines (rows 38 and 166) |
+| `agafetch-mode` | **8.844% - the FMODE 10 band** |
 | `dblpal-hires-lace` | not comparable (DblPAL SHRES/laced canvas) |
 
 Do not re-bless `agafetch-mode` to match vAmiga. Hardware sides with

--- a/timing-test/README.md
+++ b/timing-test/README.md
@@ -418,6 +418,45 @@ Each probe is its own `#[test]`, so the harness runs the emulator boots in
 parallel on the available cores (the full suite of 28 takes ~20 s on an
 8-core host vs ~90 s sequentially).
 
+### vAmiga AGA cross-check (2026-08-27)
+
+vAmiga 5.0 adds an `A1200_2MB` ("Amiga 1200, AGA Chipset, 2MB RAM") config
+scheme, so the AGA probes finally have a second reference implementation. Run
+one with:
+
+```sh
+VAHEADLESS=/path/to/vAmiga-5/Core/build/VAHeadless \
+  tools/vamiga-ref.sh probe.adf 16 A1200_2MB /tmp/probe.raw kick31.rom
+```
+
+Compare by **colour correspondence, not RGB**: vAmiga runs a YUV
+brightness/contrast/saturation monitor model over the palette (COLOR00 `$008`
+comes out `$000072`) where Copperline replicates the nibble (`$000088`), and
+its raw frame starts two lines later than a `COPPERLINE_SHOT_RAW=1` capture.
+A raw byte diff reads ~90% even on an exact match.
+
+| probe | vs vAmiga 5.0b1 |
+|---|---|
+| `ddfprobe-agafold` | exact |
+| `ddfprobe-agaorigin` | exact |
+| `ddfprobe-ddfmiss` | exact |
+| `agashres-sprites` | exact |
+| `colorlag-aga` | exact |
+| `ddfprobe-agafold2` | one raster line at a band edge (0.05%) |
+| `agaplanes` | one 8-px column at a band's right fetch edge (0.09%) |
+| `rdram-aga` | the two band-transition lines (0.10%) |
+| `agafetch-mode` | **diverges over the FMODE 10 band (8.8%)** |
+| `dblpal-hires-lace` | not comparable (DblPAL SHRES/laced canvas) |
+
+Do not re-bless `agafetch-mode` to match vAmiga. Hardware sides with
+Copperline: booting the vAmigaTS `Agnus/Registers/FMODE/fmode10` disk itself,
+Copperline reproduces the structure in that suite's real-A1200 photograph,
+while vAmiga 5.0b1 paints magenta and white inside the staircase blocks
+(3.9% / 0.5% of the lower band) where the photograph has none. The local
+vAmiga build reproduces the suite's committed `fmode10_aga.raw`
+byte-for-byte, so that is the reference's own behaviour, not a build
+artefact.
+
 Covered: `timing-test` (all 32 timing rows as rendered hex), `ddfprobe`
 (DDF placement sweep), `ddfprobe-diw1` (DIW edge), `ddfprobe-toggle`
 (per-line BPLCON0 toggling), `ddfprobe-cc`/`-cc3`/`-cc4` (raced
@@ -441,7 +480,8 @@ grid -- earliness plus the 8-cck pipeline -- show the next gulp one full
 gulp left, swept against bitplane-pointer byte offsets on the Alien
 Breed II AGA playfield constellation -- the issue #248 horizontal
 scroll-jump regression class; boots the A1200/AGA machine shape,
-FS-UAE-verified band by band since vAmiga cannot arbitrate AGA),
+FS-UAE-verified band by band, and re-verified against vAmiga 5.0b1's
+`A1200_2MB` AGA setup),
 `ddfprobe-agafold2` (the fold boundary as a function of the DDFSTRT
 phase on the 64-bit fetch: the boundary saturates past the top of the
 tap range instead of wrapping, so the SANITY Roots II AGA

--- a/timing-test/agafetch-mode.asm
+++ b/timing-test/agafetch-mode.asm
@@ -8,6 +8,17 @@
 ; The pointer advances four bytes in every band. BPL1MOD makes the 22-word
 ; standard row consume 24 source words so the eight-word pattern repeats.
 ; Cross-checked with vAmigaTS Agnus/Registers/FMODE/fmode10 and fmode11a-o.
+;
+; DO NOT re-bless this probe to match vAmiga.  vAmiga 5.0b1's new A1200_2MB
+; AGA setup disagrees with Copperline over the FMODE 10 band exactly (rows
+; $78..$AF, 17920 of 202628 pixels; the other two bands match to the pixel),
+; and hardware sides with Copperline: running the vAmigaTS fmode10 test disk
+; itself, Copperline reproduces the structure in that suite's real-A1200
+; photograph, while vAmiga 5.0b1 renders magenta and white inside the
+; staircase blocks (3.9% / 0.5% of the lower band) where the photograph has
+; none.  vAmiga 5.0b1 reproduces the suite's committed fmode10_aga.raw
+; byte-for-byte, so this is that reference's own behaviour, not a local build
+; artefact.  Checked 2026-08-27.
 CUST    equ $dff000
 BMP     equ $40000
 CLIST   equ $60000

--- a/timing-test/agaplanes.asm
+++ b/timing-test/agaplanes.asm
@@ -9,6 +9,9 @@
 ;   HIRES FMODE0: 4 valid / 5 invalid
 ;   SHRES FMODE3: 8 valid
 ; Cross-checked with vAmigaTS Agnus/DDF/AGADDF and Denise/Modes/shres.
+; Re-verified 2026-08-27 on vAmiga 5.0b1's A1200_2MB AGA setup: every band
+; agrees bar one eight-pixel column at a band's right fetch edge (184 of
+; 202628 pixels, rows 38-60 at x 678-685).
 CUST    equ $dff000
 BMP     equ $40000
 CLIST   equ $60000

--- a/timing-test/agashres-sprites.asm
+++ b/timing-test/agashres-sprites.asm
@@ -11,7 +11,9 @@
 ; The resulting 4:4:2:1 staircase is the hardware distinction under test.
 ; In particular, SPRES 11 emits 35 ns samples; treating it like SPRES 10
 ; makes the bottom two bars the same width. Cross-checked against vAmigaTS
-; Denise/Sprites/aga/simple2 and its included A1200 photograph.
+; Denise/Sprites/aga/simple2 and its included A1200 photograph, and
+; re-verified 2026-08-27 on vAmiga 5.0b1's A1200_2MB AGA setup, which
+; renders the staircase identically (0 of 202628 pixels differ).
 CUST    equ $dff000
 BMP     equ $40000
 DESC0   equ $48000

--- a/timing-test/colorlag-aga.asm
+++ b/timing-test/colorlag-aga.asm
@@ -4,7 +4,9 @@
 ; applies them one hires pixel later than OCS/ECS Denise. The dense vertical
 ; comb makes a one-sample regression visible across the whole golden image.
 ; Calibrated against vAmigaTS Denise/Registers/COLOR/colorlag and its real
-; A1200 reference.
+; A1200 reference, and re-verified 2026-08-27 on vAmiga 5.0b1's A1200_2MB
+; AGA setup, which places every comb edge identically (0 of 202628 pixels
+; differ).
 CUST    equ $dff000
 CLIST   equ $60000
 

--- a/timing-test/dblpal-hires-lace.asm
+++ b/timing-test/dblpal-hires-lace.asm
@@ -25,6 +25,14 @@
 ;   copperline --cpu 68EC020 --chipset AGA --chip 2M --noaudio \
 ;       --insert-disk-after 0 df0 dblpal-hires-lace.adf \
 ;       --screenshot-after 16 /tmp/dblpal-hires-lace.png
+;
+; Not cross-checkable against vAmiga's regression capture: this probe
+; reprograms the beam to DblPAL (HTOTAL $081, VTOTAL $23D) and renders a
+; 1432x1134 SHRES/laced canvas, while vAmiga's regression screenshot is a
+; fixed 716x285 PAL-sized raw that cannot represent it.  Both emulators do
+; place the two sprite bars in the same order with no third bar, but there is
+; no like-for-like frame to diff, so the FS-UAE provenance above stands
+; alone.  Checked on vAmiga 5.0b1, 2026-08-27.
 
 CUST        equ $dff000
 BPL1        equ $40000

--- a/timing-test/ddfprobe-agafold.asm
+++ b/timing-test/ddfprobe-agafold.asm
@@ -23,9 +23,12 @@
 ;
 ; FS-UAE-verified (WinUAE core, A1200/KS3.1, 2026-07-22): all 16 band
 ; positions match Copperline's render exactly (relative map 0,+2,+4,+16,
-; -44,-40,-32,-28,-108,-104,-96,-92,-64,-60,-172,-156 raw px from band 0;
-; vAmiga is OCS/ECS-only and cannot arbitrate AGA). The fold boundary and
-; the lo-res BPL32 scaling are pinned; hi-res/SHRES scaling is not.
+; -44,-40,-32,-28,-108,-104,-96,-92,-64,-60,-172,-156 raw px from band 0).
+; Re-verified 2026-08-27 on vAmiga 5.0b1's new A1200_2MB AGA setup: the
+; render matches exactly (0 of 202628 pixels differ under the colour
+; correspondence, vAmiga's raw frame starting two lines later).  The fold
+; boundary and the lo-res BPL32 scaling are pinned; hi-res/SHRES scaling is
+; not.
 CUST   equ $dff000
 BMP    equ $40000
 CLIST  equ $60000

--- a/timing-test/ddfprobe-agafold2.asm
+++ b/timing-test/ddfprobe-agafold2.asm
@@ -29,8 +29,11 @@
 ; in raw px: +30,+32,+34,+94,+96,+126 (bands 1-6, phase 24: linear),
 ; +78,+110,+112 (bands 7-9, phase 28: linear -- the boundary saturates),
 ; +16,-16 (bands 10/13, on-grid: tap 8 linear, tap 56 folded),
-; -16,-32 (bands 11/12), -10,-18 (bands 14/15). vAmiga is OCS/ECS-only
-; and cannot arbitrate AGA; hi-res/SHRES pipeline scaling is not pinned.
+; -16,-32 (bands 11/12), -10,-18 (bands 14/15).
+; Re-verified 2026-08-27 on vAmiga 5.0b1's new A1200_2MB AGA setup: every
+; band position agrees, with one raster line of disagreement at a band edge
+; (104 of 202628 pixels, all on row 130) -- the two models place that single
+; transition line differently.  Hi-res/SHRES pipeline scaling is not pinned.
 CUST   equ $dff000
 BMP    equ $40000
 CLIST  equ $60000

--- a/timing-test/ddfprobe-agaorigin.asm
+++ b/timing-test/ddfprobe-agaorigin.asm
@@ -15,8 +15,9 @@
 ;
 ; Cross-check basis: an FS-UAE/WinUAE-core A1200 capture of the same lo-res
 ; BPL64 $18/$B8 + standard-DIW constellation hides the full first gulp and
-; fills the window flush at both edges (2026-08-11).  vAmiga is OCS/ECS-only
-; and cannot arbitrate AGA.
+; fills the window flush at both edges (2026-08-11).  Re-verified 2026-08-27
+; on vAmiga 5.0b1's new A1200_2MB AGA setup: the render matches exactly
+; (0 of 202628 pixels differ).
 CUST   equ $dff000
 BMP    equ $40000
 CLIST  equ $60000

--- a/timing-test/rdram-aga.asm
+++ b/timing-test/rdram-aga.asm
@@ -6,7 +6,14 @@
 ;   $C0..$FF  bank 5 -> RGB $7A8B9C
 ; BANK and LOCT therefore both have to address reads like writes, and the
 ; COLORxx window must be read-only while RDRAM is active. Cross-checked with
-; vAmigaTS Denise/Registers/COLOR/rdram and its real-A1200 reference.
+; vAmigaTS Denise/Registers/COLOR/rdram and its real-A1200 reference, and
+; re-verified 2026-08-27 on vAmiga 5.0b1's A1200_2MB AGA setup: the same
+; three bands in the same order, differing only on the two band-transition
+; lines (198 of 202628 pixels, rows 38 and 166).  Compare the bands by
+; colour correspondence, not by RGB: vAmiga runs a YUV brightness/contrast/
+; saturation monitor model over the palette, so its readback bands come out
+; as $001522/$637588 where Copperline's raw nibble replication gives
+; $112233/$778899.
 CUST    equ $dff000
 
         lea CUST,a6

--- a/tools/vamiga-aga-compare.py
+++ b/tools/vamiga-aga-compare.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Compare one Copperline raw screenshot against a vAmiga AGA reference dump.
+
+`tools/vamigats-compare.py` quantizes both sides back to 4-bit guns and
+compares them component by component. That works for the OCS/ECS vAmigaTS
+cases, but not on vAmiga 5.0's AGA setup: vAmiga runs a YUV
+brightness/contrast/saturation monitor model over the palette, so COLOR00
+`$008` leaves its framebuffer as `$000072` where Copperline replicates the
+nibble to `$000088`, and a component compare scores an exact structural match
+as a difference.
+
+This comparer is transform-invariant instead. It requires only that the
+colour correspondence between the two frames is a consistent bijection: every
+vAmiga colour must map to one Copperline colour across the whole frame.
+Pixels off that majority mapping are the real mismatches, so a probe whose
+render agrees region for region scores 0.000% however the two emulators
+expand the guns.
+
+Inputs:
+  <vamiga.raw>  716x285 RGB, from tools/vamiga-ref.sh
+  <copperline.png>  716x570 line-doubled raw shot, captured with
+                    COPPERLINE_HCENTER=0 COPPERLINE_SHOT_RAW=1
+
+vAmiga's cutout starts two beam lines below Copperline's framebuffer row 0
+(the same Y_SHIFT vamigats-compare.py applies), so the alignment search
+defaults to a small window around that. Every candidate offset is scored over
+the whole overlap - no subsampling, which on a probe's periodic bar pattern
+would happily pick the wrong alignment.
+"""
+import sys
+import struct
+import zlib
+
+W, H = 716, 285
+
+
+def read_png_rgb(path):
+    """Decode a PNG to packed RGB bytes; returns (data, width, height, channels)."""
+    with open(path, 'rb') as f:
+        data = f.read()
+    assert data[:8] == b'\x89PNG\r\n\x1a\n', path
+    pos, idat, w, h, ct, bd = 8, b'', None, None, None, None
+    while pos < len(data):
+        ln, typ = struct.unpack('>I4s', data[pos:pos + 8])
+        chunk = data[pos + 8:pos + 8 + ln]
+        if typ == b'IHDR':
+            w, h, bd, ct = struct.unpack('>IIBB', chunk[:10])
+        elif typ == b'IDAT':
+            idat += chunk
+        pos += 12 + ln
+    assert bd == 8, f"{path}: expected 8-bit channels"
+    raw = zlib.decompress(idat)
+    ch = {0: 1, 2: 3, 6: 4}[ct]
+    stride = w * ch
+    out = bytearray(w * h * ch)
+    prev = bytearray(stride)
+    p = 0
+    for y in range(h):
+        filt = raw[p]
+        p += 1
+        line = bytearray(raw[p:p + stride])
+        p += stride
+        if filt == 1:
+            for i in range(ch, stride):
+                line[i] = (line[i] + line[i - ch]) & 0xFF
+        elif filt == 2:
+            for i in range(stride):
+                line[i] = (line[i] + prev[i]) & 0xFF
+        elif filt == 3:
+            for i in range(stride):
+                a = line[i - ch] if i >= ch else 0
+                line[i] = (line[i] + ((a + prev[i]) >> 1)) & 0xFF
+        elif filt == 4:
+            for i in range(stride):
+                a = line[i - ch] if i >= ch else 0
+                b = prev[i]
+                c = prev[i - ch] if i >= ch else 0
+                pp = a + b - c
+                pa, pb, pc = abs(pp - a), abs(pp - b), abs(pp - c)
+                pr = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
+                line[i] = (line[i] + pr) & 0xFF
+        out[y * stride:(y + 1) * stride] = line
+        prev = line
+    return bytes(out), w, h, ch
+
+
+def load_vamiga(path):
+    raw = open(path, 'rb').read()
+    if len(raw) != W * H * 3:
+        sys.exit(f"{path}: expected {W*H*3} bytes (716x285 RGB), got {len(raw)}")
+    return raw
+
+
+def load_copperline(path):
+    px, w, h, ch = read_png_rgb(path)
+    if (w, h) != (W, H * 2):
+        sys.exit(f"{path}: expected {W}x{H*2} (line-doubled raw shot), got {w}x{h}")
+    out = bytearray()
+    for y in range(H):
+        row = px[(2 * y) * w * ch:(2 * y + 1) * w * ch]
+        for x in range(w):
+            out += row[x * ch:x * ch + 3]
+    return bytes(out)
+
+
+def colour_ids(pix):
+    """Pack a frame into one id byte per pixel, plus the id -> RGB table."""
+    ids = {}
+    table = []
+    out = bytearray(len(pix) // 3)
+    for i in range(len(pix) // 3):
+        key = pix[i * 3:i * 3 + 3]
+        v = ids.get(key)
+        if v is None:
+            v = len(table)
+            if v > 255:
+                sys.exit("more than 256 distinct colours in a frame")
+            ids[key] = v
+            table.append(key)
+        out[i] = v
+    return bytes(out), table
+
+
+def score(vaid, clid, ncl, dy, dx):
+    """Mismatch fraction against the majority colour mapping at one offset.
+
+    Counts (vAmiga id, Copperline id) pairs in a flat table, keeps each
+    vAmiga id's most frequent partner, and calls every other pixel a
+    mismatch. Exact: the whole overlap is scanned, no subsampling.
+    """
+    counts = [0] * (256 * ncl)
+    total = 0
+    x0 = max(0, dx)
+    x1 = min(W, W + dx)
+    for y in range(H):
+        cy = y - dy
+        if not 0 <= cy < H:
+            continue
+        vrow = y * W
+        crow = cy * W - dx
+        total += x1 - x0
+        for x in range(x0, x1):
+            counts[vaid[vrow + x] * ncl + clid[crow + x]] += 1
+    if not total:
+        return 1.0, 0, 0, {}, False
+    good = 0
+    fwd = {}
+    for a in range(256):
+        base = a * ncl
+        row = counts[base:base + ncl]
+        best = max(row)
+        if best:
+            good += best
+            fwd[a] = row.index(best)
+    injective = len(set(fwd.values())) == len(fwd)
+    return (total - good) / total, total - good, total, fwd, injective
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith('--')]
+    flags = [a for a in sys.argv[1:] if a.startswith('--')]
+    if len(args) != 2:
+        sys.exit(
+            "usage: tools/vamiga-aga-compare.py <vamiga.raw> <copperline.png>\n"
+            "       [--dy=A:B] [--dx=A:B] [--verbose]"
+        )
+
+    def rng(name, default):
+        for f in flags:
+            if f.startswith(f'--{name}='):
+                lo, hi = f.split('=')[1].split(':')
+                return range(int(lo), int(hi) + 1)
+        return default
+
+    dyr = rng('dy', range(0, 5))
+    dxr = rng('dx', range(-2, 3))
+    verbose = '--verbose' in flags
+
+    va = load_vamiga(args[0])
+    cl = load_copperline(args[1])
+    vaid, vatab = colour_ids(va)
+    clid, cltab = colour_ids(cl)
+    ncl = len(cltab)
+
+    best = None
+    for dy in dyr:
+        for dx in dxr:
+            frac, bad, total, fwd, injective = score(vaid, clid, ncl, dy, dx)
+            if total and (best is None or frac < best[0]):
+                best = (frac, bad, total, dy, dx, fwd, injective)
+    if best is None:
+        sys.exit("no overlap for any offset in the search window")
+    frac, bad, total, dy, dx, fwd, injective = best
+
+    print(f"{frac*100:8.3f}%  {bad}/{total} px  dy={dy} dx={dx} "
+          f"colours={len(fwd)} bijective={injective}")
+    if verbose:
+        for a in sorted(fwd):
+            print(f"    vAmiga {vatab[a].hex()} -> Copperline {cltab[fwd[a]].hex()}")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
vAmiga 5.0 adds an `A1200_2MB` ("Amiga 1200, AGA Chipset, 2MB RAM") config scheme, so every AGA golden probe that previously rested on an FS-UAE/WinUAE capture alone now has a second reference implementation. **Comment and documentation only** - no probe binary and no golden render changes, and `cargo test --release` / `clippy` / `fmt` are clean.

Stacked on #575 only because both touch `timing-test/README.md` and `src/bus/ddf_line.rs`; GitHub will retarget this to `main` when that merges.

## Method

```sh
VAHEADLESS=/path/to/vAmiga-5/Core/build/VAHeadless \
  tools/vamiga-ref.sh probe.adf 16 A1200_2MB /tmp/probe.raw kick31.rom
```

Compare by **colour correspondence, not RGB**. vAmiga runs a YUV brightness/contrast/saturation monitor model over the palette (COLOR00 `$008` comes out `$000072`) where Copperline replicates the nibble (`$000088`), and its raw frame starts two lines later than a `COPPERLINE_SHOT_RAW=1` capture. A raw byte diff reads ~90% even on an exact match. The metric used here requires only that the colour mapping is a consistent bijection over the frame, after a small dy/dx alignment search.

## Results

| probe | vs vAmiga 5.0b1 |
|---|---|
| `ddfprobe-agafold` | exact (0 / 202628) |
| `ddfprobe-agaorigin` | exact |
| `ddfprobe-ddfmiss` | exact |
| `agashres-sprites` | exact |
| `colorlag-aga` | exact |
| `ddfprobe-agafold2` | 0.051% - one raster line (row 130) at a band edge |
| `agaplanes` | 0.091% - one 8-px column (x 678-685, rows 38-60) at a band's right fetch edge |
| `rdram-aga` | 0.098% - the two band-transition lines (rows 38 and 166) |
| `agafetch-mode` | **8.844% - the FMODE 10 band** |
| `dblpal-hires-lace` | not comparable |

## agafetch-mode: hardware sides with Copperline

The disagreement is exactly the probe's second band (`$78..$AF`, FMODE 10, aligned BPL1PT - "first word duplicated"); the other two bands match to the pixel. Rather than take either emulator's word, I booted the vAmigaTS `Agnus/Registers/FMODE/fmode10` test disk itself, which ships a real-A1200 photograph:

| | magenta | white |
|---|---|---|
| real A1200 photo (lower band) | 0.01% | 0.00% |
| Copperline | 0.00% | 0.00% |
| vAmiga 5.0b1 | 3.89% | 0.52% |

vAmiga 5.0b1 paints magenta and white inside the staircase blocks where the photograph has none, and Copperline reproduces the photograph's structure. The local vAmiga build reproduces the suite's committed `fmode10_aga.raw` byte-for-byte, so this is that reference's own behaviour rather than a build artefact. The probe header now carries a do-not-re-bless note recording all of this.

## dblpal-hires-lace

Not comparable: it reprograms the beam to DblPAL (HTOTAL `$081`, VTOTAL `$23D`) and renders a 1432x1134 SHRES/laced canvas, while vAmiga's regression screenshot is a fixed 716x285 PAL-sized raw that cannot represent it. Both emulators do place the two sprite bars in the same order with no third bar, but there is no like-for-like frame to diff, so the FS-UAE provenance stands alone. The header says so.

Also drops the now-stale "vAmiga is OCS/ECS-only and cannot arbitrate AGA" claims from `timing-test/README.md`, `docs/internals/video.md` and the `src/bus/ddf_line.rs` module doc.
