### PR TITLE
docs: fix inaccuracies, add missing options, and complete TOC

### DIFF
--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -78,6 +78,7 @@ Commands are case-insensitive. Addresses and data values use hexadecimal notatio
 | `TRACE STOP` | Stop instruction trace logging |
 | `WAVE START [ARGS]` | Arm VCD logic analyzer capture (see [](waveform.md)) |
 | `WAVE STOP` | Stop VCD capture |
+| `HELP [CMD]` (or `?`) | Display command summary or detailed command syntax |
 
 ### Memory delta search (Trainer / Value hunter)
 

--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -78,7 +78,7 @@ Commands are case-insensitive. Addresses and data values use hexadecimal notatio
 | `TRACE STOP` | Stop instruction trace logging |
 | `WAVE START [ARGS]` | Arm VCD logic analyzer capture (see [](waveform.md)) |
 | `WAVE STOP` | Stop VCD capture |
-| `HELP [CMD]` (or `?`) | Display command summary or detailed command syntax |
+| `HELP` (or `?`) | Display command summary |
 
 ### Memory delta search (Trainer / Value hunter)
 

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -157,7 +157,7 @@ events.unsubscribe {"events":["serial"]}
 - `media.cd.insert {"path": "..."}`: Insert CD image.
 - `media.cd.eject`: Eject CD image.
 
-### Save states
+### State snapshot files
 - `state.save {"path": "..."}`: Snapshot machine state to file.
 - `state.load {"path": "..."}`: Restore machine state from file.
 

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -90,6 +90,7 @@ events.unsubscribe {"events":["serial"]}
 
 ### Session management
 - `hello {"token": "..."}`: Handshake and protocol version query.
+- `auth {"token": "..."}`: Authenticate active connection.
 - `status`: Returns emulation state, frame counters, and host execution timing.
 - `shutdown`: Terminates the emulator process.
 
@@ -102,6 +103,7 @@ events.unsubscribe {"events":["serial"]}
 - `step_frame {"n": 1}`: Step video frames.
 - `run_until {"pc" | "vpos" | "frame" | "cck" | "seconds" | "stable_frames"}`: Run until condition.
 - `pause`: Pause active execution.
+- `machine.reset {"kind": "warm"|"cold"}`: Reset the emulated machine (default: warm).
 
 ### Reverse execution
 - `reverse_step {"n": 1}`: Step backward by instruction.
@@ -110,13 +112,28 @@ events.unsubscribe {"events":["serial"]}
 - `last_writer {"addr": "..."}`: Find the instruction that last wrote to memory address.
 
 ### State inspection and modification
-- `regs.get` / `regs.set`: Read or modify 68000 registers.
-- `mem.read` / `mem.write`: Read or modify memory (supports hex or base64 encoding).
-- `custom.read` / `custom.dump`: Query custom chipset registers.
+- `regs.get` / `regs.set {"reg": "...", "value": ...}`: Read or modify 68000 registers.
+- `mem.read {"addr": ..., "len": ..., "encoding": "hex"|"base64"}` / `mem.write {"addr": ..., "data": "...", "encoding": "hex"|"base64"}`: Read or modify memory.
+- `disasm {"addr": ..., "count": ...}`: Disassemble instructions at address (default: PC).
+- `custom.read {"reg": ...}` / `custom.dump`: Query custom chipset registers.
+- `custom.writer {"reg": ...}`: Query last PC and beam cycle that wrote to custom register.
 - `palette.dump`: Query active 32-color or 256-color palette.
-- `cia.get`: Query CIA-A and CIA-B timer and port states.
+- `cia.get {"cia": "a"|"b"}`: Query CIA-A or CIA-B timer, port, and interrupt states.
 - `beam.get`: Query raster beam coordinates (VPOS, HPOS, colour clock).
