### PR TITLE
ci: track driveless machines in the wasm demo smoke test

### DIFF
--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -103,7 +103,11 @@ jobs:
           if (emu.floppy_write_protected(1) !== false || emu.export_floppy(1).length !== 901120) {
             throw new Error('browser writable floppy did not survive a save-state round trip');
           }
-          for (const invalid of [0, 5, 2.5, 257, NaN, Infinity]) {
+          const driveless = new WebEmu('A500', 'PAL', 0);
+          if ([0, 1, 2, 3].some((drive) => driveless.drive_connected(drive))) {
+            throw new Error('zero browser floppy drive count left a drive connected');
+          }
+          for (const invalid of [-1, 5, 2.5, 257, NaN, Infinity]) {
             try {
               new WebEmu('A500', 'PAL', invalid);
               throw new Error(`invalid browser floppy drive count was accepted: ${invalid}`);


### PR DESCRIPTION
The Browser demo publish job fails since 2a92d61b ("ui: model driveless CD machines and show CD tracks") made a floppy drive count of zero valid in the `WebEmu` constructor: the smoke test still listed `0` among the counts expected to throw, so it now dies with `invalid browser floppy drive count was accepted: 0` before publishing (see run 33084068408).

- Probe below the valid range with `-1` instead of `0` in the invalid-count loop.
- Assert the new behavior positively: `new WebEmu('A500', 'PAL', 0)` is accepted and leaves all four drives disconnected, matching the crate's `web_constructor_accepts_no_floppy_drives` unit test.