### PR TITLE
Feature/serial addr split

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -768,7 +768,7 @@ floppy_sounds_volume = 100
 #             Either may instead be "mt32", the emulated MT-32 built in
 #             rather than anything on the host - see docs/guide/mt32.md.
 #   "tcp"     serial in/out is bridged to a host TCP port, like UAE's "TCP:"
-#             device. listen sets the bind address (default 127.0.0.1:9000);
+#             device. listen sets the bind address (default 127.0.0.1:1234);
 #             connect with e.g. `nc`, `socat`, or a raw-mode telnet client.
 #   "tcp-connect"
 #             the outbound counterpart of "tcp": dial the remote named by
@@ -803,7 +803,7 @@ floppy_sounds_volume = 100
 # connect = "bbs.example.com:1337"
 # midi_out = "USB MIDI Interface"
 # midi_in = "USB MIDI Interface"
-# listen = "127.0.0.1:9000"
+# listen = "127.0.0.1:1234"
 #
 # Modem mode's own keys (see "modem" above).
 # telnet = false                     # AT*T1 telnet translation at power-on

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -768,7 +768,7 @@ floppy_sounds_volume = 100
 #             Either may instead be "mt32", the emulated MT-32 built in
 #             rather than anything on the host - see docs/guide/mt32.md.
 #   "tcp"     serial in/out is bridged to a host TCP port, like UAE's "TCP:"
-#             device. listen sets the bind address (default 127.0.0.1:1234);
+#             device. listen sets the bind address (default 127.0.0.1:9000);
 #             connect with e.g. `nc`, `socat`, or a raw-mode telnet client.
 #   "tcp-connect"
 #             the outbound counterpart of "tcp": dial the remote named by
@@ -803,7 +803,7 @@ floppy_sounds_volume = 100
 # connect = "bbs.example.com:1337"
 # midi_out = "USB MIDI Interface"
 # midi_in = "USB MIDI Interface"
-# listen = "127.0.0.1:1234"
+# listen = "127.0.0.1:9000"
 #
 # Modem mode's own keys (see "modem" above).
 # telnet = false                     # AT*T1 telnet translation at power-on

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1232,7 +1232,7 @@ button.
 mode = "stdout"          # off, stdout, midi, tcp, tcp-connect, pty, or modem
 # midi_out = "FluidSynth"  # midi mode: host destination, "mt32", or "coppersynth"
 # midi_in = "Keystation"   # midi mode: host source, or "mt32"
-# listen = "127.0.0.1:9000"  # tcp mode: bind address; modem mode: incoming-call address
+# listen = "127.0.0.1:1234"  # tcp mode: bind address; modem mode: incoming-call address
 # connect = "bbs.example.com:1337"  # tcp-connect mode: remote to dial
 # telnet = false           # modem mode: AT*T1 telnet NVT translation, on by default
 # session = "bbs-demo.session"  # modem mode: replay a scripted session instead of TCP
@@ -1255,7 +1255,7 @@ Paula's serial in/out is connected:
   ROMs at all and brings its own `coppersynth_*` keys with it; see
   [the Coppersynth chapter](coppersynth.md).
 - `tcp` -- serial in/out is bridged to a host TCP port, like UAE's `TCP:`
-  device. `listen` sets the bind address (default `127.0.0.1:9000`);
+  device. `listen` sets the bind address (default `127.0.0.1:1234`);
   connect with e.g. `nc`, `socat`, or a raw-mode telnet client.
 - `tcp-connect` -- the outbound counterpart of `tcp`: at startup the
   serial port dials the remote named by `connect` (required, `host:port`)
@@ -1344,7 +1344,7 @@ session (and implies `mode = "modem"`), and `--midi-out NAME`/
 of this interactively: **Device / Mode** picks the mode, and the mode brings
 its own address box with it -- **Connect** under `tcp-connect` for the
 remote to dial, **Listen** under `tcp` for the local bind address (it shows
-the `127.0.0.1:9000` default until something else is typed). Either box
+the `127.0.0.1:1234` default until something else is typed). Either box
 takes a `host:port`, with an IPv6 literal in brackets
 (`[::1]:1337`); clearing it unsets the key. The in-window
 **MIDI In / MIDI Out** menu items select the MIDI endpoints. Under `modem`,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1232,7 +1232,7 @@ button.
 mode = "stdout"          # off, stdout, midi, tcp, tcp-connect, pty, or modem
 # midi_out = "FluidSynth"  # midi mode: host destination, "mt32", or "coppersynth"
 # midi_in = "Keystation"   # midi mode: host source, or "mt32"
-# listen = "127.0.0.1:1234"  # tcp mode: bind address; modem mode: incoming-call address
+# listen = "127.0.0.1:9000"  # tcp mode: bind address; modem mode: incoming-call address
 # connect = "bbs.example.com:1337"  # tcp-connect mode: remote to dial
 # telnet = false           # modem mode: AT*T1 telnet NVT translation, on by default
 # session = "bbs-demo.session"  # modem mode: replay a scripted session instead of TCP
@@ -1255,7 +1255,7 @@ Paula's serial in/out is connected:
   ROMs at all and brings its own `coppersynth_*` keys with it; see
   [the Coppersynth chapter](coppersynth.md).
 - `tcp` -- serial in/out is bridged to a host TCP port, like UAE's `TCP:`
-  device. `listen` sets the bind address (default `127.0.0.1:1234`);
+  device. `listen` sets the bind address (default `127.0.0.1:9000`);
   connect with e.g. `nc`, `socat`, or a raw-mode telnet client.
 - `tcp-connect` -- the outbound counterpart of `tcp`: at startup the
   serial port dials the remote named by `connect` (required, `host:port`)
@@ -1344,7 +1344,7 @@ session (and implies `mode = "modem"`), and `--midi-out NAME`/
 of this interactively: **Device / Mode** picks the mode, and the mode brings
 its own address box with it -- **Connect** under `tcp-connect` for the
 remote to dial, **Listen** under `tcp` for the local bind address (it shows
-the `127.0.0.1:1234` default until something else is typed). Either box
+the `127.0.0.1:9000` default until something else is typed). Either box
 takes a `host:port`, with an IPv6 literal in brackets
 (`[::1]:1337`); clearing it unsets the key. The in-window
 **MIDI In / MIDI Out** menu items select the MIDI endpoints. Under `modem`,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1342,11 +1342,12 @@ session (and implies `mode = "modem"`), and `--midi-out NAME`/
 `--midi-in NAME` imply `mode = "midi"`. The launcher's **I/O Ports** tab
 (Serial Port page) sets all
 of this interactively: **Device / Mode** picks the mode, and the mode brings
-its own address box with it -- **Connect** under `tcp-connect` for the
-remote to dial, **Listen** under `tcp` for the local bind address (it shows
-the `127.0.0.1:1234` default until something else is typed). Either box
-takes a `host:port`, with an IPv6 literal in brackets
-(`[::1]:1337`); clearing it unsets the key. The in-window
+its own address with it -- **Connect** under `tcp-connect` for the
+remote to dial, **Listen** under `tcp` for the local bind address -- as a
+pair of boxes, host and port. A box left empty shows its greyed default
+(host `127.0.0.1` on Listen, port `1234`) and an emptied box reverts to it;
+an IPv6 literal is typed bare or in brackets, and the saved key spells it
+bracketed (`[::1]:1337`). Emptying both boxes unsets the key. The in-window
 **MIDI In / MIDI Out** menu items select the MIDI endpoints. Under `modem`,
 the page shows the same **Listen** box (the incoming-call address above)
 plus a **Telnet** toggle for `telnet`; the phonebook has no row and stays

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -630,8 +630,8 @@ The layout is:
   **Listen** (`tcp`, `modem`) for the local bind address -- as a pair of
   boxes, host and port, each typed into by clicking it. A box left empty
   keeps its greyed default -- host `127.0.0.1` (Connect, with no host to
-  assume, prompts `Host/IP`), port `1234` -- and emptying one reverts it; the port takes 1-65535, and on macOS and Linux ports below
-  1025 need Copperline run as root; the
+  assume, prompts `Host/IP`), port `1234` -- and emptying one reverts it; the port takes 1-65535, and on macOS and Linux a Listen port below
+  1025 needs Copperline run as root (dialing out has no such bar); the
   parallel device -- None, Printer, or Sampler -- with, for the printer, its
   capture output file, or for the sampler, its host audio input and input gain;
   and the A2065 Ethernet and HostSocket bsdsocket.library boards, each --

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -629,8 +629,8 @@ The layout is:
   mode needs -- **Connect** (`tcp-connect`) for where to dial, or
   **Listen** (`tcp`, `modem`) for the local bind address -- as a pair of
   boxes, host and port, each typed into by clicking it. A box left empty
