### PR TITLE
video: own scaler pass, uncapped integer scaling, display-window autocrop

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -589,8 +589,8 @@ video = "PAL"
 # hardware programs (default false), so a game using fewer lines than the
 # full scan fills more of a 16:9/21:9 screen; with integer scaling the
 # whole-number fit is retaken against the crop. Window-only (captures
-# keep their aperture); suspended under a bezel/CRT preset, for RTG
-# scanout and programmable scans, and while a menu is open.
+# keep their aperture); composes with the CRT shader presets, and is
+# suspended under a bezel, for RTG scanout and for programmable scans.
 # deinterlace: motion-adaptive weaving of interlaced displays (default
 # true); false line-doubles every field, showing interlace bob/flicker like
 # a bare TV.

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -585,6 +585,12 @@ video = "PAL"
 # at multiples of their own native resolution, and falls back to the smooth
 # fit when the window is too small for even 1x rather than cropping.
 # Pair it with pixel_aspect = "square" for a fully pixel-exact picture.
+# autocrop: crop the window presentation to the display window the
+# hardware programs (default false), so a game using fewer lines than the
+# full scan fills more of a 16:9/21:9 screen; with integer scaling the
+# whole-number fit is retaken against the crop. Window-only (captures
+# keep their aperture); suspended under a bezel/CRT preset, for RTG
+# scanout and programmable scans, and while a menu is open.
 # deinterlace: motion-adaptive weaving of interlaced displays (default
 # true); false line-doubles every field, showing interlace bob/flicker like
 # a bare TV.
@@ -630,6 +636,7 @@ video = "PAL"
 # tv_v_centre = 0
 # pixel_aspect = "tv"
 # scaling = "smooth"
+# autocrop = false
 # deinterlace = true
 # phosphor = 0.4
 # shader = "none"

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -727,14 +727,16 @@ and a window left open around a shorter picture, as Kickstart's
 It grows instantly when a program opens a larger display, and tightens
 only after a smaller one has held steady for about half a second, so
 screen transitions do not pump the zoom.
-The status bar and any instrument panels keep their size in a band along
-the window bottom. A window-presentation setting only: screenshots,
-frame dumps and recordings always keep their configured aperture.
-Automatically suspended where it cannot apply -- while a menu or panel
-is open, under a monitor bezel or CRT preset (the tube look frames the
-whole glass), for RTG board scanout, and for programmable multisync
-scans. The menu's *Video Settings > Autocrop* toggle flips it live
-without touching the config.
+The status bar and any instrument panels keep their size in a band
+pinned along the window bottom; opening a menu or panel widens the
+picture to the full display area while it is up (so nothing of the
+overlay is cropped away) and the band stays put. A
+window-presentation setting only: screenshots, frame dumps and
+recordings always keep their configured aperture. Automatically
+suspended where it cannot apply -- under a monitor bezel or CRT preset
+(the tube look frames the whole glass), for RTG board scanout, and for
+programmable multisync scans. The menu's *Video Settings > Autocrop*
+toggle flips it live without touching the config.
 
 `deinterlace` controls how interlaced (LACE) displays are presented. On
 (the default), a motion-adaptive deinterlacer weaves the two fields into a

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -719,11 +719,14 @@ the 570 woven lines), and cropping the unused border lets the picture
 fill far more of a 16:9 or 21:9 screen -- with `scaling = "integer"` the
 whole-number fit is retaken against the cropped picture, so a 200-line
 game often earns a full multiple more than the uncropped canvas would.
-The crop is derived every frame from the programmed display window (the
-same per-line model the renderer paints with, so mid-frame rewrites and
-DIW tricks are already folded in), grows instantly when a program opens
-a larger display, and tightens only after a smaller one has held steady
-for about half a second, so screen transitions do not pump the zoom.
+The crop is derived every frame from the display-window rows that carry
+fetched bitplane data (the same per-line model the renderer paints
+with, so mid-frame rewrites and DIW tricks are already folded in --
+and a window left open around a shorter picture, as Kickstart's
+256-line default routinely is, crops to the picture, not the window).
+It grows instantly when a program opens a larger display, and tightens
+only after a smaller one has held steady for about half a second, so
+screen transitions do not pump the zoom.
 The status bar and any instrument panels keep their size in a band along
 the window bottom. A window-presentation setting only: screenshots,
 frame dumps and recordings always keep their configured aperture.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -732,11 +732,13 @@ pinned along the window bottom; opening a menu or panel widens the
 picture to the full display area while it is up (so nothing of the
 overlay is cropped away) and the band stays put. A
 window-presentation setting only: screenshots, frame dumps and
-recordings always keep their configured aperture. Automatically
-suspended where it cannot apply -- under a monitor bezel or CRT preset
-(the tube look frames the whole glass), for RTG board scanout, and for
-programmable multisync scans. The menu's *Video Settings > Autocrop*
-toggle flips it live without touching the config.
+recordings always keep their configured aperture. The CRT shader
+presets compose with it (the scanlines, mask or tube face are drawn
+over the cropped picture). Automatically suspended where it cannot
+apply -- under a monitor bezel (whose fixed opening frames the whole
+glass), for RTG board scanout, and for programmable multisync scans.
+The menu's *Video Settings > Autocrop* toggle flips it live without
+touching the config.
 
 `deinterlace` controls how interlaced (LACE) displays are presented. On
 (the default), a motion-adaptive deinterlacer weaves the two fields into a

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -688,14 +688,16 @@ The fit is taken in whole canvas pixels against the physical surface --
 the canvas is re-rendered at whatever factor fits, rather than drawn at
 whole multiples of a fixed high-DPI texture -- so every step exists on
 every display: a 2x-DPI laptop whose screen holds three physical pixels
-per canvas pixel but not four gets the 3x picture, and fractional desktop
-scales such as 150% take their whole physical multiples the same way. The
-status bar and menus are rendered at the fitted factor too, so they stay
-sharp at any step (the factor is capped at 4x; larger fits continue as
-whole multiples of the 4x canvas). Only when the window is too small for
-even a 1:1 copy -- smaller than the canvas itself in physical pixels --
-does the picture fall back to the smooth fit rather than cropping to what
-fits. RTG board modes follow the setting too: their frame is scaled
+per canvas pixel but not four gets the 3x picture, fractional desktop
+scales such as 150% take their whole physical multiples the same way,
+and a 5K or 6K display in fullscreen fills as much of its height as the
+next whole multiple allows (the internal render factor is capped at 4x,
+but the displayed multiple is not -- the display's pixels stay exact
+whole blocks past the cap; only the status bar and menus, drawn at the
+capped factor, are resampled there). Only when the window is too small
+for even a 1:1 copy -- smaller than the canvas itself in physical pixels
+-- does the picture fall back to the smooth fit rather than cropping to
+what fits. RTG board modes follow the setting too: their frame is scaled
 from its own native resolution, so a 640x480 board screen is drawn at 1x,
 2x, 3x of *those* pixels inside the display area.
 
@@ -709,6 +711,27 @@ onto 537 rows for the 4:3 shape before presentation. The monitor-bezel mode
 the window by design and is not itself integer-exact. The menu's *Video
 Settings > Scaling* item switches modes live without touching the config;
 there is no environment-variable override.
+
+`autocrop` (default off) crops the window presentation to the display
+window the hardware actually programs, instead of the fixed TV aperture:
+most games drive well under the full scan (a 320x200 display uses 400 of
+the 570 woven lines), and cropping the unused border lets the picture
+fill far more of a 16:9 or 21:9 screen -- with `scaling = "integer"` the
+whole-number fit is retaken against the cropped picture, so a 200-line
+game often earns a full multiple more than the uncropped canvas would.
+The crop is derived every frame from the programmed display window (the
+same per-line model the renderer paints with, so mid-frame rewrites and
+DIW tricks are already folded in), grows instantly when a program opens
+a larger display, and tightens only after a smaller one has held steady
+for about half a second, so screen transitions do not pump the zoom.
+The status bar and any instrument panels keep their size in a band along
+the window bottom. A window-presentation setting only: screenshots,
+frame dumps and recordings always keep their configured aperture.
+Automatically suspended where it cannot apply -- while a menu or panel
+is open, under a monitor bezel or CRT preset (the tube look frames the
+whole glass), for RTG board scanout, and for programmable multisync
+scans. The menu's *Video Settings > Autocrop* toggle flips it live
+without touching the config.
 
 `deinterlace` controls how interlaced (LACE) displays are presented. On
 (the default), a motion-adaptive deinterlacer weaves the two fields into a

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -354,14 +354,16 @@ belongs to the Amiga.
   underneath. The start-up mode is
   `[display] scaling`, which also notes which pixel-aspect pairing is
   fully pixel-exact (see [Configuration](configuration.md)).
-- **Autocrop**: crop the presentation to the display window the hardware
-  programs, so a game driving fewer lines than the full scan fills more
+- **Autocrop**: crop the presentation to the picture the hardware
+  fetches, so a game driving fewer lines than the full scan fills more
   of a wide screen; with integer scaling the whole-number fit is retaken
   against the crop. The status bar and panels keep their size in a band
-  along the window bottom. Presentation-only (captures keep their
-  aperture), and suspended while a menu or panel is open, under a bezel
-  or CRT preset, and for RTG or programmable scans. The start-up value
-  is `[display] autocrop` (see [Configuration](configuration.md)).
+  pinned along the window bottom; an open menu or panel widens the
+  picture to the full display area while it is up, and the band stays
+  put. Presentation-only (captures keep their aperture), and suspended
+  under a bezel or CRT preset and for RTG or programmable scans. The
+  start-up value is `[display] autocrop`
+  (see [Configuration](configuration.md)).
 - **Screen Centring**: nudge where the TV picture sits on the glass, the
   H-CENTER/V-CENTER controls a real monitor carried on its front.
   **Picture Left/Right** step one lo-res pixel (up to 16 each way),

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -360,10 +360,10 @@ belongs to the Amiga.
   against the crop. The status bar and panels keep their size in a band
   pinned along the window bottom; an open menu or panel widens the
   picture to the full display area while it is up, and the band stays
-  put. Presentation-only (captures keep their aperture), and suspended
-  under a bezel or CRT preset and for RTG or programmable scans. The
-  start-up value is `[display] autocrop`
-  (see [Configuration](configuration.md)).
+  put. Presentation-only (captures keep their aperture); the CRT
+  shader presets compose with it, while a bezel, RTG scanout and
+  programmable scans suspend it. The start-up value is
+  `[display] autocrop` (see [Configuration](configuration.md)).
 - **Screen Centring**: nudge where the TV picture sits on the glass, the
   H-CENTER/V-CENTER controls a real monitor carried on its front.
   **Picture Left/Right** step one lo-res pixel (up to 16 each way),

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -354,6 +354,14 @@ belongs to the Amiga.
   underneath. The start-up mode is
   `[display] scaling`, which also notes which pixel-aspect pairing is
   fully pixel-exact (see [Configuration](configuration.md)).