-- `copper.list`: Disassemble Copper instructions.
+- `display.get`: Query active display parameters, viewport size, and pixel format.
+- `rtc.get` / `rtc.set {"unix": ..., "time": "...", "advance": ..., "frozen": ...}`: Inspect or move real-time clock.
+- `copper.list {"addr": ..., "max": ...}`: Disassemble Copper instructions.
+- `pc_history`: Return recently executed instruction addresses.
+
+### Diagnostics and profiling
+- `chipset.validate {"enabled": ..., "clear": ...}` / `chipset.report`: Arm or query custom register access validator.
+- `smc.detect {"enabled": ..., "clear": ...}` / `smc.report`: Arm or query self-modifying code detector.
+- `fault.inject {"addr": ..., "len": ..., "on": "read"|"write"|"both", "count": ...}`: Inject memory bus faults.
+- `fault.list` / `fault.clear`: List or clear active memory bus faults.
+- `memory.heatmap {"enabled": ..., "base": ..., "span": ...}`: Enable or configure address-space access tracking.
+- `memory.heatmap.report {"path": "..."}`: Export memory access heatmap.
+- `trace.start {"path": "...", "max_lines": ...}` / `trace.stop` / `trace.status`: Control instruction execution trace logging.
+- `waveform.start {"path": "...", "trigger": "...", "duration": "...", "signals": "..."}` / `waveform.stop` / `waveform.status`: Control VCD logic analyzer waveform capture.
 
 ### Breakpoints and traps
 - `break.add`: Add breakpoint (`pc`, `watch`, `reg_watch`, `beam`, `copper`, `catch`, `loadseg`).
@@ -125,19 +142,31 @@ events.unsubscribe {"events":["serial"]}
 - `break.clear`: Remove all breakpoints.
 
 ### Input injection
-- `input.key {"rawkey": ..., "action": "press"|"release"|"tap"}`: Inject keyboard events.
-- `input.mouse {"dx": ..., "dy": ..., "left": ..., "right": ...}`: Inject mouse motion/buttons.
-- `input.mouse_to {"x": ..., "y": ...}`: Steer pointer to screen pixel coordinates via sprite 0.
-- `input.joy {"up": ..., "down": ..., "red": ...}`: Inject joystick / CD32 button state.
-- `input.set_port {"port": 1|2, "device": "mouse"|"joystick"|"cd32"|"analogue"|"none"}`: Change port device.
+- `input.key {"rawkey": ..., "action": "press"|"release"|"tap", "hold_ms": ..., "at_seconds": ...}`: Inject keyboard events.
+- `input.mouse {"dx": ..., "dy": ..., "left": ..., "right": ..., "middle": ..., "port": 1|2, "at_seconds": ...}`: Inject mouse motion/buttons.
+- `input.mouse_to {"x": ..., "y": ..., "port": 1|2, "tolerance": ..., "max_frames": ...}`: Steer pointer to screen pixel coordinates via sprite 0.
+- `input.joy {"up": ..., "down": ..., "left": ..., "right": ..., "red": ..., "blue": ..., "green": ..., "yellow": ..., "play": ..., "rwd": ..., "ffw": ..., "port": 1|2, "at_seconds": ...}`: Inject joystick / CD32 button state.
+- `input.analogue {"x": ..., "y": ..., "port": 1|2, "at_seconds": ...}`: Set analogue paddle/pot position (0-255).
+- `input.set_port {"port": 1|2, "device": "mouse"|"gamepad-mouse"|"joystick"|"cd32"|"analogue"|"none"}`: Change port device.
+- `input.get_ports`: Query active controller port device assignments.
 
 ### Media management
 - `media.floppy.insert {"drive": 0, "path": "...", "write_protected": true}`: Insert floppy disk image.
 - `media.floppy.eject {"drive": 0}`: Eject floppy disk.
+- `media.floppy.query`: Query connected floppy drives, mounted disk images, and write-protection status.
 - `media.cd.insert {"path": "..."}`: Insert CD image.
 - `media.cd.eject`: Eject CD image.
+
+### Save states
+- `state.save {"path": "..."}`: Snapshot machine state to file.
+- `state.load {"path": "..."}`: Restore machine state from file.
 
 ### Framebuffer capture
 - `capture.screenshot {"path": "..."}`: Write PNG screenshot of framebuffer.
 - `capture.digest`: Return FNV-1a hash digest of current frame.
 - `capture.region_digest {"x": ..., "y": ..., "w": ..., "h": ...}`: Return hash of screen region.