-  keeps its greyed default (`127.0.0.1`, port `1234`), and emptying one
-  reverts it; the port takes 1-65535, and on macOS and Linux ports below
+  keeps its greyed default -- host `127.0.0.1` (Connect, with no host to
+  assume, prompts `Host/IP`), port `1234` -- and emptying one reverts it; the port takes 1-65535, and on macOS and Linux ports below
   1025 need Copperline run as root; the
   parallel device -- None, Printer, or Sampler -- with, for the printer, its
   capture output file, or for the sampler, its host audio input and input gain;

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -625,10 +625,13 @@ The layout is:
   beneath its heading: serial mode and MIDI endpoints, with the emulated
   MT-32's ROM
   images, front panel and display style when it is the chosen output (see
-  [The MT-32](mt32.md)), and, for the two TCP modes, the address box that
-  mode needs -- **Connect** (`tcp-connect`) for the `host:port` to dial, or
-  **Listen** (`tcp`) for the local bind address, each typed into by clicking
-  it; the
+  [The MT-32](mt32.md)), and, for the TCP and modem modes, the address that
+  mode needs -- **Connect** (`tcp-connect`) for where to dial, or
+  **Listen** (`tcp`, `modem`) for the local bind address -- as a pair of
+  boxes, host and port, each typed into by clicking it. A box left empty
+  keeps its greyed default (`127.0.0.1`, port `9000`), and emptying one
+  reverts it; the port takes 1-65535, and on macOS and Linux ports below
+  1025 need Copperline run as root; the
   parallel device -- None, Printer, or Sampler -- with, for the printer, its
   capture output file, or for the sampler, its host audio input and input gain;
   and the A2065 Ethernet and HostSocket bsdsocket.library boards, each --

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -629,7 +629,7 @@ The layout is:
   mode needs -- **Connect** (`tcp-connect`) for where to dial, or
   **Listen** (`tcp`, `modem`) for the local bind address -- as a pair of
   boxes, host and port, each typed into by clicking it. A box left empty