+- **Autocrop**: crop the presentation to the display window the hardware
+  programs, so a game driving fewer lines than the full scan fills more
+  of a wide screen; with integer scaling the whole-number fit is retaken
+  against the crop. The status bar and panels keep their size in a band
+  along the window bottom. Presentation-only (captures keep their
+  aperture), and suspended while a menu or panel is open, under a bezel
+  or CRT preset, and for RTG or programmable scans. The start-up value
+  is `[display] autocrop` (see [Configuration](configuration.md)).
 - **Screen Centring**: nudge where the TV picture sits on the glass, the
   H-CENTER/V-CENTER controls a real monitor carried on its front.
   **Picture Left/Right** step one lo-res pixel (up to 16 each way),

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -602,9 +602,14 @@ classic letterbox gives it, so the band never eats what the crop gains. `Autocro
 immediately, border-only frames hold the previous crop (like the aperture
 latch), and a strictly smaller envelope is adopted only after holding
 steady for its stability window, so screen transitions do not pump the
-zoom. The crop suspends itself whenever another pass owns the display
-rect (open overlays, the bezel and CRT presets, RTG scanout) and for
-programmable scans; captures never see it.
+zoom. While the mode is on, the layout never snaps back to the classic
+letterbox: an open menu or panel (which draws into the display region
+against the full canvas mapping) widens the display quad to the whole
+region instead of suspending, so the overlay stays fully visible and the
+chrome band stays pinned rather than hopping to the letterbox's centred
+bar. Only another pass owning the display rect falls back to the classic
+layout -- the bezel and CRT presets, RTG scanout -- along with
+programmable scans; captures never see the crop.
 
 Every redraw first re-syncs the surface to the host window's current size
 (`resync_surface_size`), rather than trusting the Resized event to have

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -573,6 +573,37 @@ surface: the field is presented at a TV-like 4:3 aspect plus the
 is fed from `present_fb`, the post-processed presentation buffer produced by
 either the render worker or the synchronous fallback.
 
+The emulator window is drawn onto the surface by its own scaling pass
+(`window/scaler.rs`), not the `pixels` crate's built-in renderer (the tool
+windows keep the built-in Fill renderer). The built-in renderer can only
+place the texture at whole multiples of *itself*, which welds the displayed
+integer multiple to the texture's supersample factor and capped fullscreen
+integer scaling at 4x on large displays; the scaler pass takes the
+destination rect and filter as inputs instead, so the planned multiple is
+drawn whatever the texture factor is. Point sampling stays exact past the
+cap because the CPU present copy replicates each canvas pixel into an
+S-wide texel block: every sample inside a canvas pixel reads the same
+colour, and sample centres can never land on a canvas-pixel boundary
+(`window/scaler.rs` carries the arithmetic). The smooth filter is the same
+texel-snapped sharp bilinear the built-in Fill renderer used, in the pass's
+own WGSL. `PresentLayout` (`window/present.rs`) is the single source for
+the pass's draws, the cursor mapping and the overlay anchors.
+
+`[display] autocrop` presents through the same pass with a second draw:
+the display quad samples the content sub-rect of the canvas -- derived
+each frame from the programmed display window the renderer painted with
+(`RenderResult::content_rect`, carried through the same shifts
+`post_process_rendered_field` applies and inverted through the same
+row/column maps the present copy uses) -- and the chrome band (panels and
+status bar) is drawn separately along the surface bottom at its width-fit
+scale. `AutocropLatch` smooths the per-frame envelope: growth is adopted
+immediately, border-only frames hold the previous crop (like the aperture
+latch), and a strictly smaller envelope is adopted only after holding
+steady for its stability window, so screen transitions do not pump the
+zoom. The crop suspends itself whenever another pass owns the display
+rect (open overlays, the bezel and CRT presets, RTG scanout) and for
+programmable scans; captures never see it.
+
 Every redraw first re-syncs the surface to the host window's current size
 (`resync_surface_size`), rather than trusting the Resized event to have
 arrived first. `pixels` rebuilds its swapchain from the size the last
@@ -704,8 +735,8 @@ against a real emulator instance in the unit tests.
 
 The optional tube emulation (`[display] shader`, off by default) is a second
 pass inside the same `pixels` `render_with` closure the RTG texture uses:
-the scaling renderer draws the composited buffer first, then `CrtShader`
-re-draws the display rectangle through a fragment shader. Its viewport is
+the presentation scaler pass draws the composited buffer first, then
+`CrtShader` re-draws the display rectangle through a fragment shader. Its viewport is
 the display sub-rect of the letterboxed clip rect -- the clip rect scaled by
 `present_height() / window_present_height()`, the same multiply-then-divide
 the RTG display rect uses so the two land identically -- and it samples only
@@ -778,7 +809,7 @@ screenshots, frame dumps, video recording, CCP capture and the web frontend
 all read the CPU presentation buffer, and the shader only ever writes to the
 surface. Strength 0 makes every preset's arithmetic an exact identity, but
 the pass is still a resample through a plain linear sampler where the
-scaling renderer uses a texel-snapped sharp bilinear, so it is marginally
+scaler pass uses a texel-snapped sharp bilinear, so it is marginally
 softer at magnification than the pass-through; `ShaderKind::None` skips the
 pass entirely and is the only zero-cost path.
 

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -607,9 +607,12 @@ letterbox: an open menu or panel (which draws into the display region
 against the full canvas mapping) widens the display quad to the whole
 region instead of suspending, so the overlay stays fully visible and the
 chrome band stays pinned rather than hopping to the letterbox's centred
-bar. Only another pass owning the display rect falls back to the classic
-layout -- the bezel and CRT presets, RTG scanout -- along with
-programmable scans; captures never see the crop.
+bar. The CRT presets compose with the crop: `uniforms_for_rect` aims the
+pass at the layout's display rect and crop sub-rect (the same numbers
+the scaler pass drew), with the beam-line count scaled to the rows the
+crop shows. Only a pass that owns the whole display rect falls back to
+the classic layout -- the bezel's fixed opening, RTG scanout -- along
+with programmable scans; captures never see the crop.
 
 Every redraw first re-syncs the surface to the host window's current size
 (`resync_surface_size`), rather than trusting the Resized event to have

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -591,12 +591,14 @@ the pass's draws, the cursor mapping and the overlay anchors.
 
 `[display] autocrop` presents through the same pass with a second draw:
 the display quad samples the content sub-rect of the canvas -- derived
-each frame from the programmed display window the renderer painted with
-(`RenderResult::content_rect`, carried through the same shifts
+each frame from the display-window rows that carry fetched bitplane data
+(`RenderResult::content_rect`: the renderer's own per-line window model
+intersected with the captured rows, so a window left open around a
+shorter picture crops to the picture; carried through the same shifts
 `post_process_rendered_field` applies and inverted through the same
 row/column maps the present copy uses) -- and the chrome band (panels and
-status bar) is drawn separately along the surface bottom at its width-fit
-scale. `AutocropLatch` smooths the per-frame envelope: growth is adopted
+status bar) is drawn separately, bottom-anchored at exactly the size the
+classic letterbox gives it, so the band never eats what the crop gains. `AutocropLatch` smooths the per-frame envelope: growth is adopted
 immediately, border-only frames hold the previous crop (like the aperture
 latch), and a strictly smaller envelope is adopted only after holding
 steady for its stability window, so screen transitions do not pump the

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -4633,11 +4633,13 @@ fn beam_timed_display_window_changes_clip_later_bitplane_rows() {
 
 #[test]
 fn render_reports_the_playfield_content_envelope() {
-    // One plane inside a 96-line vertical window (VSTOP 0x8C, high bit
-    // set by value, so no wraparound term). The returned envelope is
-    // what the presentation-side autocrop feeds on: the display window
-    // the hardware programs, whether or not every window row fetched
-    // data -- a game's border rows belong to its picture shape.
+    // One plane fetching two rows inside a much taller programmed
+    // window (VSTOP 0x8C, high bit set by value, so no wraparound
+    // term). The returned envelope is what the presentation-side
+    // autocrop feeds on: the display-window rows that carry fetched
+    // bitplane data, not the bare window -- Kickstart routinely leaves
+    // the 256-line window open around a 200-line picture, and cropping
+    // must tighten to the picture, not the window.
     let mut bus = empty_bus();
     bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN;
     bus.denise.diwstrt = 0x2C81;
@@ -4669,9 +4671,9 @@ fn render_reports_the_playfield_content_envelope() {
 
     let mut fb = vec![0; FB_PIXELS];
     let content = bitplane::render(&mut bus, &mut fb).expect("playfield painted");
-    // The programmed window rows (0x2C..0x8C), and a column span that
-    // holds the painted pixel and stays on the canvas.
-    assert_eq!((content.y0, content.y1), (0, 0x8C - 0x2C));
+    // The two fetched rows -- not the 96 the window spans -- and a
+    // column span that holds the painted pixel and stays on the canvas.
+    assert_eq!((content.y0, content.y1), (0, 2));
     assert!(content.x0 <= STANDARD_VISIBLE_X0 + 2);
     assert!(content.x1 > STANDARD_VISIBLE_X0 + 2);
     assert!(content.x1 <= FB_WIDTH);

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -4632,6 +4632,59 @@ fn beam_timed_display_window_changes_clip_later_bitplane_rows() {
 }
 
 #[test]
+fn render_reports_the_playfield_content_envelope() {
+    // One plane inside a 96-line vertical window (VSTOP 0x8C, high bit
+    // set by value, so no wraparound term). The returned envelope is
+    // what the presentation-side autocrop feeds on: the display window
+    // the hardware programs, whether or not every window row fetched
+    // data -- a game's border rows belong to its picture shape.
+    let mut bus = empty_bus();
+    bus.agnus.dmacon = DMACON_DMAEN | DMACON_BPLEN;
+    bus.denise.diwstrt = 0x2C81;
+    bus.denise.diwstop = 0x8CC1;
+    bus.denise.ddfstrt = 0x0038;
+    bus.denise.ddfstop = 0x0048;
+    bus.denise.bplcon0 = 0x1000;
+    bus.denise.palette.write_ocs(0, 0x0000);
+    bus.denise.palette.write_ocs(1, 0x0F00);
+    bus.denise.bplpt[0] = 0x0100;
+    bus.current_frame_render_base = bus.capture_render_snapshot();
+    for y in 0..2 {
+        bus.current_frame_bitplane_rows[y] = Some(CapturedBitplaneRow {
+            nplanes: 1,
+            words_per_row: 3,
+            fetch_origin_cck: None,
+            planes: [
+                vec![0x4000, 0, 0],
+                vec![0; 3],
+                vec![0; 3],
+                vec![0; 3],
+                vec![0; 3],
+                vec![0; 3],
+                Vec::new(),
+                Vec::new(),
+            ],
+        });
+    }
+
+    let mut fb = vec![0; FB_PIXELS];
+    let content = bitplane::render(&mut bus, &mut fb).expect("playfield painted");
+    // The programmed window rows (0x2C..0x8C), and a column span that
+    // holds the painted pixel and stays on the canvas.
+    assert_eq!((content.y0, content.y1), (0, 0x8C - 0x2C));
+    assert!(content.x0 <= STANDARD_VISIBLE_X0 + 2);
+    assert!(content.x1 > STANDARD_VISIBLE_X0 + 2);
+    assert!(content.x1 <= FB_WIDTH);
+
+    // A border-only frame (no planes anywhere) reports no envelope.
+    let mut bus = empty_bus();
+    bus.denise.palette.write_ocs(0, 0x0000);
+    bus.current_frame_render_base = bus.capture_render_snapshot();
+    let mut fb = vec![0; FB_PIXELS];
+    assert!(bitplane::render(&mut bus, &mut fb).is_none());
+}
+
+#[test]
 fn hblank_tail_color_write_paints_following_row_from_left_edge() {
     // A copper COLOR00 write in the horizontal-blank tail (hpos < 0x12)
     // belongs to the previous output row's invisible tail; the following

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -307,6 +307,12 @@ pub struct Config {
     /// [`DisplayScaling`]. Orthogonal to `pixel_aspect`, which decides what
     /// the canvas itself is.
     pub scaling: DisplayScaling,
+    /// Crop the window presentation to the display window the hardware
+    /// programs (`[display] autocrop`, default off), so a display using
+    /// fewer lines than the full scan fills more of the window -- the
+    /// Amiberry-style autocrop. A window-presentation setting only:
+    /// captures always keep their configured aperture.
+    pub autocrop: bool,
     /// Motion-adaptive deinterlacing of LACE content (on by default).
     /// Off, every field is plain line-doubled as it arrives, which shows
     /// interlace bob/flicker like a real TV without persistence.
@@ -2348,6 +2354,7 @@ impl Default for Config {
             tv_centre: TvCentre::default(),
             pixel_aspect: PixelAspect::Tv,
             scaling: DisplayScaling::Smooth,
+            autocrop: false,
             deinterlace: true,
             phosphor: 0.0,
             shader: ShaderMode::None,

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -248,6 +248,7 @@ impl RawConfig {
             &overlay.display.pixel_aspect,
         );
         take(&mut self.display.scaling, &overlay.display.scaling);
+        take(&mut self.display.autocrop, &overlay.display.autocrop);
         take(&mut self.display.menu_scale, &overlay.display.menu_scale);
         take(&mut self.display.shader, &overlay.display.shader);
         take(
@@ -314,6 +315,11 @@ pub(crate) struct RawDisplay {
     /// -number multiples of the canvas, centred, point-sampled).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) scaling: Option<String>,
+    /// Crop the window presentation to the display window the hardware
+    /// programs (default false). Window-only; captures keep their
+    /// configured aperture.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) autocrop: Option<bool>,
     /// Motion-adaptive deinterlacing of interlaced content (default
     /// true); false line-doubles every field as it arrives.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1149,6 +1149,19 @@ fn display_scaling_parses_and_defaults_to_smooth() -> Result<()> {
 }
 
 #[test]
+fn display_autocrop_parses_and_defaults_off() -> Result<()> {
+    assert!(!parse_config("")?.autocrop);
+    let cfg = parse_config(
+        r#"
+            [display]
+            autocrop = true
+            "#,
+    )?;
+    assert!(cfg.autocrop);
+    Ok(())
+}
+
+#[test]
 fn display_phosphor_parses_and_rejects_out_of_range() -> Result<()> {
     assert_eq!(parse_config("")?.phosphor, 0.0);
     let cfg = parse_config(

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -326,6 +326,7 @@ impl TryFrom<RawConfig> for Config {
             None => defaults.scaling,
             Some(s) => parse_display_scaling(s)?,
         };
+        let autocrop = raw.display.autocrop.unwrap_or(defaults.autocrop);
         let deinterlace = raw.display.deinterlace.unwrap_or(defaults.deinterlace);
         let phosphor = match raw.display.phosphor {
             None => defaults.phosphor,
@@ -1244,6 +1245,7 @@ impl TryFrom<RawConfig> for Config {
             tv_centre,
             pixel_aspect,
             scaling,
+            autocrop,
             deinterlace,
             phosphor,
             shader,

--- a/src/main.rs
+++ b/src/main.rs
@@ -983,6 +983,7 @@ fn main() -> Result<()> {
     });
     video::set_pixel_aspect(config::resolve_pixel_aspect(cfg.pixel_aspect));
     video::set_display_scaling(cfg.scaling);
+    video::set_autocrop(cfg.autocrop);
     video::set_menu_scale(cfg.menu_scale);
     // A fascia belongs to a machine that carries the instrument: with the
     // serial port out of MIDI mode, or another device chosen, the strip
@@ -1142,6 +1143,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
     // the default aspect and scaling; the machine it starts applies its own
     // (see start_configured_machine).
     video::set_display_scaling(config::DisplayScaling::Smooth);
+    video::set_autocrop(false);
     // The launcher opens before a machine config is built, so the menu size
     // comes straight off the raw file.
     video::set_menu_scale(raw_cfg.menu_scale());

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -5096,20 +5096,34 @@ fn render_from_input_with_scratch(
             // This row paints playfield: fold its display-window span into
             // the frame's content envelope. Purely an accumulation for the
             // presentation-side autocrop; the paint below is untouched.
-            content_rect = Some(match content_rect {
-                None => ContentRect {
-                    x0: x_start,
-                    x1: x_stop,
-                    y0: y,
-                    y1: y + 1,
-                },
-                Some(rect) => ContentRect {
-                    x0: rect.x0.min(x_start),
-                    x1: rect.x1.max(x_stop),
-                    y0: rect.y0.min(y),
-                    y1: rect.y1.max(y + 1),
-                },
-            });
+            // Only rows that carry fetched bitplane data count: the
+            // display window is routinely left open past the last fetched
+            // line (a 200-line game inside the Kickstart 256-line window),
+            // and those rows show border or repeated data, not picture --
+            // the crop should tighten to the picture the way the eye
+            // does. A frame with no captures at all (the RAM re-fetch
+            // compatibility path) counts every window row instead.
+            let row_has_fetched_data = !has_captured_bitplane_rows
+                || captured_bitplane_rows
+                    .get(y)
+                    .and_then(Option::as_ref)
+                    .is_some();
+            if row_has_fetched_data {
+                content_rect = Some(match content_rect {
+                    None => ContentRect {
+                        x0: x_start,
+                        x1: x_stop,
+                        y0: y,
+                        y1: y + 1,
+                    },
+                    Some(rect) => ContentRect {
+                        x0: rect.x0.min(x_start),
+                        x1: rect.x1.max(x_stop),
+                        y0: rect.y0.min(y),
+                        y1: rect.y1.max(y + 1),
+                    },
+                });
+            }
             // A captured sequencer run with a comparator-anchored origin is
             // the authority for the row's word count: mid-row DDF rewrites
             // logged as control segments describe windows the sequencer
@@ -5591,6 +5605,16 @@ fn render_from_input_with_scratch(
     scratch.dma_output_start_x_by_line = dma_output_start_x_by_line;
     scratch.h_window_rows = h_window_rows;
     scratch.ham_select_pixels = ham_select_pixels;
+    // COPPERLINE_DIAG_AUTOCROP: log the per-frame content envelope the
+    // autocrop presentation feeds on, in field canvas coordinates. The
+    // tool for judging what a title's crop will be from a headless run.
+    if crate::envcfg::flag("COPPERLINE_DIAG_AUTOCROP") {
+        log::info!(
+            "[DIAG_AUTOCROP] secs={:.3} content_rect={:?}",
+            input.emulated_seconds,
+            content_rect
+        );
+    }
     RenderResult {
         timing: render_timing,
         clxdat,

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -5607,11 +5607,15 @@ fn render_from_input_with_scratch(
     scratch.ham_select_pixels = ham_select_pixels;
     // COPPERLINE_DIAG_AUTOCROP: log the per-frame content envelope the
     // autocrop presentation feeds on, in field canvas coordinates. The
-    // tool for judging what a title's crop will be from a headless run.
+    // tool for judging what a title's crop will be from a headless run;
+    // `programmable` says when the presentation will decline to crop
+    // however good the envelope looks (multisync scans present their
+    // own window in full).
     if crate::envcfg::flag("COPPERLINE_DIAG_AUTOCROP") {
         log::info!(
-            "[DIAG_AUTOCROP] secs={:.3} content_rect={:?}",
+            "[DIAG_AUTOCROP] secs={:.3} programmable={} content_rect={:?}",
             input.emulated_seconds,
+            geometry.programmable,
             content_rect
         );
     }

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -4297,6 +4297,20 @@ impl RenderInput {
     }
 }
 
+/// The display-window envelope the frame's playfield painted, in field
+/// canvas coordinates: `x0..x1` framebuffer pixels, `y0..y1` rendered
+/// field rows (both half-open). The hardware-derived source for the
+/// presentation-side autocrop -- rows and spans come from the same
+/// per-line display-window bounds the painter runs, so mid-frame DIW
+/// rewrites and carried-open flops are already folded in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ContentRect {
+    pub x0: usize,
+    pub x1: usize,
+    pub y0: usize,
+    pub y1: usize,
+}
+
 /// Outputs of `render_from_input`. Render timing is always recorded back on
 /// the main thread. `clxdat` is applied only by the synchronous wrapper; the
 /// threaded path completes CPU-visible Denise collision state at frame end
@@ -4305,6 +4319,9 @@ pub struct RenderResult {
     pub timing: VideoRenderFrameTiming,
     pub clxdat: u16,
     pub(crate) chip_ram_reads: Option<Vec<ChipRamReadDependency>>,
+    /// Playfield content envelope of this field, or `None` for a
+    /// border-only frame (see [`ContentRect`]).
+    pub content_rect: Option<ContentRect>,
 }
 
 /// Large renderer work buffers retained per host thread. The browser calls
@@ -4382,7 +4399,9 @@ impl SpriteSubpixelState {
 /// Paint the just-finished frame through the synchronous compatibility path.
 /// The render itself is a pure function of the owned snapshot
 /// (`render_from_input`); this wrapper owns the remaining bus coupling.
-pub fn render(bus: &mut Bus, fb: &mut [u32]) {
+/// Returns the frame's playfield content envelope (see [`ContentRect`]);
+/// callers with no use for it just drop the value.
+pub fn render(bus: &mut Bus, fb: &mut [u32]) -> Option<ContentRect> {
     // This path re-snapshots the bus every frame; keep one RenderInput per
     // thread so its buffers are reused instead of reallocated each time.
     thread_local! {
@@ -4405,7 +4424,8 @@ pub fn render(bus: &mut Bus, fb: &mut [u32]) {
             .as_mut()
             .expect("scratch render input present")
             .release_shared_frame_data();
-    });
+        result.content_rect
+    })
 }
 
 /// Synchronous render wrapper with exact previous-frame reuse. Returns true
@@ -4949,6 +4969,7 @@ fn render_from_input_with_scratch(
         });
 
     let playfield_started = render_timing_start();
+    let mut content_rect: Option<ContentRect> = None;
     if (has_captured_bitplane_rows || state.bplpt[0] != 0)
         && any_bitplane_control
         && (has_captured_bitplane_rows || any_bitplane_dma_control)
@@ -5072,6 +5093,23 @@ fn render_from_input_with_scratch(
             if !line_has_valid_ddf_window(control, row_control_segments) {
                 continue;
             }
+            // This row paints playfield: fold its display-window span into
+            // the frame's content envelope. Purely an accumulation for the
+            // presentation-side autocrop; the paint below is untouched.
+            content_rect = Some(match content_rect {
+                None => ContentRect {
+                    x0: x_start,
+                    x1: x_stop,
+                    y0: y,
+                    y1: y + 1,
+                },
+                Some(rect) => ContentRect {
+                    x0: rect.x0.min(x_start),
+                    x1: rect.x1.max(x_stop),
+                    y0: rect.y0.min(y),
+                    y1: rect.y1.max(y + 1),
+                },
+            });
             // A captured sequencer run with a comparator-anchored origin is
             // the authority for the row's word count: mid-row DDF rewrites
             // logged as control segments describe windows the sequencer
@@ -5557,6 +5595,7 @@ fn render_from_input_with_scratch(
         timing: render_timing,
         clxdat,
         chip_ram_reads,
+        content_rect,
     }
 }
 

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -60,6 +60,7 @@ fn repeated_frame_test_result(chip_ram_reads: Option<Vec<ChipRamReadDependency>>
         timing: VideoRenderFrameTiming::default(),
         clxdat: 0x1234,
         chip_ram_reads,
+        content_rect: None,
     }
 }
 

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -698,6 +698,7 @@ pub enum LauncherField {
     Overscan,
     PixelAspect,
     Scaling,
+    Autocrop,
     Tint,
     Deinterlace,
     Phosphor,
@@ -1241,11 +1242,12 @@ const SOUND_ROWS: [Row; 1] = [row(F::Toccata, "  Toccata", Cycle)];
 // The emulated picture, in signal order -- what the monitor is fed and how
 // it is drawn -- with the shader pair last, since strength greys off the
 // shader. The host window's own settings are DISPLAY_ROWS.
-const VIDEO_ROWS: [Row; 9] = [
+const VIDEO_ROWS: [Row; 10] = [
     row(F::Bezel, "Monitor bezel", Cycle),
     row(F::Overscan, "Overscan", Cycle),
     row(F::PixelAspect, "Pixel aspect", Cycle),
     row(F::Scaling, "Scaling", Cycle),
+    row(F::Autocrop, "Autocrop", Cycle),
     row(F::Deinterlace, "Deinterlace", Cycle),
     row(F::Tint, "Screen tint", Cycle),
     row(F::Phosphor, "Phosphor", Cycle),
@@ -2295,6 +2297,9 @@ pub struct MachineSetup {
     pixel_aspect: PixelAspect,
     /// How the canvas is scaled into the window ([display] scaling).
     scaling: DisplayScaling,
+    /// Crop the presentation to the programmed display window
+    /// ([display] autocrop).
+    autocrop: bool,
     /// Motion-adaptive interlace weaving ([display] deinterlace).
     deinterlace: bool,
     phosphor: f32,
@@ -2606,6 +2611,7 @@ impl MachineSetup {
             overscan: cfg.overscan,
             pixel_aspect: cfg.pixel_aspect,
             scaling: cfg.scaling,
+            autocrop: cfg.autocrop,
             deinterlace: cfg.deinterlace,
             phosphor: cfg.phosphor,
             shader: cfg.shader.clone(),
@@ -3123,6 +3129,9 @@ impl MachineSetup {
         if self.scaling != base.scaling {
             raw.display.scaling = Some(display_scaling_name(self.scaling).to_string());
         }
+        if self.autocrop != base.autocrop {
+            raw.display.autocrop = Some(self.autocrop);
+        }
         if self.deinterlace != base.deinterlace {
             raw.display.deinterlace = Some(self.deinterlace);
         }
@@ -3460,6 +3469,7 @@ impl MachineSetup {
         self.overscan = base.overscan;
         self.pixel_aspect = base.pixel_aspect;
         self.scaling = base.scaling;
+        self.autocrop = base.autocrop;
         self.deinterlace = base.deinterlace;
         self.phosphor = base.phosphor;
         // The remembered user-shader path survives: it came from the config
@@ -3831,6 +3841,7 @@ impl MachineSetup {
             F::FloppySounds => self.floppy_sounds,
             F::StartFullscreen => self.start_fullscreen,
             F::ShowStatusBar => self.show_status_bar,
+            F::Autocrop => self.autocrop,
             F::Deinterlace => self.deinterlace,
             F::PerfOverlay => self.perf_overlay,
             F::Mt32Panel => self.mt32_panel,
@@ -4361,6 +4372,7 @@ impl MachineSetup {
             F::StartFullscreen => enabled_label(self.start_fullscreen),
             F::ShowStatusBar => enabled_label(self.show_status_bar),
             F::PerfOverlay => enabled_label(self.perf_overlay),
+            F::Autocrop => enabled_label(self.autocrop),
             F::Deinterlace => enabled_label(self.deinterlace),
             F::FloppySounds => enabled_label(self.floppy_sounds),
             F::PowerOn => enabled_label(self.power_on),
@@ -4836,6 +4848,7 @@ impl MachineSetup {
             F::StartFullscreen => self.start_fullscreen = !self.start_fullscreen,
             F::ShowStatusBar => self.show_status_bar = !self.show_status_bar,
             F::PerfOverlay => self.perf_overlay = !self.perf_overlay,
+            F::Autocrop => self.autocrop = !self.autocrop,
             F::Deinterlace => self.deinterlace = !self.deinterlace,
             F::FloppySounds => self.floppy_sounds = !self.floppy_sounds,
             F::PowerOn => self.power_on = !self.power_on,

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -42,6 +42,7 @@ pub enum MenuAction {
     // Video.
     SetPixelAspect(PixelAspect),
     SetDisplayScaling(DisplayScaling),
+    ToggleAutocrop,
     SetShader(ShaderKind),
     SetTint(Tint),
     SetMenuScale(MenuScale),
@@ -467,6 +468,9 @@ pub struct MenuState<'a> {
     pub port_devices: [PortDevice; 2],
     pub pixel_aspect: PixelAspect,
     pub scaling: DisplayScaling,
+    /// Whether the window presentation crops to the programmed display
+    /// window ([display] autocrop).
+    pub autocrop: bool,
     /// Where the TV presentation centres the picture, and whether the
     /// control applies (it is a TV-aperture nudge, so full overscan has
     /// nothing for it to move).
@@ -781,6 +785,7 @@ fn video_rows(s: &MenuState) -> Vec<MenuRow> {
         MenuRow::submenu("Menu Size", menu_size_rows(s)).with_value(s.menu_scale.label()),
         MenuRow::submenu("Pixel Aspect", aspect_rows(s)),
         MenuRow::submenu("Scaling", scaling_rows(s)),
+        MenuRow::toggle("Autocrop", MenuAction::ToggleAutocrop, s.autocrop),
         centring_row(s),
         MenuRow::submenu("CRT Shader", shader_rows(s)),
         shader_strength_row(s),
@@ -807,6 +812,7 @@ fn player_video_rows(s: &MenuState) -> Vec<MenuRow> {
         MenuRow::submenu("Menu Size", menu_size_rows(s)).with_value(s.menu_scale.label()),
         MenuRow::submenu("Pixel Aspect", aspect_rows(s)),
         MenuRow::submenu("Scaling", scaling_rows(s)),
+        MenuRow::toggle("Autocrop", MenuAction::ToggleAutocrop, s.autocrop),
         centring_row(s),
         MenuRow::submenu("CRT Shader", shader_rows(s)),
         shader_strength_row(s),
@@ -1330,6 +1336,7 @@ mod tests {
             port_devices: [PortDevice::Mouse, PortDevice::Joystick],
             pixel_aspect: PixelAspect::Tv,
             scaling: DisplayScaling::Smooth,
+            autocrop: false,
             tv_centre: TvCentre::default(),
             tv_centre_applies: true,
             shader: ShaderKind::None,

--- a/src/video/mod.rs
+++ b/src/video/mod.rs
@@ -140,6 +140,20 @@ pub fn display_scaling() -> crate::config::DisplayScaling {
     }
 }
 
+/// Whether the window presentation crops to the display window the
+/// hardware programs (`[display] autocrop`, runtime-toggled by the
+/// menu's Autocrop item). Main thread only, like
+/// [`SQUARE_PIXEL_ASPECT`]; the atomic only satisfies `static` safety.
+static AUTOCROP: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+pub fn set_autocrop(autocrop: bool) {
+    AUTOCROP.store(autocrop, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn autocrop() -> bool {
+    AUTOCROP.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Whether the status bar is hidden, so the emulated display scales to fill the
 /// whole window. Toggled live from the window/menu (main thread only, like
 /// [`SQUARE_PIXEL_ASPECT`]); the atomic only satisfies `static` safety.

--- a/src/video/ui/tests.rs
+++ b/src/video/ui/tests.rs
@@ -3079,6 +3079,7 @@ fn panels_render_into_their_rects() {
         ],
         pixel_aspect: PixelAspect::Tv,
         scaling: crate::config::DisplayScaling::Smooth,
+        autocrop: false,
         tv_centre: crate::config::TvCentre::default(),
         tv_centre_applies: true,
         shader: crate::config::ShaderKind::None,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -946,6 +946,10 @@ pub struct App {
     /// shows, in woven presentation-buffer space (see [`AutocropLatch`]);
     /// `None` until a standard frame has painted playfield.
     present_content_rect: Option<bitplane::ContentRect>,
+    /// The last layout the COPPERLINE_DIAG_AUTOCROP trace logged, so the
+    /// trace reports changes rather than every redraw. Unused while the
+    /// flag is off.
+    last_diag_layout: Option<PresentLayout>,
     /// The grow-fast/shrink-stable smoothing behind it.
     autocrop_latch: AutocropLatch,
     /// Whether the presented frame came from a programmable (multisync) scan
@@ -1994,6 +1998,7 @@ impl App {
             present_tv_aperture_rows: Some(TV_PAL_PRESENT_HEIGHT),
             presentation_latch: PresentationLatch::default(),
             present_content_rect: None,
+            last_diag_layout: None,
             autocrop_latch: AutocropLatch::default(),
             present_programmable: false,
             render: None,
@@ -4380,6 +4385,25 @@ impl ApplicationHandler for App {
                     // bezel) only run when autocrop is suspended, so their
                     // layout is the classic whole-texture letterbox.
                     let layout = main_present_layout(r, autocrop_src);
+                    // COPPERLINE_DIAG_AUTOCROP: the window half of the
+                    // renderer-side envelope trace -- the exact rects the
+                    // scaler pass draws this frame, logged when they
+                    // change. Together the two lines say whether a crop
+                    // was derived and whether the presentation used it.
+                    if crate::envcfg::flag("COPPERLINE_DIAG_AUTOCROP")
+                        && self.last_diag_layout != Some(layout)
+                    {
+                        info!(
+                            "[DIAG_AUTOCROP] layout surface={:?} src_canvas={:?} \
+                             display_dst={:?} chrome_dst={:?} filter={:?}",
+                            r.surface_size,
+                            layout.src_canvas,
+                            layout.display_dst,
+                            layout.chrome_dst,
+                            layout.filter,
+                        );
+                        self.last_diag_layout = Some(layout);
+                    }
                     let present_clip = layout.display_dst;
                     let present_draws = layout.draws();
                     let scaler = &mut r.scaler;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1103,8 +1103,12 @@ pub struct App {
     cursor_pos: Option<(i32, i32)>,
     last_display_cursor_pos: Option<(i32, i32)>,
     /// Most recent raw host cursor position (physical pixels) from the last
-    /// CursorMoved. Kept only for the COPPERLINE_DIAG_CURSOR click trace, which
-    /// needs the un-mapped coordinate alongside the mapped pixel.
+    /// CursorMoved while the pointer is inside the window (cleared on
+    /// CursorLeft). The redraw re-maps `cursor_pos` from it whenever the
+    /// presentation layout changes under a stationary pointer (autocrop
+    /// latch adoption, a menu suspending the crop), and the
+    /// COPPERLINE_DIAG_CURSOR click trace logs it alongside the mapped
+    /// pixel.
     last_cursor_phys: Option<winit::dpi::PhysicalPosition<f64>>,
     volume_dragging: bool,
     /// A scroll arrow held down: which control, and when its next repeat is
@@ -3844,6 +3848,7 @@ impl ApplicationHandler for App {
             WindowEvent::CursorLeft { .. } => {
                 let previous_cursor_pos = self.cursor_pos;
                 self.cursor_pos = None;
+                self.last_cursor_phys = None;
                 self.last_display_cursor_pos = None;
                 self.volume_dragging = false;
                 self.analyzer_dragging = false;
@@ -4142,6 +4147,16 @@ impl ApplicationHandler for App {
                 if self.render.as_ref().is_some_and(|r| r.minimized) {
                     return;
                 }
+                // The presentation layout can change under a stationary
+                // pointer -- the autocrop latch adopting a new crop, a menu
+                // suspending it, a toggle -- and every such change requests
+                // a redraw, so re-mapping the cached host position here
+                // keeps hover and click hit-testing aligned with the
+                // pixels this frame actually shows.
+                let autocrop_src = self.autocrop_canvas_src();
+                if let (Some(phys), Some(r)) = (self.last_cursor_phys, self.render.as_ref()) {
+                    self.cursor_pos = main_cursor_position(r, autocrop_src, phys);
+                }
                 let status = status_with_latched_fdd_track(
                     self.emu.bus().front_panel_status(),
                     &mut self.last_fdd_track,
@@ -4192,7 +4207,6 @@ impl ApplicationHandler for App {
                 // every frame rather than mirrored from the clicks.
                 let kbd_panel = super::keyboard_panel_shown().then(|| self.keyboard_panel_view());
                 let ui_data = self.build_panel_view_data();
-                let autocrop_src = self.autocrop_canvas_src();
                 if let Some(r) = self.render.as_mut() {
                     // RTG with a working GPU pipeline presents the native frame
                     // through its own texture in the GPU render pass below.

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -213,9 +213,10 @@ const MAX_TEXTURE_SCALE: usize = 2;
 /// Cap on the integer-scaling supersample factor, which follows the window
 /// fit rather than the host DPI (see `plan_present_scaling`). Bounds the
 /// backing texture and the per-frame present copy on very large displays;
-/// at 4x the canvas the picture is already 2864 physical pixels wide, and
-/// beyond it PixelPerfect's own whole multiples of the capped texture keep
-/// the fit integer.
+/// at 4x the canvas the texture is already 2864 physical pixels wide. The
+/// *displayed* multiple is not capped: the scaler pass draws the planned
+/// multiple whatever the texture factor, and its point sampling of the
+/// replicated display region stays exact past the cap (see `scaler`).
 const MAX_INTEGER_TEXTURE_SCALE: usize = 4;
 const STATUS_BAR_HEIGHT: usize = 44;
 /// How long the pointer rests on a menu category before it opens.
@@ -941,6 +942,12 @@ pub struct App {
     /// presentation geometry instead of snapping to the full framebuffer,
     /// so the picture does not jump at every Kickstart mode change.
     presentation_latch: PresentationLatch,
+    /// The smoothed playfield content envelope the autocrop presentation
+    /// shows, in woven presentation-buffer space (see [`AutocropLatch`]);
+    /// `None` until a standard frame has painted playfield.
+    present_content_rect: Option<bitplane::ContentRect>,
+    /// The grow-fast/shrink-stable smoothing behind it.
+    autocrop_latch: AutocropLatch,
     /// Whether the presented frame came from a programmable (multisync) scan
     /// rather than a woven 15 kHz one. Those fields reach the presentation
     /// buffer at their native height, so neither the CRT pass nor its
@@ -1460,6 +1467,11 @@ struct Render {
     window: Arc<Window>,
     pixels: Pixels<'static>,
     texture_scale: usize,
+    /// The pass that puts the composited buffer on the surface (see
+    /// [`scaler`]): the emulator window's replacement for the `pixels`
+    /// built-in scaling renderer, so the displayed integer multiple is
+    /// not welded to the texture's supersample factor.
+    scaler: scaler::PresentScaler,
     /// Native-resolution RTG display texture, drawn over the UI buffer in
     /// the `pixels` render pass (see [`rtg_texture`]). Present whenever the
     /// window is (its pipeline uses the same GPU device as `pixels`).
@@ -1583,6 +1595,10 @@ struct RenderWorkerResult {
     /// frames keep the previous geometry.
     tv_aperture: TvApertureFrame,
     programmable: bool,
+    /// Playfield content envelope in woven presentation-buffer space (x
+    /// in framebuffer pixels, y in woven rows), for the autocrop
+    /// presentation; `None` for border-only or programmable frames.
+    content_rect: Option<bitplane::ContentRect>,
     /// The job's frame snapshot, handed back for buffer reuse.
     input: bitplane::RenderInput,
 }
@@ -1973,6 +1989,8 @@ impl App {
             rtg_present_dims: None,
             present_tv_aperture_rows: Some(TV_PAL_PRESENT_HEIGHT),
             presentation_latch: PresentationLatch::default(),
+            present_content_rect: None,
+            autocrop_latch: AutocropLatch::default(),
             present_programmable: false,
             render: None,
             debugger_tool_window: None,
@@ -3352,11 +3370,12 @@ impl ApplicationHandler for App {
         #[cfg(target_os = "macos")]
         set_macos_dock_icon();
         let inner = window.inner_size();
-        let (texture_scale, scaling_mode) = plan_present_scaling(
+        let texture_scale = plan_present_scaling(
             integer_scaling_requested(),
             window.scale_factor(),
             (inner.width.max(1), inner.height.max(1)),
-        );
+        )
+        .texture_scale;
         // On Linux, restrict wgpu to the Vulkan backend. wgpu's GL fallback
         // initializes its EGL instance without a display handle (pixels uses
         // InstanceDescriptor::new_without_display_handle), so EGL drops to the
@@ -3370,23 +3389,22 @@ impl ApplicationHandler for App {
         // Other platforms keep wgpu's default backend set (Metal on macOS,
         // DX12/Vulkan on Windows). cfg!() (not #[cfg]) keeps the Linux branch
         // type-checked on every host.
-        let pixels =
-            match build_pixels_for_window(window.clone(), texture_scale, true, scaling_mode) {
-                Ok(p) => p,
-                Err(e) => {
-                    error!("pixels init failed: {e}");
-                    if cfg!(target_os = "linux") {
-                        error!(
-                            "Copperline requires a Vulkan driver on Linux. Update your GPU \
+        let pixels = match build_pixels_for_window(window.clone(), texture_scale, true) {
+            Ok(p) => p,
+            Err(e) => {
+                error!("pixels init failed: {e}");
+                if cfg!(target_os = "linux") {
+                    error!(
+                        "Copperline requires a Vulkan driver on Linux. Update your GPU \
                          drivers, or install a software Vulkan ICD (lavapipe): \
                          'vulkan-swrast' on Arch, 'mesa-vulkan-drivers' on Debian/Ubuntu, \
                          'mesa-vulkan-drivers' (or 'vulkan-loader') on Fedora."
-                        );
-                    }
-                    event_loop.exit();
-                    return;
+                    );
                 }
-            };
+                event_loop.exit();
+                return;
+            }
+        };
         info!(
             "window + pixels surface ready ({}x{}, texture {}x{})",
             inner.width,
@@ -3394,6 +3412,7 @@ impl ApplicationHandler for App {
             texture_width(texture_scale),
             texture_height(texture_scale)
         );
+        let scaler = scaler::PresentScaler::new(pixels.device(), pixels.render_texture_format());
         let rtg_texture =
             rtg_texture::RtgTexture::new(pixels.device(), pixels.render_texture_format());
         let mut crt_shader =
@@ -3423,6 +3442,7 @@ impl ApplicationHandler for App {
             window,
             pixels,
             texture_scale,
+            scaler,
             rtg_texture,
             crt_shader,
             bezel_shader,
@@ -3738,10 +3758,11 @@ impl ApplicationHandler for App {
             WindowEvent::CursorMoved { position, .. } => {
                 let previous_cursor_pos = self.cursor_pos;
                 self.last_cursor_phys = Some(position);
+                let autocrop_src = self.autocrop_canvas_src();
                 let pos = self
                     .render
                     .as_ref()
-                    .and_then(|r| cursor_texture_position(&r.pixels, position, r.texture_scale));
+                    .and_then(|r| main_cursor_position(r, autocrop_src, position));
                 // A button held on the dial turns it by following the hand
                 // round the face.
                 #[cfg(feature = "mt32")]
@@ -4099,13 +4120,11 @@ impl ApplicationHandler for App {
                 // resizes the surface via the Resized event that follows, but
                 // the backing texture is sized FB_WIDTH x window height
                 // times an integer supersample factor captured at window
-                // creation. Left stale, cursor_texture_position maps clicks
-                // against a texture extent that no longer matches the surface,
-                // so a status-bar click is mis-classified as a display click
-                // and grabs the mouse. Re-plan for the new scale (which also
-                // re-fits integer scaling, whose factor tracks the surface
-                // rather than the DPI); the Resized event that follows
-                // recomputes the scaling matrix from it.
+                // creation. Left stale, the UI drawn into it keeps the old
+                // monitor's crispness. Re-plan for the new scale (which also
+                // re-fits integer scaling's texture factor, which tracks the
+                // surface rather than the DPI); the redraw recomputes the
+                // clip rect from the same plan.
                 if let Some(r) = self.render.as_mut() {
                     let surface = r.window.inner_size();
                     if let Err(e) = sync_main_present_scaling(r, (surface.width, surface.height)) {
@@ -4173,6 +4192,7 @@ impl ApplicationHandler for App {
                 // every frame rather than mirrored from the clicks.
                 let kbd_panel = super::keyboard_panel_shown().then(|| self.keyboard_panel_view());
                 let ui_data = self.build_panel_view_data();
+                let autocrop_src = self.autocrop_canvas_src();
                 if let Some(r) = self.render.as_mut() {
                     // RTG with a working GPU pipeline presents the native frame
                     // through its own texture in the GPU render pass below.
@@ -4298,10 +4318,14 @@ impl ApplicationHandler for App {
                         self.shader_strength,
                         r.texture_scale,
                     );
+                    // The corner overlays anchor to the display region the
+                    // viewer actually sees: the whole display classically,
+                    // the crop rect while autocrop presents.
+                    let overlay_anchor = autocrop_src.unwrap_or((0, 0, FB_WIDTH, present_height()));
                     if recording {
                         // Painted into the presentation texture only, so
                         // the badge never appears in the recorded file.
-                        draw_record_badge(frame, r.texture_scale, corner);
+                        draw_record_badge(frame, r.texture_scale, corner, overlay_anchor);
                     }
                     if self.perf_overlay {
                         draw_perf_overlay(
@@ -4310,10 +4334,18 @@ impl ApplicationHandler for App {
                             r.texture_scale,
                             recording,
                             corner,
+                            overlay_anchor,
                         );
                     }
                     if let Some((text, warning)) = &osd {
-                        draw_osd(frame, text, *warning, r.texture_scale, corner);
+                        draw_osd(
+                            frame,
+                            text,
+                            *warning,
+                            r.texture_scale,
+                            corner,
+                            overlay_anchor,
+                        );
                     }
                     // The focus lights its control the way the pointer
                     // does, breathing between the two.
@@ -4326,6 +4358,17 @@ impl ApplicationHandler for App {
                     if self.drop_hover && !matches!(self.ui.panel, Some(Panel::Launcher(_))) {
                         ui::draw_drop_hint(frame, r.texture_scale);
                     }
+                    // The scaler pass draws the composited buffer with this
+                    // layout; every overlay pass below keys its viewport off
+                    // the same display rect, and the cursor mapping inverts
+                    // the same layout, so all of them agree by construction.
+                    // The branches that draw over the display (RTG, CRT,
+                    // bezel) only run when autocrop is suspended, so their
+                    // layout is the classic whole-texture letterbox.
+                    let layout = main_present_layout(r, autocrop_src);
+                    let present_clip = layout.display_dst;
+                    let present_draws = layout.draws();
+                    let scaler = &mut r.scaler;
                     let render_result = if rtg_gpu {
                         // Draw the UI buffer, then overdraw the display region
                         // with the native RTG texture (GPU-scaled). The display
@@ -4335,11 +4378,18 @@ impl ApplicationHandler for App {
                         // The board frame is drawn straight to the surface,
                         // so integer scaling applies to it in its own native
                         // pixels rather than through the canvas texture the
-                        // scaling renderer letterboxed above.
+                        // scaler pass letterboxed above.
                         let integer_scaling = integer_scaling_requested();
                         r.pixels.render_with(|encoder, target, ctx| {
-                            ctx.scaling_renderer.render(encoder, target);
-                            let (cx, cy, cw, ch) = ctx.scaling_renderer.clip_rect();
+                            scaler.render(
+                                &ctx.device,
+                                &ctx.queue,
+                                &ctx.texture,
+                                encoder,
+                                target,
+                                &present_draws,
+                            );
+                            let (cx, cy, cw, ch) = present_clip;
                             let disp_h = ch as f32 * present_height() as f32
                                 / window_present_height() as f32;
                             rtg.render(
@@ -4393,11 +4443,18 @@ impl ApplicationHandler for App {
                         let bezel_shader = &mut r.bezel_shader;
                         let sticker_pass = &mut r.sticker_pass;
                         r.pixels.render_with(|encoder, target, ctx| {
-                            ctx.scaling_renderer.render(encoder, target);
+                            scaler.render(
+                                &ctx.device,
+                                &ctx.queue,
+                                &ctx.texture,
+                                encoder,
+                                target,
+                                &present_draws,
+                            );
                             let (uniforms, viewport) = crt_shader::uniforms_for(
                                 kind,
                                 strength,
-                                ctx.scaling_renderer.clip_rect(),
+                                present_clip,
                                 present_height(),
                                 window_present_height(),
                                 (ctx.texture_extent.width, ctx.texture_extent.height),
@@ -4453,7 +4510,17 @@ impl ApplicationHandler for App {
                             Ok(())
                         })
                     } else {
-                        r.pixels.render()
+                        r.pixels.render_with(|encoder, target, ctx| {
+                            scaler.render(
+                                &ctx.device,
+                                &ctx.queue,
+                                &ctx.texture,
+                                encoder,
+                                target,
+                                &present_draws,
+                            );
+                            Ok(())
+                        })
                     };
                     if let Err(e) = render_result {
                         error!("pixels.render: {e}");
@@ -6200,6 +6267,7 @@ mod kbdpanel;
 mod mt32panel;
 mod present;
 mod rtg_texture;
+mod scaler;
 pub(in crate::video) mod statusbar;
 mod stickers;
 pub(super) use present::{scale_rect, texture_height, texture_width, Rect};

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4388,14 +4388,33 @@ impl ApplicationHandler for App {
                     // COPPERLINE_DIAG_AUTOCROP: the window half of the
                     // renderer-side envelope trace -- the exact rects the
                     // scaler pass draws this frame, logged when they
-                    // change. Together the two lines say whether a crop
-                    // was derived and whether the presentation used it.
+                    // change, with the mode spelled out: a classic layout
+                    // must say WHY it is classic (toggle off, or which
+                    // condition suspended the crop), because the envelope
+                    // line prints whether or not the mode is on and the
+                    // difference is invisible from it alone.
                     if crate::envcfg::flag("COPPERLINE_DIAG_AUTOCROP")
                         && self.last_diag_layout != Some(layout)
                     {
+                        let mode = if !crate::video::autocrop() {
+                            "off"
+                        } else if self.rtg_present_dims.is_some() {
+                            "suspended(rtg)"
+                        } else if self.present_programmable {
+                            "suspended(programmable)"
+                        } else if self.present_width != FB_WIDTH {
+                            "suspended(canvas-width)"
+                        } else if self.bezel.is_on() {
+                            "suspended(bezel)"
+                        } else if self.crt_shader_kind != crate::config::ShaderKind::None {
+                            "suspended(crt-shader)"
+                        } else {
+                            "active"
+                        };
                         info!(
-                            "[DIAG_AUTOCROP] layout surface={:?} src_canvas={:?} \
+                            "[DIAG_AUTOCROP] layout mode={} surface={:?} src_canvas={:?} \
                              display_dst={:?} chrome_dst={:?} filter={:?}",
+                            mode,
                             r.surface_size,
                             layout.src_canvas,
                             layout.display_dst,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4406,8 +4406,6 @@ impl ApplicationHandler for App {
                             "suspended(canvas-width)"
                         } else if self.bezel.is_on() {
                             "suspended(bezel)"
-                        } else if self.crt_shader_kind != crate::config::ShaderKind::None {
-                            "suspended(crt-shader)"
                         } else {
                             "active"
                         };
@@ -4493,6 +4491,20 @@ impl ApplicationHandler for App {
                         let kind = self.crt_shader_kind;
                         let strength = self.shader_strength;
                         let bezel_style = self.bezel;
+                        // Under the autocrop layout the preset re-draws the
+                        // crop into the crop's own viewport -- the same
+                        // sub-rect the scaler pass just drew -- with the
+                        // beam-line count scaled to the rows the crop shows.
+                        // The bezel suspends autocrop, so this is never the
+                        // bezel case.
+                        let crt_crop = autocrop_src.map(|_| {
+                            (
+                                layout.display_dst,
+                                layout.src_canvas,
+                                scanlines * layout.src_canvas.3 as f32
+                                    / present_height().max(1) as f32,
+                            )
+                        });
                         // The closure is FnOnce and captures `r`, so the
                         // shaders have to be split out of it as separate
                         // borrows rather than reached through `r` inside.
@@ -4508,15 +4520,28 @@ impl ApplicationHandler for App {
                                 target,
                                 &present_draws,
                             );
-                            let (uniforms, viewport) = crt_shader::uniforms_for(
-                                kind,
-                                strength,
-                                present_clip,
-                                present_height(),
-                                window_present_height(),
-                                (ctx.texture_extent.width, ctx.texture_extent.height),
-                                scanlines,
-                            );
+                            let texture_extent =
+                                (ctx.texture_extent.width, ctx.texture_extent.height);
+                            let (uniforms, viewport) = match crt_crop {
+                                Some((dst, src, crop_scanlines)) => crt_shader::uniforms_for_rect(
+                                    kind,
+                                    strength,
+                                    dst,
+                                    src,
+                                    (FB_WIDTH, window_present_height()),
+                                    texture_extent,
+                                    crop_scanlines,
+                                ),
+                                None => crt_shader::uniforms_for(
+                                    kind,
+                                    strength,
+                                    present_clip,
+                                    present_height(),
+                                    window_present_height(),
+                                    texture_extent,
+                                    scanlines,
+                                ),
+                            };
                             if bezel_active {
                                 let opening = bezel::opening_rect(bezel_style, viewport);
                                 if crt_active {

--- a/src/video/window/app_display.rs
+++ b/src/video/window/app_display.rs
@@ -511,6 +511,49 @@ impl App {
         self.request_redraw();
     }
 
+    /// The content rect the autocrop presentation crops to, in canvas
+    /// pixels of the display region -- or `None` whenever the classic
+    /// whole-canvas layout must present instead: autocrop off, no
+    /// content yet, or a frame the crop does not apply to. An open
+    /// overlay suspends it (menus and panels draw into the display
+    /// region against the full canvas mapping, like the CRT and RTG
+    /// passes suspend themselves); the bezel and the CRT presets frame
+    /// the whole glass, so the tube look wins while one is on; RTG
+    /// board frames and programmable scans present their own geometry.
+    pub(super) fn autocrop_canvas_src(&self) -> Option<(usize, usize, usize, usize)> {
+        if !crate::video::autocrop()
+            || self.ui.active()
+            || self.rtg_present_dims.is_some()
+            || self.present_programmable
+            || self.present_width != FB_WIDTH
+            || self.bezel.is_on()
+            || self.crt_shader_kind != crate::config::ShaderKind::None
+        {
+            return None;
+        }
+        canvas_content_rect(
+            self.present_content_rect?,
+            self.present_rows,
+            self.overscan,
+            self.tv_centre,
+            self.present_tv_aperture_rows,
+            present_height(),
+        )
+    }
+
+    /// Switch the autocrop presentation live. Purely a scaler-pass
+    /// input -- the canvas, texture and window are untouched -- so
+    /// nothing needs rebuilding; the next redraw draws the other layout.
+    pub(super) fn apply_autocrop(&mut self, autocrop: bool) {
+        if autocrop == crate::video::autocrop() {
+            return;
+        }
+        crate::video::set_autocrop(autocrop);
+        self.show_osd(format!("Autocrop: {}", if autocrop { "on" } else { "off" }));
+        self.main_presentation_dirty = true;
+        self.request_redraw();
+    }
+
     /// Nudge the TV-presentation centring (Video Settings -> Screen
     /// Centring), the front-panel H-CENTER/V-CENTER knobs of a real
     /// monitor. A live presentation change like the bezel toggle: captures
@@ -621,6 +664,8 @@ impl App {
         self.last_rendered_emulated_frame = None;
         self.last_submitted_render_frame = None;
         self.presentation_latch.reset();
+        self.autocrop_latch.reset();
+        self.present_content_rect = None;
         self.last_main_redraw_state = None;
         self.main_presentation_dirty = true;
         let _ = self.collect_threaded_render_results(false);
@@ -637,6 +682,17 @@ impl App {
                 self.render_recycle_fb = result.presentation_fb;
             }
             return false;
+        }
+
+        // Advance the autocrop smoothing on every rendered frame, reused
+        // ones included: a static screen is exactly what lets a smaller
+        // envelope prove itself stable. A change to the *presented* crop
+        // must repaint even when the pixels themselves are unchanged
+        // (the shrink adoption fires on the Nth identical frame).
+        let smoothed = self.autocrop_latch.resolve(result.content_rect);
+        if smoothed != self.present_content_rect {
+            self.present_content_rect = smoothed;
+            self.main_presentation_dirty = true;
         }
 
         if result.reused_previous {
@@ -806,6 +862,8 @@ impl App {
             // buffer instead of producing the first returning chipset frame.
             self.render_generation = self.render_generation.wrapping_add(1);
             self.presentation_latch.reset();
+            self.autocrop_latch.reset();
+            self.present_content_rect = None;
         }
         self.rtg_present_dims = Some((native_w, native_h));
         self.main_presentation_dirty = true;
@@ -852,7 +910,7 @@ impl App {
         } else {
             0
         };
-        bitplane::render(self.emu.bus_mut(), &mut self.fb);
+        let field_content = bitplane::render(self.emu.bus_mut(), &mut self.fb);
         let geometry = self.emu.bus().frame_geometry();
         let canvas_scale = self.emu.bus().frame_canvas_scale();
         let field_rows = post_process_rendered_field(
@@ -878,6 +936,18 @@ impl App {
             !geometry.programmable,
             &mut next_present_fb,
         );
+        let smoothed = self.autocrop_latch.resolve(woven_content_rect(
+            field_content,
+            geometry.programmable,
+            visible_start_vpos,
+            h_shift,
+            FB_WIDTH * canvas_scale,
+            rows,
+        ));
+        if smoothed != self.present_content_rect {
+            self.present_content_rect = smoothed;
+            self.main_presentation_dirty = true;
+        }
         let next_tv_aperture_rows = self
             .presentation_latch
             .resolve_tv_aperture(standard_tv_aperture_frame(geometry, rows, &base));

--- a/src/video/window/app_display.rs
+++ b/src/video/window/app_display.rs
@@ -549,7 +549,16 @@ impl App {
             return;
         }
         crate::video::set_autocrop(autocrop);
-        self.show_osd(format!("Autocrop: {}", if autocrop { "on" } else { "off" }));
+        // Turning it on under a bezel or CRT preset changes nothing on
+        // screen (the tube look owns the glass and the crop suspends
+        // itself); say so, or the toggle looks broken.
+        let suspended =
+            self.bezel.is_on() || self.crt_shader_kind != crate::config::ShaderKind::None;
+        self.show_osd(match (autocrop, suspended) {
+            (true, true) => "Autocrop: on (suspended while a bezel or CRT shader is on)",
+            (true, false) => "Autocrop: on",
+            (false, _) => "Autocrop: off",
+        });
         self.main_presentation_dirty = true;
         self.request_redraw();
     }

--- a/src/video/window/app_display.rs
+++ b/src/video/window/app_display.rs
@@ -511,18 +511,23 @@ impl App {
         self.request_redraw();
     }
 
-    /// The content rect the autocrop presentation crops to, in canvas
-    /// pixels of the display region -- or `None` whenever the classic
-    /// whole-canvas layout must present instead: autocrop off, no
-    /// content yet, or a frame the crop does not apply to. An open
-    /// overlay suspends it (menus and panels draw into the display
-    /// region against the full canvas mapping, like the CRT and RTG
-    /// passes suspend themselves); the bezel and the CRT presets frame
-    /// the whole glass, so the tube look wins while one is on; RTG
-    /// board frames and programmable scans present their own geometry.
+    /// The rect the autocrop presentation shows of the display region,
+    /// in canvas pixels -- or `None` whenever the classic whole-canvas
+    /// layout must present instead: autocrop off, or a frame the mode
+    /// does not apply to (the bezel and the CRT presets frame the whole
+    /// glass, so the tube look wins while one is on; RTG board frames
+    /// and programmable scans present their own geometry).
+    ///
+    /// While the mode is on, the layout never falls back to the classic
+    /// letterbox: an open menu or panel, or a session with no content
+    /// yet, widens the rect to the full display region instead. The
+    /// overlays draw into the display region against the full canvas
+    /// mapping, so this keeps them entirely visible -- and it keeps the
+    /// status-bar band pinned to the window bottom, rather than hopping
+    /// between the bottom-anchored band and the letterbox's centred bar
+    /// every time a menu opens.
     pub(super) fn autocrop_canvas_src(&self) -> Option<(usize, usize, usize, usize)> {
         if !crate::video::autocrop()
-            || self.ui.active()
             || self.rtg_present_dims.is_some()
             || self.present_programmable
             || self.present_width != FB_WIDTH
@@ -531,13 +536,23 @@ impl App {
         {
             return None;
         }
-        canvas_content_rect(
-            self.present_content_rect?,
-            self.present_rows,
-            self.overscan,
-            self.tv_centre,
-            self.present_tv_aperture_rows,
-            present_height(),
+        let full = (0, 0, FB_WIDTH, present_height());
+        if self.ui.active() {
+            return Some(full);
+        }
+        let Some(content) = self.present_content_rect else {
+            return Some(full);
+        };
+        Some(
+            canvas_content_rect(
+                content,
+                self.present_rows,
+                self.overscan,
+                self.tv_centre,
+                self.present_tv_aperture_rows,
+                present_height(),
+            )
+            .unwrap_or(full),
         )
     }
 

--- a/src/video/window/app_display.rs
+++ b/src/video/window/app_display.rs
@@ -514,9 +514,10 @@ impl App {
     /// The rect the autocrop presentation shows of the display region,
     /// in canvas pixels -- or `None` whenever the classic whole-canvas
     /// layout must present instead: autocrop off, or a frame the mode
-    /// does not apply to (the bezel and the CRT presets frame the whole
-    /// glass, so the tube look wins while one is on; RTG board frames
-    /// and programmable scans present their own geometry).
+    /// does not apply to (the bezel frames the whole glass with a fixed
+    /// opening, so it wins while it is on; RTG board frames and
+    /// programmable scans present their own geometry). The CRT presets
+    /// compose: the pass re-draws whatever rect the layout shows.
     ///
     /// While the mode is on, the layout never falls back to the classic
     /// letterbox: an open menu or panel, or a session with no content
@@ -532,7 +533,6 @@ impl App {
             || self.present_programmable
             || self.present_width != FB_WIDTH
             || self.bezel.is_on()
-            || self.crt_shader_kind != crate::config::ShaderKind::None
         {
             return None;
         }
@@ -564,13 +564,12 @@ impl App {
             return;
         }
         crate::video::set_autocrop(autocrop);
-        // Turning it on under a bezel or CRT preset changes nothing on
-        // screen (the tube look owns the glass and the crop suspends
+        // Turning it on under a bezel changes nothing on screen (the
+        // front's fixed opening owns the glass and the crop suspends
         // itself); say so, or the toggle looks broken.
-        let suspended =
-            self.bezel.is_on() || self.crt_shader_kind != crate::config::ShaderKind::None;
+        let suspended = self.bezel.is_on();
         self.show_osd(match (autocrop, suspended) {
-            (true, true) => "Autocrop: on (suspended while a bezel or CRT shader is on)",
+            (true, true) => "Autocrop: on (suspended while a bezel is on)",
             (true, false) => "Autocrop: on",
             (false, _) => "Autocrop: off",
         });

--- a/src/video/window/app_input.rs
+++ b/src/video/window/app_input.rs
@@ -114,9 +114,13 @@ impl App {
         let inner = r.window.inner_size();
         let phys = self.last_cursor_phys;
         let context = r.pixels.context();
-        let clip = main_clip_rect(r);
+        // The rect the display quad is actually drawn into -- the crop's
+        // under autocrop, the classic letterbox otherwise -- so the trace
+        // shows the same mapping the position below went through.
+        let layout = main_present_layout(r, autocrop_src);
+        let clip = layout.display_dst;
         let texture = (context.texture_extent.width, context.texture_extent.height);
-        let pos = phys.and_then(|p| main_cursor_position(r, autocrop_src, p));
+        let pos = phys.and_then(|p| layout.cursor_position(p));
         let region = match pos {
             Some(p) if cursor_in_status_bar(p) => "status_bar",
             Some(p) if cursor_in_display(p) => "display(->capture)",

--- a/src/video/window/app_input.rs
+++ b/src/video/window/app_input.rs
@@ -97,15 +97,16 @@ impl App {
     }
 
     /// COPPERLINE_DIAG_CURSOR: trace how the most recent click maps from host
-    /// physical coordinates through the scaling renderer's clip rect into a
-    /// texture/region hit. The tool for diagnosing mouse capture on DPI scale
+    /// physical coordinates through the scaler pass's clip rect into a
+    /// canvas/region hit. The tool for diagnosing mouse capture on DPI scale
     /// changes and mixed-scale monitors (see the ScaleFactorChanged handler):
     /// if a status-bar click logs region=display(->capture), the surface and
-    /// texture extents have drifted out of agreement.
+    /// clip rect have drifted out of agreement.
     pub(super) fn log_cursor_diag(&self, button: MouseButton) {
         if !crate::envcfg::flag("COPPERLINE_DIAG_CURSOR") {
             return;
         }
+        let autocrop_src = self.autocrop_canvas_src();
         let Some(r) = self.render.as_ref() else {
             return;
         };
@@ -113,9 +114,9 @@ impl App {
         let inner = r.window.inner_size();
         let phys = self.last_cursor_phys;
         let context = r.pixels.context();
-        let clip = context.scaling_renderer.clip_rect();
+        let clip = main_clip_rect(r);
         let texture = (context.texture_extent.width, context.texture_extent.height);
-        let pos = phys.and_then(|p| cursor_texture_position(&r.pixels, p, r.texture_scale));
+        let pos = phys.and_then(|p| main_cursor_position(r, autocrop_src, p));
         let region = match pos {
             Some(p) if cursor_in_status_bar(p) => "status_bar",
             Some(p) if cursor_in_display(p) => "display(->capture)",

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -1372,6 +1372,7 @@ impl App {
         self.tv_centre = cfg.tv_centre;
         self.apply_pixel_aspect(crate::config::resolve_pixel_aspect(cfg.pixel_aspect));
         self.apply_display_scaling(cfg.scaling);
+        self.apply_autocrop(cfg.autocrop);
         // Apply the configured start-up window state; the runtime toggles
         // (Cmd+F, Cmd+Shift+F) take over from here. Reuse the toggles so the
         // surface/window resize stays in one place.

--- a/src/video/window/app_menus.rs
+++ b/src/video/window/app_menus.rs
@@ -123,6 +123,7 @@ impl App {
             ],
             pixel_aspect: crate::video::pixel_aspect(),
             scaling: crate::video::display_scaling(),
+            autocrop: crate::video::autocrop(),
             tv_centre: self.tv_centre,
             tv_centre_applies: self.overscan == Overscan::Tv,
             shader: self.crt_shader_kind,
@@ -288,6 +289,7 @@ impl App {
 
             A::SetPixelAspect(aspect) => self.apply_pixel_aspect(aspect),
             A::SetDisplayScaling(scaling) => self.apply_display_scaling(scaling),
+            A::ToggleAutocrop => self.apply_autocrop(!crate::video::autocrop()),
             A::StepTvCentre(dh, dv) => self.step_tv_centre(dh, dv),
             A::ResetTvCentre => {
                 self.tv_centre = crate::config::TvCentre::default();

--- a/src/video/window/app_panels.rs
+++ b/src/video/window/app_panels.rs
@@ -1165,12 +1165,7 @@ impl App {
         // A tool window shows panel text, not the emulated picture, so it
         // always takes the aspect-preserving fit -- integer scaling is a
         // setting for the machine's display.
-        let pixels = match build_pixels_for_window(
-            window.clone(),
-            texture_scale,
-            false,
-            ScalingMode::Fill,
-        ) {
+        let pixels = match build_pixels_for_window(window.clone(), texture_scale, false) {
             Ok(p) => p,
             Err(e) => {
                 warn!("tool window pixels init failed: {e}");

--- a/src/video/window/crt_shader.rs
+++ b/src/video/window/crt_shader.rs
@@ -574,20 +574,7 @@ pub(super) fn uniforms_for(
         }
     };
     let viewport = (cx as f32, cy as f32, cw as f32, display_fraction(ch as f32));
-    // mask kind, curvature, vignette
-    let (mask, curvature, vignette) = match kind {
-        ShaderKind::Scanlines => (0.0, 0.0, 0.0),
-        // 2: staggered dot/shadow mask.
-        ShaderKind::Mask => (2.0, 0.0, 0.0),
-        // 1: aperture grille, with a bowed face and corner falloff. The
-        // curvature reproduces the screen-edge arcs of the 1084's tube
-        // datasheet (Philips M34EAQ10X) under crt.wgsl's aspect-weighted
-        // warp; the derivation is with the warp function.
-        ShaderKind::Crt => (1.0, face_curvature(kind), 0.15),
-        // A user shader gets the frame geometry and the two knobs it can
-        // sensibly honour; the preset look table means nothing to it.
-        ShaderKind::None | ShaderKind::Custom => (0.0, 0.0, 0.0),
-    };
+    let (mask, curvature, vignette) = preset_look(kind);
     let uniforms = CrtUniforms {
         src_rect: [0.0, 0.0, 1.0, display_fraction(1.0)],
         size: [
@@ -602,9 +589,117 @@ pub(super) fn uniforms_for(
     (uniforms, viewport)
 }
 
+/// The preset look table: mask kind, curvature, vignette.
+fn preset_look(kind: ShaderKind) -> (f32, f32, f32) {
+    match kind {
+        ShaderKind::Scanlines => (0.0, 0.0, 0.0),
+        // 2: staggered dot/shadow mask.
+        ShaderKind::Mask => (2.0, 0.0, 0.0),
+        // 1: aperture grille, with a bowed face and corner falloff. The
+        // curvature reproduces the screen-edge arcs of the 1084's tube
+        // datasheet (Philips M34EAQ10X) under crt.wgsl's aspect-weighted
+        // warp; the derivation is with the warp function.
+        ShaderKind::Crt => (1.0, face_curvature(kind), 0.15),
+        // A user shader gets the frame geometry and the two knobs it can
+        // sensibly honour; the preset look table means nothing to it.
+        ShaderKind::None | ShaderKind::Custom => (0.0, 0.0, 0.0),
+    }
+}
+
+/// [`uniforms_for`] for an arbitrary picture rect: the pass re-draws the
+/// `src_canvas` sub-rect of the canvas (`(x, y, w, h)` in logical canvas
+/// pixels of a `canvas`-sized buffer) into `viewport` (physical surface
+/// pixels). The autocrop layout's form, where the picture is a crop of
+/// the display region rather than the whole region under the status
+/// bar; the scaler pass draws the same sub-rect into the same viewport,
+/// so the two land identically. `scanlines` is the beam-line count
+/// across *this* rect, not the whole display.
+///
+/// Pure arithmetic, like [`uniforms_for`].
+pub(super) fn uniforms_for_rect(
+    kind: ShaderKind,
+    strength: f32,
+    viewport: (u32, u32, u32, u32),
+    src_canvas: (usize, usize, usize, usize),
+    canvas: (usize, usize),
+    texture_extent: (u32, u32),
+    scanlines: f32,
+) -> (CrtUniforms, (f32, f32, f32, f32)) {
+    let (vx, vy, vw, vh) = viewport;
+    let viewport = (vx as f32, vy as f32, vw as f32, vh as f32);
+    let (sx, sy, sw, sh) = src_canvas;
+    let (cw, ch) = (canvas.0.max(1) as f32, canvas.1.max(1) as f32);
+    let (mask, curvature, vignette) = preset_look(kind);
+    let uniforms = CrtUniforms {
+        src_rect: [
+            sx as f32 / cw,
+            sy as f32 / ch,
+            sw as f32 / cw,
+            sh as f32 / ch,
+        ],
+        size: [
+            viewport.2,
+            viewport.3,
+            sw as f32 * texture_extent.0 as f32 / cw,
+            sh as f32 * texture_extent.1 as f32 / ch,
+        ],
+        params: [strength, scanlines, mask, curvature],
+        params2: [vignette, 0.0, 0.0, 0.0],
+    };
+    (uniforms, viewport)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The rect form maps an autocrop sub-rect of the display region:
+    /// the source rect is the crop's uv position in the whole buffer,
+    /// the source size its texel extent, and the viewport is taken as
+    /// given -- the same numbers the scaler pass draws the crop with.
+    #[test]
+    fn rect_uniforms_map_the_crop_not_the_whole_display() {
+        // A 640x400 crop at (38, 71) of a 716x581 canvas, on a 2x
+        // texture, drawn into a 1280x800 viewport at (76, 170).
+        let (u, viewport) = uniforms_for_rect(
+            ShaderKind::Scanlines,
+            1.0,
+            (76, 170, 1280, 800),
+            (38, 71, 640, 400),
+            (716, 581),
+            (1432, 1162),
+            200.0,
+        );
+        assert_eq!(viewport, (76.0, 170.0, 1280.0, 800.0));
+        assert_eq!(
+            u.src_rect,
+            [38.0 / 716.0, 71.0 / 581.0, 640.0 / 716.0, 400.0 / 581.0]
+        );
+        // Source texels: the crop at the texture's supersample factor.
+        assert_eq!(u.size, [1280.0, 800.0, 1280.0, 800.0]);
+        assert_eq!(u.params[1], 200.0);
+        // The look table is the same one the classic form uses.
+        let (classic, _) = uniforms_for(
+            ShaderKind::Crt,
+            0.5,
+            (0, 0, 1432, 1162),
+            537,
+            581,
+            (1432, 1162),
+            270.0,
+        );
+        let (rect, _) = uniforms_for_rect(
+            ShaderKind::Crt,
+            0.5,
+            (0, 0, 1432, 1074),
+            (0, 0, 716, 537),
+            (716, 581),
+            (1432, 1162),
+            270.0,
+        );
+        assert_eq!(rect.params[2..], classic.params[2..]);
+        assert_eq!(rect.params2, classic.params2);
+    }
 
     const PRESET_SOURCES: [(&str, &str); 3] = [
         ("scanlines", SCANLINES_WGSL),

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -700,42 +700,43 @@ pub(super) fn main_present_layout(
             chrome_dst: None,
         };
     };
+    // The chrome band keeps exactly the size and position the classic
+    // letterbox gives it -- only bottom-anchored -- so toggling autocrop
+    // resizes the picture, never the bar, and the band can never eat
+    // more height than the crop gains (a surface-width bar on a 5K
+    // fullscreen would be over 300 rows tall).
+    let chrome_rows = window_present_height() - present_height();
+    let classic = main_clip_rect(r);
+    let chrome_dst = (chrome_rows > 0 && classic.3 > 0).then(|| {
+        let h =
+            ((u64::from(classic.3) * chrome_rows as u64 / window_present_height().max(1) as u64)
+                as u32)
+                .clamp(1, surface.1);
+        (classic.0, surface.1 - h, classic.2, h)
+    });
     // The *requested* setting, not the classic plan's resolved multiple:
     // a surface too small for the whole canvas can still hold a whole
     // multiple of the crop (a 700-wide window around a 640-wide game),
     // and autocrop_layout takes its own fit against the crop.
-    autocrop_layout(
-        surface,
-        integer_scaling_requested(),
-        crop,
-        window_present_height() - present_height(),
-    )
+    autocrop_layout(surface, integer_scaling_requested(), crop, chrome_dst)
 }
 
 /// The autocrop layout, pure of the live globals: `crop` (canvas pixels
-/// of the display region) placed on `surface`, with `chrome_rows` canvas
-/// rows of panels and status bar kept as a band along the surface
-/// bottom.
+/// of the display region) placed on `surface`, above the already-sized
+/// `chrome_dst` band (panels and status bar; `None` when there is no
+/// chrome to show).
 ///
-/// The chrome band spans the surface at the width-fit scale the classic
-/// width-limited letterbox gives it. Integer scaling re-fits against the
-/// crop -- a display using fewer lines earns a larger whole multiple,
-/// which is the point of the feature -- and falls back to the smooth fit
-/// of the crop when not even 1x fits, exactly as the classic layout
-/// falls back.
+/// Integer scaling re-fits against the crop -- a display using fewer
+/// lines earns a larger whole multiple, which is the point of the
+/// feature -- and falls back to the smooth fit of the crop when not
+/// even 1x fits, exactly as the classic layout falls back.
 pub(super) fn autocrop_layout(
     surface: (u32, u32),
     integer: bool,
     crop: (usize, usize, usize, usize),
-    chrome_rows: usize,
+    chrome_dst: Option<(u32, u32, u32, u32)>,
 ) -> PresentLayout {
-    let (chrome_dst, avail_h) = if chrome_rows > 0 {
-        let hb = ((chrome_rows as u64 * u64::from(surface.0) / FB_WIDTH as u64) as u32)
-            .clamp(1, surface.1.saturating_sub(1).max(1));
-        (Some((0, surface.1 - hb, surface.0, hb)), surface.1 - hb)
-    } else {
-        (None, surface.1)
-    };
+    let avail_h = surface.1 - chrome_dst.map_or(0, |(_, _, _, h)| h.min(surface.1));
     let avail = (surface.0, avail_h.max(1));
     let multiple = integer
         .then(|| (avail.0 as usize / crop.2).min(avail.1 as usize / crop.3))

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -692,18 +692,21 @@ pub(super) fn main_present_layout(
     autocrop_src: Option<(usize, usize, usize, usize)>,
 ) -> PresentLayout {
     let surface = (r.surface_size.0.max(1), r.surface_size.1.max(1));
-    let plan = main_present_plan(r);
     let Some(crop) = autocrop_src.filter(|(_, _, w, h)| *w > 0 && *h > 0) else {
         return PresentLayout {
             src_canvas: (0, 0, FB_WIDTH, window_present_height()),
             display_dst: main_clip_rect(r),
-            filter: plan.filter(),
+            filter: main_present_plan(r).filter(),
             chrome_dst: None,
         };
     };
+    // The *requested* setting, not the classic plan's resolved multiple:
+    // a surface too small for the whole canvas can still hold a whole
+    // multiple of the crop (a 700-wide window around a 640-wide game),
+    // and autocrop_layout takes its own fit against the crop.
     autocrop_layout(
         surface,
-        plan.multiple.is_some(),
+        integer_scaling_requested(),
         crop,
         window_present_height() - present_height(),
     )

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -27,6 +27,7 @@ struct RepeatedPresentationMetadata {
     present_width: usize,
     tv_aperture: TvApertureFrame,
     programmable: bool,
+    content_rect: Option<bitplane::ContentRect>,
 }
 
 /// Exact previous-frame detector owned by the render worker. The bitplane
@@ -123,6 +124,7 @@ pub(super) fn render_job_to_presentation(
             present_width: metadata.present_width,
             tv_aperture: metadata.tv_aperture,
             programmable: metadata.programmable,
+            content_rect: metadata.content_rect,
             input,
         };
     }
@@ -157,11 +159,20 @@ pub(super) fn render_job_to_presentation(
         !geometry.programmable,
         &mut presentation_fb,
     );
+    let content_rect = woven_content_rect(
+        render_result.content_rect,
+        geometry.programmable,
+        visible_start_vpos,
+        h_shift,
+        canvas_width,
+        present_rows,
+    );
     let metadata = RepeatedPresentationMetadata {
         present_rows,
         present_width,
         tv_aperture: standard_tv_aperture_frame(geometry, present_rows, &base),
         programmable: geometry.programmable,
+        content_rect,
     };
     repeated_frame_cache.note_rendered(&input, &mut render_result, settings, phosphor, metadata);
     RenderWorkerResult {
@@ -174,7 +185,181 @@ pub(super) fn render_job_to_presentation(
         present_width,
         tv_aperture: metadata.tv_aperture,
         programmable: metadata.programmable,
+        content_rect,
         input,
+    }
+}
+
+/// Map the renderer's field-space content envelope into woven
+/// presentation-buffer space: the same shifts
+/// `post_process_rendered_field` applied to the pixels (vertical
+/// centring, horizontal recentring), then each field row onto its two
+/// woven rows. Programmable scans present their own window in full and
+/// never autocrop, so they map to `None`.
+pub(super) fn woven_content_rect(
+    rect: Option<bitplane::ContentRect>,
+    programmable: bool,
+    visible_start_vpos: u32,
+    h_shift: usize,
+    canvas_width: usize,
+    present_rows: usize,
+) -> Option<bitplane::ContentRect> {
+    rect.filter(|_| !programmable)
+        .map(|rect| {
+            let y_off = presentation_source_y_offset(visible_start_vpos);
+            let x0 = rect.x0.saturating_sub(h_shift).min(canvas_width);
+            let x1 = rect.x1.saturating_sub(h_shift).clamp(x0, canvas_width);
+            let y0 = (2 * (rect.y0 + y_off)).min(present_rows);
+            let y1 = (2 * (rect.y1 + y_off)).clamp(y0, present_rows);
+            bitplane::ContentRect { x0, x1, y0, y1 }
+        })
+        .filter(|rect| rect.x1 > rect.x0 && rect.y1 > rect.y0)
+}
+
+/// Map a woven-space content envelope into canvas coordinates -- the
+/// space of the texture's display region -- by inverting the same row
+/// and column mapping `copy_window_present_frame` used for this frame's
+/// branch. Returns `(x, y, w, h)` in canvas pixels, or `None` when no
+/// canvas pixel shows content (crop everything away and there is nothing
+/// to present).
+///
+/// The inversion scans the canvas axes against the copy's forward maps
+/// rather than deriving closed forms: a few hundred iterations, run only
+/// when autocrop is presenting, and immune to drifting out of agreement
+/// with the copy it mirrors.
+pub(super) fn canvas_content_rect(
+    content: bitplane::ContentRect,
+    src_rows: usize,
+    overscan: Overscan,
+    tv_centre: TvCentre,
+    tv_aperture_rows: Option<usize>,
+    canvas_rows: usize,
+) -> Option<(usize, usize, usize, usize)> {
+    let (mut y_min, mut y_max) = (None, None);
+    let (mut x_min, mut x_max) = (None, None);
+    match tv_aperture_rows {
+        Some(aperture_rows) if overscan == Overscan::Tv => {
+            let (x_off, y_off) = tv_centre_source_offset(tv_centre);
+            for y in 0..canvas_rows {
+                let src = tv_aperture_source_row(y, canvas_rows, 1, aperture_rows)
+                    .map(|crop_y| (TV_PRESENT_SOURCE_Y + crop_y) as i32 + y_off)
+                    .filter(|src| (content.y0 as i32..content.y1 as i32).contains(src));
+                if src.is_some() {
+                    y_min.get_or_insert(y);
+                    y_max = Some(y);
+                }
+            }
+            let square = canvas_rows == crate::video::PRESENT_HEIGHT_SQUARE;
+            for x in 0..FB_WIDTH {
+                let src = if square {
+                    (TV_LIVE_PAD_X..TV_LIVE_PAD_X + TV_CAPTURED_WIDTH)
+                        .contains(&x)
+                        .then(|| TV_CAPTURED_SOURCE_X as i32 + x_off + (x - TV_LIVE_PAD_X) as i32)
+                } else {
+                    // The glass resample's source centre for this canvas
+                    // column (`tv_glass_sample`'s 8.8 sample point).
+                    let s = (TV_CAPTURED_SOURCE_X as i64 + x_off as i64) * 256
+                        + ((2 * x as i64 + 1) * (TV_CAPTURED_WIDTH as i64) * 256)
+                            / (2 * FB_WIDTH as i64)
+                        - 128;
+                    Some((s >> 8) as i32)
+                };
+                if src.is_some_and(|src| (content.x0 as i32..content.x1 as i32).contains(&src)) {
+                    x_min.get_or_insert(x);
+                    x_max = Some(x);
+                }
+            }
+        }
+        _ => {
+            for y in 0..canvas_rows {
+                let src = screenshot::scaled_source_row(y, src_rows, canvas_rows);
+                if (content.y0..content.y1).contains(&src) {
+                    y_min.get_or_insert(y);
+                    y_max = Some(y);
+                }
+            }
+            x_min = Some(content.x0.min(FB_WIDTH - 1));
+            x_max = Some(content.x1.saturating_sub(1).min(FB_WIDTH - 1));
+        }
+    }
+    let (x0, x1, y0, y1) = (x_min?, x_max?, y_min?, y_max?);
+    Some((x0, y0, x1 + 1 - x0, y1 + 1 - y0))
+}
+
+/// Presentation smoothing for the autocrop rect. Per-frame content
+/// envelopes jitter -- loaders blank the screen, screen transitions
+/// rebuild the copper list over a frame or two, games flip between
+/// differently-sized displays -- and the presented crop must not pump
+/// with them. The latch grows immediately (content must never be cut)
+/// to the union of the old and new envelopes, holds through border-only
+/// frames like the aperture latch does, and shrinks only after the
+/// smaller envelope has held steady for [`Self::SHRINK_STABLE_FRAMES`]
+/// consecutive rendered frames.
+#[derive(Default)]
+pub(super) struct AutocropLatch {
+    active: Option<bitplane::ContentRect>,
+    candidate: Option<bitplane::ContentRect>,
+    stable_frames: u32,
+}
+
+impl AutocropLatch {
+    /// Rendered frames a strictly-smaller envelope must persist for
+    /// before the presentation tightens onto it: about half a second of
+    /// PAL frames, long enough to sit out a screen transition.
+    pub(super) const SHRINK_STABLE_FRAMES: u32 = 25;
+
+    pub(super) fn resolve(
+        &mut self,
+        frame: Option<bitplane::ContentRect>,
+    ) -> Option<bitplane::ContentRect> {
+        let Some(frame) = frame else {
+            // Border-only frame: keep presenting the previous crop, and
+            // keep any shrink candidate's clock running from zero again
+            // once content returns.
+            self.candidate = None;
+            self.stable_frames = 0;
+            return self.active;
+        };
+        let Some(active) = self.active else {
+            self.active = Some(frame);
+            return self.active;
+        };
+        let contained = frame.x0 >= active.x0
+            && frame.x1 <= active.x1
+            && frame.y0 >= active.y0
+            && frame.y1 <= active.y1;
+        if !contained {
+            self.active = Some(bitplane::ContentRect {
+                x0: active.x0.min(frame.x0),
+                x1: active.x1.max(frame.x1),
+                y0: active.y0.min(frame.y0),
+                y1: active.y1.max(frame.y1),
+            });
+            self.candidate = None;
+            self.stable_frames = 0;
+        } else if frame != active {
+            if self.candidate == Some(frame) {
+                self.stable_frames += 1;
+                if self.stable_frames >= Self::SHRINK_STABLE_FRAMES {
+                    self.active = Some(frame);
+                    self.candidate = None;
+                    self.stable_frames = 0;
+                }
+            } else {
+                self.candidate = Some(frame);
+                self.stable_frames = 1;
+            }
+        } else {
+            self.candidate = None;
+            self.stable_frames = 0;
+        }
+        self.active
+    }
+
+    /// Forget the crop across a presentation discontinuity (power cycle,
+    /// RTG entry), like `PresentationLatch::reset`.
+    pub(super) fn reset(&mut self) {
+        *self = Self::default();
     }
 }
 
@@ -378,46 +563,67 @@ pub(super) fn texture_scale_for_factor(scale_factor: f64) -> usize {
     (scale_factor.round() as usize).clamp(1, MAX_TEXTURE_SCALE)
 }
 
-/// The presentation plan for a window: the supersample factor its backing
-/// texture is rendered at, and the `pixels` scaling mode that puts the
-/// texture on the surface. The pure form of [`plan_present_scaling`], with
-/// the canvas size (in canvas pixels) passed in.
+/// The presentation plan for the emulator window: the supersample factor
+/// its backing texture is rendered at, and the whole-canvas-pixel
+/// multiple integer scaling draws it at (`None` for the smooth fit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct PresentPlan {
+    /// Supersample factor of the backing texture.
+    pub(super) texture_scale: usize,
+    /// Whole number of physical surface pixels per canvas pixel, or
+    /// `None` for the smooth aspect fit.
+    pub(super) multiple: Option<usize>,
+}
+
+impl PresentPlan {
+    /// How the scaler pass resamples the texture for this plan.
+    pub(super) fn filter(&self) -> scaler::ScaleFilter {
+        match self.multiple {
+            Some(_) => scaler::ScaleFilter::Nearest,
+            None => scaler::ScaleFilter::SharpBilinear,
+        }
+    }
+}
+
+/// The presentation plan for a window, with the canvas size (in canvas
+/// pixels) passed in: the pure form of [`plan_present_scaling`].
 ///
-/// Smooth scaling supersamples by the rounded host DPI factor and fits with
-/// filtering. Integer scaling instead takes the fit in whole *canvas*
-/// pixels against the physical surface: the factor is the largest whole
-/// number of physical pixels per canvas pixel that fits, the canvas is
-/// rendered at that factor, and `ScalingMode::PixelPerfect` draws the
-/// texture 1:1 and point-sampled. Deriving the texture from the fit rather
-/// than the DPI is what makes every whole multiple reachable: a
-/// DPI-supersampled texture can only be drawn at whole multiples of
-/// *itself*, which on a 2x display skips every odd number of physical
-/// pixels per canvas pixel -- a Retina laptop tall enough for a 3x picture
-/// but not a 4x one would show no zoom at all. The factor is capped at
-/// `MAX_INTEGER_TEXTURE_SCALE` to bound the texture and the per-frame
-/// present copy; past the cap, PixelPerfect's own whole multiples of the
-/// capped texture keep the fit integer (`floor` at that stage, so the
-/// result never exceeds the surface).
+/// Smooth scaling supersamples by the rounded host DPI factor and fits
+/// with the sharp-bilinear filter. Integer scaling instead takes the fit
+/// in whole *canvas* pixels against the physical surface: the multiple
+/// is the largest whole number of physical pixels per canvas pixel that
+/// fits, and the scaler pass draws the picture at exactly that multiple.
+/// Deriving the multiple from the fit rather than the DPI is what makes
+/// every whole multiple reachable -- a Retina laptop tall enough for a
+/// 3x picture but not a 4x one gets its 3x. The texture factor follows
+/// the multiple up to `MAX_INTEGER_TEXTURE_SCALE`, which bounds the
+/// texture and the per-frame present copy on very large displays; a
+/// multiple past the cap is still drawn in full, because point-sampling
+/// the replicated display region is exact whether or not the texture
+/// factor divides the multiple (see `scaler`).
 ///
 /// A surface smaller than the canvas has no whole multiple to offer
-/// (PixelPerfect floors its scale at 1 and would crop), so it falls back to
-/// the smooth plan -- shrinking the picture beats cropping it.
+/// (drawing at 1x would crop), so it falls back to the smooth plan --
+/// shrinking the picture beats cropping it.
 pub(super) fn plan_present_scaling_for(
     integer_requested: bool,
     scale_factor: f64,
     surface: (u32, u32),
     canvas: (u32, u32),
-) -> (usize, ScalingMode) {
+) -> PresentPlan {
     if integer_requested && canvas.0 > 0 && canvas.1 > 0 {
         let fit = (surface.0 / canvas.0).min(surface.1 / canvas.1) as usize;
         if fit >= 1 {
-            return (
-                fit.min(MAX_INTEGER_TEXTURE_SCALE),
-                ScalingMode::PixelPerfect,
-            );
+            return PresentPlan {
+                texture_scale: fit.min(MAX_INTEGER_TEXTURE_SCALE),
+                multiple: Some(fit),
+            };
         }
     }
-    (texture_scale_for_factor(scale_factor), ScalingMode::Fill)
+    PresentPlan {
+        texture_scale: texture_scale_for_factor(scale_factor),
+        multiple: None,
+    }
 }
 
 /// [`plan_present_scaling_for`] against the live canvas: `FB_WIDTH` by the
@@ -426,13 +632,180 @@ pub(super) fn plan_present_scaling(
     integer_requested: bool,
     scale_factor: f64,
     surface: (u32, u32),
-) -> (usize, ScalingMode) {
+) -> PresentPlan {
     plan_present_scaling_for(
         integer_requested,
         scale_factor,
         surface,
         (FB_WIDTH as u32, window_present_height() as u32),
     )
+}
+
+/// The live plan for the emulator window, from its configured surface
+/// size and the current scaling setting. Recomputed where it is needed
+/// rather than stored, so it can never lag a resize or a toggle.
+pub(super) fn main_present_plan(r: &Render) -> PresentPlan {
+    plan_present_scaling(
+        integer_scaling_requested(),
+        r.window.scale_factor(),
+        (r.surface_size.0.max(1), r.surface_size.1.max(1)),
+    )
+}
+
+/// The surface rect the emulator window's picture is drawn into: the
+/// scaler pass's destination, and the rect cursor mapping inverts.
+pub(super) fn main_clip_rect(r: &Render) -> (u32, u32, u32, u32) {
+    scaler::clip_rect_for(
+        (r.surface_size.0.max(1), r.surface_size.1.max(1)),
+        (FB_WIDTH as u32, window_present_height() as u32),
+        main_present_plan(r).multiple,
+    )
+}
+
+/// The emulator window's presentation layout: what part of the canvas
+/// the display draw shows, where it and the chrome band land on the
+/// surface, and how they are filtered. One function feeds the scaler
+/// pass, the cursor mapping and the overlay anchors, so all three agree
+/// by construction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct PresentLayout {
+    /// The canvas sub-rect the display draw samples, in logical canvas
+    /// pixels `(x, y, w, h)`. The whole window canvas -- chrome included
+    /// -- in the classic layout; the autocrop rect (display region only)
+    /// when cropping.
+    pub(super) src_canvas: (usize, usize, usize, usize),
+    /// Where that lands on the surface, physical pixels.
+    pub(super) display_dst: (u32, u32, u32, u32),
+    pub(super) filter: scaler::ScaleFilter,
+    /// The chrome band's destination when the layout splits it from the
+    /// display (autocrop only): the texture rows below `present_height`
+    /// drawn across the surface bottom.
+    pub(super) chrome_dst: Option<(u32, u32, u32, u32)>,
+}
+
+/// The layout for the current frame. `autocrop_src` is the content rect
+/// to crop to, in canvas pixels of the display region, or `None` for the
+/// classic whole-canvas letterbox (autocrop off, suspended, or nothing
+/// to crop to).
+pub(super) fn main_present_layout(
+    r: &Render,
+    autocrop_src: Option<(usize, usize, usize, usize)>,
+) -> PresentLayout {
+    let surface = (r.surface_size.0.max(1), r.surface_size.1.max(1));
+    let plan = main_present_plan(r);
+    let Some(crop) = autocrop_src.filter(|(_, _, w, h)| *w > 0 && *h > 0) else {
+        return PresentLayout {
+            src_canvas: (0, 0, FB_WIDTH, window_present_height()),
+            display_dst: main_clip_rect(r),
+            filter: plan.filter(),
+            chrome_dst: None,
+        };
+    };
+    autocrop_layout(
+        surface,
+        plan.multiple.is_some(),
+        crop,
+        window_present_height() - present_height(),
+    )
+}
+
+/// The autocrop layout, pure of the live globals: `crop` (canvas pixels
+/// of the display region) placed on `surface`, with `chrome_rows` canvas
+/// rows of panels and status bar kept as a band along the surface
+/// bottom.
+///
+/// The chrome band spans the surface at the width-fit scale the classic
+/// width-limited letterbox gives it. Integer scaling re-fits against the
+/// crop -- a display using fewer lines earns a larger whole multiple,
+/// which is the point of the feature -- and falls back to the smooth fit
+/// of the crop when not even 1x fits, exactly as the classic layout
+/// falls back.
+pub(super) fn autocrop_layout(
+    surface: (u32, u32),
+    integer: bool,
+    crop: (usize, usize, usize, usize),
+    chrome_rows: usize,
+) -> PresentLayout {
+    let (chrome_dst, avail_h) = if chrome_rows > 0 {
+        let hb = ((chrome_rows as u64 * u64::from(surface.0) / FB_WIDTH as u64) as u32)
+            .clamp(1, surface.1.saturating_sub(1).max(1));
+        (Some((0, surface.1 - hb, surface.0, hb)), surface.1 - hb)
+    } else {
+        (None, surface.1)
+    };
+    let avail = (surface.0, avail_h.max(1));
+    let multiple = integer
+        .then(|| (avail.0 as usize / crop.2).min(avail.1 as usize / crop.3))
+        .filter(|fit| *fit >= 1);
+    let display_dst = scaler::clip_rect_for(avail, (crop.2 as u32, crop.3 as u32), multiple);
+    PresentLayout {
+        src_canvas: crop,
+        display_dst,
+        filter: if multiple.is_some() {
+            scaler::ScaleFilter::Nearest
+        } else {
+            scaler::ScaleFilter::SharpBilinear
+        },
+        chrome_dst,
+    }
+}
+
+impl PresentLayout {
+    /// The scaler-pass draws this layout amounts to. The classic layout
+    /// is one whole-texture draw; the autocrop layout samples the crop's
+    /// uv sub-rect and adds the chrome band below it.
+    pub(super) fn draws(&self) -> Vec<scaler::ScalerDraw> {
+        let canvas_h = window_present_height() as f32;
+        let (sx, sy, sw, sh) = self.src_canvas;
+        let mut draws = vec![scaler::ScalerDraw {
+            src: [
+                sx as f32 / FB_WIDTH as f32,
+                sy as f32 / canvas_h,
+                sw as f32 / FB_WIDTH as f32,
+                sh as f32 / canvas_h,
+            ],
+            dst: self.display_dst,
+            filter: self.filter,
+        }];
+        if let Some(chrome_dst) = self.chrome_dst {
+            let chrome_rows = (window_present_height() - present_height()) as f32;
+            draws.push(scaler::ScalerDraw {
+                src: [
+                    0.0,
+                    present_height() as f32 / canvas_h,
+                    1.0,
+                    chrome_rows / canvas_h,
+                ],
+                dst: chrome_dst,
+                filter: scaler::ScaleFilter::SharpBilinear,
+            });
+        }
+        draws
+    }
+
+    /// Invert the layout for a host cursor position: surface physical
+    /// pixels to logical canvas pixels, or `None` outside both rects.
+    pub(super) fn cursor_position(
+        &self,
+        position: winit::dpi::PhysicalPosition<f64>,
+    ) -> Option<(i32, i32)> {
+        let (sx, sy, sw, sh) = self.src_canvas;
+        if let Some((x, y)) = cursor_position_in_texture(
+            (position.x, position.y),
+            self.display_dst,
+            (sw as u32, sh as u32),
+        ) {
+            return Some(((sx + x) as i32, (sy + y) as i32));
+        }
+        let chrome_dst = self.chrome_dst?;
+        let chrome_rows = window_present_height() - present_height();
+        let (x, y) = cursor_position_in_texture(
+            (position.x, position.y),
+            chrome_dst,
+            (FB_WIDTH as u32, chrome_rows as u32),
+        )?;
+        Some((x as i32, (present_height() + y) as i32))
+    }
 }
 
 /// Whether the emulator window presents at whole-number scale
@@ -443,28 +816,25 @@ pub(super) fn integer_scaling_requested() -> bool {
 }
 
 /// Re-plan the emulator window's presentation for the given surface size
-/// (physical pixels), its live canvas and the scaling setting: apply the
-/// scaling mode and, when the planned supersample factor or the canvas
-/// underneath it changed, resize the backing texture to match.
-///
-/// `set_scaling_mode` only stores the mode: the scaling matrix and the clip
-/// rect are recomputed by the next `resize_surface`/`resize_buffer`, so a
-/// caller whose own resize is not the next thing to run must re-apply the
-/// current surface size itself.
+/// (physical pixels), its live canvas and the scaling setting: when the
+/// planned supersample factor or the canvas underneath it changed, resize
+/// the backing texture to match. The destination rect and filter are not
+/// stored anywhere -- the redraw recomputes them from the same plan.
 ///
 /// On `Ok` the texture and `r.texture_scale` agree with the plan; on `Err`
-/// both keep their old extent, like `resize_buffer` (the stored mode is
-/// re-decided by the next call, and the matrix never saw it).
+/// both keep their old extent, like `resize_buffer`. The scaler pass draws
+/// the planned rect either way: its point sampling does not need the
+/// texture factor to match the multiple.
 pub(super) fn sync_main_present_scaling(
     r: &mut Render,
     surface: (u32, u32),
 ) -> std::result::Result<(), pixels::TextureError> {
-    let (scale, mode) = plan_present_scaling(
+    let plan = plan_present_scaling(
         integer_scaling_requested(),
         r.window.scale_factor(),
         (surface.0.max(1), surface.1.max(1)),
     );
-    r.pixels.set_scaling_mode(mode);
+    let scale = plan.texture_scale;
     let want = (texture_width(scale) as u32, texture_height(scale) as u32);
     let have = r.pixels.context().texture_extent;
     if (have.width, have.height) != want {
@@ -526,7 +896,6 @@ pub(super) fn build_pixels_for_window(
     window: Arc<Window>,
     texture_scale: usize,
     vsync: bool,
-    scaling_mode: ScalingMode,
 ) -> std::result::Result<Pixels<'static>, pixels::Error> {
     let inner = window.inner_size();
     let surface = (inner.width.max(1), inner.height.max(1));
@@ -544,11 +913,13 @@ pub(super) fn build_pixels_for_window(
         builder
     };
     let mut pixels = builder.build()?;
-    pixels.set_scaling_mode(scaling_mode);
-    // The scaling matrix and clip rect stay the builder's PixelPerfect ones
-    // until a resize recomputes them. Re-apply the surface size so the cursor
-    // mapping and the render scissor agree with the mode just set from the
-    // first frame, not the first resize.
+    // The tool windows draw through the built-in Fill renderer (the
+    // emulator window's own scaler pass ignores the mode). The scaling
+    // matrix and clip rect stay the builder's defaults until a resize
+    // recomputes them; re-apply the surface size so the cursor mapping
+    // and the render scissor agree with the mode from the first frame,
+    // not the first resize.
+    pixels.set_scaling_mode(ScalingMode::Fill);
     pixels.resize_surface(surface.0, surface.1)?;
     Ok(pixels)
 }
@@ -570,8 +941,9 @@ pub(in crate::video) fn scale_rect(rect: Rect, scale: usize) -> Rect {
     }
 }
 
-/// Map a host cursor position (surface physical pixels) into a logical canvas
-/// position, or None outside the presented picture.
+/// Map a host cursor position (surface physical pixels) into a *tool*
+/// window's logical canvas position, or None outside the presented
+/// picture.
 ///
 /// Deliberately not pixels' `window_pos_to_pixel`: that helper re-centres
 /// through `min(texture, surface) / 2`, which is only correct while the
@@ -596,6 +968,21 @@ pub(super) fn cursor_texture_position(
         (context.texture_extent.width, context.texture_extent.height),
     )?;
     Some(((x / texture_scale) as i32, (y / texture_scale) as i32))
+}
+
+/// The emulator window's cursor mapping: host surface position to logical
+/// canvas position, or None outside the presented picture. The emulator
+/// window is drawn by the scaler pass, not the built-in renderer, so the
+/// rects inverted here are the same [`PresentLayout`] rects the pass
+/// draws into, and the mapping lands directly in logical canvas pixels.
+/// `autocrop_src` must be the same crop the redraw presents
+/// (`App::autocrop_canvas_src`), so clicks land where the picture is.
+pub(super) fn main_cursor_position(
+    r: &Render,
+    autocrop_src: Option<(usize, usize, usize, usize)>,
+    position: winit::dpi::PhysicalPosition<f64>,
+) -> Option<(i32, i32)> {
+    main_present_layout(r, autocrop_src).cursor_position(position)
 }
 
 /// The pure half of [`cursor_texture_position`]: position and clip rect in

--- a/src/video/window/scaler.rs
+++ b/src/video/window/scaler.rs
@@ -1,0 +1,708 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The main-window presentation scaler: draws the composited `pixels`
+//! buffer (display, status bar, panels, overlays) onto the surface.
+//!
+//! This pass replaces the `pixels` crate's built-in scaling renderer for
+//! the emulator window. The built-in renderer can only place the texture
+//! at whole multiples of *itself* (PixelPerfect) or fill the surface
+//! (Fill), which welds the displayed integer multiple to the supersample
+//! factor of the backing texture: a multiple past the texture cap was
+//! unreachable, so a large display stopped zooming at
+//! `MAX_INTEGER_TEXTURE_SCALE` times the canvas however much room it had.
+//! This pass takes the destination rect (`clip_rect_for`) and the filter
+//! as inputs instead, so the planned multiple is drawn whatever the
+//! texture's own factor is.
+//!
+//! Point-sampling a texture whose supersample factor S does not divide
+//! the displayed multiple M is still exact for the display region: the
+//! CPU present copy builds the texture by replicating each canvas pixel
+//! into an S-wide block, so every texel a sample can land on inside a
+//! canvas pixel holds the same colour, and a canvas-pixel *boundary* in
+//! surface space sits at a multiple of M while sample centres sit at
+//! half-integers -- `(p + 0.5) * S / M` is never an integer multiple of
+//! S, so float jitter cannot flip a sample across a boundary. UI drawn
+//! into the texture at S (status bar, open menus) has per-texel detail,
+//! so at M > S its nearest resample picks uneven texel runs; that only
+//! arises past the texture cap (M > 4), where the picture is large
+//! enough that the unevenness is a few per cent of a glyph stroke.
+//!
+//! The smooth filter is the same texel-snapped sharp bilinear the
+//! `pixels` Fill renderer uses: texel centres are sampled flat and the
+//! transition between texels is spread over one surface pixel, which
+//! keeps a magnified picture sharp without the shimmer of raw nearest
+//! sampling at a fractional scale.
+//!
+//! Like the built-in renderer, the pass clears the whole surface first
+//! (the letterbox borders are its clear colour) and then draws one
+//! viewport-restricted triangle.
+
+use pixels::wgpu;
+use std::borrow::Cow;
+use zerocopy::{Immutable, IntoBytes};
+
+const SHADER: &str = r#"
+struct VOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+struct ScalerUniforms {
+    // xy: uv origin of the sampled source rect, zw: its size. The
+    // identity (0, 0, 1, 1) maps the whole texture across the viewport.
+    rect: vec4<f32>,
+    // x: 1.0 = nearest (texel-centre) sampling, 0.0 = sharp bilinear.
+    // yzw: reserved.
+    params: vec4<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) idx: u32) -> VOut {
+    // Fullscreen triangle: the viewport restricts it to the destination
+    // rect.
+    let tc = vec2<f32>(f32((idx << 1u) & 2u), f32(idx & 2u));
+    var out: VOut;
+    out.uv = tc;
+    out.pos = vec4<f32>(tc * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0), 0.0, 1.0);
+    return out;
+}
+
+@group(0) @binding(0) var tex: texture_2d<f32>;
+@group(0) @binding(1) var samp: sampler;
+@group(0) @binding(2) var<uniform> u: ScalerUniforms;
+
+@fragment
+fn fs_main(in: VOut) -> @location(0) vec4<f32> {
+    let dims = vec2<f32>(textureDimensions(tex));
+    // Sample position in texel coordinates.
+    let t = (u.rect.xy + in.uv * u.rect.zw) * dims;
+    let tf = fract(t);
+    // Texels per surface pixel, from the rasterizer's own derivatives.
+    let tpp = max(vec2<f32>(abs(dpdx(t.x)), abs(dpdy(t.y))), vec2<f32>(1e-6));
+    // Sharp bilinear: hold the texel centre across the texel and spread
+    // the transition to the next one over a single surface pixel.
+    let sharp = clamp(tf / tpp, vec2<f32>(0.0), vec2<f32>(0.5))
+        + clamp((tf - vec2<f32>(1.0)) / tpp + vec2<f32>(0.5), vec2<f32>(0.0), vec2<f32>(0.5));
+    // Nearest: always the texel centre. Both run through the one linear
+    // sampler; sampling exactly at a centre returns that texel alone.
+    let sub = select(sharp, vec2<f32>(0.5), u.params.x > 0.5);
+    let coord = (floor(t) + sub) / dims;
+    return textureSample(tex, samp, coord);
+}
+"#;
+
+/// How the pass resamples the texture onto the destination rect.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ScaleFilter {
+    /// Texel-centre point sampling: integer scaling's exact blocks.
+    Nearest,
+    /// Texel-snapped sharp bilinear: the smooth fit's filter.
+    SharpBilinear,
+}
+
+/// The uniform block the pass sees; mirrors `ScalerUniforms` in the WGSL
+/// source. `#[repr(C)]` with 16-byte members only, so the two layouts
+/// agree with no padding.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, IntoBytes, Immutable)]
+struct ScalerUniforms {
+    rect: [f32; 4],
+    params: [f32; 4],
+}
+
+/// Size of the uniform block, in bytes. Also the layout's
+/// `min_binding_size`.
+const UNIFORM_BYTES: u64 = std::mem::size_of::<ScalerUniforms>() as u64;
+
+/// One resample the pass performs: a source sub-rect of the texture onto
+/// a destination rect of the surface.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct ScalerDraw {
+    /// Source rect in the texture's 0..1 uv space; `[0, 0, 1, 1]` maps
+    /// the whole texture.
+    pub(super) src: [f32; 4],
+    /// Destination rect on the surface, physical pixels.
+    pub(super) dst: (u32, u32, u32, u32),
+    pub(super) filter: ScaleFilter,
+}
+
+impl ScalerDraw {
+    /// The classic whole-texture draw: everything the buffer holds onto
+    /// one letterboxed rect. (The live layout builds its draws itself;
+    /// the offscreen tests use this shorthand.)
+    #[cfg(test)]
+    pub(super) fn full(dst: (u32, u32, u32, u32), filter: ScaleFilter) -> Self {
+        Self {
+            src: [0.0, 0.0, 1.0, 1.0],
+            dst,
+            filter,
+        }
+    }
+}
+
+/// Most draws the pass accepts per frame: the display picture and the
+/// chrome band below it (panels and status bar) under the autocrop
+/// layout. Each needs its own uniform buffer, written once per frame.
+const MAX_DRAWS: usize = 2;
+
+/// Where the picture lands on the surface: the destination rect for a
+/// `canvas`-sized logical picture on a `surface`, both in physical
+/// pixels, centred either at the whole-canvas-pixel `multiple` or at the
+/// aspect-preserving smooth fit when `multiple` is `None`.
+///
+/// The smooth arithmetic mirrors the `pixels` Fill renderer's
+/// `ScalingMatrix` so the picture occupies the same pixels it always
+/// did; the integer rect is exact by construction. A degenerate surface
+/// or canvas collapses to an empty rect rather than dividing by zero.
+pub(super) fn clip_rect_for(
+    surface: (u32, u32),
+    canvas: (u32, u32),
+    multiple: Option<usize>,
+) -> (u32, u32, u32, u32) {
+    let (sw, sh) = surface;
+    let (cw, ch) = canvas;
+    if sw == 0 || sh == 0 || cw == 0 || ch == 0 {
+        return (0, 0, 0, 0);
+    }
+    let (w, h) = match multiple {
+        Some(m) => {
+            let m = m as u32;
+            (cw.saturating_mul(m).min(sw), ch.saturating_mul(m).min(sh))
+        }
+        None => {
+            let scale = (sw as f32 / cw as f32).min(sh as f32 / ch as f32);
+            (
+                ((cw as f32 * scale) as u32).min(sw).max(1),
+                ((ch as f32 * scale) as u32).min(sh).max(1),
+            )
+        }
+    };
+    ((sw - w) / 2, (sh - h) / 2, w, h)
+}
+
+/// The scaling pass: one pipeline, one linear sampler, and per-draw
+/// uniform buffers with their bind groups against the current `pixels`
+/// backing texture.
+pub(super) struct PresentScaler {
+    pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    sampler: wgpu::Sampler,
+    uniforms: [wgpu::Buffer; MAX_DRAWS],
+    bind_groups: Option<[wgpu::BindGroup; MAX_DRAWS]>,
+    /// The texture the bind groups view, compared by identity: `pixels`
+    /// recreates its backing texture on a buffer resize, and the stale
+    /// views have to be dropped with it.
+    bound_texture: Option<wgpu::Texture>,
+}
+
+impl PresentScaler {
+    pub(super) fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("present_scaler_shader"),
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(SHADER)),
+        });
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("present_scaler_bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(UNIFORM_BYTES),
+                    },
+                    count: None,
+                },
+            ],
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("present_scaler_pl"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("present_scaler_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: target_format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            multiview_mask: None,
+            cache: None,
+        });
+        // One linear sampler serves both filters: the nearest path
+        // samples exactly at texel centres, where linear filtering
+        // returns that texel alone.
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("present_scaler_sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            ..Default::default()
+        });
+        let uniforms = std::array::from_fn(|i| {
+            device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some(&format!("present_scaler_uniforms_{i}")),
+                size: UNIFORM_BYTES,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            })
+        });
+        Self {
+            pipeline,
+            bind_group_layout,
+            sampler,
+            uniforms,
+            bind_groups: None,
+            bound_texture: None,
+        }
+    }
+
+    /// Draw `texture` onto `target`: clear the whole surface to black,
+    /// then run each of `draws` (at most [`MAX_DRAWS`]; extras are
+    /// ignored) in order. An empty draw list, or one of empty rects,
+    /// still clears, so a surface too small for any picture goes black
+    /// rather than stale.
+    pub(super) fn render(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texture: &wgpu::Texture,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+        draws: &[ScalerDraw],
+    ) {
+        if self
+            .bound_texture
+            .as_ref()
+            .is_none_or(|bound| bound != texture)
+        {
+            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+            self.bind_groups = Some(std::array::from_fn(|i| {
+                device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some(&format!("present_scaler_bg_{i}")),
+                    layout: &self.bind_group_layout,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::TextureView(&view),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::Sampler(&self.sampler),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 2,
+                            resource: self.uniforms[i].as_entire_binding(),
+                        },
+                    ],
+                })
+            }));
+            self.bound_texture = Some(texture.clone());
+        }
+        for (i, draw) in draws.iter().take(MAX_DRAWS).enumerate() {
+            let uniforms = ScalerUniforms {
+                rect: draw.src,
+                params: [
+                    match draw.filter {
+                        ScaleFilter::Nearest => 1.0,
+                        ScaleFilter::SharpBilinear => 0.0,
+                    },
+                    0.0,
+                    0.0,
+                    0.0,
+                ],
+            };
+            queue.write_buffer(&self.uniforms[i], 0, uniforms.as_bytes());
+        }
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("present_scaler_pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        let Some(bind_groups) = self.bind_groups.as_ref() else {
+            return;
+        };
+        pass.set_pipeline(&self.pipeline);
+        for (i, draw) in draws.iter().take(MAX_DRAWS).enumerate() {
+            let (x, y, w, h) = draw.dst;
+            if w == 0 || h == 0 {
+                continue;
+            }
+            pass.set_bind_group(0, &bind_groups[i], &[]);
+            pass.set_viewport(x as f32, y as f32, w as f32, h as f32, 0.0, 1.0);
+            pass.draw(0..3, 0..1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The pass's WGSL has to compile like the preset shaders do, and
+    /// validating the source says so on a machine with no GPU adapter.
+    #[test]
+    fn the_scaler_shader_source_validates() {
+        assert_eq!(
+            super::super::crt_shader::validate_wgsl_source(SHADER),
+            Ok(())
+        );
+    }
+
+    /// An integer multiple places an exact `canvas * m` rect, centred with
+    /// the odd spare pixel biased the way the smooth fit's cast biases it.
+    #[test]
+    fn integer_clip_rect_is_the_exact_multiple_centred() {
+        // 716x581 canvas at 3x on a laptop panel: 2148x1743, centred.
+        assert_eq!(
+            clip_rect_for((3024, 1964), (716, 581), Some(3)),
+            ((3024 - 2148) / 2, (1964 - 1743) / 2, 2148, 1743)
+        );
+        // An exact fit fills the axis.
+        assert_eq!(
+            clip_rect_for((1432, 1162), (716, 581), Some(2)),
+            (0, 0, 1432, 1162)
+        );
+        // A multiple past the surface is clamped rather than cropped
+        // (the planner never asks for one; the clamp is the safety net).
+        assert_eq!(
+            clip_rect_for((700, 500), (716, 581), Some(1)),
+            (0, 0, 700, 500)
+        );
+    }
+
+    /// The smooth fit preserves the canvas aspect and touches the
+    /// limiting axis, like the `pixels` Fill matrix it replaces.
+    #[test]
+    fn smooth_clip_rect_is_the_aspect_fit() {
+        // Width-limited: a square surface around the 716x581 canvas.
+        let (x, y, w, h) = clip_rect_for((1000, 1000), (716, 581), None);
+        assert_eq!(w, 1000);
+        assert_eq!(x, 0);
+        assert_eq!(h, (581.0 * (1000.0 / 716.0)) as u32);
+        assert_eq!(y, (1000 - h) / 2);
+        // Height-limited: a wide surface.
+        let (x, y, w, h) = clip_rect_for((3000, 581), (716, 581), None);
+        assert_eq!(h, 581);
+        assert_eq!(y, 0);
+        assert_eq!(w, 716);
+        assert_eq!(x, (3000 - 716) / 2);
+        // Degenerate inputs collapse to empty rather than dividing by
+        // zero.
+        assert_eq!(clip_rect_for((0, 100), (716, 581), None), (0, 0, 0, 0));
+        assert_eq!(clip_rect_for((100, 100), (0, 581), None), (0, 0, 0, 0));
+    }
+
+    // --- offscreen render (needs a GPU adapter) -------------------------
+
+    const RED: u32 = 0xFF00_00FF;
+    const GREEN: u32 = 0xFF00_FF00;
+    const BLUE: u32 = 0xFFFF_0000;
+    const WHITE: u32 = 0xFFFF_FFFF;
+    const FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+    const BLACK: [u8; 4] = [0, 0, 0, 255];
+    /// Cleared into the target before the pass to catch fragments it
+    /// never wrote; the pass's own clear must replace every one.
+    const SENTINEL_CLEAR: wgpu::Color = wgpu::Color {
+        r: 1.0,
+        g: 0.0,
+        b: 1.0,
+        a: 1.0,
+    };
+    const SENTINEL: [u8; 4] = [255, 0, 255, 255];
+
+    fn gpu() -> Option<super::super::crt_shader::TestGpu> {
+        super::super::crt_shader::test_gpu("present_scaler_test")
+    }
+
+    /// Upload `texels` as a `w` x `h` source texture, run the real pass
+    /// into a `target` surface with the given clip and filter, and read
+    /// the result back per pixel.
+    fn render_pass(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texels: &[u32],
+        tex_size: (u32, u32),
+        target_size: (u32, u32),
+        clip: (u32, u32, u32, u32),
+        filter: ScaleFilter,
+    ) -> Vec<[u8; 4]> {
+        let (tw, th) = tex_size;
+        let (w, h) = target_size;
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("present_scaler_test_source"),
+            size: wgpu::Extent3d {
+                width: tw,
+                height: th,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: FORMAT,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let bytes =
+            unsafe { std::slice::from_raw_parts(texels.as_ptr() as *const u8, texels.len() * 4) };
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            bytes,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(tw * 4),
+                rows_per_image: Some(th),
+            },
+            wgpu::Extent3d {
+                width: tw,
+                height: th,
+                depth_or_array_layers: 1,
+            },
+        );
+        let target = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("present_scaler_test_target"),
+            size: wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let view = target.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        drop(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("present_scaler_test_clear"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(SENTINEL_CLEAR),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        }));
+        let mut scaler = PresentScaler::new(device, FORMAT);
+        scaler.render(
+            device,
+            queue,
+            &texture,
+            &mut encoder,
+            &view,
+            &[ScalerDraw::full(clip, filter)],
+        );
+
+        let padded = (w * 4).div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT)
+            * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let readback = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("present_scaler_test_readback"),
+            size: (padded * h) as u64,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: &target,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &readback,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded),
+                    rows_per_image: Some(h),
+                },
+            },
+            wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(Some(encoder.finish()));
+        let (tx, rx) = std::sync::mpsc::channel();
+        readback.slice(..).map_async(wgpu::MapMode::Read, move |r| {
+            let _ = tx.send(r);
+        });
+        device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .expect("poll");
+        rx.recv().expect("map callback").expect("buffer mapped");
+        let mapped = readback.slice(..).get_mapped_range();
+        let mut px = Vec::with_capacity((w * h) as usize);
+        for y in 0..h {
+            let base = (y * padded) as usize;
+            for x in 0..w {
+                let off = base + (x * 4) as usize;
+                px.push([
+                    mapped[off],
+                    mapped[off + 1],
+                    mapped[off + 2],
+                    mapped[off + 3],
+                ]);
+            }
+        }
+        drop(mapped);
+        readback.unmap();
+        px
+    }
+
+    /// A 2x2-canvas frame replicated into a 4x4 texture (supersample
+    /// factor 2), drawn at a 3x canvas multiple the factor does not
+    /// divide: the module contract says the blocks still come out exact,
+    /// and the surface around the rect is the pass's own black.
+    #[test]
+    fn nearest_blocks_are_exact_when_the_texture_factor_does_not_divide_the_multiple() {
+        let Some(gpu) = gpu() else {
+            return;
+        };
+        let (device, queue) = (gpu.device(), gpu.queue());
+        // Canvas [[RED, GREEN], [BLUE, WHITE]] at supersample 2.
+        #[rustfmt::skip]
+        let texels = [
+            RED, RED, GREEN, GREEN,
+            RED, RED, GREEN, GREEN,
+            BLUE, BLUE, WHITE, WHITE,
+            BLUE, BLUE, WHITE, WHITE,
+        ];
+        let (w, h) = (10u32, 8u32);
+        // 3x of the 2x2 canvas: a 6x6 picture centred at (2, 1).
+        let clip = (2u32, 1u32, 6u32, 6u32);
+        let px = render_pass(
+            device,
+            queue,
+            &texels,
+            (4, 4),
+            (w, h),
+            clip,
+            ScaleFilter::Nearest,
+        );
+        let at = |x: u32, y: u32| px[(y * w + x) as usize];
+        for y in 0..h {
+            for x in 0..w {
+                let inside = (2..8).contains(&x) && (1..7).contains(&y);
+                if !inside {
+                    assert_eq!(at(x, y), BLACK, "border at ({x}, {y}) not black");
+                    continue;
+                }
+                let want = match ((x - 2) / 3, (y - 1) / 3) {
+                    (0, 0) => RED,
+                    (1, 0) => GREEN,
+                    (0, 1) => BLUE,
+                    _ => WHITE,
+                };
+                assert_eq!(
+                    at(x, y),
+                    want.to_le_bytes(),
+                    "({x}, {y}) not its canvas pixel's exact colour"
+                );
+            }
+        }
+        assert!(
+            px.iter().all(|p| *p != SENTINEL),
+            "the pass left a hole in the surface"
+        );
+    }
+
+    /// The sharp-bilinear fit holds each texel flat away from its edges:
+    /// block centres are exact even though the scale is fractional, and
+    /// the corners of the rect hold the corner texels.
+    #[test]
+    fn sharp_bilinear_holds_texel_centres_flat() {
+        let Some(gpu) = gpu() else {
+            return;
+        };
+        let (device, queue) = (gpu.device(), gpu.queue());
+        let texels = [RED, GREEN, BLUE, WHITE];
+        // 2x2 texture over a 9x9 rect: 4.5 surface pixels per texel, a
+        // fractional scale raw nearest would shimmer at.
+        let px = render_pass(
+            device,
+            queue,
+            &texels,
+            (2, 2),
+            (9, 9),
+            (0, 0, 9, 9),
+            ScaleFilter::SharpBilinear,
+        );
+        let at = |x: u32, y: u32| px[(y * 9 + x) as usize];
+        // Texel interiors, away from the blended seam at 4..5.
+        for (x, y, want) in [
+            (1, 1, RED),
+            (7, 1, GREEN),
+            (1, 7, BLUE),
+            (7, 7, WHITE),
+            (0, 0, RED),
+            (8, 8, WHITE),
+        ] {
+            assert_eq!(at(x, y), want.to_le_bytes(), "({x}, {y}) not flat");
+        }
+    }
+}