+
+### Streaming events
+- `events.subscribe {"events": [...], "frame_interval": ..., "frame_digest": ...}`: Subscribe to asynchronous event stream.
+- `events.unsubscribe {"events": [...]}`: Unsubscribe from events.
+- `events.list`: List active event subscriptions.

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -146,10 +146,10 @@ requestAnimationFrame(renderLoop);
 - `key_event(code, pressed)`: Send W3C keyboard event code (e.g., `"KeyA"`, `"Digit1"`).
 - `key_raw(rawCode, pressed)`: Send Amiga raw key scan code.
 - `mouse_delta(dx, dy)`: Inject relative mouse motion.
-- `mouse_button(button, pressed)`: Set mouse button state (`0` = Left, `1` = Right, `2` = Middle).
-- `set_joystick_port(port, up, down, left, right, fire1, fire2)`: Set joystick directional and fire state (0-based port).
-- `set_cd32_buttons_port(port, red, blue, green, yellow, play, rwd, ffw)`: Set CD32 pad button state (0-based port).
-- `set_port_device(port, device)`: Configure controller port device (`"mouse"`, `"joystick"`, `"cd32"`, etc.).
+- `mouse_button(button, pressed)`: Set mouse button state (`0` = Left, `1` = Middle, `2` = Right, matching `MouseEvent.button`).
+- `set_joystick_port(port, up, down, left, right, fire, button2)`: Set joystick directional and fire button state (`port` 1 or 2).
+- `set_cd32_buttons_port(port, play, rwd, ffw, green, yellow)`: Set CD32 pad extra button state (`port` 1 or 2; red/blue map to `fire`/`button2` via `set_joystick_port`).
+- `set_port_device(port, device)`: Configure controller port device (`port` 1 or 2, e.g., `"mouse"`, `"joystick"`, `"cd32"`, `"analogue"`, `"none"`).
 - `save_state()`: Export full machine state as `Uint8Array`.
 - `load_state(stateBytes)`: Restore machine state from `Uint8Array`.
 

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -142,10 +142,14 @@ requestAnimationFrame(renderLoop);
 - `insert_floppy(driveIndex, diskBytes, label)`: Insert read-only floppy image.
 - `insert_floppy_writable(driveIndex, diskBytes, label)`: Insert writable in-memory floppy image.
 - `export_floppy(driveIndex)`: Export current in-memory floppy image as `Uint8Array`.
-- `key_down(rawCode)` / `key_up(rawCode)`: Send Amiga raw key events.
-- `mouse_move(dx, dy)`: Inject relative mouse motion.
-- `mouse_button(button, down)`: Set mouse button state (`0` = Left, `1` = Right, `2` = Middle).
-- `joystick_button(port, button, down)`: Set joystick / CD32 button state.
+- `eject_floppy(driveIndex)`: Eject floppy image from drive.
+- `key_event(code, pressed)`: Send W3C keyboard event code (e.g., `"KeyA"`, `"Digit1"`).
+- `key_raw(rawCode, pressed)`: Send Amiga raw key scan code.
+- `mouse_delta(dx, dy)`: Inject relative mouse motion.
+- `mouse_button(button, pressed)`: Set mouse button state (`0` = Left, `1` = Right, `2` = Middle).
+- `set_joystick_port(port, up, down, left, right, fire1, fire2)`: Set joystick directional and fire state (0-based port).
+- `set_cd32_buttons_port(port, red, blue, green, yellow, play, rwd, ffw)`: Set CD32 pad button state (0-based port).
+- `set_port_device(port, device)`: Configure controller port device (`"mouse"`, `"joystick"`, `"cd32"`, etc.).
 - `save_state()`: Export full machine state as `Uint8Array`.
 - `load_state(stateBytes)`: Restore machine state from `Uint8Array`.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -68,9 +68,26 @@ range checks as the equivalent TOML fields:
 | `--port1 DEVICE` | `[input] port1` | `mouse` (default), `joystick`, `cd32`, `analogue`, `none` |
 | `--port2 DEVICE` | `[input] port2` | same devices; default `joystick` (`cd32` on the CD32 profile) |
 | `--autofire HZ` | `[input] autofire_hz` | `0` (off, the default) to `30` |