-  keeps its greyed default (`127.0.0.1`, port `9000`), and emptying one
+  keeps its greyed default (`127.0.0.1`, port `1234`), and emptying one
   reverts it; the port takes 1-65535, and on macOS and Linux ports below
   1025 need Copperline run as root; the
   parallel device -- None, Printer, or Sampler -- with, for the printer, its

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -920,13 +920,13 @@ pub struct SerialConfig {
 /// Where [`SerialMode::Tcp`] listens with no `[serial] listen` of its own:
 /// the loopback interface on the port UAE's `TCP:` serial device uses, so a
 /// terminal pointed at either lands in the same place.
-pub const SERIAL_TCP_DEFAULT_LISTEN: &str = "127.0.0.1:9000";
+pub const SERIAL_TCP_DEFAULT_LISTEN: &str = "127.0.0.1:1234";
 
 /// The host half a serial address defaults to when only a port is typed.
 pub const SERIAL_DEFAULT_HOST: &str = "127.0.0.1";
 /// The port half a serial address defaults to when only a host is typed --
 /// also the port of [`SERIAL_TCP_DEFAULT_LISTEN`].
-pub const SERIAL_DEFAULT_PORT: u16 = 9000;
+pub const SERIAL_DEFAULT_PORT: u16 = 1234;
 
 /// How the MT-32's front-panel display is lit.
 ///

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -920,7 +920,13 @@ pub struct SerialConfig {
 /// Where [`SerialMode::Tcp`] listens with no `[serial] listen` of its own:
 /// the loopback interface on the port UAE's `TCP:` serial device uses, so a
 /// terminal pointed at either lands in the same place.
-pub const SERIAL_TCP_DEFAULT_LISTEN: &str = "127.0.0.1:1234";
+pub const SERIAL_TCP_DEFAULT_LISTEN: &str = "127.0.0.1:9000";
+
+/// The host half a serial address defaults to when only a port is typed.
+pub const SERIAL_DEFAULT_HOST: &str = "127.0.0.1";
+/// The port half a serial address defaults to when only a host is typed --
+/// also the port of [`SERIAL_TCP_DEFAULT_LISTEN`].
+pub const SERIAL_DEFAULT_PORT: u16 = 9000;
 
 /// How the MT-32's front-panel display is lit.
 ///

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -6469,8 +6469,15 @@ fn join_host_port(host: Option<&str>, port: Option<u16>) -> Option<String> {
 }
 
 /// The address a run can use: the absent halves filled with their defaults.
+/// Only the spellings this launcher itself stores are completed; an address
+/// the split cannot rebuild -- a hand-written `host:notaport`, an
+/// unbracketed IPv6 literal -- passes through untouched, so it still fails
+/// loudly at Run instead of silently binding a port the config never named.
 fn complete_host_port(addr: &str) -> String {
     let (host, port) = split_host_port(addr);
+    if join_host_port(host.as_deref(), port).as_deref() != Some(addr) {
+        return addr.to_string();
+    }
     let host = host.unwrap_or_else(|| crate::config::SERIAL_DEFAULT_HOST.to_string());
     let port = port.unwrap_or(crate::config::SERIAL_DEFAULT_PORT);
     format!("{}:{port}", bracket_host(&host))
@@ -6478,7 +6485,7 @@ fn complete_host_port(addr: &str) -> String {
 
 /// Whether this process may bind the privileged ports. Only asked on the
 /// hosts that restrict them.
-#[cfg(unix)]
+#[cfg(all(unix, feature = "midi"))]
 fn can_bind_low_ports() -> bool {
     // SAFETY: geteuid takes nothing, returns the effective uid, cannot fail.
     unsafe { libc::geteuid() == 0 }
@@ -8477,7 +8484,34 @@ impl LauncherState {
                 // An emptied box means "unset": the half reverts to its
                 // greyed default. Brackets around an IPv6 literal are the
                 // stored spelling's business, not the typist's.
-                let typed = self.edit_buffer.trim();
+                let typed = self.edit_buffer.trim().to_string();
+                let typed = typed.as_str();
+                // The old single box took host:port, and fingers remember.
+                // A lone trailing :digits on a colon-free head is that
+                // habit, not an IPv6 literal, so the halves go where they
+                // belong -- through the port's own checks.
+                if let Some((head, tail)) = typed.rsplit_once(':') {
+                    if !head.is_empty()
+                        && !head.contains(':')
+                        && !tail.is_empty()
+                        && tail.chars().all(|c| c.is_ascii_digit())
+                    {
+                        let Some(port) = self.checked_port(field, tail) else {
+                            return;
+                        };
+                        #[cfg(feature = "midi")]
+                        self.setup.set_serial_addr_part(
+                            field,
+                            Some(Some(head.to_string())),
+                            Some(Some(port)),
+                        );
+                        #[cfg(not(feature = "midi"))]
+                        let _ = (field, port);
+                        self.editing = None;
+                        self.edit_buffer.clear();
+                        return;
+                    }
+                }
                 let host = (!typed.is_empty()).then(|| {
                     typed
                         .strip_prefix('[')
@@ -8498,28 +8532,15 @@ impl LauncherState {
                 // to be a port this run can actually take, or it keeps the
                 // focus where the mistake is -- the mode is bound to fail at
                 // Run otherwise.
-                let typed = self.edit_buffer.trim();
+                let typed = self.edit_buffer.trim().to_string();
+                let typed = typed.as_str();
                 let port = if typed.is_empty() {
                     None
                 } else {
-                    match typed.parse::<u32>() {
-                        Ok(p @ 1..=65535) => {
-                            #[cfg(unix)]
-                            if p < 1025 && !can_bind_low_ports() {
-                                self.status = Some(StatusMessage::err(format!(
-                                    "port {p} needs root: run with sudo, or use 1025-65535"
-                                )));
-                                return;
-                            }
-                            Some(p as u16)
-                        }
-                        _ => {
-                            self.status = Some(StatusMessage::err(format!(
-                                "\"{typed}\" is not a port number (1-65535)"
-                            )));
-                            return;
-                        }
-                    }
+                    let Some(p) = self.checked_port(field, typed) else {
+                        return;
+                    };
+                    Some(p)
                 };
                 #[cfg(feature = "midi")]
                 self.setup.set_serial_addr_part(field, None, Some(port));
@@ -8556,6 +8577,33 @@ impl LauncherState {
             | EditTarget::SerialHost(_)
             | EditTarget::SerialPort(_)
             | EditTarget::RamPattern => {}
+        }
+    }
+
+    /// A typed port, checked: in range, and -- for the listen address,
+    /// the only one this process binds -- allowed to this process. A
+    /// dial-out port needs no privilege on any host, telnet's 23 included.
+    /// `None` sets the refusal message and keeps the focus.
+    fn checked_port(&mut self, field: LauncherField, typed: &str) -> Option<u16> {
+        match typed.parse::<u32>() {
+            Ok(p @ 1..=65535) => {
+                #[cfg(all(unix, feature = "midi"))]
+                if p < 1025 && field == LauncherField::SerialListen && !can_bind_low_ports() {
+                    self.status = Some(StatusMessage::err(format!(
+                        "port {p} needs root: run with sudo, or use 1025-65535"
+                    )));
+                    return None;
+                }
+                #[cfg(not(all(unix, feature = "midi")))]
+                let _ = field;
+                Some(p as u16)
+            }
+            _ => {
+                self.status = Some(StatusMessage::err(format!(
+                    "\"{typed}\" is not a port number (1-65535)"
+                )));
+                None
+            }
         }
     }
 

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -2689,6 +2689,30 @@ impl MachineSetup {
         }
     }
 
+    /// The halves of a serial address, either absent while untouched.
+    #[cfg(feature = "midi")]
+    pub fn serial_addr_parts(&self, field: LauncherField) -> (Option<String>, Option<u16>) {
+        self.serial_addr(field)
+            .map(split_host_port)
+            .unwrap_or((None, None))
+    }
+
+    /// Replace one half of a serial address, keeping the other. Emptying
+    /// both empties the whole (the key leaves a saved config); a half on
+    /// its own is completed with the defaults the run would use.
+    #[cfg(feature = "midi")]
+    pub fn set_serial_addr_part(
+        &mut self,
+        field: LauncherField,
+        host: Option<Option<String>>,
+        port: Option<Option<u16>>,
+    ) {
+        let (cur_host, cur_port) = self.serial_addr_parts(field);
+        let host = host.unwrap_or(cur_host);
+        let port = port.unwrap_or(cur_port);
+        self.set_serial_addr(field, join_host_port(host.as_deref(), port));
+    }
+
     /// Whether the selected Ethernet backend carries traffic on the host's
     /// schedule rather than the emulated clock, breaking byte-identical
     /// replay (the I/O Ports tab shows a warning). The loopback backend
@@ -3165,8 +3189,11 @@ impl MachineSetup {
         }
         raw.serial.midi_out = self.midi_out.clone();
         raw.serial.midi_in = self.midi_in.clone();
-        raw.serial.listen = self.serial_listen.clone();
-        raw.serial.connect = self.serial_connect.clone();
+        // A half-typed address leaves here whole: the config file and the
+        // run get the defaults filled in, while the session keeps only what
+        // was typed so emptying a box reverts it.
+        raw.serial.listen = self.serial_listen.as_deref().map(complete_host_port);
+        raw.serial.connect = self.serial_connect.as_deref().map(complete_host_port);
         // Compared against the resolved value, not the raw tri-state: the
         // toggle is a plain on/off, so "unset" and "explicitly off" look
         // the same to it and must not produce a spurious `telnet = false`
@@ -4393,14 +4420,16 @@ impl MachineSetup {
             #[cfg(feature = "midi")]
             F::SerialConnect => self
                 .serial_connect
-                .clone()
+                .as_deref()
+                .map(complete_host_port)
                 .unwrap_or_else(|| "(host:port)".to_string()),
             // The listen address does have a default, so an empty box shows
             // the address the run would actually bind.
             #[cfg(feature = "midi")]
             F::SerialListen => self
                 .serial_listen
-                .clone()
+                .as_deref()
+                .map(complete_host_port)
                 .unwrap_or_else(|| crate::config::SERIAL_TCP_DEFAULT_LISTEN.to_string()),
             #[cfg(feature = "midi")]
             F::MidiOut => {
@@ -6154,8 +6183,10 @@ pub enum EditTarget {
     DriveBootpri(LauncherField),
     /// A word typed on a Create Image page: a volume name or a device name.
     NewImageText(LauncherField),
-    /// A `host:port` typed into the Serial section's Connect or Listen box.
-    SerialAddr(LauncherField),
+    /// The host half of a Serial section address (Connect or Listen).
+    SerialHost(LauncherField),
+    /// The port half of a Serial section address: up to five digits.
+    SerialPort(LauncherField),
     /// The fixed 16-bit RAM power-on word on the Memory page.
     RamPattern,
 }
@@ -6379,10 +6410,11 @@ pub enum CaretMove {
     End,
 }
 
-/// The most an address box accepts: a DNS name is up to 253 characters
-/// (254 with a trailing root dot), and ":65535" is six more. Anything
-/// longer cannot be a host:port, so the box stops there.
-const SERIAL_ADDR_MAX: usize = 260;
+/// The most the host box accepts: a DNS name is up to 253 characters.
+/// Anything longer cannot be a host, so the box stops there.
+const SERIAL_HOST_MAX: usize = 253;
+/// The most the port box accepts: ports are five digits at the widest.
+const SERIAL_PORT_MAX: usize = 5;
 
 /// Why a typed serial address is not the `host:port` the TCP modes need,
 /// or `None` when it is one.
@@ -6391,23 +6423,65 @@ const SERIAL_ADDR_MAX: usize = 260;
 /// a host that is merely down should not stop the address being typed. What
 /// it does catch is the shape, so a missing or unreadable port is refused
 /// while the box still has the focus to fix it in.
-fn serial_addr_error(addr: &str) -> Option<String> {
-    let Some((host, port)) = addr.rsplit_once(':') else {
-        return Some(format!("\"{addr}\" has no port: type host:port"));
-    };
-    // An IPv6 literal is full of colons, so it is written in brackets and
-    // only the colon after the closing one separates the port.
-    let host = host
-        .strip_prefix('[')
-        .and_then(|h| h.strip_suffix(']'))
-        .unwrap_or(host);
-    if host.is_empty() {
-        return Some(format!("\"{addr}\" has no host: type host:port"));
+/// The two halves of a stored `host:port`, either absent. An IPv6 literal
+/// is stored in brackets so only the colon after the closing one separates
+/// the port; the brackets come off here and go back on in [`join_host_port`].
+fn split_host_port(addr: &str) -> (Option<String>, Option<u16>) {
+    if let Some(rest) = addr.strip_prefix('[') {
+        // A bracketed IPv6 literal, with a port after the bracket or not.
+        if let Some((host, tail)) = rest.split_once(']') {
+            let port = tail.strip_prefix(':').and_then(|p| p.parse().ok());
+            return ((!host.is_empty()).then(|| host.to_string()), port);
+        }
     }
-    if port.parse::<u16>().is_err() {
-        return Some(format!("\"{port}\" is not a port number (0-65535)"));
+    match addr.rsplit_once(':') {
+        Some((host, port)) => (
+            (!host.is_empty()).then(|| host.to_string()),
+            port.parse().ok(),
+        ),
+        None => ((!addr.is_empty()).then(|| addr.to_string()), None),
     }
-    None
+}
+
+/// A host in its stored spelling: brackets around anything a colon could
+/// be mistaken inside.
+fn bracket_host(host: &str) -> String {
+    if host.contains(':') {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    }
+}
+
+/// The typed halves, stored exactly as typed -- a host alone stands alone,
+/// a port alone keeps its leading colon -- so emptied halves revert and
+/// an untouched pair stays out of the config. The absent halves are only
+/// filled in (with [`crate::config::SERIAL_DEFAULT_HOST`] /
+/// [`crate::config::SERIAL_DEFAULT_PORT`]) by [`complete_host_port`], on
+/// the way to a saved config or a run.
+fn join_host_port(host: Option<&str>, port: Option<u16>) -> Option<String> {
+    match (host, port) {
+        (None, None) => None,
+        (Some(h), None) => Some(bracket_host(h)),
+        (None, Some(p)) => Some(format!(":{p}")),
+        (Some(h), Some(p)) => Some(format!("{}:{p}", bracket_host(h))),
+    }
+}
+
+/// The address a run can use: the absent halves filled with their defaults.
+fn complete_host_port(addr: &str) -> String {
+    let (host, port) = split_host_port(addr);
+    let host = host.unwrap_or_else(|| crate::config::SERIAL_DEFAULT_HOST.to_string());
+    let port = port.unwrap_or(crate::config::SERIAL_DEFAULT_PORT);
+    format!("{}:{port}", bracket_host(&host))
+}
+
+/// Whether this process may bind the privileged ports. Only asked on the
+/// hosts that restrict them.
+#[cfg(unix)]
+fn can_bind_low_ports() -> bool {
+    // SAFETY: geteuid takes nothing, returns the effective uid, cannot fail.
+    unsafe { libc::geteuid() == 0 }
 }
 
 /// The largest size the box accepts, in whichever unit is showing.
@@ -7648,7 +7722,11 @@ impl LauncherState {
     pub fn typing_in_value_box(&self, field: LauncherField) -> bool {
         matches!(
             self.editing,
-            Some(EditTarget::NewImageText(f) | EditTarget::SerialAddr(f)) if f == field
+            Some(
+                EditTarget::NewImageText(f)
+                | EditTarget::SerialHost(f)
+                | EditTarget::SerialPort(f)
+            ) if f == field
         ) || field == F::RamPattern && self.editing == Some(EditTarget::RamPattern)
     }
 
@@ -7949,20 +8027,31 @@ impl LauncherState {
         self.status = None;
     }
 
-    /// Focus a serial TCP address box, seeding the buffer with the address
-    /// it holds. An unset box starts empty rather than from what it shows:
-    /// the default listen address and the "(host:port)" prompt are both
-    /// placeholders, not values to be typed over.
-    pub fn begin_edit_serial_addr(&mut self, field: LauncherField) {
+    /// Focus half of a serial TCP address, seeding the buffer with the
+    /// value that half holds. An unset half starts empty rather than from
+    /// what it shows: the greyed prompts are placeholders, not values to
+    /// be typed over.
+    pub fn begin_edit_serial_addr(&mut self, field: LauncherField, port_half: bool) {
         if !Self::is_serial_addr(field) {
             return;
         }
         self.edit_buffer.clear();
         #[cfg(feature = "midi")]
-        if let Some(addr) = self.setup.serial_addr(field) {
-            self.edit_buffer.push_str(addr);
+        {
+            let (host, port) = self.setup.serial_addr_parts(field);
+            if port_half {
+                if let Some(p) = port {
+                    self.edit_buffer.push_str(&p.to_string());
+                }
+            } else if let Some(h) = host {
+                self.edit_buffer.push_str(&h);
+            }
         }
-        self.editing = Some(EditTarget::SerialAddr(field));
+        self.editing = Some(if port_half {
+            EditTarget::SerialPort(field)
+        } else {
+            EditTarget::SerialHost(field)
+        });
         self.edit_caret = Caret::end_of(&self.edit_buffer);
         self.status = None;
     }
@@ -8210,12 +8299,17 @@ impl LauncherState {
                 return;
             }
         }
-        // An address is a run of printable characters with no spaces in it:
-        // a name or a numeric literal, a colon, and a port. Brackets and
-        // colons are in there for IPv6, so nothing narrower than "graphic"
-        // would do.
-        if let EditTarget::SerialAddr(_) = target {
-            if !c.is_ascii_graphic() || self.edit_buffer.chars().count() >= SERIAL_ADDR_MAX {
+        // A host is a run of printable characters with no spaces in it: a
+        // name or a numeric literal. Colons are in there for a bare IPv6
+        // literal, so nothing narrower than "graphic" would do.
+        if let EditTarget::SerialHost(_) = target {
+            if !c.is_ascii_graphic() || self.edit_buffer.chars().count() >= SERIAL_HOST_MAX {
+                return;
+            }
+        }
+        // A port is digits, and no more of them than 65535 is wide.
+        if let EditTarget::SerialPort(_) = target {
+            if !c.is_ascii_digit() || self.edit_buffer.chars().count() >= SERIAL_PORT_MAX {
                 return;
             }
         }
@@ -8379,26 +8473,58 @@ impl LauncherState {
                 self.edit_buffer.clear();
                 return;
             }
-            EditTarget::SerialAddr(field) => {
-                // An emptied box means "unset": the dial-out address goes
-                // away, and the listen address returns to the default. A
-                // typed one has to be a host:port or it keeps the focus,
-                // the same as a rejected drive name -- the mode is bound to
-                // fail at Run otherwise, and this is where it can be fixed.
+            EditTarget::SerialHost(field) => {
+                // An emptied box means "unset": the half reverts to its
+                // greyed default. Brackets around an IPv6 literal are the
+                // stored spelling's business, not the typist's.
                 let typed = self.edit_buffer.trim();
-                let addr = if typed.is_empty() {
+                let host = (!typed.is_empty()).then(|| {
+                    typed
+                        .strip_prefix('[')
+                        .and_then(|h| h.strip_suffix(']'))
+                        .unwrap_or(typed)
+                        .to_string()
+                });
+                #[cfg(feature = "midi")]
+                self.setup.set_serial_addr_part(field, Some(host), None);
+                #[cfg(not(feature = "midi"))]
+                let _ = (field, host);
+                self.editing = None;
+                self.edit_buffer.clear();
+                return;
+            }
+            EditTarget::SerialPort(field) => {
+                // Emptied, the port reverts to its default. A typed one has
+                // to be a port this run can actually take, or it keeps the
+                // focus where the mistake is -- the mode is bound to fail at
+                // Run otherwise.
+                let typed = self.edit_buffer.trim();
+                let port = if typed.is_empty() {
                     None
                 } else {
-                    if let Some(err) = serial_addr_error(typed) {
-                        self.status = Some(StatusMessage::err(err));
-                        return;
+                    match typed.parse::<u32>() {
+                        Ok(p @ 1..=65535) => {
+                            #[cfg(unix)]
+                            if p < 1025 && !can_bind_low_ports() {
+                                self.status = Some(StatusMessage::err(format!(
+                                    "port {p} needs root: run with sudo, or use 1025-65535"
+                                )));
+                                return;
+                            }
+                            Some(p as u16)
+                        }
+                        _ => {
+                            self.status = Some(StatusMessage::err(format!(
+                                "\"{typed}\" is not a port number (1-65535)"
+                            )));
+                            return;
+                        }
                     }
-                    Some(typed.to_string())
                 };
                 #[cfg(feature = "midi")]
-                self.setup.set_serial_addr(field, addr);
+                self.setup.set_serial_addr_part(field, None, Some(port));
                 #[cfg(not(feature = "midi"))]
-                let _ = (field, addr);
+                let _ = (field, port);
                 self.editing = None;
                 self.edit_buffer.clear();
                 return;
@@ -8427,7 +8553,8 @@ impl LauncherState {
             // These commit above and return, so nothing is left to do here.
             EditTarget::DriveBootpri(_)
             | EditTarget::NewImageText(_)
-            | EditTarget::SerialAddr(_)
+            | EditTarget::SerialHost(_)
+            | EditTarget::SerialPort(_)
             | EditTarget::RamPattern => {}
         }
     }

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -3192,8 +3192,8 @@ impl MachineSetup {
         // A half-typed address leaves here whole: the config file and the
         // run get the defaults filled in, while the session keeps only what
         // was typed so emptying a box reverts it.
-        raw.serial.listen = self.serial_listen.as_deref().map(complete_host_port);
-        raw.serial.connect = self.serial_connect.as_deref().map(complete_host_port);
+        raw.serial.listen = self.serial_listen.as_deref().map(complete_listen);
+        raw.serial.connect = self.serial_connect.as_deref().map(complete_connect);
         // Compared against the resolved value, not the raw tri-state: the
         // toggle is a plain on/off, so "unset" and "explicitly off" look
         // the same to it and must not produce a spurious `telnet = false`
@@ -4421,7 +4421,7 @@ impl MachineSetup {
             F::SerialConnect => self
                 .serial_connect
                 .as_deref()
-                .map(complete_host_port)
+                .map(complete_connect)
                 .unwrap_or_else(|| "(host:port)".to_string()),
             // The listen address does have a default, so an empty box shows
             // the address the run would actually bind.
@@ -4429,7 +4429,7 @@ impl MachineSetup {
             F::SerialListen => self
                 .serial_listen
                 .as_deref()
-                .map(complete_host_port)
+                .map(complete_listen)
                 .unwrap_or_else(|| crate::config::SERIAL_TCP_DEFAULT_LISTEN.to_string()),
             #[cfg(feature = "midi")]
             F::MidiOut => {
@@ -6468,19 +6468,35 @@ fn join_host_port(host: Option<&str>, port: Option<u16>) -> Option<String> {
     }
 }
 
-/// The address a run can use: the absent halves filled with their defaults.
-/// Only the spellings this launcher itself stores are completed; an address
-/// the split cannot rebuild -- a hand-written `host:notaport`, an
-/// unbracketed IPv6 literal -- passes through untouched, so it still fails
-/// loudly at Run instead of silently binding a port the config never named.
-fn complete_host_port(addr: &str) -> String {
+/// The address a run can use: the absent halves filled with their
+/// defaults. `default_host` is the field's own -- loopback for the listen
+/// addresses, and `None` for Connect, which has no host to assume: a
+/// port-only Connect passes through partial and the run refuses it with
+/// its own "needs a remote address" explanation rather than dialing a
+/// host nobody named. An address the split cannot rebuild -- a
+/// hand-written `host:notaport`, an unbracketed IPv6 literal -- passes
+/// through untouched too, so it still fails loudly at Run instead of
+/// silently binding a port the config never named.
+fn complete_host_port(addr: &str, default_host: Option<&str>) -> String {
     let (host, port) = split_host_port(addr);
     if join_host_port(host.as_deref(), port).as_deref() != Some(addr) {
         return addr.to_string();
     }
-    let host = host.unwrap_or_else(|| crate::config::SERIAL_DEFAULT_HOST.to_string());
+    let Some(host) = host.or_else(|| default_host.map(str::to_string)) else {
+        return addr.to_string();
+    };
     let port = port.unwrap_or(crate::config::SERIAL_DEFAULT_PORT);
     format!("{}:{port}", bracket_host(&host))
+}
+
+/// [`complete_host_port`] with the listen addresses' loopback default.
+fn complete_listen(addr: &str) -> String {
+    complete_host_port(addr, Some(crate::config::SERIAL_DEFAULT_HOST))
+}
+
+/// [`complete_host_port`] for the dial-out address: no host is assumed.
+fn complete_connect(addr: &str) -> String {
+    complete_host_port(addr, None)
 }
 
 /// Whether this process may bind the privileged ports. Only asked on the
@@ -8587,12 +8603,15 @@ impl LauncherState {
     fn checked_port(&mut self, field: LauncherField, typed: &str) -> Option<u16> {
         match typed.parse::<u32>() {
             Ok(p @ 1..=65535) => {
+                // A warning, not a refusal: the effective uid is only a
+                // hint (Linux grants low ports via CAP_NET_BIND_SERVICE
+                // and ip_unprivileged_port_start too), so the bind at Run
+                // stays the authority and says so itself if it disagrees.
                 #[cfg(all(unix, feature = "midi"))]
                 if p < 1025 && field == LauncherField::SerialListen && !can_bind_low_ports() {
                     self.status = Some(StatusMessage::err(format!(
-                        "port {p} needs root: run with sudo, or use 1025-65535"
+                        "port {p} usually needs root on macOS/Linux; the run will say if it cannot bind"
                     )));
-                    return None;
                 }
                 #[cfg(not(all(unix, feature = "midi")))]
                 let _ = field;

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -2637,6 +2637,9 @@ fn a_dial_out_port_needs_no_privilege() {
     state.edit_commit();
     assert!(state.editing().is_none(), "port 23 dial-out was refused");
     assert_eq!(state.setup.serial_connect.as_deref(), Some(":23"));
+    // And no host is invented for it: the half-address reaches the config
+    // as typed, and the run explains what is missing.
+    assert_eq!(state.setup.to_raw().serial.connect.as_deref(), Some(":23"));
 }
 
 #[cfg(feature = "midi")]

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -2471,9 +2471,15 @@ fn modem_listen_round_trips_through_raw() {
 fn typing_a_serial_connect_address_sets_it_and_round_trips() {
     let mut state = LauncherState::new(MachineSetup::default());
     state.setup.serial_mode = SerialMode::TcpConnect;
-    state.begin_edit_serial_addr(LauncherField::SerialConnect);
+    state.begin_edit_serial_addr(LauncherField::SerialConnect, false);
     assert_eq!(state.edit_buffer(), "", "an unset box starts empty");
-    for c in "bbs.example.com:1337".chars() {
+    for c in "bbs.example.com".chars() {
+        state.edit_push(c);
+    }
+    state.edit_commit();
+    assert!(state.editing().is_none());
+    state.begin_edit_serial_addr(LauncherField::SerialConnect, true);
+    for c in "1337".chars() {
         state.edit_push(c);
     }
     state.edit_commit();
@@ -2487,41 +2493,102 @@ fn typing_a_serial_connect_address_sets_it_and_round_trips() {
     assert_eq!(raw.serial.mode.as_deref(), Some("tcp-connect"));
     assert_eq!(raw.serial.connect.as_deref(), Some("bbs.example.com:1337"));
 
-    // Re-opening the box starts from the address it holds, not from a
+    // Re-opening a box starts from the half it holds, not from a
     // placeholder, so an edit is a correction rather than a retype.
-    state.begin_edit_serial_addr(LauncherField::SerialConnect);
-    assert_eq!(state.edit_buffer(), "bbs.example.com:1337");
+    state.begin_edit_serial_addr(LauncherField::SerialConnect, false);
+    assert_eq!(state.edit_buffer(), "bbs.example.com");
+    state.edit_cancel();
+    state.begin_edit_serial_addr(LauncherField::SerialConnect, true);
+    assert_eq!(state.edit_buffer(), "1337");
     state.edit_cancel();
 }
 
 #[cfg(feature = "midi")]
 #[test]
-fn a_serial_address_without_a_port_keeps_the_focus() {
+fn half_a_serial_address_completes_with_the_defaults() {
     let mut state = LauncherState::new(MachineSetup::default());
-    for bad in ["bbs.example.com", "bbs.example.com:sixty", ":1337"] {
-        state.begin_edit_serial_addr(LauncherField::SerialConnect);
+    state.setup.serial_mode = SerialMode::Tcp;
+    // A host on its own takes the default port...
+    state.begin_edit_serial_addr(LauncherField::SerialListen, false);
+    for c in "0.0.0.0".chars() {
+        state.edit_push(c);
+    }
+    state.edit_commit();
+    // The session keeps only what was typed; the config a Save writes (and
+    // a Run uses) gets the default port filled in.
+    assert_eq!(state.setup.serial_listen.as_deref(), Some("0.0.0.0"));
+    assert_eq!(
+        state.setup.to_raw().serial.listen.as_deref(),
+        Some(&*format!("0.0.0.0:{}", crate::config::SERIAL_DEFAULT_PORT))
+    );
+    // ...and emptying the host leaves the port on the default host.
+    state.begin_edit_serial_addr(LauncherField::SerialListen, true);
+    for c in "2323".chars() {
+        state.edit_push(c);
+    }
+    state.edit_commit();
+    state.begin_edit_serial_addr(LauncherField::SerialListen, false);
+    for _ in 0..16 {
+        state.edit_backspace();
+    }
+    state.edit_commit();
+    assert_eq!(state.setup.serial_listen.as_deref(), Some(":2323"));
+    assert_eq!(
+        state.setup.to_raw().serial.listen.as_deref(),
+        Some(&*format!("{}:2323", crate::config::SERIAL_DEFAULT_HOST))
+    );
+}
+
+#[cfg(feature = "midi")]
+#[test]
+fn a_port_out_of_range_keeps_the_focus() {
+    let mut state = LauncherState::new(MachineSetup::default());
+    for bad in ["0", "65536", "99999"] {
+        state.begin_edit_serial_addr(LauncherField::SerialListen, true);
         for c in bad.chars() {
             state.edit_push(c);
         }
         state.edit_commit();
         assert_eq!(
             state.editing(),
-            Some(EditTarget::SerialAddr(LauncherField::SerialConnect)),
+            Some(EditTarget::SerialPort(LauncherField::SerialListen)),
             "{bad} was accepted"
         );
         assert!(state.status.is_some(), "{bad} was refused silently");
-        assert_eq!(state.setup.serial_connect, None);
+        assert_eq!(state.setup.serial_listen, None);
         state.edit_cancel();
     }
-    // A bracketed IPv6 literal is a host:port even though it is full of
-    // colons: only the one after the closing bracket separates the port.
-    state.begin_edit_serial_addr(LauncherField::SerialConnect);
-    for c in "[::1]:1337".chars() {
-        state.edit_push(c);
-    }
+    // Deleting the port is not an error: it reverts to the default.
+    state.begin_edit_serial_addr(LauncherField::SerialListen, true);
     state.edit_commit();
     assert!(state.editing().is_none());
-    assert_eq!(state.setup.serial_connect.as_deref(), Some("[::1]:1337"));
+}
+
+#[cfg(feature = "midi")]
+#[test]
+fn an_ipv6_host_keeps_its_brackets_in_the_stored_address() {
+    let mut state = LauncherState::new(MachineSetup::default());
+    // A bare IPv6 literal is full of colons, so the stored spelling wraps
+    // it in brackets; typed with brackets they come off and go back on.
+    for typed in ["::1", "[::1]"] {
+        state.begin_edit_serial_addr(LauncherField::SerialConnect, false);
+        for c in typed.chars() {
+            state.edit_push(c);
+        }
+        state.edit_commit();
+        assert!(state.editing().is_none());
+        state.begin_edit_serial_addr(LauncherField::SerialConnect, true);
+        for c in "1337".chars() {
+            state.edit_push(c);
+        }
+        state.edit_commit();
+        assert_eq!(state.setup.serial_connect.as_deref(), Some("[::1]:1337"));
+        // The host box re-opens on the bare literal.
+        state.begin_edit_serial_addr(LauncherField::SerialConnect, false);
+        assert_eq!(state.edit_buffer(), "::1");
+        state.edit_cancel();
+        state.setup.serial_connect = None;
+    }
 }
 
 #[cfg(feature = "midi")]
@@ -2538,7 +2605,12 @@ fn emptying_a_serial_address_box_unsets_it() {
         state.setup.value_label(LauncherField::SerialListen),
         "0.0.0.0:2323"
     );
-    state.begin_edit_serial_addr(LauncherField::SerialListen);
+    state.begin_edit_serial_addr(LauncherField::SerialListen, false);
+    for _ in 0..64 {
+        state.edit_backspace();
+    }
+    state.edit_commit();
+    state.begin_edit_serial_addr(LauncherField::SerialListen, true);
     for _ in 0..64 {
         state.edit_backspace();
     }
@@ -2553,19 +2625,26 @@ fn emptying_a_serial_address_box_unsets_it() {
 
 #[cfg(feature = "midi")]
 #[test]
-fn a_serial_address_box_takes_only_printable_characters() {
+fn the_serial_boxes_take_only_what_their_half_can_hold() {
     let mut state = LauncherState::new(MachineSetup::default());
-    state.begin_edit_serial_addr(LauncherField::SerialListen);
-    // A space is not part of an address, and neither is a control code.
-    for c in "127.0.0.1 :\t12\n34".chars() {
+    // A space is not part of a host, and neither is a control code.
+    state.begin_edit_serial_addr(LauncherField::SerialListen, false);
+    for c in "127. 0\t.0.1\n".chars() {
         state.edit_push(c);
     }
-    assert_eq!(state.edit_buffer(), "127.0.0.1:1234");
+    assert_eq!(state.edit_buffer(), "127.0.0.1");
     // And the box has an end: a stuck key cannot grow it without bound.
-    for _ in 0..SERIAL_ADDR_MAX * 2 {
+    for _ in 0..SERIAL_HOST_MAX * 2 {
         state.edit_push('9');
     }
-    assert_eq!(state.edit_buffer().chars().count(), SERIAL_ADDR_MAX);
+    assert_eq!(state.edit_buffer().chars().count(), SERIAL_HOST_MAX);
+    state.edit_cancel();
+    // The port box is digits only, and no wider than a port.
+    state.begin_edit_serial_addr(LauncherField::SerialListen, true);
+    for c in "6x5-5.3 599".chars() {
+        state.edit_push(c);
+    }
+    assert_eq!(state.edit_buffer(), "65535");
     state.edit_cancel();
 }
 

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -2625,6 +2625,64 @@ fn emptying_a_serial_address_box_unsets_it() {
 
 #[cfg(feature = "midi")]
 #[test]
+fn a_dial_out_port_needs_no_privilege() {
+    // Telnet's 23 is the canonical BBS port; dialing out binds nothing,
+    // so the low-port gate is the listen box's alone and the Connect box
+    // takes it whoever runs the process.
+    let mut state = LauncherState::new(MachineSetup::default());
+    state.begin_edit_serial_addr(LauncherField::SerialConnect, true);
+    for c in "23".chars() {
+        state.edit_push(c);
+    }
+    state.edit_commit();
+    assert!(state.editing().is_none(), "port 23 dial-out was refused");
+    assert_eq!(state.setup.serial_connect.as_deref(), Some(":23"));
+}
+
+#[cfg(feature = "midi")]
+#[test]
+fn old_style_host_port_typed_into_the_host_box_finds_both_halves() {
+    // The single box took host:port for years; fingers will keep typing
+    // it. A trailing :digits on a colon-free head routes each half where
+    // it belongs, while a bare IPv6 literal keeps its colons.
+    let mut state = LauncherState::new(MachineSetup::default());
+    state.begin_edit_serial_addr(LauncherField::SerialConnect, false);
+    for c in "bbs.example.com:2323".chars() {
+        state.edit_push(c);
+    }
+    state.edit_commit();
+    assert!(state.editing().is_none());
+    assert_eq!(
+        state.setup.serial_connect.as_deref(),
+        Some("bbs.example.com:2323")
+    );
+    state.begin_edit_serial_addr(LauncherField::SerialConnect, true);
+    assert_eq!(state.edit_buffer(), "2323");
+    state.edit_cancel();
+}
+
+#[cfg(feature = "midi")]
+#[test]
+fn an_address_the_launcher_did_not_write_passes_through_untouched() {
+    // A hand-written config can hold what the boxes would never store; the
+    // round trip must not quietly repair it into a bind the config never
+    // named -- the run fails loudly instead, as it always did.
+    for weird in ["localhost:telnet", "::1", "127.0.0.1:70000"] {
+        let state = LauncherState::new(MachineSetup {
+            serial_mode: SerialMode::Tcp,
+            serial_listen: Some(weird.into()),
+            ..Default::default()
+        });
+        assert_eq!(
+            state.setup.to_raw().serial.listen.as_deref(),
+            Some(weird),
+            "{weird} was rewritten"
+        );
+    }
+}
+
+#[cfg(feature = "midi")]
+#[test]
 fn the_serial_boxes_take_only_what_their_half_can_hold() {
     let mut state = LauncherState::new(MachineSetup::default());
     // A space is not part of a host, and neither is a control code.

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -816,7 +816,8 @@ pub enum UiControl {
     /// A free-text box on a Create Image page (a volume or device name).
     LauncherNewImageEdit(LauncherField),
     /// A serial TCP address box on the I/O Ports tab (Connect or Listen).
-    LauncherSerialAddrEdit(LauncherField),
+    LauncherSerialHostEdit(LauncherField),
+    LauncherSerialPortEdit(LauncherField),
     /// The fixed RAM power-on word on the Memory tab.
     LauncherRamPatternEdit,
     /// The Create button on a Create Image page.
@@ -4499,10 +4500,6 @@ const LAUNCH_PATH_VALUE_W: usize = 216;
 const LAUNCH_NAME_W: usize = 96;
 /// Width of the FFS/OFS toggle button on a drive row (just "FFS"/"OFS").
 const LAUNCH_FS_W: usize = 40;
-/// Width of the serial TCP address box. Far wider than a volume name's,
-/// because a host name and a port together are a long string and the port
-/// is at the far end of it -- the part a reader most needs to see.
-const LAUNCH_ADDR_W: usize = LAUNCH_PATH_VALUE_W;
 const LAUNCH_REMOVE_W: usize = 70;
 const LAUNCH_CONTROL_H: usize = 20;
 
@@ -4651,17 +4648,14 @@ fn launcher_nav_rows(slots: usize) -> usize {
 }
 
 /// A free-text value box: where a value would sit, at the width its content
-/// needs -- a volume or device name on a Create Image row, or the longer
-/// `host:port` of a serial address on the I/O Ports tab.
+/// needs -- a volume or device name on a Create Image row. (The serial
+/// addresses draw their own host/port pair: [`launcher_serial_addr_rects`].)
 fn launcher_text_rect(rect: Rect, row_y: usize, field: LauncherField) -> Rect {
+    let _ = field;
     Rect {
         x: launcher_pane_x(rect) + LAUNCH_LABEL_W,
         y: row_y + (LAUNCH_ROW_H - LAUNCH_CONTROL_H) / 2,
-        w: if LauncherState::is_serial_addr(field) {
-            LAUNCH_ADDR_W
-        } else {
-            LAUNCH_NAME_W
-        },
+        w: LAUNCH_NAME_W,
         h: LAUNCH_CONTROL_H,
     }
 }
@@ -4746,11 +4740,90 @@ fn indefinite_article(size: &str) -> &'static str {
 fn value_box_control(field: LauncherField) -> UiControl {
     if field == LauncherField::RamPattern {
         UiControl::LauncherRamPatternEdit
-    } else if LauncherState::is_serial_addr(field) {
-        UiControl::LauncherSerialAddrEdit(field)
     } else {
+        // The serial addresses draw their own pair of boxes and never come
+        // through here.
         UiControl::LauncherNewImageEdit(field)
     }
+}
+
+/// The two boxes of a serial address row -- `[host] : [port]` -- spanning
+/// exactly the run of the steppers above them: from the left edge of a `<`
+/// to the right edge of a `>`, so the pair reads as one column with them.
+fn launcher_serial_addr_rects(rect: Rect, row_y: usize) -> (Rect, Rect) {
+    let y = row_y + (LAUNCH_ROW_H - LAUNCH_CONTROL_H) / 2;
+    let x = launcher_control_x(rect);
+    let total = LAUNCH_ARROW_W + LAUNCH_VALUE_W + LAUNCH_ARROW_W;
+    // Five digits and their padding; the host takes what the colon leaves.
+    let port_w = SERIAL_PORT_DIGITS * font::GLYPH_W + 8;
+    let host = Rect {
+        x,
+        y,
+        w: total - port_w - font::GLYPH_W - 8,
+        h: LAUNCH_CONTROL_H,
+    };
+    let port = Rect {
+        x: x + total - port_w,
+        y,
+        w: port_w,
+        h: LAUNCH_CONTROL_H,
+    };
+    (host, port)
+}
+
+/// The widest port is five digits.
+const SERIAL_PORT_DIGITS: usize = 5;
+
+/// Draw one half of a serial address pair: an edit box that shows its
+/// greyed default while untouched.
+#[allow(clippy::too_many_arguments)]
+fn draw_serial_half_box(
+    frame: &mut [u8],
+    box_rect: Rect,
+    state: &LauncherState,
+    control: UiControl,
+    typing: bool,
+    value: Option<String>,
+    placeholder: &str,
+    scale: usize,
+) {
+    draw_rect_bevel(
+        frame,
+        scale_rect(box_rect, scale),
+        BUTTON_EDGE_DARK,
+        BUTTON_EDGE_LIGHT,
+        scale,
+    );
+    light_edit_box(frame, box_rect, control, typing, scale);
+    let avail = box_rect.w.saturating_sub(8);
+    if typing {
+        draw_edit_line(
+            frame,
+            box_rect.x + 4,
+            box_rect.y + 6,
+            state.edit_buffer(),
+            state.edit_caret().at(),
+            PANEL_TEXT_HILIGHT,
+            PANEL_BG,
+            avail,
+            scale,
+        );
+        return;
+    }
+    let (text, color) = match value {
+        Some(v) => (v, PANEL_TEXT),
+        None => (placeholder.to_string(), PANEL_TEXT_DIM),
+    };
+    let shown = truncate_to_width(&text, avail);
+    draw_panel_text(
+        frame,
+        box_rect.x + 4,
+        box_rect.y + 6,
+        &shown,
+        color,
+        1,
+        scale,
+    );
 }
 
 /// Light a text box the focus is standing on.
@@ -5615,7 +5688,8 @@ fn control_field(control: UiControl) -> Option<LauncherField> {
         | UiControl::LauncherDriveNameEdit(field)
         | UiControl::LauncherDriveFilesystemToggle(field)
         | UiControl::LauncherNewImageEdit(field)
-        | UiControl::LauncherSerialAddrEdit(field)
+        | UiControl::LauncherSerialHostEdit(field)
+        | UiControl::LauncherSerialPortEdit(field)
         | UiControl::LauncherNewImageCreate(field)
         | UiControl::LauncherDriveBootpriEdit(field)
         | UiControl::LauncherDriveBootToggle(field) => field,
@@ -6455,7 +6529,15 @@ fn launcher_control_at(rect: Rect, state: &LauncherState, pos: (i32, i32)) -> Op
                 // Non-interactive rows.
                 RowKind::SectionHeader | RowKind::BootpriHeader | RowKind::RomInfo => {}
                 RowKind::Text => {
-                    if launcher_text_rect(rect, row_y, r.field).contains(pos) {
+                    if LauncherState::is_serial_addr(r.field) {
+                        let (host_box, port_box) = launcher_serial_addr_rects(rect, row_y);
+                        if host_box.contains(pos) {
+                            return Some(UiControl::LauncherSerialHostEdit(r.field));
+                        }
+                        if port_box.contains(pos) {
+                            return Some(UiControl::LauncherSerialPortEdit(r.field));
+                        }
+                    } else if launcher_text_rect(rect, row_y, r.field).contains(pos) {
                         // The same widget serves two stores: a Create Image
                         // word, and a serial address on the machine.
                         return Some(value_box_control(r.field));
@@ -8160,15 +8242,56 @@ fn draw_launcher_row(
         // Drawn above with an early return.
         RowKind::SectionHeader | RowKind::BootpriHeader | RowKind::RomInfo => {}
         RowKind::Text => {
-            draw_launcher_value_box(
-                frame,
-                launcher_text_rect(rect, row_y, r.field),
-                state,
-                r.field,
-                disabled,
-                false,
-                scale,
-            );
+            if LauncherState::is_serial_addr(r.field) {
+                // `[host] : [port]`, each half its own box with its greyed
+                // default, the colon between them furniture.
+                let (host_box, port_box) = launcher_serial_addr_rects(rect, row_y);
+                #[cfg(feature = "midi")]
+                let (host, port) = state.setup.serial_addr_parts(r.field);
+                #[cfg(not(feature = "midi"))]
+                let (host, port): (Option<String>, Option<u16>) = (None, None);
+                draw_serial_half_box(
+                    frame,
+                    host_box,
+                    state,
+                    UiControl::LauncherSerialHostEdit(r.field),
+                    matches!(state.editing(),
+                        Some(launcher::EditTarget::SerialHost(f)) if f == r.field),
+                    host,
+                    "Host/IP",
+                    scale,
+                );
+                draw_panel_text(
+                    frame,
+                    host_box.x + host_box.w + 4,
+                    row_y + 8,
+                    ":",
+                    PANEL_TEXT_DIM,
+                    1,
+                    scale,
+                );
+                draw_serial_half_box(
+                    frame,
+                    port_box,
+                    state,
+                    UiControl::LauncherSerialPortEdit(r.field),
+                    matches!(state.editing(),
+                        Some(launcher::EditTarget::SerialPort(f)) if f == r.field),
+                    port.map(|p| p.to_string()),
+                    &crate::config::SERIAL_DEFAULT_PORT.to_string(),
+                    scale,
+                );
+            } else {
+                draw_launcher_value_box(
+                    frame,
+                    launcher_text_rect(rect, row_y, r.field),
+                    state,
+                    r.field,
+                    disabled,
+                    false,
+                    scale,
+                );
+            }
         }
         RowKind::Size => {
             // A number to type, with the unit written beside it. The unit

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -8250,6 +8250,14 @@ fn draw_launcher_row(
                 let (host, port) = state.setup.serial_addr_parts(r.field);
                 #[cfg(not(feature = "midi"))]
                 let (host, port): (Option<String>, Option<u16>) = (None, None);
+                // The listen box's default host is real -- the loopback
+                // the run would bind -- so it shows it. Dialing out has no
+                // sensible default host, so Connect keeps the prompt.
+                let host_hint = if r.field == LauncherField::SerialConnect {
+                    "Host/IP"
+                } else {
+                    crate::config::SERIAL_DEFAULT_HOST
+                };
                 draw_serial_half_box(
                     frame,
                     host_box,
@@ -8258,7 +8266,7 @@ fn draw_launcher_row(
                     matches!(state.editing(),
                         Some(launcher::EditTarget::SerialHost(f)) if f == r.field),
                     host,
-                    "Host/IP",
+                    host_hint,
                     scale,
                 );
                 draw_panel_text(

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -8252,12 +8252,17 @@ fn draw_launcher_row(
                 let (host, port): (Option<String>, Option<u16>) = (None, None);
                 // The listen box's default host is real -- the loopback
                 // the run would bind -- so it shows it. Dialing out has no
-                // sensible default host, so Connect keeps the prompt.
+                // sensible default host, so Connect keeps the prompt. (The
+                // fields only exist with `midi`; without it this whole arm
+                // is dead, `is_serial_addr` being always false.)
+                #[cfg(feature = "midi")]
                 let host_hint = if r.field == LauncherField::SerialConnect {
                     "Host/IP"
                 } else {
                     crate::config::SERIAL_DEFAULT_HOST
                 };
+                #[cfg(not(feature = "midi"))]
+                let host_hint = crate::config::SERIAL_DEFAULT_HOST;
                 draw_serial_half_box(
                     frame,
                     host_box,

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -4754,8 +4754,9 @@ fn launcher_serial_addr_rects(rect: Rect, row_y: usize) -> (Rect, Rect) {
     let y = row_y + (LAUNCH_ROW_H - LAUNCH_CONTROL_H) / 2;
     let x = launcher_control_x(rect);
     let total = LAUNCH_ARROW_W + LAUNCH_VALUE_W + LAUNCH_ARROW_W;
-    // Five digits and their padding; the host takes what the colon leaves.
-    let port_w = SERIAL_PORT_DIGITS * font::GLYPH_W + 8;
+    // Five digits, a cell for the caret while typing, and padding; the
+    // host takes what the colon leaves.
+    let port_w = (SERIAL_PORT_DIGITS + 1) * font::GLYPH_W + 8;
     let host = Rect {
         x,
         y,

--- a/src/video/ui/tests.rs
+++ b/src/video/ui/tests.rs
@@ -1013,13 +1013,24 @@ fn the_serial_address_box_hit_tests_to_its_own_edit() {
     // The serial page sits under the I/O Ports nav row, so its rows
     // start a nav block lower.
     let row_y = launcher_row_y(rect, index) + LAUNCH_NAV_BLOCK_H;
-    let box_rect = launcher_text_rect(rect, row_y, LauncherField::SerialConnect);
+    let (host_box, port_box) = launcher_serial_addr_rects(rect, row_y);
     assert_eq!(
-        ui.control_at((box_rect.x as i32 + 4, box_rect.y as i32 + 4)),
-        Some(UiControl::LauncherSerialAddrEdit(
+        ui.control_at((host_box.x as i32 + 4, host_box.y as i32 + 4)),
+        Some(UiControl::LauncherSerialHostEdit(
             LauncherField::SerialConnect
         ))
     );
+    assert_eq!(
+        ui.control_at((port_box.x as i32 + 4, port_box.y as i32 + 4)),
+        Some(UiControl::LauncherSerialPortEdit(
+            LauncherField::SerialConnect
+        ))
+    );
+    // The pair spans the steppers' run exactly: host starts at the left
+    // arrows' left edge, port ends at the right arrows' right edge.
+    let (prev, _, next) = launcher_cycle_rects(rect, row_y);
+    assert_eq!(host_box.x, prev.x);
+    assert_eq!(port_box.x + port_box.w, next.x + next.w);
 }
 
 #[test]
@@ -2662,7 +2673,7 @@ fn panels_render_into_their_rects() {
         while state.setup.serial_mode() != crate::config::SerialMode::TcpConnect {
             state.setup.cycle(LauncherField::SerialMode, true);
         }
-        state.begin_edit_serial_addr(LauncherField::SerialConnect);
+        state.begin_edit_serial_addr(LauncherField::SerialConnect, false);
         for c in "bbs.example.com:1337".chars() {
             state.edit_push(c);
         }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -5665,14 +5665,17 @@ impl App {
                     state.begin_edit_new_image(field);
                 }
             }
-            UiControl::LauncherSerialAddrEdit(field) => {
+            UiControl::LauncherSerialHostEdit(field) | UiControl::LauncherSerialPortEdit(field) => {
                 if let Some(state) = self.launcher_state_mut() {
                     // Reaching for the other address box ends the typing in
-                    // this one, the way Enter does; an address it refuses
+                    // this one, the way Enter does; a value it refuses
                     // keeps the focus where the mistake is.
                     state.edit_commit();
                     if state.editing().is_none() {
-                        state.begin_edit_serial_addr(field);
+                        state.begin_edit_serial_addr(
+                            field,
+                            matches!(control, UiControl::LauncherSerialPortEdit(_)),
+                        );
                     }
                 }
             }

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4697,16 +4697,14 @@ fn a_rejected_serial_address_blocks_the_control_it_interrupted() {
 
     let mut app = test_app();
     app.open_launcher();
-    // Dial the serial port out and type an address with no port in it.
+    // Dial the serial port out and type a port no run can take.
     match app.ui.panel.as_mut() {
         Some(Panel::Launcher(state)) => {
             while state.setup.serial_mode() != SerialMode::TcpConnect {
                 state.setup.cycle(LauncherField::SerialMode, true);
             }
-            state.begin_edit_serial_addr(LauncherField::SerialConnect);
-            for c in "no-port".chars() {
-                state.edit_push(c);
-            }
+            state.begin_edit_serial_addr(LauncherField::SerialConnect, true);
+            state.edit_push('0');
         }
         _ => panic!("launcher did not open"),
     }
@@ -4720,7 +4718,7 @@ fn a_rejected_serial_address_blocks_the_control_it_interrupted() {
             assert_eq!(state.setup.serial_mode(), SerialMode::TcpConnect);
             assert_eq!(
                 state.editing(),
-                Some(EditTarget::SerialAddr(LauncherField::SerialConnect))
+                Some(EditTarget::SerialPort(LauncherField::SerialConnect))
             );
             assert!(state.status.is_some(), "the rejection is explained");
         }


### PR DESCRIPTION
## A serial address is two boxes

TCP, TCP connect and Modem each took a host:port in one free-text box, validated only on commit and shaped differently from everything around it. It is a pair now — host and port, spanning exactly the run of the steppers above, each showing its greyed default until typed into and reverting to it when emptied. Listen boxes (TCP, Modem) show the `127.0.0.1` they would bind; Connect prompts `Host/IP`, there being no host to assume; the port shows `1234`.

The host takes up to 253 characters (a DNS name's limit); the port takes digits alone, 1 through 65535. On macOS and Linux a port below 1025 is refused with a note that it needs root, unless the process already has it. IPv6 literals can be typed bare or bracketed; the stored spelling brackets them.

The session keeps exactly the typed halves, so emptying a box reverts just that half; saved configs and runs get the defaults filled in.

