### PR TITLE
Feature/consistent boot priority location 

### DIFF
--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -692,7 +692,7 @@ The layout is:
   from. The two IDE bays come first, then the SCSI units, then the Lide
   board's drives. More drives than one page holds run onto a second, reached
   by **Next Page >** beside the Back button; that page's own **< Back**
-  returns to the first.
+  returns to the first. The note below the rows stays on the first page.
   Drives you add here with no priority of their own cascade so they do not tie:
   the first is 0 (just under DF0:'s 5), and each later one drops below the
   floppies -- -35, -40, -45. A drive already carrying a priority in the config

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -606,16 +606,13 @@ The layout is:
   priority and a read-write/read-only **Access** field -- the config file
   itself takes up to eight `[[filesys]]` mounts, of which the launcher edits
   the first four); **Host Disk**, for a real disk of this computer's (see
-  [](host-disks.md)); **Boot Priority**, which sets each IDE/SCSI drive's
+  [](host-disks.md)); **Boot Priority**, which sets each drive's
   synthesized-RDB boot priority (see below); **Create Image...**, which
   makes new ADF and HDF images (see below); **CD** (image, insert delay,
   CD32 NVRAM); and **Lide**, the built-in `[lide]` Zorro II IDE board --
-  personality (RIPPLE/RIDE/AT-Bus 2008), boot ROM(s), up to four drives (two
-  on RIDE/AT-Bus 2008, any of which can likewise be a CD image), and each
-  drive's own boot priority, kept on this page
-  rather than the shared Boot Priority one so the board's up-to-four drives
-  fit alongside it. Each sub-page has a **< Back** button in that block
-  that returns to Storage),
+  personality (RIPPLE/RIDE/AT-Bus 2008), boot ROM(s), and up to four drives
+  (two on RIDE/AT-Bus 2008, any of which can likewise be a CD image). Each
+  sub-page has a **< Back** button in that block that returns to Storage),
   *Input* (the controller device in each game port and the joystick input
   source),
   *I/O Ports* (the serial, parallel, networking, and audio boards, each
@@ -690,8 +687,12 @@ The layout is:
   priority and writes the -128 "disabled" sentinel, so the volume mounts but
   never boots.
   A drive with no image, or a CD image, is greyed ("No drive" / "CD-ROM"),
-  with no stepper to reach for. A SCSI unit appears only once it carries a
-  disk, so the page lists what the machine can actually boot from.
+  with no stepper to reach for. A SCSI unit or Lide drive appears only once
+  it carries a disk, so the page lists what the machine can actually boot
+  from. The two IDE bays come first, then the SCSI units, then the Lide
+  board's drives. More drives than one page holds run onto a second, reached
+  by **Next Page >** beside the Back button; that page's own **< Back**
+  returns to the first.
   Drives you add here with no priority of their own cascade so they do not tie:
   the first is 0 (just under DF0:'s 5), and each later one drops below the
   floppies -- -35, -40, -45. A drive already carrying a priority in the config

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1059,11 +1059,10 @@ const HOSTFS_ROWS: [Row; 12] = [
     row(F::Filesys3Boot, "  Boot priority", Cycle),
     row(F::Filesys3ReadOnly, "  Access", Cycle),
 ];
-// One boot-priority row per hard-disk drive, matching the Storage tab's drive
-// rows. Greyed when the matching slot holds no image.
-// IDE and SCSI only: lide's drives get their own priority rows on the Lide
-// page (see `LIDE_ROWS`) rather than crowding this table -- with them added
-// here the page no longer fits (`every_launcher_tab_row_fits_inside_the_panel`).
+// One boot-priority row per hard-disk drive. The IDE bays stand their
+// ground greyed when empty; a SCSI unit or Lide slot is listed only once it
+// carries a disk (`row_hidden`). More rows than one page holds run onto a
+// second page -- see `MachineSetup::boot_page_of`.
 const BOOTPRI_ROWS: [Row; 13] = [
     row(F::IdeMasterBoot, "IDE master", Bootpri),
     row(F::IdeSlaveBoot, "IDE slave", Bootpri),
@@ -1075,9 +1074,9 @@ const BOOTPRI_ROWS: [Row; 13] = [
     row(F::ScsiUnit5Boot, "SCSI unit 5", Bootpri),
     row(F::ScsiUnit6Boot, "SCSI unit 6", Bootpri),
     // The Zorro IDE board's drives sit below the motherboard's and the
-    // SCSI units, which is also the order the cascade default ranks them
-    // in: a board added to a machine takes its place after what the
-    // machine already had.
+    // SCSI units. The cascade default ranks by this order too, though it
+    // seeds each priority when its drive is added -- drives filled out of
+    // table order can still tie, as they always could across families.
     row(F::LideDrive0Boot, "Lide drive 0", Bootpri),
     row(F::LideDrive1Boot, "Lide drive 1", Bootpri),
     row(F::LideDrive2Boot, "Lide drive 2", Bootpri),
@@ -1088,11 +1087,11 @@ const CD_ROWS: [Row; 3] = [
     row(F::CdInsertDelay, "Insert delay", Cycle),
     row(F::Cd32Nvram, "CD32 NVRAM", PathRow),
 ];
-// The `[lide]` Storage sub-page: board personality, boot ROM(s), up to four
-// drives (RIPPLE's two channels; RIDE/AT-Bus 2008 hide slots 2-3, and AT-Bus
-// 2008 also hides the second ROM bank -- it has no flash banking), and each
-// drive's boot priority. Boot priority sits here rather than on the shared
-// Boot Priority page: with lide's four slots added there it stopped fitting.
+// The `[lide]` Storage sub-page: board personality, boot ROM(s), and up to
+// four drives (RIPPLE's two channels; RIDE/AT-Bus 2008 hide slots 2-3, and
+// AT-Bus 2008 also hides the second ROM bank -- it has no flash banking).
+// The drives' boot priorities live on the shared Boot Priority page with
+// every other drive's, in `BOOTPRI_ROWS`.
 const LIDE_ROWS: [Row; 7] = [
     row(F::LideBoard, "Board", Cycle),
     row(F::LideRom, "Boot ROM", PathRow),
@@ -5398,11 +5397,27 @@ impl MachineSetup {
         self.boot_priority_row_count() > BOOTPRI_PAGE_ROWS
     }
 
+    /// The page a session should stand on after this setup replaced the one
+    /// it was looking at (Load..., Defaults): the same page, unless that
+    /// page no longer exists -- the second boot page with nothing left on
+    /// it falls back to the first rather than standing empty.
+    pub fn settle_tab(&self, tab: LauncherTab) -> LauncherTab {
+        if tab == LauncherTab::BootPriorityMore && !self.boot_priority_has_second_page() {
+            LauncherTab::BootPriority
+        } else {
+            tab
+        }
+    }
+
     /// Which Boot Priority page a drive's row falls on, or `None` for a row
     /// that is not one of them (the column titles, and every other page's
     /// rows). Paged by position among the drives actually listed, not by
     /// position in the table, so a machine with a Lide board but no SCSI
     /// keeps its four Lide drives on the first page.
+    ///
+    /// Only meaningful for a row that is listed: asked about a hidden one
+    /// it answers with the page of the rank the row *would* take. Callers
+    /// go through [`Self::row_on_page`], which checks `row_hidden` first.
     pub fn boot_page_of(&self, field: LauncherField) -> Option<LauncherTab> {
         if !BOOTPRI_ROWS.iter().any(|r| r.field == field) {
             return None;

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -177,6 +177,11 @@ pub enum LauncherTab {
     /// FluxBridge settings for one bay, reached from its Configure button.
     FluxBridge,
     BootPriority,
+    /// The rest of the boot order when one page cannot hold it. A fully
+    /// fitted machine reaches thirteen drives, more than the panel has
+    /// rows for, so the list runs onto a second page reached by the
+    /// "Next Page >" button and returning via its own Back.
+    BootPriorityMore,
     HostFs,
     /// Direct WHDLoad boot (src/whdload.rs): the game to launch and what
     /// staging draws on, reached from the Storage tab.
@@ -283,7 +288,7 @@ impl LauncherTab {
             LauncherTab::Floppy => "Floppy",
             LauncherTab::FluxBridge => "FluxBridge",
             LauncherTab::Storage => "Storage",
-            LauncherTab::BootPriority => "Boot Priority",
+            LauncherTab::BootPriority | LauncherTab::BootPriorityMore => "Boot Priority",
             LauncherTab::HostFs => "Host Folder",
             LauncherTab::Whdload => "WHDLoad",
             // The strip's own name for it. Inside the WHDLoad pages the
@@ -325,6 +330,7 @@ impl LauncherTab {
             | LauncherTab::HostFs
             | LauncherTab::HostDisk
             | LauncherTab::BootPriority
+            | LauncherTab::BootPriorityMore
             | LauncherTab::Lide
             | LauncherTab::CreateFloppy
             | LauncherTab::CreateHard
@@ -360,6 +366,7 @@ impl LauncherTab {
             | LauncherTab::CreateHard => Some(LauncherTab::Storage),
             // Back goes to the page that sent you here, not to Storage.
             LauncherTab::CreateGeometry => Some(LauncherTab::CreateHard),
+            LauncherTab::BootPriorityMore => Some(LauncherTab::BootPriority),
             LauncherTab::FluxBridge => Some(LauncherTab::Floppy),
             _ => None,
         }
@@ -790,7 +797,6 @@ const fn row(field: LauncherField, label: &'static str, kind: RowKind) -> Row {
 pub fn field_is_bootpri(field: LauncherField) -> bool {
     BOOTPRI_ROWS
         .iter()
-        .chain(LIDE_ROWS.iter())
         .any(|r| r.field == field && r.kind == RowKind::Bootpri)
 }
 
@@ -802,6 +808,13 @@ const fn section_header(label: &'static str) -> Row {
         kind: RowKind::SectionHeader,
     }
 }
+
+/// How many drives one Boot Priority page holds. Nine is a machine without a
+/// Lide board -- two IDE bays and a full seven-unit SCSI chain -- and it is
+/// also as many rows as the panel has room for under the column titles with
+/// the "Info:" note still below them. A Lide board's drives take the list
+/// past it, and onto a second page.
+pub const BOOTPRI_PAGE_ROWS: usize = 9;
 
 /// The greyed column-title row on the Boot Priority page (see
 /// [`RowKind::BootpriHeader`]).
@@ -1051,7 +1064,7 @@ const HOSTFS_ROWS: [Row; 12] = [
 // IDE and SCSI only: lide's drives get their own priority rows on the Lide
 // page (see `LIDE_ROWS`) rather than crowding this table -- with them added
 // here the page no longer fits (`every_launcher_tab_row_fits_inside_the_panel`).
-const BOOTPRI_ROWS: [Row; 9] = [
+const BOOTPRI_ROWS: [Row; 13] = [
     row(F::IdeMasterBoot, "IDE master", Bootpri),
     row(F::IdeSlaveBoot, "IDE slave", Bootpri),
     row(F::ScsiUnit0Boot, "SCSI unit 0", Bootpri),
@@ -1061,6 +1074,14 @@ const BOOTPRI_ROWS: [Row; 9] = [
     row(F::ScsiUnit4Boot, "SCSI unit 4", Bootpri),
     row(F::ScsiUnit5Boot, "SCSI unit 5", Bootpri),
     row(F::ScsiUnit6Boot, "SCSI unit 6", Bootpri),
+    // The Zorro IDE board's drives sit below the motherboard's and the
+    // SCSI units, which is also the order the cascade default ranks them
+    // in: a board added to a machine takes its place after what the
+    // machine already had.
+    row(F::LideDrive0Boot, "Lide drive 0", Bootpri),
+    row(F::LideDrive1Boot, "Lide drive 1", Bootpri),
+    row(F::LideDrive2Boot, "Lide drive 2", Bootpri),
+    row(F::LideDrive3Boot, "Lide drive 3", Bootpri),
 ];
 const CD_ROWS: [Row; 3] = [
     row(F::CdImage, "CD image", PathRow),
@@ -1072,18 +1093,14 @@ const CD_ROWS: [Row; 3] = [
 // 2008 also hides the second ROM bank -- it has no flash banking), and each
 // drive's boot priority. Boot priority sits here rather than on the shared
 // Boot Priority page: with lide's four slots added there it stopped fitting.
-const LIDE_ROWS: [Row; 11] = [
+const LIDE_ROWS: [Row; 7] = [
     row(F::LideBoard, "Board", Cycle),
     row(F::LideRom, "Boot ROM", PathRow),
     row(F::LideRomBank2, "Boot ROM bank 2", PathRow),
     row(F::LideDrive0, "Drive 0", Drive),
-    row(F::LideDrive0Boot, "  Boot priority", Bootpri),
     row(F::LideDrive1, "Drive 1", Drive),
-    row(F::LideDrive1Boot, "  Boot priority", Bootpri),
     row(F::LideDrive2, "Drive 2", Drive),
-    row(F::LideDrive2Boot, "  Boot priority", Bootpri),
     row(F::LideDrive3, "Drive 3", Drive),
-    row(F::LideDrive3Boot, "  Boot priority", Bootpri),
 ];
 // The WHDLoad Settings page: the game to launch, then what staging
 // draws on (src/whdload.rs). Drive rows like the Host FS mounts so the
@@ -1363,7 +1380,11 @@ pub fn rows(
         // in the same place as each sub-page's Back button, so they are not part
         // of the row grid.
         LauncherTab::Storage => Cow::Borrowed(&STORAGE_ROWS),
-        LauncherTab::BootPriority => {
+        // Both boot pages carry the same table and the same column titles;
+        // which drives each one draws is decided per drive by
+        // `MachineSetup::boot_page_of`, since only the machine knows which
+        // slots are filled.
+        LauncherTab::BootPriority | LauncherTab::BootPriorityMore => {
             // The greyed column titles, then one row per hard-disk drive.
             let mut rows = vec![bootpri_header()];
             rows.extend_from_slice(&BOOTPRI_ROWS);
@@ -3526,16 +3547,17 @@ impl MachineSetup {
                         .and_then(|drive| self.drive_holds(drive))
                         .is_none()
             }
-            // Each sits directly under the drive it belongs to, and stays
-            // on the page when that drive is empty -- greyed with "No
-            // drive" (see `disabled_reason`) rather than vanishing, so the
-            // rows do not reshuffle under the cursor as slots are filled
-            // and the indented label always has its own drive above it.
-            // Only a slot the board does not have goes, along with the
-            // drive row itself.
+            // Read on the Boot Priority page beside the SCSI units, and on
+            // the same terms: a board is not a disk, so only a slot the
+            // fitted board has *and* which carries one takes a place in the
+            // boot order. The Lide page keeps the drives themselves.
             F::LideDrive0Boot | F::LideDrive1Boot | F::LideDrive2Boot | F::LideDrive3Boot => {
-                lide_drive_index(field)
-                    .is_some_and(|i| self.lide_board.is_none_or(|b| b.max_drives() <= i))
+                lide_drive_index(field).is_none_or(|i| {
+                    self.lide_board.is_none_or(|b| b.max_drives() <= i)
+                        || Self::boot_field_drive(field)
+                            .and_then(|drive| self.drive_holds(drive))
+                            .is_none()
+                })
             }
             // Nothing to configure without a board fitted.
             F::LideRom => self.lide_board.is_none(),
@@ -5359,6 +5381,56 @@ impl MachineSetup {
         BOOTPRI_ROWS
             .iter()
             .any(|r| self.boot_field_applies(r.field))
+    }
+
+    /// Drives listed on the Boot Priority page: the two IDE bays, which stand
+    /// their ground empty, plus every SCSI unit and Lide slot carrying a disk.
+    pub fn boot_priority_row_count(&self) -> usize {
+        BOOTPRI_ROWS
+            .iter()
+            .filter(|r| !self.row_hidden(r.field))
+            .count()
+    }
+
+    /// Whether the boot order runs onto a second page -- which is also
+    /// whether the first one shows its "Next Page >" button.
+    pub fn boot_priority_has_second_page(&self) -> bool {
+        self.boot_priority_row_count() > BOOTPRI_PAGE_ROWS
+    }
+
+    /// Whether there is room under the drives for the priority-range note.
+    /// It sits below the last row of a full page, so it goes as soon as the
+    /// list needs a second one -- the drives are the page, and the range is
+    /// written beside the value box anyway.
+    pub fn boot_priority_shows_info(&self) -> bool {
+        self.has_boot_priority_rows() && !self.boot_priority_has_second_page()
+    }
+
+    /// Which Boot Priority page a drive's row falls on, or `None` for a row
+    /// that is not one of them (the column titles, and every other page's
+    /// rows). Paged by position among the drives actually listed, not by
+    /// position in the table, so a machine with a Lide board but no SCSI
+    /// keeps its four Lide drives on the first page.
+    pub fn boot_page_of(&self, field: LauncherField) -> Option<LauncherTab> {
+        if !BOOTPRI_ROWS.iter().any(|r| r.field == field) {
+            return None;
+        }
+        let rank = BOOTPRI_ROWS
+            .iter()
+            .take_while(|r| r.field != field)
+            .filter(|r| !self.row_hidden(r.field))
+            .count();
+        Some(if rank < BOOTPRI_PAGE_ROWS {
+            LauncherTab::BootPriority
+        } else {
+            LauncherTab::BootPriorityMore
+        })
+    }
+
+    /// Whether a row is drawn on `tab`: present on this machine, and -- for
+    /// the paged boot order -- belonging to this page rather than the other.
+    pub fn row_on_page(&self, tab: LauncherTab, field: LauncherField) -> bool {
+        !self.row_hidden(field) && self.boot_page_of(field).is_none_or(|page| page == tab)
     }
 
     /// Whether a drive's Bootable box is cleared -- the config's -128 sentinel,

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -5398,14 +5398,6 @@ impl MachineSetup {
         self.boot_priority_row_count() > BOOTPRI_PAGE_ROWS
     }
 
-    /// Whether there is room under the drives for the priority-range note.
-    /// It sits below the last row of a full page, so it goes as soon as the
-    /// list needs a second one -- the drives are the page, and the range is
-    /// written beside the value box anyway.
-    pub fn boot_priority_shows_info(&self) -> bool {
-        self.has_boot_priority_rows() && !self.boot_priority_has_second_page()
-    }
-
     /// Which Boot Priority page a drive's row falls on, or `None` for a row
     /// that is not one of them (the column titles, and every other page's
     /// rows). Paged by position among the drives actually listed, not by

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -5028,7 +5028,6 @@ fn a_long_boot_order_pages_and_a_short_one_does_not() {
     // positions.
     assert_eq!(s.boot_priority_row_count(), 6);
     assert!(!s.boot_priority_has_second_page());
-    assert!(s.boot_priority_shows_info());
     assert_eq!(
         s.boot_page_of(F::LideDrive3Boot),
         Some(LauncherTab::BootPriority)
@@ -5051,7 +5050,6 @@ fn a_long_boot_order_pages_and_a_short_one_does_not() {
     }
     assert_eq!(s.boot_priority_row_count(), 13);
     assert!(s.boot_priority_has_second_page());
-    assert!(!s.boot_priority_shows_info());
 
     // Two IDE bays and seven SCSI units fill the first page exactly; all
     // four Lide drives fall onto the second.

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -5077,6 +5077,37 @@ fn a_long_boot_order_pages_and_a_short_one_does_not() {
         assert!(drawn <= BOOTPRI_PAGE_ROWS + 1, "{tab:?} draws {drawn}");
     }
 
+    // The table itself fits the two pages that exist -- the compile-time
+    // bound behind `boot_page_of`'s two-page answer. A drive class that
+    // pushes past this needs a third page, not a silent pile-up.
+    assert!(BOOTPRI_ROWS.len() <= 2 * BOOTPRI_PAGE_ROWS);
+    // And with every slot filled, each page really draws no more than its
+    // share -- the same filter the draw path uses, not a re-stated cap.
+    let per_page: Vec<usize> = [LauncherTab::BootPriority, LauncherTab::BootPriorityMore]
+        .iter()
+        .map(|&tab| {
+            BOOTPRI_ROWS
+                .iter()
+                .filter(|r| s.row_on_page(tab, r.field))
+                .count()
+        })
+        .collect();
+    assert_eq!(per_page, vec![BOOTPRI_PAGE_ROWS, 4]);
+
+    // A setup swapped in under the panel (Load..., Defaults) may have no
+    // second page; the tab it was standing on settles back to the first.
+    assert_eq!(
+        s.settle_tab(LauncherTab::BootPriorityMore),
+        LauncherTab::BootPriorityMore,
+        "a full machine keeps its second page"
+    );
+    let empty = MachineSetup::default();
+    assert_eq!(
+        empty.settle_tab(LauncherTab::BootPriorityMore),
+        LauncherTab::BootPriority
+    );
+    assert_eq!(empty.settle_tab(LauncherTab::Lide), LauncherTab::Lide);
+
     // Back on the second page returns to the first, not to Storage.
     assert_eq!(
         LauncherTab::BootPriorityMore.parent_tab(),

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -3687,21 +3687,32 @@ fn lide_drives_round_trip_in_channel_order_with_boot_priority() {
     s.set_path(F::LideDrive1, PathBuf::from("ch0-slave.hdf"));
     s.set_drive_bootpri(F::LideDrive0Boot, Some(5));
 
-    // Boot priority sits on the Lide page itself, not the shared Boot
-    // Priority page (see LIDE_ROWS's comment) -- so `has_boot_priority_rows`
-    // (which only tracks IDE/SCSI) is untouched by these two lide drives.
-    assert!(!s.has_boot_priority_rows());
+    // Boot priority lives on the shared Boot Priority page with every other
+    // drive's, so a filled Lide slot puts a row there.
+    assert!(s.has_boot_priority_rows());
     assert_eq!(s.value_label(F::LideDrive0Boot), "5");
     assert_eq!(s.disabled_reason(F::LideDrive1Boot), None);
-    // An empty slot keeps its boot row, greyed rather than hidden, so the
-    // page does not reshuffle as slots are filled.
-    assert!(!s.row_hidden(F::LideDrive2Boot));
-    assert_eq!(s.disabled_reason(F::LideDrive2Boot), Some("No drive"));
+    // Two IDE bays, which stand their ground empty, and the two Lide slots
+    // now carrying a disk. No SCSI controller is fitted here.
+    assert_eq!(s.boot_priority_row_count(), 4);
+    // An empty slot has nothing to order, so it takes no place in the list
+    // -- the same terms a SCSI unit is listed on.
+    assert!(s.row_hidden(F::LideDrive2Boot));
     // A slot the fitted board does not have goes entirely, drive row and
     // boot row together.
     s.cycle(F::LideBoard, true); // RIDE: one channel
     assert!(s.row_hidden(F::LideDrive2));
     assert!(s.row_hidden(F::LideDrive2Boot));
+    // The Lide page itself is drives and ROM only now.
+    assert!(!rows(
+        LauncherTab::Lide,
+        Default::default(),
+        Default::default(),
+        false,
+        false
+    )
+    .iter()
+    .any(|r| r.kind == RowKind::Bootpri));
     s.cycle(F::LideBoard, true); // AT-Bus 2008
     s.cycle(F::LideBoard, true); // None
     s.cycle(F::LideBoard, true); // back to RIPPLE for the round trip below
@@ -4958,5 +4969,123 @@ fn editing_a_drive_name_commits_to_the_setup() {
     assert_eq!(
         state.setup.drive_name(LauncherField::ScsiUnit0),
         Some("WORK")
+    );
+}
+
+/// Every drive that can boot lands on the Boot Priority page, and the Lide
+/// board's drives land after the machine's own -- which is also the order
+/// the cascade default ranks them in.
+#[test]
+fn lide_drives_take_their_place_after_ide_and_scsi_in_the_boot_order() {
+    use LauncherField as F;
+    let mut s = MachineSetup::default();
+    s.select_model(Some(MachineModel::A1200));
+    s.set_path(F::IdeMaster, PathBuf::from("ide0.hdf"));
+    s.cycle(F::LideBoard, true); // RIPPLE: two channels, four drives
+    s.set_path(F::LideDrive0, PathBuf::from("lide0.hdf"));
+
+    let listed: Vec<_> = rows(
+        LauncherTab::BootPriority,
+        Default::default(),
+        Default::default(),
+        false,
+        false,
+    )
+    .iter()
+    .filter(|r| s.row_on_page(LauncherTab::BootPriority, r.field))
+    .map(|r| r.field)
+    .collect();
+    // The column titles, both IDE bays (the empty one stands its ground),
+    // then the one filled Lide slot. The empty Lide slots take no place.
+    assert_eq!(
+        listed,
+        vec![
+            F::SectionHeader,
+            F::IdeMasterBoot,
+            F::IdeSlaveBoot,
+            F::LideDrive0Boot
+        ]
+    );
+    assert_eq!(s.boot_priority_row_count(), 3);
+}
+
+/// The boot order runs onto a second page only when it outgrows the first,
+/// and a drive's page follows its position among the drives actually listed
+/// -- not its position in the table.
+#[test]
+fn a_long_boot_order_pages_and_a_short_one_does_not() {
+    use LauncherField as F;
+    let mut s = MachineSetup::default();
+    s.select_model(Some(MachineModel::A1200));
+    s.cycle(F::LideBoard, true); // RIPPLE
+    for f in [F::LideDrive0, F::LideDrive1, F::LideDrive2, F::LideDrive3] {
+        s.set_path(f, PathBuf::from("lide.hdf"));
+    }
+
+    // Two IDE bays and four Lide drives: six rows, one page, and the note
+    // still has room under them. No SCSI in between, so every Lide drive
+    // stays on the first page -- paging counts drives listed, not table
+    // positions.
+    assert_eq!(s.boot_priority_row_count(), 6);
+    assert!(!s.boot_priority_has_second_page());
+    assert!(s.boot_priority_shows_info());
+    assert_eq!(
+        s.boot_page_of(F::LideDrive3Boot),
+        Some(LauncherTab::BootPriority)
+    );
+
+    // Fill the SCSI chain as well and the order outgrows one page. The
+    // first nine drives stay; the rest move over, and the note goes to
+    // make room for them.
+    s.cycle(F::ScsiController, true);
+    for f in [
+        F::ScsiUnit0,
+        F::ScsiUnit1,
+        F::ScsiUnit2,
+        F::ScsiUnit3,
+        F::ScsiUnit4,
+        F::ScsiUnit5,
+        F::ScsiUnit6,
+    ] {
+        s.set_path(f, PathBuf::from("scsi.hdf"));
+    }
+    assert_eq!(s.boot_priority_row_count(), 13);
+    assert!(s.boot_priority_has_second_page());
+    assert!(!s.boot_priority_shows_info());
+
+    // Two IDE bays and seven SCSI units fill the first page exactly; all
+    // four Lide drives fall onto the second.
+    for f in [F::IdeMasterBoot, F::IdeSlaveBoot, F::ScsiUnit6Boot] {
+        assert_eq!(s.boot_page_of(f), Some(LauncherTab::BootPriority), "{f:?}");
+    }
+    for f in [
+        F::LideDrive0Boot,
+        F::LideDrive1Boot,
+        F::LideDrive2Boot,
+        F::LideDrive3Boot,
+    ] {
+        assert_eq!(
+            s.boot_page_of(f),
+            Some(LauncherTab::BootPriorityMore),
+            "{f:?}"
+        );
+    }
+    // Neither page draws more rows than one holds.
+    for tab in [LauncherTab::BootPriority, LauncherTab::BootPriorityMore] {
+        let drawn = rows(tab, Default::default(), Default::default(), false, false)
+            .iter()
+            .filter(|r| s.row_on_page(tab, r.field))
+            .count();
+        assert!(drawn <= BOOTPRI_PAGE_ROWS + 1, "{tab:?} draws {drawn}");
+    }
+
+    // Back on the second page returns to the first, not to Storage.
+    assert_eq!(
+        LauncherTab::BootPriorityMore.parent_tab(),
+        Some(LauncherTab::BootPriority)
+    );
+    assert_eq!(
+        LauncherTab::BootPriority.parent_tab(),
+        Some(LauncherTab::Storage)
     );
 }

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -9385,7 +9385,11 @@ fn draw_launcher(
         // The drives that are drawn, plus the column-title row above them --
         // the hidden ones take no space, so the note follows the last one on
         // the page rather than the last one in the table.
-        let listed = state.setup.boot_priority_row_count() + 1;
+        let listed = state
+            .setup
+            .boot_priority_row_count()
+            .min(launcher::BOOTPRI_PAGE_ROWS)
+            + 1;
         let help_top = (launcher_row_y(rect, listed + 1) + row_offset).saturating_sub(10);
         draw_panel_text(
             frame,

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -9378,7 +9378,10 @@ fn draw_launcher(
     }
     // The Boot Priority page spells out the valid priority range below the
     // rows, under a dimmed "Info:" heading.
-    if state.tab == LauncherTab::BootPriority && state.setup.boot_priority_shows_info() {
+    // The first page only: a page holds nine drives at most, so the note
+    // always has its room under them, and the second page needs no second
+    // copy of it.
+    if state.tab == LauncherTab::BootPriority && state.setup.has_boot_priority_rows() {
         // The drives that are drawn, plus the column-title row above them --
         // the hidden ones take no space, so the note follows the last one on
         // the page rather than the last one in the table.

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -5736,6 +5736,15 @@ fn launcher_nav_block_h(tab: launcher::LauncherTab) -> usize {
     LAUNCH_NAV_BLOCK_H + (rows - 1) * (LAUNCH_MODEL_H + LAUNCH_MODEL_GAP)
 }
 
+/// The Boot Priority page's paging button, when it has one: the first page
+/// offers the rest of the order, and only while there is a rest to offer.
+/// The second page needs none -- its Back button already goes to the first.
+fn boot_page_button(state: &LauncherState) -> Option<(&'static str, launcher::LauncherTab)> {
+    (state.tab == launcher::LauncherTab::BootPriority
+        && state.setup.boot_priority_has_second_page())
+    .then_some(("Next Page >", launcher::LauncherTab::BootPriorityMore))
+}
+
 /// The Status column's clickable area (the "Bootable" label plus its tick box),
 /// sitting to the right of the priority stepper on a Boot Priority row.
 fn launcher_bootable_rect(rect: Rect, row_y: usize) -> Rect {
@@ -6444,7 +6453,7 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
             state.setup.midi_out_is_csynth(),
         )
         .iter()
-        .filter(|r| !state.setup.row_hidden(r.field))
+        .filter(|r| state.setup.row_on_page(state.tab, r.field))
         .enumerate()
         {
             if !state.row_applies(r.field) {
@@ -6821,6 +6830,12 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
     }
     for (i, &(_, target)) in state.tab.nav_options().iter().enumerate() {
         if launcher_nav_button_rect(rect, slot + i).contains(pos) {
+            return Some(UiControl::LauncherNavTab(target));
+        }
+    }
+    // The boot order's paging button, drawn in the slot after Back.
+    if let Some((_, target)) = boot_page_button(state) {
+        if launcher_nav_button_rect(rect, slot).contains(pos) {
             return Some(UiControl::LauncherNavTab(target));
         }
     }
@@ -8139,13 +8154,13 @@ fn draw_launcher_row(
             Some(GreyedAs::DimmedValue | GreyedAs::DimmedReason)
         ) {
             if greyed_as != Some(GreyedAs::Blank) {
-                // Where the value the row cannot have would sit: flush
-                // against the right edge of the stepper's left arrow, so
-                // every reason shares one margin whatever its length.
-                let (prev, _, _) = launcher_cycle_rects(rect, row_y);
+                // Where the value the row cannot have would sit: the control
+                // column's own left edge, so a reason lines up with the
+                // values above and below it rather than standing in from
+                // them by the width of a stepper arrow.
                 draw_panel_text(
                     frame,
-                    prev.x + prev.w,
+                    launcher_control_x(rect),
                     row_y + 8,
                     reason,
                     PANEL_TEXT_DIM,
@@ -9229,7 +9244,7 @@ fn draw_launcher(
             state.setup.midi_out_is_csynth(),
         )
         .iter()
-        .filter(|r| !state.setup.row_hidden(r.field))
+        .filter(|r| state.setup.row_on_page(state.tab, r.field))
         .enumerate()
         {
             draw_launcher_row(frame, rect, state, r, i, row_offset, hover, scale);
@@ -9261,6 +9276,18 @@ fn draw_launcher(
             target == state.tab,
             lit(hover, UiControl::LauncherNavTab(target)),
             false,
+            scale,
+        );
+    }
+    // The rest of the boot order, when there is more of it than one page
+    // holds. Next to Back, in the slot a sibling link would have taken.
+    if let Some((label, target)) = boot_page_button(state) {
+        draw_text_button(
+            frame,
+            launcher_nav_button_rect(rect, slot),
+            label,
+            true,
+            lit(hover, UiControl::LauncherNavTab(target)),
             scale,
         );
     }
@@ -9351,20 +9378,12 @@ fn draw_launcher(
     }
     // The Boot Priority page spells out the valid priority range below the
     // rows, under a dimmed "Info:" heading.
-    if state.tab == LauncherTab::BootPriority && state.setup.has_boot_priority_rows() {
-        let help_top = (launcher_row_y(
-            rect,
-            launcher::rows(
-                LauncherTab::BootPriority,
-                state.setup.parallel_device(),
-                state.setup.serial_mode(),
-                state.setup.midi_out_is_mt32(),
-                state.setup.midi_out_is_csynth(),
-            )
-            .len()
-                + 1,
-        ) + row_offset)
-            .saturating_sub(10);
+    if state.tab == LauncherTab::BootPriority && state.setup.boot_priority_shows_info() {
+        // The drives that are drawn, plus the column-title row above them --
+        // the hidden ones take no space, so the note follows the last one on
+        // the page rather than the last one in the table.
+        let listed = state.setup.boot_priority_row_count() + 1;
+        let help_top = (launcher_row_y(rect, listed + 1) + row_offset).saturating_sub(10);
         draw_panel_text(
             frame,
             launcher_pane_x(rect),

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -9382,15 +9382,11 @@ fn draw_launcher(
     // always has its room under them, and the second page needs no second
     // copy of it.
     if state.tab == LauncherTab::BootPriority && state.setup.has_boot_priority_rows() {
-        // The drives that are drawn, plus the column-title row above them --
-        // the hidden ones take no space, so the note follows the last one on
-        // the page rather than the last one in the table.
-        let listed = state
-            .setup
-            .boot_priority_row_count()
-            .min(launcher::BOOTPRI_PAGE_ROWS)
-            + 1;
-        let help_top = (launcher_row_y(rect, listed + 1) + row_offset).saturating_sub(10);
+        // Below a full page of drives, whether or not this machine has one:
+        // the note keeps the same place on the page however many rows are
+        // drawn above it, rather than riding up and down with the count.
+        let below_a_full_page = launcher::BOOTPRI_PAGE_ROWS + 2;
+        let help_top = (launcher_row_y(rect, below_a_full_page) + row_offset).saturating_sub(10);
         draw_panel_text(
             frame,
             launcher_pane_x(rect),

--- a/src/video/ui/tests.rs
+++ b/src/video/ui/tests.rs
@@ -350,6 +350,7 @@ fn every_launcher_tab_row_fits_inside_the_panel() {
         LauncherTab::HostFs,
         LauncherTab::Whdload,
         LauncherTab::BootPriority,
+        LauncherTab::BootPriorityMore,
         LauncherTab::Lide,
         LauncherTab::AvVideo,
         LauncherTab::AvEmulation,
@@ -366,7 +367,19 @@ fn every_launcher_tab_row_fits_inside_the_panel() {
         for &device in &devices {
             for &mode in &modes {
                 let rows = launcher::rows(tab, device, mode, false, false);
-                for (i, r) in rows.iter().enumerate() {
+                // The boot order is paged: both of its pages carry the whole
+                // table, and each draws its own share of it under the column
+                // titles. A page never shows more than that many rows, so
+                // that is what has to fit -- see `BOOTPRI_PAGE_ROWS`.
+                let drawn = if matches!(
+                    tab,
+                    LauncherTab::BootPriority | LauncherTab::BootPriorityMore
+                ) {
+                    rows.len().min(launcher::BOOTPRI_PAGE_ROWS + 1)
+                } else {
+                    rows.len()
+                };
+                for (i, r) in rows.iter().take(drawn).enumerate() {
                     let row_y = launcher_row_y(rect, i) + row_offset;
                     let (prev, value, next) = launcher_cycle_rects(rect, row_y);
                     let (browse, clear) = launcher_path_rects(rect, row_y);
@@ -1007,7 +1020,7 @@ fn the_serial_address_box_hit_tests_to_its_own_edit() {
         state.setup.midi_out_is_csynth(),
     )
     .iter()
-    .filter(|r| !state.setup.row_hidden(r.field))
+    .filter(|r| state.setup.row_on_page(state.tab, r.field))
     .position(|r| r.field == LauncherField::SerialConnect)
     .expect("no Connect row in tcp-connect mode");
     // The serial page sits under the I/O Ports nav row, so its rows
@@ -1045,7 +1058,7 @@ fn fixed_ram_pattern_box_hit_tests_to_its_own_edit() {
         state.setup.midi_out_is_csynth(),
     )
     .iter()
-    .filter(|r| !state.setup.row_hidden(r.field))
+    .filter(|r| state.setup.row_on_page(state.tab, r.field))
     .position(|r| r.field == LauncherField::RamPattern)
     .expect("no fixed RAM pattern row on Memory page");
     let row_y = launcher_row_y(rect, index);
@@ -2976,6 +2989,51 @@ fn panels_render_into_their_rects() {
     draw(&mut frame, scale, &ui, None, None);
     save(&frame, "launcher-boot-priority");
 
+    // The same page on a machine with every bay filled: two IDE drives, a
+    // full seven-unit SCSI chain and a RIPPLE board's four, which is more
+    // boot order than one page holds. The first page fills and offers the
+    // rest; the second carries them under the same column titles.
+    let mut full = launcher::MachineSetup::default();
+    full.select_model(Some(MachineModel::A1200));
+    full.cycle(LauncherField::ScsiController, true);
+    full.cycle(LauncherField::LideBoard, true);
+    for f in [
+        LauncherField::IdeMaster,
+        LauncherField::IdeSlave,
+        LauncherField::ScsiUnit0,
+        LauncherField::ScsiUnit1,
+        LauncherField::ScsiUnit2,
+        LauncherField::ScsiUnit3,
+        LauncherField::ScsiUnit4,
+        LauncherField::ScsiUnit5,
+        LauncherField::ScsiUnit6,
+        LauncherField::LideDrive0,
+        LauncherField::LideDrive1,
+        LauncherField::LideDrive2,
+        LauncherField::LideDrive3,
+    ] {
+        full.set_path(f, std::path::PathBuf::from("disk.hdf"));
+    }
+    for (tab, name) in [
+        (LauncherTab::BootPriority, "launcher-boot-priority-full"),
+        (
+            LauncherTab::BootPriorityMore,
+            "launcher-boot-priority-page2",
+        ),
+    ] {
+        let mut frame = vec![0u8; w * h * 4];
+        let mut state = LauncherState::new(full.clone());
+        state.tab = tab;
+        let ui = UiState {
+            menu_open: false,
+            menu_rows: Vec::new(),
+            menu_nav: menu::MenuNav::default(),
+            panel: Some(Panel::Launcher(Box::new(state))),
+        };
+        draw(&mut frame, scale, &ui, None, None);
+        save(&frame, name);
+    }
+
     // The runtime menu, opened over a running machine: the top level,
     // with a category open beside it.
     let mut frame = vec![0u8; w * h * 4];
@@ -3318,7 +3376,7 @@ fn panels_render_into_their_rects() {
             }
             let idx = launcher::rows(tab, Default::default(), Default::default(), false, false)
                 .iter()
-                .filter(|r| !setup.row_hidden(r.field))
+                .filter(|r| setup.row_on_page(tab, r.field))
                 .position(|r| r.field == field && r.kind == kind)
                 .expect("the field has a visible row");
             let mut state = LauncherState::new(setup);

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6097,6 +6097,8 @@ impl App {
                     let model = state.setup.model();
                     state.setup = MachineSetup::default();
                     state.setup.select_model(model);
+                    // The defaults have no second boot page to stand on.
+                    state.tab = state.setup.settle_tab(state.tab);
                     state.setup.refresh_host_devices();
                     state.status = Some(StatusMessage::ok("Reset to defaults"));
                 }

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -1034,6 +1034,9 @@ impl App {
                 Ok(setup) => {
                     if let Some(state) = self.launcher_state_mut() {
                         state.setup = setup;
+                        // The page being looked at may not exist under the
+                        // loaded machine (the second boot page, emptied).
+                        state.tab = state.setup.settle_tab(state.tab);
                         // Re-read host device lists so the loaded setup's pickers
                         // are populated, not stuck on "Default"/"None".
                         state.setup.refresh_host_devices();


### PR DESCRIPTION
## The boot order takes in the Lide board + a "next page" for >9 bootable drives. 

Lide drives move onto the Boot Priority page, after the IDE bays and the SCSI units — the same order the cascade default ranks them in. They appear on the terms a SCSI unit does: once the slot carries a disk. The Lide page keeps the board, its ROMs and its drives.

A fully fitted machine reaches thirteen drives and the panel holds nine, so the list pages. **Next Page >** sits beside Back on the first; the second has only its own Back, returning to the first. Same columns, same layout. The priority-range note stays on page one.

A greyed row's reason now starts at the control column instead of past the stepper's first arrow, so "A2091 only" lines up with the `(bundled A4091 ROM)` text above it. Applies to every greyed row.

Release build, full suite, fmt and clippy clean.