+| `--run-ahead FRAMES` | `[emulation] run_ahead_frames` | run-ahead latency reduction: `0` (off) to `4` |
 | `--full-screen` / `--windowed` | `[display] full_screen` | open fullscreen or windowed at start (default windowed) |
 | `--show-status-bar` / `--hide-status-bar` | `[display] status_bar` | status bar at start (default shown) |
+| `--perf-overlay` | `[display] perf_overlay` | show performance overlay at start |
 | `--menu-scale SIZE` | `[display] menu_scale` | size of the pop-up menu: `1x` (default) or `2x` |
+| `--rtc-time TIME` | `[machine] rtc_time` | seed battery clock with Unix seconds or `"YYYY-MM-DD HH:MM[:SS]"` |
+| `--rtc-frozen` | `[machine] rtc_frozen` | stop seeded clock at `--rtc-time` exactly |
+| `--audio` / `--noaudio` | `[audio] output_enabled` | enable (default) or disable real-time audio |
+| `--audio-device NAME` | `[audio] output_device` | host audio output device (substring match) |
+| `--audio-channel-mode MODE` | `[audio] channel_mode` | `stereo` (default) or `mono` |
+| `--audio-stereo-separation PCT` | `[audio] stereo_separation` | stereo width `0`-`100` (`100` default, `0` = mono) |
+| `--audio-filter MODE` | `[audio] audio_filter` | Paula filter: `auto` (default), `on`, `off` |
+| `--serial MODE` | `[serial] mode` | `off`, `stdout`, `midi`, `tcp`, `tcp-connect`, `pty`, `modem` |
+| `--parallel DEVICE` | `[parallel] device` | `none`, `printer`, `sampler` |
+| `--a2065-net BACKEND` | `[a2065] net` | `none`, `loopback`, `nat`, `bridge` |
+| `--a2065-interface NAME` | `[a2065] interface` | bridge adapter name (implies `--a2065-net bridge`) |
+| `--hostsocket-net BACKEND` | `[hostsocket] net` | `none`, `loopback`, `nat`, `bridge`, `host` |
+| `--hostsocket-interface NAME` | `[hostsocket] interface` | bridge adapter name (implies `--hostsocket-net bridge`) |
+| `--host-disk DEVICE [ATTACH]` | `[[host_disk]]` | attach host storage device read-write |
+| `--host-disk-read-only DEVICE [ATTACH]` | `[[host_disk]]` | attach host storage device read-only (default) |
 
 For example, to boot a stock A1200 profile but with 8 MB of fast RAM and a
 faster CPU, with no config file at all:

--- a/docs/guide/coppersynth.md
+++ b/docs/guide/coppersynth.md
@@ -116,5 +116,5 @@ To exclude Coppersynth when compiling from source:
 
 ```sh
 cargo build --release --no-default-features \
-  --features "midi,frontend,wasm-boards,control,ctl-bin,net-nat,net-bridge,fluxbridge,mt32,cpu-jit,profile-stats,game-library,mhi,cd-mp3"
+  --features "midi,frontend,wasm-boards,control,ctl-bin,import-uae-bin,net-nat,net-bridge,fluxbridge,mt32,cpu-jit,profile-stats,game-library,mhi,cd-mp3,cd32-fmv,gdb"
 ```

--- a/docs/guide/fluxbridge.md
+++ b/docs/guide/fluxbridge.md
@@ -19,7 +19,7 @@ drive support:
 
 ```sh
 cargo build --release --no-default-features \
-  --features "midi,frontend,wasm-boards,control,ctl-bin,net-nat,net-bridge,mt32,cpu-jit,profile-stats"
+  --features "midi,frontend,wasm-boards,control,ctl-bin,import-uae-bin,net-nat,net-bridge,mt32,coppersynth,cpu-jit,profile-stats,game-library,mhi,cd-mp3,cd32-fmv,gdb"
 ```
 
 ## Configuration

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -6,7 +6,7 @@ system requirements, installation, building from source, and initial setup.
 
 ## System requirements
 
