### PR TITLE
Fix/storage scsi alignment

### DIFF
--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -611,8 +611,11 @@ The layout is:
   makes new ADF and HDF images (see below); **CD** (image, insert delay,
   CD32 NVRAM); and **Lide**, the built-in `[lide]` Zorro II IDE board --
   personality (RIPPLE/RIDE/AT-Bus 2008), boot ROM(s), and up to four drives
-  (two on RIDE/AT-Bus 2008, any of which can likewise be a CD image). Each
-  sub-page has a **< Back** button in that block that returns to Storage),
+  (two on RIDE/AT-Bus 2008, any of which can likewise be a CD image);
+  **Boot Priority**, which sets each drive's
+  synthesized-RDB boot priority (see below); and **Create Image...**, which
+  makes new ADF and HDF images (see below). Each sub-page has a **< Back**
+  button in that block that returns to Storage),
   *Input* (the controller device in each game port and the joystick input
   source),
   *I/O Ports* (the serial, parallel, networking, and audio boards, each

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -598,18 +598,18 @@ The layout is:
   serial port, drive select, density, read mode and replay speed, greying
   whatever the chosen interface does not honour. See [](fluxbridge.md)),
   *Storage* (IDE master/slave -- either can be a CD image instead of a hard
-  disk, attaching an ATAPI CD-ROM drive there -- the SCSI controller --
-  A2091, A4091, or the A3000's onboard SCSI -- and its boot ROM and units,
-  a unit likewise a CD image attaching a SCSI CD-ROM drive; a block of buttons at
-  the top links to six sub-pages: **Host Folder**, for host directories
+  disk, attaching an ATAPI CD-ROM drive there -- and the SCSI controller --
+  A2091, A4091, or the A3000's onboard SCSI. Its boot ROM and unit rows, a
+  unit likewise a CD image attaching a SCSI CD-ROM drive, appear once a
+  controller is chosen and are hidden with none, the same way disabled
+  floppy drives are; a block of buttons at
+  the top links to six sub-pages: **CD** (image, insert delay,
+  CD32 NVRAM); **Host Folder**, for host directories
   served live as AmigaDOS volumes (up to four mounts, each with a boot
   priority and a read-write/read-only **Access** field -- the config file
   itself takes up to eight `[[filesys]]` mounts, of which the launcher edits
   the first four); **Host Disk**, for a real disk of this computer's (see
-  [](host-disks.md)); **Boot Priority**, which sets each drive's
-  synthesized-RDB boot priority (see below); **Create Image...**, which
-  makes new ADF and HDF images (see below); **CD** (image, insert delay,
-  CD32 NVRAM); and **Lide**, the built-in `[lide]` Zorro II IDE board --
+  [](host-disks.md)); **Lide**, the built-in `[lide]` Zorro II IDE board --
   personality (RIPPLE/RIDE/AT-Bus 2008), boot ROM(s), and up to four drives
   (two on RIDE/AT-Bus 2008, any of which can likewise be a CD image);
   **Boot Priority**, which sets each drive's
@@ -678,7 +678,7 @@ The layout is:
   Kickstart from 1.2 onward can read with no guest-side setup).
   A setting that does not apply to the chosen machine is greyed and
   shows why in place of its control -- "needs 32-bit CPU" for Zorro III RAM
-  and the RTG card, "needs 68020+" for the FPU, "needs A600/A1200/A4000" for
+  and the RTG card, "needs 68020+" for the FPU, "needs A600/A1200/A4000 or Lide" for
   IDE.
 - **Boot Priority sub-page** (from *Storage*). One row per hard-disk drive,
   under **Drive** / **Priority** / **Status** columns, setting the `de_BootPri`

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -3634,9 +3634,7 @@ impl MachineSetup {
                     },
                 )
             }
-            F::IdeMaster | F::IdeSlave => {
-                reason(self.has_ide(), "needs A600/A1200/A4000 (or Lide)")
-            }
+            F::IdeMaster | F::IdeSlave => reason(self.has_ide(), "needs A600/A1200/A4000"),
             // The ROM and drives belong to the fitted controller; greyed with
             // none. The A3000's motherboard SCSI has no ROM of its own, and
             // rom_odd is an A2091 split-EPROM option only.

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -3548,6 +3548,17 @@ impl MachineSetup {
             F::HostSocketInterface => {
                 !matches!(self.hostsocket_net.as_ref(), Some(NetConfig::Bridge { .. }))
             }
+            // No controller, no SCSI: the ROM and unit rows go rather than
+            // stand greyed under a setting most machines leave at None. They
+            // return the moment a controller is chosen.
+            F::ScsiRom | F::ScsiRomOdd => self.scsi_controller.is_none(),
+            F::ScsiUnit0
+            | F::ScsiUnit1
+            | F::ScsiUnit2
+            | F::ScsiUnit3
+            | F::ScsiUnit4
+            | F::ScsiUnit5
+            | F::ScsiUnit6 => self.scsi_controller.is_none(),
             // A controller is not a disk: only the units carrying one have a
             // place in the boot order, so the empty six or seven go rather
             // than standing in a column saying so.
@@ -3634,7 +3645,7 @@ impl MachineSetup {
                     },
                 )
             }