--- a/src/video/window/statusbar.rs
+++ b/src/video/window/statusbar.rs
@@ -1923,7 +1923,15 @@ pub(super) fn edge(a: (f32, f32), b: (f32, f32), c: (f32, f32)) -> f32 {
 /// texture after the frame is captured, so it is never recorded.
 /// `corner_inset` is the same figure the other two overlays take: the
 /// badge shares the performance readout's corner and loses it the same way.
-pub(super) fn draw_record_badge(frame: &mut [u8], texture_scale: usize, corner_inset: usize) {
+/// `anchor` is the visible display region in canvas pixels `(x, y, w,
+/// h)` -- the whole display classically, the crop rect under autocrop --
+/// so the badge stays in the corner the viewer actually sees.
+pub(super) fn draw_record_badge(
+    frame: &mut [u8],
+    texture_scale: usize,
+    corner_inset: usize,
+    anchor: (usize, usize, usize, usize),
+) {
     let s = texture_scale;
     let px = 2 * s;
     let pad = 4 * s;
@@ -1936,8 +1944,8 @@ pub(super) fn draw_record_badge(frame: &mut [u8], texture_scale: usize, corner_i
     let text_h = font::text_height(px);
     let box_w = dot_d + gap + text_w + 2 * pad;
     let box_h = text_h + 2 * pad;
-    let box_x = (FB_WIDTH * s).saturating_sub(margin + corner_inset + box_w);
-    let box_y = margin + corner_inset;
+    let box_x = ((anchor.0 + anchor.2) * s).saturating_sub(margin + corner_inset + box_w);
+    let box_y = anchor.1 * s + margin + corner_inset;
 
     fill_rect_blend(
         frame,
@@ -2001,6 +2009,7 @@ pub(super) fn draw_perf_overlay(
     texture_scale: usize,
     below_record_badge: bool,
     corner_inset: usize,
+    anchor: (usize, usize, usize, usize),
 ) {
     let s = texture_scale;
     let px = crate::video::menu_scale().factor() * s;
@@ -2021,9 +2030,10 @@ pub(super) fn draw_perf_overlay(
     let box_h = lines.len() * text_h + lines.len().saturating_sub(1) * line_gap + 2 * pad;
     // Away from the top-right corner on both axes, for the same reason and
     // by the same figure as the OSD leaves the bottom-left one.
-    let box_x = (FB_WIDTH * s).saturating_sub(margin + corner_inset + box_w);
+    let box_x = ((anchor.0 + anchor.2) * s).saturating_sub(margin + corner_inset + box_w);
     let record_badge_h = font::text_height(2 * s) + 2 * (4 * s);
-    let box_y = corner_inset
+    let box_y = anchor.1 * s
+        + corner_inset
         + if below_record_badge {
             margin + record_badge_h + 4 * s
         } else {
@@ -2066,23 +2076,27 @@ pub(super) fn draw_osd(
     warning: bool,
     texture_scale: usize,
     corner_inset: usize,
+    anchor: (usize, usize, usize, usize),
 ) {
     let s = texture_scale;
     let px = 2 * s; // font pixel -> device pixels
     let pad = 4 * s;
     let margin = 8 * s;
     let fw = texture_width(s);
-    // Above the MT-32 panel as well as the status bar: the message belongs
-    // over the picture, not over the instrument under it.
-    let display_h = present_height() * s;
+    // The bottom-left of the visible display region (`anchor`, in canvas
+    // pixels: the whole display classically, the crop rect under
+    // autocrop): above the MT-32 panel as well as the status bar, since
+    // the message belongs over the picture, not the instrument under it.
+    let anchor_right = ((anchor.0 + anchor.2) * s).min(fw);
+    let display_h = (anchor.1 + anchor.3) * s;
 
-    let text_w =
-        font::text_width(text, px).min(fw.saturating_sub(2 * margin + corner_inset + 2 * pad));
+    let text_w = font::text_width(text, px)
+        .min(anchor_right.saturating_sub(anchor.0 * s + 2 * margin + corner_inset + 2 * pad));
     let text_h = font::text_height(px);
     let box_h = text_h + 2 * pad;
-    let box_x = margin + corner_inset;
+    let box_x = anchor.0 * s + margin + corner_inset;
     // What is left of the width once the box has come in off the corner.
-    let box_w = (text_w + 2 * pad).min(fw.saturating_sub(box_x + margin));
+    let box_w = (text_w + 2 * pad).min(anchor_right.saturating_sub(box_x + margin));
     let box_y = display_h.saturating_sub(margin + box_h + corner_inset);
 
     fill_rect_blend(

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -8653,16 +8653,16 @@ fn autocrop_latch_grows_fast_and_shrinks_only_when_stable() {
 #[test]
 fn autocrop_layout_refits_the_multiple_against_the_crop() {
     // A 200-line lo-res game (400 woven rows, 640 canvas px wide) on a
-    // 2000x1200 surface with the 44-row status bar.
-    let layout = super::autocrop_layout((2000, 1200), true, (38, 69, 640, 400), 44);
-    // The band: 44 canvas rows at the 2000/716 width fit.
-    let hb = (44u64 * 2000 / FB_WIDTH as u64) as u32;
-    assert_eq!(layout.chrome_dst, Some((0, 1200 - hb, 2000, hb)));
-    // The crop fits 2x whole (min(2000/640, 1078/400) = 2), centred in
-    // the region above the band.
+    // 2000x1200 surface, above a pre-sized 100-row chrome band (the
+    // caller sizes the band at the classic letterbox scale).
+    let chrome = (30u32, 1100u32, 1940u32, 100u32);
+    let layout = super::autocrop_layout((2000, 1200), true, (38, 69, 640, 400), Some(chrome));
+    // The band passes through untouched, and the crop fits 2x whole
+    // (min(2000/640, 1100/400) = 2), centred in the region above it.
+    assert_eq!(layout.chrome_dst, Some(chrome));
     assert_eq!(
         layout.display_dst,
-        ((2000 - 1280) / 2, (1200 - hb - 800) / 2, 1280, 800)
+        ((2000 - 1280) / 2, (1100 - 800) / 2, 1280, 800)
     );
     assert_eq!(layout.filter, super::scaler::ScaleFilter::Nearest);
     assert_eq!(layout.src_canvas, (38, 69, 640, 400));
@@ -8675,19 +8675,19 @@ fn autocrop_layout_refits_the_multiple_against_the_crop() {
     );
 
     // Without a whole multiple the crop falls back to its smooth fit.
-    let layout = super::autocrop_layout((600, 500), true, (38, 69, 640, 400), 44);
+    let layout = super::autocrop_layout((600, 500), true, (38, 69, 640, 400), None);
     assert_eq!(layout.filter, super::scaler::ScaleFilter::SharpBilinear);
     assert!(layout.display_dst.2 <= 600);
 
     // A surface too small for the whole 716-wide canvas still holds a
     // whole multiple of a 640-wide crop: the fit is the crop's own, not
     // an inherited fallback from the classic full-canvas plan.
-    let layout = super::autocrop_layout((700, 500), true, (38, 69, 640, 400), 44);
+    let layout = super::autocrop_layout((700, 500), true, (38, 69, 640, 400), None);
     assert_eq!(layout.filter, super::scaler::ScaleFilter::Nearest);
     assert_eq!((layout.display_dst.2, layout.display_dst.3), (640, 400));
 
     // Smooth scaling keeps the sharp-bilinear fit of the crop.
-    let layout = super::autocrop_layout((2000, 1200), false, (38, 69, 640, 400), 0);
+    let layout = super::autocrop_layout((2000, 1200), false, (38, 69, 640, 400), None);
     assert_eq!(layout.chrome_dst, None);
     assert_eq!(layout.filter, super::scaler::ScaleFilter::SharpBilinear);
     // Aspect preserved: 640x400 into 2000x1200 is height-limited.

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -8550,6 +8550,8 @@ fn canvas_content_rect_inverts_the_tv_aperture_mapping() {
     )
     .expect("content inside the aperture maps");
     assert!(w > 0 && h > 0);
+    // The rect stays on the canvas.
+    assert!(x + w <= FB_WIDTH && y + h <= canvas_rows);
     // Forward-map the returned row range: rows inside land in the
     // content interval, the rows just outside do not.
     let src_of = |canvas_y: usize| {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -5,7 +5,6 @@
 //! and keep full access to the parent's private items via `super::`.
 
 use super::ui::{AnalyzerTab, Panel, UiControl};
-use super::ScalingMode;
 use super::{
     bar_layout, center_present_frame_for_visible_start, center_present_frame_horizontally,
     control_at, copperline_icon_image, copperline_logo_image, copy_present_frame,
@@ -8433,49 +8432,259 @@ fn cursor_mapping_rejects_pillarbox_clicks() {
 }
 
 /// `[display] scaling = "integer"` fits in whole *canvas* pixels against
-/// the physical surface, and the supersample factor follows that fit: the
-/// canvas is rendered at the fitted factor and PixelPerfect draws it 1:1.
-/// Deriving the factor from the fit rather than the host DPI is what makes
-/// odd physical multiples reachable -- a DPI-supersampled texture can only
-/// be drawn at whole multiples of itself, which on a 2x display skips 1x
-/// and 3x physical pixels per canvas pixel. Only a surface smaller than the
-/// canvas (no whole multiple at all; PixelPerfect would crop) falls back to
-/// the smooth DPI-supersampled Fill plan.
+/// the physical surface: the multiple is the fit itself, uncapped, and
+/// the supersample factor follows it up to `MAX_INTEGER_TEXTURE_SCALE`.
+/// Deriving the multiple from the fit rather than the host DPI is what
+/// makes odd physical multiples reachable -- a DPI-supersampled texture
+/// can only be drawn at whole multiples of itself, which on a 2x display
+/// skips 1x and 3x physical pixels per canvas pixel. Only a surface
+/// smaller than the canvas (no whole multiple at all; 1x would crop)
+/// falls back to the smooth DPI-supersampled plan.
 #[test]
 fn integer_scaling_fits_in_whole_canvas_pixels() {
-    // ScalingMode is not PartialEq, so extract the planned factor and
-    // whether the integer mode was chosen rather than comparing values.
     let plan = |requested, dpi, surface| {
-        let (scale, mode) = plan_present_scaling_for(requested, dpi, surface, (716, 581));
-        (scale, matches!(mode, ScalingMode::PixelPerfect))
+        let plan = plan_present_scaling_for(requested, dpi, surface, (716, 581));
+        (plan.texture_scale, plan.multiple)
     };
 
     // A 2x-DPI laptop panel (3024x1964) holds three whole canvas pixels per
     // axis but not four: an odd multiple a 2x texture could never reach.
-    assert_eq!(plan(true, 2.0, (3024, 1964)), (3, true));
+    assert_eq!(plan(true, 2.0, (3024, 1964)), (3, Some(3)));
     // The canvas-sized window on the same panel: exactly 2x physical.
-    assert_eq!(plan(true, 2.0, (1432, 1162)), (2, true));
+    assert_eq!(plan(true, 2.0, (1432, 1162)), (2, Some(2)));
     // A window shrunk below the default still holds one physical pixel per
     // canvas pixel, so it stays integer (small and crisp) instead of
     // falling back to smooth.
-    assert_eq!(plan(true, 2.0, (1000, 840)), (1, true));
+    assert_eq!(plan(true, 2.0, (1000, 840)), (1, Some(1)));
     // The 150% fractional-DPI desktop's canvas-sized window (1.5x physical)
     // holds a whole 1x too -- under the old texture-multiple fit this was a
     // forced smooth fallback.
-    assert_eq!(plan(true, 1.5, (1074, 872)), (1, true));
+    assert_eq!(plan(true, 1.5, (1074, 872)), (1, Some(1)));
     // The exact-fit boundary, and one pixel short in either dimension:
-    // below the canvas there is no whole multiple, and PixelPerfect would
-    // crop, so the plan is the smooth one (DPI-supersampled Fill).
-    assert_eq!(plan(true, 2.0, (716, 581)), (1, true));
-    assert_eq!(plan(true, 2.0, (715, 581)), (2, false));
-    assert_eq!(plan(true, 2.0, (716, 580)), (2, false));
-    // A huge surface caps the supersample; PixelPerfect's own whole
-    // multiples of the capped texture carry on above it.
-    assert_eq!(plan(true, 2.0, (8000, 5000)), (4, true));
+    // below the canvas there is no whole multiple, and 1x would crop, so
+    // the plan is the smooth one (DPI-supersampled sharp bilinear).
+    assert_eq!(plan(true, 2.0, (716, 581)), (1, Some(1)));
+    assert_eq!(plan(true, 2.0, (715, 581)), (2, None));
+    assert_eq!(plan(true, 2.0, (716, 580)), (2, None));
+    // A huge surface caps the supersample factor but not the multiple:
+    // the scaler pass draws the full fit from the capped texture (a 5K
+    // display fits 7x across but only 5x down with this canvas).
+    assert_eq!(plan(true, 2.0, (8000, 5000)), (4, Some(8)));
+    assert_eq!(plan(true, 2.0, (5120, 2880)), (4, Some(4)));
+    assert_eq!(plan(true, 2.0, (6016, 3384)), (4, Some(5)));
 
-    // Smooth never leaves Fill or the DPI factor, whatever the room.
-    assert_eq!(plan(false, 2.0, (3024, 1964)), (2, false));
-    assert_eq!(plan(false, 1.0, (3024, 1964)), (1, false));
+    // Smooth never leaves the DPI factor or gains a multiple, whatever
+    // the room.
+    assert_eq!(plan(false, 2.0, (3024, 1964)), (2, None));
+    assert_eq!(plan(false, 1.0, (3024, 1964)), (1, None));
+}
+
+/// The renderer's field-space content envelope reaches presentation
+/// space through the exact shifts the pixels took: vertical centring by
+/// `presentation_source_y_offset`, horizontal recentring by `h_shift`,
+/// then each field row onto its two woven rows. Programmable scans never
+/// map (they present their own window in full).
+#[test]
+fn woven_content_rect_applies_the_post_process_shifts_and_weaves() {
+    use crate::video::bitplane::ContentRect;
+    let rect = ContentRect {
+        x0: 100,
+        x1: 500,
+        y0: 30,
+        y1: 230,
+    };
+    let y_off = super::presentation_source_y_offset(0x2C);
+
+    let woven = super::woven_content_rect(Some(rect), false, 0x2C, 10, FB_WIDTH, 570)
+        .expect("standard frame maps");
+    assert_eq!((woven.x0, woven.x1), (90, 490));
+    assert_eq!((woven.y0, woven.y1), (2 * (30 + y_off), 2 * (230 + y_off)));
+
+    // Programmable scans and border-only frames give nothing to crop to.
+    assert_eq!(
+        super::woven_content_rect(Some(rect), true, 0x2C, 0, FB_WIDTH, 570),
+        None
+    );
+    assert_eq!(
+        super::woven_content_rect(None, false, 0x2C, 0, FB_WIDTH, 570),
+        None
+    );
+
+    // The woven rows clamp to the frame actually presented, and a rect
+    // shifted entirely off the canvas collapses to None rather than an
+    // inverted interval.
+    let low = ContentRect {
+        x0: 0,
+        x1: 4,
+        y0: 280,
+        y1: 285,
+    };
+    assert_eq!(
+        super::woven_content_rect(Some(low), false, 0x2C, 8, FB_WIDTH, 570),
+        None
+    );
+}
+
+/// The canvas-space inversion agrees with the copy it mirrors: every
+/// canvas row and column the rect includes maps into the content
+/// interval under the forward TV-aperture mapping, and the rows just
+/// outside it do not.
+#[test]
+fn canvas_content_rect_inverts_the_tv_aperture_mapping() {
+    use crate::video::bitplane::ContentRect;
+    let aperture_rows = TV_PAL_PRESENT_HEIGHT;
+    let canvas_rows = crate::video::PRESENT_HEIGHT_TV;
+    let content = ContentRect {
+        x0: 120,
+        x1: 620,
+        y0: 100,
+        y1: 400,
+    };
+    let (x, y, w, h) = super::canvas_content_rect(
+        content,
+        570,
+        Overscan::Tv,
+        crate::config::TvCentre::default(),
+        Some(aperture_rows),
+        canvas_rows,
+    )
+    .expect("content inside the aperture maps");
+    assert!(w > 0 && h > 0);
+    // Forward-map the returned row range: rows inside land in the
+    // content interval, the rows just outside do not.
+    let src_of = |canvas_y: usize| {
+        super::tv_aperture_source_row(canvas_y, canvas_rows, 1, aperture_rows)
+            .map(|crop_y| TV_PRESENT_SOURCE_Y + crop_y)
+    };
+    for canvas_y in y..y + h {
+        let src = src_of(canvas_y).expect("aperture row");
+        assert!(
+            (content.y0..content.y1).contains(&src),
+            "canvas row {canvas_y} maps to {src}, outside content"
+        );
+    }
+    if y > 0 {
+        let src = src_of(y - 1).expect("aperture row");
+        assert!(!(content.y0..content.y1).contains(&src));
+    }
+    if let Some(src) = src_of(y + h) {
+        assert!(!(content.y0..content.y1).contains(&src));
+    }
+
+    // The plain (full-overscan) branch is a straight row map: content
+    // rows come back as themselves when the canvas matches the source.
+    let (px, py, pw, ph) = super::canvas_content_rect(
+        content,
+        570,
+        Overscan::Full,
+        crate::config::TvCentre::default(),
+        None,
+        570,
+    )
+    .expect("plain branch maps");
+    assert_eq!((px, py, pw, ph), (120, 100, 500, 300));
+
+    // Content entirely outside the aperture (deep top overscan) crops to
+    // nothing rather than a degenerate rect.
+    let off_glass = ContentRect {
+        x0: 120,
+        x1: 620,
+        y0: 0,
+        y1: TV_PRESENT_SOURCE_Y / 2,
+    };
+    assert_eq!(
+        super::canvas_content_rect(
+            off_glass,
+            570,
+            Overscan::Tv,
+            crate::config::TvCentre::default(),
+            Some(aperture_rows),
+            canvas_rows,
+        ),
+        None
+    );
+}
+
+/// The autocrop latch grows immediately (content must never be cut),
+/// holds through border-only frames, and shrinks only after the smaller
+/// envelope has held steady for its stability window.
+#[test]
+fn autocrop_latch_grows_fast_and_shrinks_only_when_stable() {
+    use crate::video::bitplane::ContentRect;
+    let rect = |y0: usize, y1: usize| ContentRect {
+        x0: 100,
+        x1: 600,
+        y0,
+        y1,
+    };
+    let mut latch = super::AutocropLatch::default();
+
+    // First content adopts outright.
+    assert_eq!(latch.resolve(Some(rect(100, 400))), Some(rect(100, 400)));
+    // Growth is immediate, to the union.
+    assert_eq!(latch.resolve(Some(rect(50, 400))), Some(rect(50, 400)));
+    // A border-only frame holds the crop.
+    assert_eq!(latch.resolve(None), Some(rect(50, 400)));
+    // A smaller envelope has to persist before the crop tightens...
+    for _ in 0..super::AutocropLatch::SHRINK_STABLE_FRAMES - 1 {
+        assert_eq!(latch.resolve(Some(rect(100, 350))), Some(rect(50, 400)));
+    }
+    // ...and adopts on the Nth consecutive frame.
+    assert_eq!(latch.resolve(Some(rect(100, 350))), Some(rect(100, 350)));
+
+    // A shrink candidate interrupted by a different frame starts over.
+    let mut latch = super::AutocropLatch::default();
+    latch.resolve(Some(rect(50, 400)));
+    for _ in 0..super::AutocropLatch::SHRINK_STABLE_FRAMES - 1 {
+        latch.resolve(Some(rect(100, 350)));
+    }
+    assert_eq!(latch.resolve(Some(rect(50, 400))), Some(rect(50, 400)));
+    assert_eq!(latch.resolve(Some(rect(100, 350))), Some(rect(50, 400)));
+
+    // Reset forgets everything, like a power cycle.
+    latch.reset();
+    assert_eq!(latch.resolve(None), None);
+}
+
+/// The autocrop layout splits the chrome band off at the width-fit
+/// scale, and integer scaling re-fits its whole multiple against the
+/// crop rather than the full canvas -- the display using fewer lines is
+/// what earns the larger multiple.
+#[test]
+fn autocrop_layout_refits_the_multiple_against_the_crop() {
+    // A 200-line lo-res game (400 woven rows, 640 canvas px wide) on a
+    // 2000x1200 surface with the 44-row status bar.
+    let layout = super::autocrop_layout((2000, 1200), true, (38, 69, 640, 400), 44);
+    // The band: 44 canvas rows at the 2000/716 width fit.
+    let hb = (44u64 * 2000 / FB_WIDTH as u64) as u32;
+    assert_eq!(layout.chrome_dst, Some((0, 1200 - hb, 2000, hb)));
+    // The crop fits 2x whole (min(2000/640, 1078/400) = 2), centred in
+    // the region above the band.
+    assert_eq!(
+        layout.display_dst,
+        ((2000 - 1280) / 2, (1200 - hb - 800) / 2, 1280, 800)
+    );
+    assert_eq!(layout.filter, super::scaler::ScaleFilter::Nearest);
+    assert_eq!(layout.src_canvas, (38, 69, 640, 400));
+
+    // The classic full canvas only fits 1x on the same surface: the crop
+    // doubled the picture.
+    assert_eq!(
+        super::scaler::clip_rect_for((2000, 1200), (716, 581), Some(1)).2,
+        716
+    );
+
+    // Without a whole multiple the crop falls back to its smooth fit.
+    let layout = super::autocrop_layout((600, 500), true, (38, 69, 640, 400), 44);
+    assert_eq!(layout.filter, super::scaler::ScaleFilter::SharpBilinear);
+    assert!(layout.display_dst.2 <= 600);
+
+    // Smooth scaling keeps the sharp-bilinear fit of the crop.
+    let layout = super::autocrop_layout((2000, 1200), false, (38, 69, 640, 400), 0);
+    assert_eq!(layout.chrome_dst, None);
+    assert_eq!(layout.filter, super::scaler::ScaleFilter::SharpBilinear);
+    // Aspect preserved: 640x400 into 2000x1200 is height-limited.
+    assert_eq!(layout.display_dst.3, 1200);
 }
 
 /// A redraw that finds the host window at a size the surface was not
@@ -8591,6 +8800,12 @@ fn perf_overlay_lines_format_one_data_point_per_line() {
     );
 }
 
+/// The classic overlay anchor: the whole display region, what every
+/// call site passes while autocrop is not presenting.
+fn full_anchor() -> (usize, usize, usize, usize) {
+    (0, 0, crate::video::FB_WIDTH, super::present_height())
+}
+
 #[test]
 fn perf_overlay_draws_top_right_and_steps_below_the_record_badge() {
     let scale = 1;
@@ -8600,7 +8815,7 @@ fn perf_overlay_draws_top_right_and_steps_below_the_record_badge() {
     let probe_y = margin + 2;
 
     let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
-    super::draw_perf_overlay(&mut frame, &lines, scale, false, 0);
+    super::draw_perf_overlay(&mut frame, &lines, scale, false, 0, full_anchor());
     // The backing box reaches the top-right margin corner...
     assert_ne!(pixel(&frame, probe_x, probe_y, scale), [0, 0, 0, 0]);
     // ...and the top-left of the display is untouched.
@@ -8609,12 +8824,12 @@ fn perf_overlay_draws_top_right_and_steps_below_the_record_badge() {
     // With the record badge up the block starts below it, leaving the
     // badge's corner rows alone.
     let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
-    super::draw_perf_overlay(&mut frame, &lines, scale, true, 0);
+    super::draw_perf_overlay(&mut frame, &lines, scale, true, 0, full_anchor());
     assert_eq!(pixel(&frame, probe_x, probe_y, scale), [0, 0, 0, 0]);
 
     // Nothing to draw is a no-op, not a stray empty box.
     let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
-    super::draw_perf_overlay(&mut frame, &[], scale, false, 0);
+    super::draw_perf_overlay(&mut frame, &[], scale, false, 0, full_anchor());
     assert!(frame.iter().all(|&b| b == 0));
 
     // A monitor front and a bowed preset round that corner away, so the
@@ -8633,7 +8848,7 @@ fn perf_overlay_draws_top_right_and_steps_below_the_record_badge() {
         "the inset must clear the probe to be tested"
     );
     let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
-    super::draw_perf_overlay(&mut frame, &lines, scale, false, inset);
+    super::draw_perf_overlay(&mut frame, &lines, scale, false, inset, full_anchor());
     assert_eq!(pixel(&frame, probe_x, probe_y, scale), [0, 0, 0, 0]);
     assert_ne!(
         pixel(&frame, probe_x - inset, probe_y + inset, scale),
@@ -8682,7 +8897,7 @@ fn the_overlays_leave_the_corner_on_both_axes() {
     // The message is in the bottom-left corner: in from the left and up
     // from the foot of the picture, by the inset on each.
     let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
-    super::draw_osd(&mut frame, "corner", false, scale, inset);
+    super::draw_osd(&mut frame, "corner", false, scale, inset, full_anchor());
     let (x0, _, _, y1) = bounds(&frame);
     assert_eq!(x0, margin + inset, "the OSD did not come in from the left");
     assert_eq!(
@@ -8693,7 +8908,7 @@ fn the_overlays_leave_the_corner_on_both_axes() {
 
     // The badge and the readout share the top-right one.
     let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
-    super::draw_record_badge(&mut frame, scale, inset);
+    super::draw_record_badge(&mut frame, scale, inset, full_anchor());
     let (_, x1, y0, _) = bounds(&frame);
     assert_eq!(
         x1,
@@ -8703,7 +8918,14 @@ fn the_overlays_leave_the_corner_on_both_axes() {
     assert_eq!(y0, margin + inset, "the record badge did not drop");
 
     let mut frame = vec![0u8; texture_width(scale) * texture_height(scale) * 4];
-    super::draw_perf_overlay(&mut frame, &["50.0 fps".to_string()], scale, false, inset);
+    super::draw_perf_overlay(
+        &mut frame,
+        &["50.0 fps".to_string()],
+        scale,
+        false,
+        inset,
+        full_anchor(),
+    );
     let (_, x1, y0, _) = bounds(&frame);
     assert_eq!(
         x1,

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -8679,6 +8679,13 @@ fn autocrop_layout_refits_the_multiple_against_the_crop() {
     assert_eq!(layout.filter, super::scaler::ScaleFilter::SharpBilinear);
     assert!(layout.display_dst.2 <= 600);
 
+    // A surface too small for the whole 716-wide canvas still holds a
+    // whole multiple of a 640-wide crop: the fit is the crop's own, not
+    // an inherited fallback from the classic full-canvas plan.
+    let layout = super::autocrop_layout((700, 500), true, (38, 69, 640, 400), 44);
+    assert_eq!(layout.filter, super::scaler::ScaleFilter::Nearest);
+    assert_eq!((layout.display_dst.2, layout.display_dst.3), (640, 400));
+
     // Smooth scaling keeps the sharp-bilinear fit of the crop.
     let layout = super::autocrop_layout((2000, 1200), false, (38, 69, 640, 400), 0);
     assert_eq!(layout.chrome_dst, None);


### PR DESCRIPTION
Part of #591.

Two presentation changes, in the direction discussed on the issue:

## Own scaling pass for the emulator window (uncapped integer scaling)

The `pixels` crate's built-in renderer draws its texture only at whole multiples of *itself*, which welds the displayed integer multiple to the supersample cap (`MAX_INTEGER_TEXTURE_SCALE = 4`) - so fullscreen integer scaling stopped at 4x the canvas on a 5K/6K display however much room it had. The new pass (`window/scaler.rs`) takes the destination rect and filter as inputs instead, so the planned multiple is drawn whatever the texture factor is; the texture stays bounded at 4x.

Point sampling stays exact past the cap: the present copy replicates each canvas pixel into an S-wide texel block, so every texel a sample can land on inside a canvas pixel holds the same colour, and sample centres at `(p + 0.5) * S / M` can never fall on a canvas-pixel boundary. The module docs carry the argument, and an offscreen GPU test draws an S=2 texture at a 3x multiple and asserts exact blocks. The smooth filter is the same texel-snapped sharp bilinear the built-in Fill renderer used, in the pass's own WGSL. Tool windows keep the built-in renderer.

`PresentLayout` is the single source for the pass's draws, the cursor mapping and the overlay anchors, so they agree by construction.

## `[display] autocrop` (default off)

Crops the window presentation to the display window the hardware programs, so a game driving fewer lines than the full scan fills more of a 16:9/21:9 screen - with integer scaling the whole-number fit is retaken against the crop, which is where the multiple gains come from. Amiberry-style, and per the discussion on #591 it is purely content-derived: the envelope comes from the renderer's own per-line display-window bounds (mid-frame DIW rewrites and carried-open flops already folded in), never from title identity.

The per-frame envelope rides the same shifts and row/column maps the present copy applies, and is smoothed by a latch: growth is adopted immediately (content is never cut), border-only frames hold the previous crop like the aperture latch, and a strictly smaller window is adopted only after ~half a second of stability, so screen transitions do not pump the zoom. The status bar and instrument panels keep their size in a band along the window bottom; the OSD, REC badge and perf overlay anchor inside the crop.

Presentation-only: screenshots, dumps and recordings keep their configured aperture. Suspended while a menu or panel is open, under a bezel or CRT preset (the tube look frames the whole glass), for RTG scanout and for programmable scans. Toggles live from Video Settings and the launcher's Video page.

## Validation

- 3196 unit tests (18 new: GPU pass + clip math, layout planner, latch behaviour, both coordinate-space mappings, renderer envelope from a synthetic frame, config parse)
- All 44 golden render probes byte-exact - the renderer-side change (content-envelope accumulation) is pixel-neutral
- clippy and fmt clean; docs updated (`configuration.md`, `ui.md`, `internals/video.md`, example TOML)

**Not yet verified live**: the GPU present path cannot be exercised headlessly, so a manual windowed session flipping integer/autocrop/bezel/menus - ideally fullscreen on a big display - is the remaining check before merge.

Deferred from the issue discussion: per-axis PAR-aware integer scaling under the tv aspect (needs the square-canvas switch under integer+tv, which reaches through `present_height()` into window sizing).
