### PR TITLE
launcher: the window and the picture part ways

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -876,7 +876,7 @@ display, one line per data point (see
 Cmd+P (macOS) / Alt+P toggles it live for the rest of the session without
 touching the config, `--perf-overlay` shows it for one run, and
 `COPPERLINE_PERF_OVERLAY=1|0` overrides the config for a single run; the
-launcher's *Perf overlay* row (*A/V & Emu*, *Video*) writes it. Like the
+launcher's *Perf overlay* row (*A/V & Emu*, *Display*) writes it. Like the
 transient message overlay it is presentation only: screenshots, frame
 dumps, and recordings never include it.
 
@@ -1004,7 +1004,7 @@ shader never fails the config, and never stops the machine from running.
 whole menu, rows and text together. It is a start-up preference:
 *Video Settings > Menu Size* changes it live without altering the saved
 value, `--menu-scale` sets it on the command line, and the launcher's A/V &
-Emu page (Video category) has a *Menu size* picker for the same.
+Emu page (Display category) has a *Menu size* picker for the same.
 
 `full_screen` opens the window fullscreen at start (borderless), and
 `status_bar` chooses whether the status bar starts visible. Both are start-up
@@ -1012,7 +1012,7 @@ preferences; the runtime toggles -- `Cmd+F` / `Alt+F` for fullscreen and
 `Cmd+Shift+F` / `Alt+Shift+F` for the status bar, plus their menu items --
 still flip either live without changing the saved value. On the command line
 `--full-screen` / `--windowed` set the fullscreen state and `--show-status-bar` /
-`--hide-status-bar` set the status bar; the launcher's A/V & Emu page (Video
+`--hide-status-bar` set the status bar; the launcher's A/V & Emu page (Display
 category) has *Start fullscreen* and *Status bar* toggles for the same. Left
 unset they keep the defaults: windowed, status bar shown.
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -229,7 +229,7 @@ presentation only: screenshots, frame dumps, and recordings never include
 it. While a video recording is running the block steps below the `REC`
 badge. `COPPERLINE_PERF_OVERLAY=1|0` overrides the config for a single
 run, and `--perf-overlay` shows it from the command line; the launcher's
-*Perf overlay* row (*A/V & Emu*, *Video*) makes it stick. The same
+*Perf overlay* row (*A/V & Emu*, *Display*) makes it stick. The same
 counters are exported through the control protocol's `status` reply for
 headless runs (see [](../debugger/control)).
 
@@ -294,7 +294,7 @@ Opening the menu also releases a captured mouse.
 
 **Menu Size** under *Video Settings* draws the whole menu at 1x or 2x. The
 start-up size is `[display] menu_scale`, `--menu-scale`, or *Menu size* on
-the launcher's A/V & Emu page (Video category).
+the launcher's A/V & Emu page (Display category).
 
 Tool windows are separate native windows so the emulated display remains visible;
 the debugger and frame analyzer can be open at the same time. They take their
@@ -651,7 +651,7 @@ The layout is:
   fullscreen, status bar, perf overlay, menu size),
   **Emulation**
   (power-on, realtime priority, pacing, warp speed),
-  and **Paths** -- opening on Audio, and switched freely between the four.
+  and **Paths** -- opening on Audio, and switched freely between the five.
   The Paths page edits the `[paths]` section of the configuration (see
   [](configuration.md)): the base folder on top, then one row per folder.
   A row reads `(default)` until a folder is chosen for it; **Browse** picks

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -645,10 +645,10 @@ The layout is:
   [](whdload.md)),
   and *A/V & Emu*, split by a row of category buttons at the top into
   **Audio** (output device, channel mode, stereo separation, filter, floppy
-  sounds and volume), **Video** (start fullscreen, status bar, monitor bezel
-  style,
-  perf overlay, menu size, overscan, pixel aspect, scaling, deinterlace,
-  screen tint, phosphor, CRT shader and shader strength),
+  sounds and volume), **Video** -- the emulated picture (monitor bezel style,
+  overscan, pixel aspect, scaling, deinterlace, screen tint, phosphor, CRT
+  shader and shader strength), **Display** -- the host window (start
+  fullscreen, status bar, perf overlay, menu size),
   **Emulation**
   (power-on, realtime priority, pacing, warp speed),
   and **Paths** -- opening on Audio, and switched freely between the four.

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -1220,7 +1220,7 @@ const SOUND_ROWS: [Row; 2] = [
 ];
 #[cfg(not(feature = "mhi"))]
 const SOUND_ROWS: [Row; 1] = [row(F::Toccata, "  Toccata", Cycle)];