-- **Rust:** 1.93 or newer (tested with Rust 1.96).
+- **Rust:** 1.95 or newer (tested with Rust 1.96).
 - **Supported operating systems:** macOS, Linux, and Windows.
 - **Graphics backend:** Metal on macOS, Direct3D 12 on Windows, and Vulkan on Linux
   (see [](#vulkan-is-required-on-linux)).

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -3,7 +3,7 @@
 ## The wrapper and the bus adapter
 
 `M68kMachine` (`src/cpu.rs`) wraps the published pure-Rust
-[`m68k` 0.10 core](https://docs.rs/crate/m68k/0.10.13). The core sees
+[`m68k` 0.11 core](https://docs.rs/crate/m68k/0.11.0). The core sees
 the machine through an adapter implementing its `AddressBus` trait, so
 every CPU-visible access -- RAM, ROM, custom registers, CIA, RTC,
 autoconfig, Gayle, Akiko -- routes into the shared `Bus` and is billed in
@@ -35,7 +35,7 @@ fits a 68881/68882 to any 020/030 (and is on by default for the 68040,
 whose FPU is on-die): the `m68k` core executes the 6888x instruction
 set in true 80-bit extended precision via a pure-Rust software floating-
 point engine
-([`softfloat.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.10.13/src/fpu/softfloat.rs)).
+([`softfloat.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/fpu/softfloat.rs)).
 Arithmetic (add, sub,
 mul, div, sqrt, and the single-accuracy FSGLMUL/FSGLDIV, which round the
 mantissa to 24 bits but keep the extended exponent range -- gcc -m68040
@@ -53,13 +53,13 @@ whose saved FPU frame carries a foreign size) are all modelled. The transcendent
 FASIN/FACOS/FATAN, the hyperbolics, FETOX/FETOXM1/FTWOTOX/FTENTOX,
 FLOGN/FLOGNP1/FLOG2/FLOG10) and FSINCOS run in extended precision too: a
 double-`FloatX80` ("double-double", ~128-bit) layer
-([`dd.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.10.13/src/fpu/dd.rs))
+([`dd.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/fpu/dd.rs))
 evaluates Taylor/atanh series over reduced
 ranges and rounds the result to extended under the FPCR mode, setting INEX
 and the domain flags (OPERR/DZ). Accuracy is validated against an
 arbitrary-precision oracle (the pure-Rust `astro-float`, a dev-only
 dependency;
-[`fpu_accuracy.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.10.13/tests/fpu_accuracy.rs)):
+[`fpu_accuracy.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/tests/fpu_accuracy.rs)):
 every function is within
 1 ULP across a wide sweep and all four rounding modes, and round-to-nearest
 is correctly rounded in practice. They are not chip-bit-exact -- the real
@@ -69,7 +69,7 @@ quotient byte. This covers Kickstart's
 detection and per-task FPU context switching. The
 68000's per-instruction cycle counts in the `m68k` core have been
 corrected to exact totals across the SingleStepTests 68000 cycle corpus
-([validation details](https://github.com/benletchford/m68k-rs/tree/m68k-v0.10.13#validation--testing)),
+([validation details](https://github.com/benletchford/m68k-rs/tree/m68k-v0.11.0#validation--testing)),
 which is what makes
 cycle-budgeted pacing trustworthy.
 
@@ -139,7 +139,7 @@ precise.
 
 The 68000's two-word instruction prefetch queue (IRD/IRC) is modelled in
 the `m68k` core
-([`prefetch_queue`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.10.13/src/core/cpu.rs)):
+([`prefetch_queue`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/core/cpu.rs)):
 the
 next opcode is fetched before the current instruction finishes, so
 self-modifying code that overwrites the *next* instruction executes the
@@ -201,13 +201,13 @@ DBcc loop mode: a DBcc that branches -4 back to a loopable one-word
 instruction holds the body/DBcc pair in the prefetch queue and re-executes
 it with no instruction fetches until the condition turns true, the counter
 expires, or an exception intervenes (`loop_mode` in
-[`core/cpu.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.10.13/src/core/cpu.rs);
+[`core/cpu.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/core/cpu.rs);
 the loopable set and the DBcc entry/exit arms live in
-[`core/decode.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.10.13/src/core/decode.rs)).
+[`core/decode.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/core/decode.rs)).
 A looping DBcc iteration costs 6 internal
 clocks and touches the bus only for the body's operands, which is what
 makes tight copy/clear loops measurably faster on a real 68010.
-[`loop_mode_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.10.13/tests/loop_mode_timing_tests.rs)
+[`loop_mode_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/tests/loop_mode_timing_tests.rs)
 pins engagement, the
 68000's non-engagement, and the no-fetch iteration cost.
 
@@ -231,7 +231,7 @@ the STOP itself, so the handler's RTE re-executes it; a pending trace
 (T set in the SR the instruction started with) has priority and recovers
 from the stop, while a T bit loaded *by* STOP does not fire while
 stopped.
-[`stop_and_68010_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.10.13/tests/stop_and_68010_timing_tests.rs)
+[`stop_and_68010_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/tests/stop_and_68010_timing_tests.rs)
 pins all of these.
 
 ## Caches
@@ -315,7 +315,7 @@ shares the 040's three-level walker and TC[15] enable; PTEST is gone
 faulting with the format $4 frame.
 
 **Timing.**
-[`timing_060.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.10.13/src/core/timing_060.rs)
+[`timing_060.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/core/timing_060.rs)
 replaces the 020+
 scaling formula for the 060: every opcode word classifies (a build-once
 64K table over a pure function) into the MC68060UM Chapter 10 dispatch
@@ -357,7 +357,7 @@ instruction cache, a three-stage pipeline, execution overlap, dynamic bus
 sizing, and alignment-dependent transfers, so an opcode does not have one
 context-free cycle count.
 
-[`timing_020.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.10.13/src/core/timing_020.rs)
+[`timing_020.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/core/timing_020.rs)
 transcribes the integer timing tables
 from section 8.2 of the
 [MC68020 User's Manual](https://www.nxp.com/docs/en/data-sheet/MC68020UM.pdf).
@@ -508,7 +508,7 @@ The same column appeared to show 020 result forwarding -- the RAW-dependent
 MOVE pair of `timing-test` row 29 runs one clock per iteration faster than
 the independent pair of row 28 -- and m68k modelled it as such up to and
 including 0.5.0. **That model was wrong; it was removed upstream in m68k
-0.5.1, and remains absent from this tree's 0.10.13 dependency.** A second probe disk
+0.5.1, and remains absent from this tree's 0.11.0 dependency.** A second probe disk
 (`timing-test/fwdprobe.asm`) ran the same two
 loops at the opposite alignments on the same machine and reversed the
 ordering, which closes the 2x2: with the register dependency and the branch

--- a/docs/internals/mhi.md
+++ b/docs/internals/mhi.md
@@ -44,6 +44,7 @@ guest-side and why.
   time, at the decoded-audio rate -- see [Determinism and timing](#determinism-and-timing)),
   never *how*.
 
+(register-map)=
 ## Register map
 
 All registers are 16-bit and word-aligned; addresses are offsets within the
@@ -81,6 +82,7 @@ future protocol versions (M3's seek support, a wider param space, etc.)
 without moving the board to a bigger window, which would change its
 autoconfig identity.
 
+(capability-version-registers)=
 ### Capability/version registers
 
 - **`VERSION`** (`0x00`, RO) -- the register-protocol version this board
@@ -203,6 +205,7 @@ INT2, level-sensitive: the line is asserted whenever `(INTREQ & INTENA) !=
   on power-on/reset. The guest library must set the bits it wants before
   it can expect INT2 to fire.
 
+(descriptor-queue-and-doorbell)=
 ### Descriptor queue and doorbell
 
 The board holds a FIFO queue of up to `QUEUE_DEPTH` descriptors, each an
@@ -286,6 +289,7 @@ records:
   `MHIAllocDecoder` model) must resynchronize its local counter to `0`
   rather than compute a delta across the reset.
 
+(param-latches)=
 ### Param latches
 
 MHI's tone/volume/panning controls (`MHISetParam`) are modeled as a
@@ -447,6 +451,7 @@ decoder's own reservoir does.
   uses for the LED filter, reused here rather than inventing a second
   filter-processing convention in the same codebase).
 
+(access-size-and-alignment)=
 ## Access size and alignment
 
 The window behaves like a 16-bit peripheral: every register above is a
@@ -485,6 +490,7 @@ decodes even addresses.
   described above, and every other register is freely, repeatedly
   pollable.
 
+(out-of-data-semantics)=
 ## Out-of-data semantics
 
 `STATUS` transitions to `OUT_OF_DATA` (`3`) exactly when playback drains
@@ -532,6 +538,7 @@ guest-visible contract changes -- `COMPLETED_COUNT`/`QUEUE_COUNT`/`INTREQ`
 still only ever advance in whole-descriptor, whole-frame steps -- only the
 emulated wall-clock-adjacent pacing of how many ticks that takes.
 
+(seek-entry-hardening)=
 ### Seek-entry hardening
 
 MHI itself has no seek call -- the ABI is exactly `MHIAllocDecoder`/
@@ -598,6 +605,7 @@ mid-frame. The exact bound is an implementation choice, not part of this
 protocol's guest-visible contract -- Copperline's is documented in its own
 implementation notes below.
 
+(determinism-and-timing)=
 ## Determinism and timing
 
 The board consumes a descriptor's bitstream at the **decoded audio's own
@@ -618,6 +626,7 @@ byte-for-byte and makes `--audio-wav`/stem captures of its output
 deterministic across runs, the same guarantee every other Copperline
 audio path already gives.
 
+(the-mhi-api-board-split)=
 ## The MHI-API/board split
 
 This board's registers are deliberately **innocent of MHI's own
@@ -642,6 +651,7 @@ version's constants -- and it is what makes the split in
 [Porting to another emulator](#porting-to-another-emulator) below
 possible without also porting MHI-specific glue.
 
+(versioning)=
 ## Versioning
 
 `VERSION` (`0x00`) is the register-protocol's own version number, starting
@@ -675,6 +685,7 @@ board and a new board agree on what an old guest sees there) -- exactly
 the "new fields land at previously-reserved offsets" case this section
 describes as not needing special-casing beyond the bump itself.
 
+(porting-to-another-emulator)=
 ## Porting to another emulator
 
 Everything above is expressed purely in terms of the autoconfigured

--- a/docs/internals/mhi.md
+++ b/docs/internals/mhi.md
@@ -7,7 +7,7 @@ Interface) MPEG audio decoder board, precisely enough that the host board
 independently against it and interoperate. Where this document and either
 implementation disagree, this document wins -- fix the implementation, not
 the spec, unless the spec itself is being deliberately revised (see
-[Versioning](#versioning)).
+[Versioning](#mhi-versioning)).
 
 The protocol is deliberately **bus-agnostic**: every offset below is
 relative to the start of the board's autoconfigured window, and nothing in
@@ -87,9 +87,9 @@ autoconfig identity.
 
 - **`VERSION`** (`0x00`, RO) -- the register-protocol version this board
   implements, currently `2` (bumped from `1` by M4 -- see
-  [Versioning](#versioning)'s worked example). A guest library reads this once at
+  [Versioning](#mhi-versioning)'s worked example). A guest library reads this once at
   `FindConfigDev` time and refuses to drive a board whose major protocol
-  it does not understand (see [Versioning](#versioning)).
+  it does not understand (see [Versioning](#mhi-versioning)).
 - **`CAPS`** (`0x02`, RO) -- a bitmask of the MPEG formats and bitrate
   modes this board's decoder accepts. Bit layout:
 
@@ -118,7 +118,7 @@ autoconfig identity.
   guarantee about behavior the board's registers never described a limit
   on in the first place -- not a change to any offset, width, access
   rule, or bit meaning `VERSION` exists to gate. **M4** adds bit 6
-  (`VERSION` 2 -- see [Versioning](#versioning)), a genuine behavior
+  (`VERSION` 2 -- see [Versioning](#mhi-versioning)), a genuine behavior
   change unlike bit 5's rewording. This register is what the guest
   library's `MHIQuery` handler consults for
   `MHIQ_MPEG1`/`MHIQ_MPEG2`/`MHIQ_MPEG25`/`MHIQ_LAYER3`/
@@ -651,7 +651,7 @@ version's constants -- and it is what makes the split in
 [Porting to another emulator](#porting-to-another-emulator) below
 possible without also porting MHI-specific glue.
 
-(versioning)=
+(mhi-versioning)=
 ## Versioning
 
 `VERSION` (`0x00`) is the register-protocol's own version number, starting
@@ -724,7 +724,7 @@ default-on `mhi` build feature); it does not change any of the protocol
 content above.
 
 - **Decoder**:
-  [Symphonia](https://crates.io/crates/symphonia-bundle-mp3)'s pure-Rust
+  [Symphonia](https://github.com/pdeljanov/Symphonia)'s pure-Rust
   MPEG audio decoder (`MpaDecoder`, MPL-2.0), with only its Layer III
   feature enabled to match `CAPS`. Pure Rust is the point: the previous
   decoder (`minimp3-sys`) compiled a vendored C minimp3 whose SIMD

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -692,7 +692,7 @@ debits a per-frame instruction budget one of two ways, selected by
   tails, chip-bus grants and contention waits -- so the slice's elapsed bus
   CCK is the true hardware cost (`real_slice_accounting` in
   `src/emulator.rs`). Because the m68k core's 68000 cycle totals are exact
-  across its [SingleStepTests validation corpus](https://github.com/benletchford/m68k-rs/tree/m68k-v0.10.13#validation--testing),
+  across its [SingleStepTests validation corpus](https://github.com/benletchford/m68k-rs/tree/m68k-v0.11.0#validation--testing),
   this matches a stock PAL 68000.
 - `instructions`: a flat cycles-per-instruction quota
   (`COPPERLINE_REAL_CPU_CPI`, default 4.0), debited by retired

--- a/docs/internals/zz9k.md
+++ b/docs/internals/zz9k.md
@@ -113,6 +113,7 @@ u32, 48-byte inline payload. The board echoes `request_id`, `opcode`, and
 `user_cookie` into the completion (the transport matches on all three) and
 sets `status` to the result. Error completions carry an empty payload.
 
+(capability-bits)=
 ### Capability bits
 
 The descriptor and `QUERY_CAPS` advertise `0x7D07`: MAILBOX (1<<0),

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -65,8 +65,14 @@ project:
         - file: internals/timing.md
         - file: internals/chipset.md
         - file: internals/video.md
+        - file: internals/audio.md
         - file: internals/cpu.md
         - file: internals/peripherals.md
+        - file: internals/toccata.md
+        - file: internals/mhi.md
+        - file: internals/zz9k.md
+        - file: internals/picasso2.md
+        - file: internals/graffity.md
         - file: internals/savestate.md
         - file: internals/reference-docs.md
   exports:
@@ -102,8 +108,14 @@ project:
         - internals/timing.md
         - internals/chipset.md
         - internals/video.md
+        - internals/audio.md
         - internals/cpu.md
         - internals/peripherals.md
+        - internals/toccata.md
+        - internals/mhi.md
+        - internals/zz9k.md
+        - internals/picasso2.md
+        - internals/graffity.md
         - internals/savestate.md
         - internals/reference-docs.md
 site:


### PR DESCRIPTION
## Summary

- **TOC & PDF export**: Added missing internal reference chapters (`internals/audio.md`, `internals/toccata.md`, `internals/mhi.md`, `internals/zz9k.md`, `internals/picasso2.md`, `internals/graffity.md`) to `docs/myst.yml`.
- **Reference anchors**: Added explicit MyST target labels to `docs/internals/mhi.md` and `docs/internals/zz9k.md` to eliminate implicit reference warnings during doc builds.
- **Control Protocol (CCP)**: Expanded `docs/debugger/control.md` command reference summary with all implemented JSON-RPC methods and parameter options (including diagnostics, profiling, input injection, and streaming events).
- **WebAssembly / Browser API**: Updated `docs/guide/browser.md` WebEmu JavaScript method signatures to match the actual exported wasm-bindgen names.
- **Getting Started & Configuration**: Corrected Rust MSRV to 1.95 in `docs/guide/getting-started.md` and expanded the quick CLI overrides table in `docs/guide/configuration.md`.
- **CPU & Timing Internals**: Updated `m68k` version references from 0.10 to 0.11 across internals documentation.
- **Console & Guides**: Added `HELP` to console command reference and refreshed feature lists in compilation examples.

## Verification

- `myst build --html` builds all 38 pages cleanly with 0 warnings.
- `cargo fmt --check` passed.
- `cargo clippy --all-targets --all-features --locked -- -D warnings` passed with 0 warnings.
- `cargo test` passed.