-            F::IdeMaster | F::IdeSlave => reason(self.has_ide(), "needs A600/A1200/A4000"),
+            F::IdeMaster | F::IdeSlave => reason(self.has_ide(), "needs A600/A1200/A4000 or Lide"),
             // The ROM and drives belong to the fitted controller; greyed with
             // none. The A3000's motherboard SCSI has no ROM of its own, and
             // rom_odd is an A2091 split-EPROM option only.

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -409,16 +409,16 @@ impl LauncherTab {
 
 /// The Storage tab's top nav links (its sub-pages), left to right.
 const STORAGE_NAV: &[(&str, LauncherTab)] = &[
+    // The first row is the hardware -- what a machine can have attached.
+    ("CD", LauncherTab::Cd),
     ("Host Folder", LauncherTab::HostFs),
     ("Host Disk", LauncherTab::HostDisk),
-    ("Boot Priority", LauncherTab::BootPriority),
-    // Last of the four, because it is the one entry that makes something
-    // rather than attaching something: nothing on its pages describes this
-    // machine, which is why they are pages of their own.
-    ("Create Image...", LauncherTab::CreateFloppy),
-    // Four to a row, so these two wrap onto a second.
-    ("CD", LauncherTab::Cd),
     ("Lide", LauncherTab::Lide),
+    // Four to a row, so the second holds what is done with it: the boot
+    // order across everything above, and the one entry that makes
+    // something rather than attaching something.
+    ("Boot Priority", LauncherTab::BootPriority),
+    ("Create Image...", LauncherTab::CreateFloppy),
 ];
 
 /// The workshop's two pages. Reached from Storage, so they show a Back

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -3551,8 +3551,9 @@ impl MachineSetup {
             // No controller, no SCSI: the ROM and unit rows go rather than
             // stand greyed under a setting most machines leave at None. They
             // return the moment a controller is chosen.
-            F::ScsiRom | F::ScsiRomOdd => self.scsi_controller.is_none(),
-            F::ScsiUnit0
+            F::ScsiRom
+            | F::ScsiRomOdd
+            | F::ScsiUnit0
             | F::ScsiUnit1
             | F::ScsiUnit2
             | F::ScsiUnit3
@@ -3646,25 +3647,16 @@ impl MachineSetup {
                 )
             }
             F::IdeMaster | F::IdeSlave => reason(self.has_ide(), "needs A600/A1200/A4000 or Lide"),
-            // The ROM and drives belong to the fitted controller; greyed with
-            // none. The A3000's motherboard SCSI has no ROM of its own, and
-            // rom_odd is an A2091 split-EPROM option only.
+            // The ROM and drives belong to the fitted controller, and with
+            // none the rows are hidden outright (`row_hidden`), so only a
+            // fitted-but-unsuitable controller is ever explained here: the
+            // A3000's motherboard SCSI has no ROM of its own, and rom_odd
+            // is an A2091 split-EPROM option only.
             F::ScsiRom => reason(
                 self.scsi_controller
                     .is_some_and(ScsiController::is_zorro_board),
-                if self.scsi_controller.is_some() {
-                    "Zorro boards only"
-                } else {
-                    "no controller"
-                },
+                "Zorro boards only",
             ),
-            F::ScsiUnit0
-            | F::ScsiUnit1
-            | F::ScsiUnit2
-            | F::ScsiUnit3
-            | F::ScsiUnit4
-            | F::ScsiUnit5
-            | F::ScsiUnit6 => reason(self.scsi_controller.is_some(), "no controller"),
             F::ScsiRomOdd => reason(
                 self.scsi_controller == Some(ScsiController::A2091),
                 "A2091 only",

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -3435,6 +3435,40 @@ fn av_emu_categories() {
 }
 
 #[test]
+fn scsi_rows_hidden_until_a_controller_is_chosen() {
+    use LauncherField as F;
+    let mut s = MachineSetup::default();
+    let scsi_rows = [
+        F::ScsiRom,
+        F::ScsiRomOdd,
+        F::ScsiUnit0,
+        F::ScsiUnit1,
+        F::ScsiUnit2,
+        F::ScsiUnit3,
+        F::ScsiUnit4,
+        F::ScsiUnit5,
+        F::ScsiUnit6,
+    ];
+    // No controller: the ROM and unit rows go rather than stand greyed.
+    assert_eq!(s.scsi_controller, None);
+    for f in scsi_rows {
+        assert!(s.row_hidden(f), "{f:?} shown with no controller");
+    }
+    // Choosing one brings every row back...
+    s.cycle(F::ScsiController, true);
+    assert!(s.scsi_controller.is_some());
+    for f in scsi_rows {
+        assert!(!s.row_hidden(f), "{f:?} hidden with a controller fitted");
+    }
+    // ...and cycling back to None takes them away again.
+    s.cycle(F::ScsiController, false);
+    assert_eq!(s.scsi_controller, None);
+    for f in scsi_rows {
+        assert!(s.row_hidden(f), "{f:?} shown after the controller left");
+    }
+}
+
+#[test]
 fn floppy_rows_hidden_until_wired() {
     use LauncherField as F;
     let with_drives = |n: u8| {

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -3314,12 +3314,12 @@ fn sub_pages_of_hdd_cd() {
     assert_eq!(
         storage_nav,
         [
+            LauncherTab::Cd,
             LauncherTab::HostFs,
             LauncherTab::HostDisk,
+            LauncherTab::Lide,
             LauncherTab::BootPriority,
             LauncherTab::CreateFloppy,
-            LauncherTab::Cd,
-            LauncherTab::Lide,
         ]
     );
 

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -8008,14 +8008,7 @@ fn greyed_presentation(r: &launcher::Row, setup: &launcher::MachineSetup) -> Gre
         // has no drive-select line, but with no interface at all there is
         // nothing to say.
         F::BridgeCable if setup.bridge_interface_selected() => GreyedAs::DimmedValue,
-        F::ScsiUnit0
-        | F::ScsiUnit1
-        | F::ScsiUnit2
-        | F::ScsiUnit3
-        | F::ScsiUnit4
-        | F::ScsiUnit5
-        | F::ScsiUnit6
-        | F::BridgeDevice
+        F::BridgeDevice
         | F::BridgePort
         | F::BridgeCable
         | F::BridgeDensity

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -5867,8 +5867,8 @@ fn launcher_path_buttons(setup: &launcher::MachineSetup, field: LauncherField) -
 /// tells you where everything is would be the wrong thing to play down.
 fn launcher_path_inherits(setup: &launcher::MachineSetup, field: LauncherField) -> bool {
     // The soundfont row reads the same way: unset means the bundled
-    // bank, centred and dimmed as a default rather than left-aligned
-    // as if it were a chosen path.
+    // bank, dimmed as Copperline's answer and reading from the left
+    // like the bundled ROM defaults do.
     #[cfg(feature = "coppersynth")]
     if field == LauncherField::CsynthSoundfont {
         return setup.path(field).is_none();

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -8717,23 +8717,24 @@ fn draw_launcher_row(
             let inherits = launcher_path_inherits(setup, r.field);
             let (value_color, text_x) = if inherits {
                 let text_w = text.chars().count() * font::GLYPH_W;
-                // The bundled-ROM defaults read from the left like a
-                // chosen path would, just dimmed; the SoundFont default
-                // sits in line with the cycle value column, centred
-                // under the arrows of the rows around it; the Paths
-                // page's inherited rows keep their centred `(default)`.
-                if matches!(r.field, LauncherField::Rom | LauncherField::ScsiRom) {
+                // The bundled defaults -- the ROMs' and the SoundFont's --
+                // read from the left like a chosen path would, just dimmed;
+                // the Paths page's inherited rows keep their centred
+                // `(default)`.
+                let reads_left = matches!(r.field, LauncherField::Rom | LauncherField::ScsiRom)
+                    || {
+                        #[cfg(feature = "coppersynth")]
+                        {
+                            r.field == LauncherField::CsynthSoundfont
+                        }
+                        #[cfg(not(feature = "coppersynth"))]
+                        {
+                            false
+                        }
+                    };
+                if reads_left {
                     (PANEL_TEXT_DIM, value_x)
                 } else {
-                    #[cfg(feature = "coppersynth")]
-                    if r.field == LauncherField::CsynthSoundfont {
-                        let (_, value_box, _) = launcher_cycle_rects(rect, row_y);
-                        let x = value_box.x + value_box.w.saturating_sub(text_w) / 2;
-                        (PANEL_TEXT_DIM, x)
-                    } else {
-                        (PANEL_TEXT_DIM, value_x + avail.saturating_sub(text_w) / 2)
-                    }
-                    #[cfg(not(feature = "coppersynth"))]
                     (PANEL_TEXT_DIM, value_x + avail.saturating_sub(text_w) / 2)
                 }
             } else {


### PR DESCRIPTION
## The Storage page earns its quiet

Without a SCSI controller the ROM and unit rows go rather than stand greyed under a setting most machines leave at None; they return the moment one is chosen.

The sub-page links sort into what attaches and what acts: CD, Host Folder, Host Disk, Lide on the first row — the hardware — and Boot Priority, Create Image... on the second.

Greyed reasons drew one arrow-width in from where every value starts, which offset the whole column under the SCSI controller's stepper. A reason now starts at the control column's left edge, on every page. The IDE bays' reason reads "needs A600/A1200/A4000 or Lide".

I/O Ports (Coppersynth):
The SoundFont's bundled default reads from the left like the ROM defaults do, instead of centring under the steppers.