-// The A/V & Emu tab is split into three categories switched via the top nav row.
+// The A/V & Emu tab is split into five categories switched via the top nav row.
 // The Video category also carries the CRT-shader controls (a picture setting).
 // The emulated picture, in signal order -- what the monitor is fed and how
 // it is drawn -- with the shader pair last, since strength greys off the

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -211,6 +211,10 @@ pub enum LauncherTab {
     /// `AvAudio.label()` is therefore the strip's "A/V & Emu", not "Audio".
     AvAudio,
     AvVideo,
+    /// The host window and its furniture -- fullscreen at start, the status
+    /// bar, the perf overlay, menu size -- as distinct from `AvVideo`, which
+    /// is the emulated picture itself.
+    AvDisplay,
     AvEmulation,
     /// Where Copperline keeps what it produces and where its file dialogs
     /// open. Its rows are the configuration's `[paths]` section, saved
@@ -302,6 +306,7 @@ impl LauncherTab {
             LauncherTab::Zorro => "Zorro",
             LauncherTab::AvAudio => "A/V & Emu",
             LauncherTab::AvVideo => "Video",
+            LauncherTab::AvDisplay => "Display",
             LauncherTab::AvEmulation => "Emulation",
             LauncherTab::AvPaths => "Paths",
             LauncherTab::CreateFloppy => "Floppy Disk",
@@ -330,9 +335,10 @@ impl LauncherTab {
             | LauncherTab::CreateHard
             | LauncherTab::CreateGeometry => LauncherTab::Storage,
             LauncherTab::FluxBridge => LauncherTab::Floppy,
-            LauncherTab::AvVideo | LauncherTab::AvEmulation | LauncherTab::AvPaths => {
-                LauncherTab::AvAudio
-            }
+            LauncherTab::AvVideo
+            | LauncherTab::AvDisplay
+            | LauncherTab::AvEmulation
+            | LauncherTab::AvPaths => LauncherTab::AvAudio,
             LauncherTab::IoParallel | LauncherTab::IoNetworking | LauncherTab::IoAudio => {
                 LauncherTab::IoPorts
             }
@@ -373,6 +379,7 @@ impl LauncherTab {
             LauncherTab::Storage => STORAGE_NAV,
             LauncherTab::AvAudio
             | LauncherTab::AvVideo
+            | LauncherTab::AvDisplay
             | LauncherTab::AvEmulation
             | LauncherTab::AvPaths => AV_NAV,
             LauncherTab::IoPorts
@@ -439,7 +446,9 @@ const IO_NAV: &[(&str, LauncherTab)] = &[
 const AV_NAV: &[(&str, LauncherTab)] = &[
     ("Audio", LauncherTab::AvAudio),
     ("Video", LauncherTab::AvVideo),
+    ("Display", LauncherTab::AvDisplay),
     ("Emulation", LauncherTab::AvEmulation),
+    // Four to a row, so this one wraps onto a second.
     ("Paths", LauncherTab::AvPaths),
 ];
 
@@ -1213,12 +1222,11 @@ const SOUND_ROWS: [Row; 2] = [
 const SOUND_ROWS: [Row; 1] = [row(F::Toccata, "  Toccata", Cycle)];
 // The A/V & Emu tab is split into three categories switched via the top nav row.
 // The Video category also carries the CRT-shader controls (a picture setting).
-const VIDEO_ROWS: [Row; 13] = [
-    row(F::StartFullscreen, "Start fullscreen", Cycle),
-    row(F::ShowStatusBar, "Status bar", Cycle),
+// The emulated picture, in signal order -- what the monitor is fed and how
+// it is drawn -- with the shader pair last, since strength greys off the
+// shader. The host window's own settings are DISPLAY_ROWS.
+const VIDEO_ROWS: [Row; 9] = [
     row(F::Bezel, "Monitor bezel", Cycle),
-    row(F::PerfOverlay, "Perf overlay", Cycle),
-    row(F::MenuScale, "Menu size", Cycle),
     row(F::Overscan, "Overscan", Cycle),
     row(F::PixelAspect, "Pixel aspect", Cycle),
     row(F::Scaling, "Scaling", Cycle),
@@ -1227,6 +1235,14 @@ const VIDEO_ROWS: [Row; 13] = [
     row(F::Phosphor, "Phosphor", Cycle),
     row(F::Shader, "CRT shader", Cycle),
     row(F::ShaderStrength, "Shader strength", Cycle),
+];
+
+// The host window and its furniture, as distinct from the picture inside it.
+const DISPLAY_ROWS: [Row; 4] = [
+    row(F::StartFullscreen, "Start fullscreen", Cycle),
+    row(F::ShowStatusBar, "Status bar", Cycle),
+    row(F::PerfOverlay, "Perf overlay", Cycle),
+    row(F::MenuScale, "Menu size", Cycle),
 ];
 const AUDIO_ROWS: [Row; 6] = [
     row(F::AudioDevice, "Audio output", Cycle),
@@ -1392,6 +1408,7 @@ pub fn rows(
         // sibling categories, switched via the top nav row.
         LauncherTab::AvAudio => Cow::Borrowed(&AUDIO_ROWS),
         LauncherTab::AvVideo => Cow::Borrowed(&VIDEO_ROWS),
+        LauncherTab::AvDisplay => Cow::Borrowed(&DISPLAY_ROWS),
         LauncherTab::AvEmulation => Cow::Borrowed(&EMULATION_ROWS),
         LauncherTab::AvPaths => Cow::Borrowed(&PATHS_ROWS),
     }

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -3374,8 +3374,8 @@ fn sub_pages_of_hdd_cd() {
 #[test]
 fn av_emu_categories() {
     use LauncherField as F;
-    // Only "A/V & Emu" (the Audio default) is a strip tab; Video and
-    // Emulation are its categories.
+    // Only "A/V & Emu" (the Audio default) is a strip tab; Video, Display,
+    // Emulation and Paths are its categories.
     assert!(TABS.contains(&LauncherTab::AvAudio));
     assert!(!TABS.contains(&LauncherTab::AvVideo));
     assert!(!TABS.contains(&LauncherTab::AvDisplay));

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -3378,10 +3378,12 @@ fn av_emu_categories() {
     // Emulation are its categories.
     assert!(TABS.contains(&LauncherTab::AvAudio));
     assert!(!TABS.contains(&LauncherTab::AvVideo));
+    assert!(!TABS.contains(&LauncherTab::AvDisplay));
     assert!(!TABS.contains(&LauncherTab::AvEmulation));
     assert!(!TABS.contains(&LauncherTab::AvPaths));
     for t in [
         LauncherTab::AvVideo,
+        LauncherTab::AvDisplay,
         LauncherTab::AvEmulation,
         LauncherTab::AvPaths,
     ] {
@@ -3397,11 +3399,13 @@ fn av_emu_categories() {
         [
             ("Audio", LauncherTab::AvAudio),
             ("Video", LauncherTab::AvVideo),
+            ("Display", LauncherTab::AvDisplay),
             ("Emulation", LauncherTab::AvEmulation),
             ("Paths", LauncherTab::AvPaths),
         ]
     );
     assert_eq!(LauncherTab::AvVideo.nav_options(), nav);
+    assert_eq!(LauncherTab::AvDisplay.nav_options(), nav);
     assert!(LauncherTab::AvAudio.has_top_nav());
     assert!(LauncherTab::Storage.has_top_nav());
     assert!(!LauncherTab::System.has_top_nav());
@@ -3411,9 +3415,20 @@ fn av_emu_categories() {
     let audio = page(LauncherTab::AvAudio);
     assert!(audio.iter().any(|r| r.field == F::AudioDevice));
     assert!(audio.iter().all(|r| r.field != F::StartFullscreen));
+    // Video is the emulated picture; Display is the host window. The
+    // fullscreen switch is the window's, the shader the picture's.
     assert!(page(LauncherTab::AvVideo)
         .iter()
+        .any(|r| r.field == F::Shader));
+    assert!(page(LauncherTab::AvVideo)
+        .iter()
+        .all(|r| r.field != F::StartFullscreen));
+    assert!(page(LauncherTab::AvDisplay)
+        .iter()
         .any(|r| r.field == F::StartFullscreen));
+    assert!(page(LauncherTab::AvDisplay)
+        .iter()
+        .all(|r| r.field != F::Bezel));
     assert!(page(LauncherTab::AvEmulation)
         .iter()
         .any(|r| r.field == F::PowerOn));

--- a/src/video/ui/tests.rs
+++ b/src/video/ui/tests.rs
@@ -354,13 +354,16 @@ fn every_launcher_tab_row_fits_inside_the_panel() {
         LauncherTab::AvVideo,
         LauncherTab::AvDisplay,
         LauncherTab::AvEmulation,
+        LauncherTab::AvPaths,
     ];
     for &tab in launcher::TABS.iter().chain(off_strip.iter()) {
         // The row grid always ends above the status line; on tabs with a top
-        // nav it starts a nav block lower, leaving it less room.
+        // nav it starts a nav block lower, leaving it less room -- two nav
+        // rows' worth where the nav wraps (the A/V pages' five chips, the
+        // Storage links), which is what the draw path reserves too.
         let bound = launcher_status_y(rect);
         let row_offset = if tab.has_top_nav() {
-            LAUNCH_NAV_BLOCK_H
+            launcher_nav_block_h(tab)
         } else {
             0
         };

--- a/src/video/ui/tests.rs
+++ b/src/video/ui/tests.rs
@@ -352,6 +352,7 @@ fn every_launcher_tab_row_fits_inside_the_panel() {
         LauncherTab::BootPriority,
         LauncherTab::Lide,
         LauncherTab::AvVideo,
+        LauncherTab::AvDisplay,
         LauncherTab::AvEmulation,
     ];
     for &tab in launcher::TABS.iter().chain(off_strip.iter()) {
@@ -3092,6 +3093,20 @@ fn panels_render_into_their_rects() {
     };
     draw(&mut frame, scale, &ui, None, None);
     save(&frame, "launcher-av-video");
+
+    // The Display category: the host window's own settings, under the same
+    // nav row (which wraps -- five categories, four to a row).
+    let mut frame = vec![0u8; w * h * 4];
+    let mut state = LauncherState::new(launcher::MachineSetup::default());
+    state.tab = LauncherTab::AvDisplay;
+    let ui = UiState {
+        menu_open: false,
+        menu_rows: Vec::new(),
+        menu_nav: menu::MenuNav::default(),
+        panel: Some(Panel::Launcher(Box::new(state))),
+    };
+    draw(&mut frame, scale, &ui, None, None);
+    save(&frame, "launcher-av-display");
 
     // The Floppy tab with two drives wired in: each drive is a greyed "DFn:"
     // heading with indented settings; DF2/DF3 are hidden until enabled.


### PR DESCRIPTION
## The window and the picture part ways

The `Video` category under `A/V & Emu` carried both the emulated picture and the host window's furniture and was starting to look a little too "busy". 

They split: **Video** keeps the signal — bezel, overscan, pixel aspect, scaling, deinterlace, tint, phosphor, the shader pair — and a new **Display** category takes the window's own settings: start fullscreen, status bar, perf overlay, menu size.

Audio keeps its A/V partner beside it; Paths wraps onto the nav row's second line, as Storage's links already do. No setting changed its key or behaviour — only which page it lives on.

Release build, full suite, fmt and clippy clean.