### PR TITLE
warp boot: warp any configuration's boot until storage settles or a timestamp

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -78,6 +78,23 @@ pacing_budget = "cycles"
 # it live from Warp Settings > Warp Limit or Cmd+Shift+W / Alt+Shift+W.
 # warp_speed = "max"
 
+# Warp boot: run unpaced (audio muted) from power-on until the boot storage
+# -- the floppy and hard-disk activity the front-panel LEDs show -- has been
+# idle for warp_boot_idle emulated seconds, then resume real-time pacing.
+# Same idea as --run's automatic warp launch, for any configuration that
+# boots from its own media (a Workbench install, a hard-disk setup, a CD).
+# The idle threshold must outlast the boot's longest storage-quiet stretch:
+# a big-RAM machine's SetPatch MMU table build keeps the disk idle for
+# seconds while the CPU walks every page of fitted RAM. The manual warp
+# toggle cancels the phase; headless captures are already unpaced and
+# ignore it. CD audio does not count as activity.
+# warp_boot = false
+# warp_boot_idle = 10
+
+# Warp boot until an absolute emulated timestamp instead: deterministic,
+# for a setup whose boot time is known (mutually exclusive with warp_boot).
+# warp_until = 12.0
+
 # Record rewind history from power-on, so Cmd+Z / Alt+Z (and the Rewind menu
 # item) can step the machine back through it. Off by default because it is
 # not free: every rewind_interval_frames the whole machine is serialized, and

--- a/crates/copperline-player/src/main.rs
+++ b/crates/copperline-player/src/main.rs
@@ -136,6 +136,9 @@ fn main() -> Result<()> {
         Vec::new(),
         None,
         run_warp_target,
+        // Publisher bundles boot their staged program via the warp launch
+        // above; the general warp-boot gate is not exposed here.
+        None,
         cfg.floppy_playlists.clone(),
         disk_write_protected,
         config::resolve_overscan(cfg.overscan),

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -364,6 +364,9 @@ power_on = true            # false = start powered off at the test screen
 pacing_budget = "cycles"   # "cycles" (hardware-accurate) or "instructions"
 realtime_priority = false  # true = raise the pacer/audio thread priority
 warp_speed = "max"         # turbo limit: "2x", "4x", "8x", "16x", or "max"
+warp_boot = false          # warp the boot until storage goes idle
+warp_boot_idle = 10        # ...for this many emulated seconds
+# warp_until = 12.0        # or warp until an absolute emulated time
 rewind = false             # true = record rewind history from power-on
 rewind_budget_mb = 256     # host memory the rewind history may hold
 rewind_interval_frames = 25 # emulated frames per rewind step
@@ -412,6 +415,26 @@ carried no information.)
   out and still presents at vsync. Adjust it live from the **Warp Limit**
   menu item or `Cmd+Shift+W` / `Alt+Shift+W` (see [The window and its
   controls](ui.md)).
+- `warp_boot = true` warps the boot: from power-on the machine runs unpaced
+  with audio muted -- exactly like the automatic warp launch `--run` performs
+  -- until the boot storage (the floppy and hard-disk activity the
+  front-panel LEDs show) has been idle for `warp_boot_idle` emulated seconds
+  (default 10), then real-time pacing and audio resume. A hard-disk setup
+  like AmigaVision lands at its menu in a couple of wall-clock seconds.
+  Landing a few emulated seconds late is free -- the extra idle time passes
+  at warp speed -- but the idle threshold must outlast the boot's longest
+  storage-quiet stretch: a big-RAM machine's boot-time MMU table build keeps
+  the disk idle for seconds while the CPU walks every page of fitted RAM, so
+  raise `warp_boot_idle` if the warp ends early on such a machine. CD audio
+  deliberately does not count as activity (CD *data* traffic rides the
+  hard-disk LED), so a menu's background CD-DA cannot hold the warp forever;
+  a boot whose storage never settles gives up after 600 emulated seconds.
+  `warp_until = SECS` is the deterministic alternative: warp until an
+  absolute emulated timestamp, for a setup whose boot time is known. The two
+  are mutually exclusive, `--warp-boot`/`--warp-until` set them from the
+  command line, the manual warp toggle cancels the phase, headless captures
+  (already unpaced end to end) ignore both, and `--run` (whose own warp
+  launch ends at a sharper condition) cannot combine with them.
 - `rewind = true` records rewind history from power-on, so `Cmd+Z` / `Alt+Z`
   and the **Rewind** menu item can step the whole machine backward through
   it. It rides the same deterministic snapshot ring as the debugger's reverse

--- a/docs/guide/run.md
+++ b/docs/guide/run.md
@@ -32,6 +32,9 @@ copperline --model A1200 --fast 8M KICK31.ROM --run build/demo
 ## Fast-forward boot (Warp mode)
 
 In interactive windowed sessions, `--run` automatically enables warp mode during boot.
+(For a configuration that boots from its own media rather than through
+`--run`, the same idea is available as `--warp-boot` / `--warp-until`; see
+[Configuration](configuration.md).)
 The emulator runs unthrottled with audio muted until the guest OS loads the executable
 (tracked at the `LoadSeg` call before executing the first instruction). Once loaded,
 emulation and audio immediately return to normal real-time playback.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@
 //! Command-line argument parsing for the Copperline binary: the flag
 //! grammar, `--script` file expansion, and the parsed `CliArgs` shape.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use std::path::PathBuf;
 
 use copperline::config::ConfigOverrides;
@@ -26,6 +26,13 @@ pub struct CliArgs {
     /// `--run-args STRING`: extra guest command-line arguments appended to
     /// the `--run` program's invocation.
     pub run_args: Option<String>,
+    /// `--warp-boot`: warp boot -- run unpaced from power-on until the
+    /// boot storage has been idle for `[emulation] warp_boot_idle`
+    /// emulated seconds, then resume real-time pacing (src/warpboot.rs).
+    pub warp_boot: bool,
+    /// `--warp-until SECS`: warp boot until an absolute emulated
+    /// timestamp instead of the storage-idle heuristic.
+    pub warp_until: Option<f64>,
     /// `--screenshot-after SECS PATH`: save the framebuffer after SECS
     /// emulated seconds. Repeatable, like the scheduled-input flags: every
     /// occurrence is captured, and the run ends once the last one has
@@ -325,6 +332,8 @@ where
     let mut rom_path: Option<PathBuf> = None;
     let mut whdload: Option<PathBuf> = None;
     let mut run: Option<PathBuf> = None;
+    let mut warp_boot = false;
+    let mut warp_until: Option<f64> = None;
     let mut run_args: Option<String> = None;
     let mut screenshot_after: Vec<(f32, PathBuf)> = Vec::new();
     let mut save_state_after: Vec<(f32, PathBuf)> = Vec::new();
@@ -468,6 +477,20 @@ where
                     .next()
                     .ok_or_else(|| anyhow!("--run-args requires an argument string"))?;
                 run_args = Some(v);
+            }
+            "--warp-boot" => {
+                warp_boot = true;
+            }
+            "--warp-until" => {
+                let secs: f64 = next_arg(
+                    &mut args,
+                    "--warp-until requires SECS",
+                    "--warp-until SECS must be a number",
+                )?;
+                if secs <= 0.0 || !secs.is_finite() {
+                    bail!("--warp-until SECS must be a positive number of emulated seconds");
+                }
+                warp_until = Some(secs);
             }
             "--model" => {
                 overrides.model = Some(
@@ -1217,6 +1240,8 @@ where
         rom_path,
         whdload,
         run,
+        warp_boot,
+        warp_until,
         run_args,
         screenshot_after,
         save_state_after,
@@ -1324,6 +1349,9 @@ fn print_help() {
          \x20                            the host, unthrottled until the OS loads it\n  \
          \x20                            (see docs/guide/run.md)\n  \
          --run-args STRING              extra guest command-line arguments for --run\n  \
+         --warp-boot                    warp the boot: unthrottled until the boot storage has\n  \
+         \x20                            been idle for [emulation] warp_boot_idle seconds\n  \
+         --warp-until SECS              warp the boot until an absolute emulated time\n  \
          --model NAME                   machine profile: A1000, A500, A500OCS, A500Plus, A600,\n  \
          \x20                              A1200, A3000, A4000, CDTV, CD32\n  \
          --chipset NAME                 chipset preset: OCS, ECS, or AGA\n  \

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1238,7 +1238,8 @@ impl LideConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// No Eq: `warp_boot_idle`/`warp_until` are f64 thresholds.
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Emulation {
     /// Whether the machine starts running (powered on) at launch. When
     /// false, the emulator sits powered off showing a test screen until
@@ -1259,6 +1260,17 @@ pub struct Emulation {
     /// as an output frame-skip level. See [`WarpSpeed`]. Adjustable at runtime
     /// from the Emulator menu and the keyboard.
     pub warp_speed: WarpSpeed,
+    /// Warp boot: run unpaced from power-on until the boot storage
+    /// (floppy/HDD LEDs) has been idle for [`Emulation::warp_boot_idle`]
+    /// emulated seconds, then resume real-time pacing. Windowed sessions
+    /// only (headless runs are already unpaced); the manual warp hotkey
+    /// cancels it. Mutually exclusive with `warp_until` and `--run`.
+    pub warp_boot: bool,
+    /// The storage-idle threshold for `warp_boot`, in emulated seconds.
+    pub warp_boot_idle: f64,
+    /// Warp boot until an absolute emulated timestamp instead: the
+    /// deterministic variant for a setup whose boot time is known.
+    pub warp_until: Option<f64>,
     /// Record rewind history from power-on, so the rewind hotkey and menu item
     /// work without opening the debugger. Off by default: capturing costs a
     /// whole-machine serialize every `rewind_interval_frames` and the retained
@@ -2281,6 +2293,9 @@ impl Default for Config {
                 pacing_budget: PacingBudget::Cycles,
                 realtime_priority: false,
                 warp_speed: WarpSpeed::default(),
+                warp_boot: false,
+                warp_boot_idle: 10.0,
+                warp_until: None,
                 rewind: false,
                 rewind_budget_mb: REWIND_DEFAULT_BUDGET_MB,
                 rewind_interval_frames: REWIND_DEFAULT_INTERVAL_FRAMES,

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -1056,6 +1056,21 @@ pub(crate) struct RawEmulation {
     /// UI warp/turbo speed: "2x", "4x", "8x", "16x", or "max" (default).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) warp_speed: Option<String>,
+    /// Warp boot: run unpaced from power-on until the boot storage has
+    /// been idle for `warp_boot_idle` emulated seconds (default false).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) warp_boot: Option<bool>,
+    /// The storage-idle threshold for `warp_boot`, in emulated seconds
+    /// (default 10). Must outlast the boot's longest storage-quiet
+    /// stretch (a big-RAM machine's SetPatch MMU table build keeps the
+    /// disk idle for seconds).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) warp_boot_idle: Option<f64>,
+    /// Warp boot until an absolute emulated timestamp, in seconds.
+    /// Deterministic alternative to `warp_boot`; the two are mutually
+    /// exclusive.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) warp_until: Option<f64>,
     /// Record rewind history from power-on (default false), so the rewind
     /// hotkey works outside the debugger.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -115,6 +115,24 @@ impl TryFrom<RawConfig> for Config {
                 None => defaults.emulation.warp_speed,
                 Some(s) => parse_warp_speed(s)?,
             },
+            warp_boot: raw
+                .emulation
+                .warp_boot
+                .unwrap_or(defaults.emulation.warp_boot),
+            warp_boot_idle: match raw.emulation.warp_boot_idle {
+                None => defaults.emulation.warp_boot_idle,
+                Some(secs) if secs > 0.0 && secs.is_finite() => secs,
+                Some(secs) => {
+                    bail!("[emulation] warp_boot_idle must be a positive number of seconds, got {secs}")
+                }
+            },
+            warp_until: match raw.emulation.warp_until {
+                None => defaults.emulation.warp_until,
+                Some(secs) if secs > 0.0 && secs.is_finite() => Some(secs),
+                Some(secs) => {
+                    bail!("[emulation] warp_until must be a positive number of seconds, got {secs}")
+                }
+            },
             rewind: raw.emulation.rewind.unwrap_or(defaults.emulation.rewind),
             rewind_budget_mb: match raw.emulation.rewind_budget_mb {
                 None => defaults.emulation.rewind_budget_mb,

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -98,6 +98,23 @@ impl TryFrom<RawConfig> for Config {
                  deterministic cycle-driven core is the only timing model"
             );
         }
+        let warp_boot = raw
+            .emulation
+            .warp_boot
+            .unwrap_or(defaults.emulation.warp_boot);
+        let warp_until = match raw.emulation.warp_until {
+            None => defaults.emulation.warp_until,
+            Some(secs) if secs > 0.0 && secs.is_finite() => Some(secs),
+            Some(secs) => {
+                bail!("[emulation] warp_until must be a positive number of seconds, got {secs}")
+            }
+        };
+        if warp_boot && warp_until.is_some() {
+            bail!(
+                "[emulation] warp_boot and warp_until are mutually exclusive: \
+                 pick the storage-idle heuristic or the fixed timestamp"
+            );
+        }
         let emulation = Emulation {
             power_on: raw
                 .emulation
@@ -115,10 +132,7 @@ impl TryFrom<RawConfig> for Config {
                 None => defaults.emulation.warp_speed,
                 Some(s) => parse_warp_speed(s)?,
             },
-            warp_boot: raw
-                .emulation
-                .warp_boot
-                .unwrap_or(defaults.emulation.warp_boot),
+            warp_boot,
             warp_boot_idle: match raw.emulation.warp_boot_idle {
                 None => defaults.emulation.warp_boot_idle,
                 Some(secs) if secs > 0.0 && secs.is_finite() => secs,
@@ -126,13 +140,7 @@ impl TryFrom<RawConfig> for Config {
                     bail!("[emulation] warp_boot_idle must be a positive number of seconds, got {secs}")
                 }
             },
-            warp_until: match raw.emulation.warp_until {
-                None => defaults.emulation.warp_until,
-                Some(secs) if secs > 0.0 && secs.is_finite() => Some(secs),
-                Some(secs) => {
-                    bail!("[emulation] warp_until must be a positive number of seconds, got {secs}")
-                }
-            },
+            warp_until,
             rewind: raw.emulation.rewind.unwrap_or(defaults.emulation.rewind),
             rewind_budget_mb: match raw.emulation.rewind_budget_mb {
                 None => defaults.emulation.rewind_budget_mb,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ pub mod timestamp;
 pub mod timetravel;
 pub mod toccata;
 pub mod video;
+pub mod warpboot;
 pub mod wasm_manifest;
 #[cfg(feature = "wasm-boards")]
 pub mod wasmboard;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1013,6 +1013,32 @@ fn main() -> Result<()> {
     // run is already unpaced end to end and must never be re-paced when the
     // program loads.
     let run_warp_target = if headless_capture { None } else { run_warp };
+    // The general warp-boot gate (--warp-boot / --warp-until,
+    // src/warpboot.rs): same interactive-session-only rule. --run has its
+    // own gate with a sharper end condition, so combining them is a
+    // configuration error rather than a fight between two gates.
+    let warp_until = cli.warp_until.or(cfg.emulation.warp_until);
+    let warp_boot = cli.warp_boot || cfg.emulation.warp_boot;
+    let warp_boot_gate = match (warp_boot, warp_until) {
+        (false, None) => None,
+        _ if cli.run.is_some() => {
+            anyhow::bail!("--warp-boot/--warp-until cannot combine with --run, which already warp-boots until the program loads");
+        }
+        (true, Some(_)) => {
+            anyhow::bail!("--warp-boot and --warp-until are mutually exclusive: pick the storage-idle heuristic or the fixed timestamp");
+        }
+        (false, Some(secs)) => Some(copperline::warpboot::WarpBootGate::new(
+            copperline::warpboot::WarpBootCondition::Until(secs),
+        )),
+        (true, None) => Some(copperline::warpboot::WarpBootGate::new(
+            copperline::warpboot::WarpBootCondition::StorageIdle(cfg.emulation.warp_boot_idle),
+        )),
+    };
+    let warp_boot_gate = if headless_capture {
+        None
+    } else {
+        warp_boot_gate
+    };
     #[cfg_attr(not(feature = "control"), allow(unused_mut))]
     let mut app = App::new(
         emu,
@@ -1030,6 +1056,7 @@ fn main() -> Result<()> {
         cli.cd_insert_after,
         cli.record_input,
         run_warp_target,
+        warp_boot_gate,
         cfg.floppy_playlists.clone(),
         disk_write_protected,
         config::resolve_overscan(cfg.overscan),
@@ -1162,6 +1189,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         Vec::new(),
         Vec::new(),
         Vec::new(),
+        None,
         None,
         None,
         std::array::from_fn(|_| Vec::new()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -804,6 +804,27 @@ fn main() -> Result<()> {
     // builds.
     #[cfg(not(feature = "gdb"))]
     let _ = &run_prog_name;
+    // --warp-boot/--warp-until (src/warpboot.rs): validate the flag combos
+    // before any mode dispatch, so a bad combination errors even on the
+    // gdb/control/benchmark paths that return early below. The TOML-level
+    // both-set case is rejected by shared config validation; this merged
+    // check also catches a CLI flag against a config-file setting. --run
+    // has its own gate with a sharper end condition, so combining them is
+    // a configuration error rather than a fight between two gates.
+    let warp_until = cli.warp_until.or(cfg.emulation.warp_until);
+    let warp_boot = cli.warp_boot || cfg.emulation.warp_boot;
+    if (warp_boot || warp_until.is_some()) && cli.run.is_some() {
+        return Err(anyhow!(
+            "--warp-boot/--warp-until cannot combine with --run, which already \
+             warp-boots until the program loads"
+        ));
+    }
+    if warp_boot && warp_until.is_some() {
+        return Err(anyhow!(
+            "--warp-boot and --warp-until are mutually exclusive: pick the \
+             storage-idle heuristic or the fixed timestamp"
+        ));
+    }
     if cli.load_state.is_some() {
         // A save state restores the full ROM image, so a Kickstart file is not
         // required to load one. Still resolve the bundled-AROS sentinel when
@@ -1013,31 +1034,16 @@ fn main() -> Result<()> {
     // run is already unpaced end to end and must never be re-paced when the
     // program loads.
     let run_warp_target = if headless_capture { None } else { run_warp };
-    // The general warp-boot gate (--warp-boot / --warp-until,
-    // src/warpboot.rs): same interactive-session-only rule. --run has its
-    // own gate with a sharper end condition, so combining them is a
-    // configuration error rather than a fight between two gates.
-    let warp_until = cli.warp_until.or(cfg.emulation.warp_until);
-    let warp_boot = cli.warp_boot || cfg.emulation.warp_boot;
-    let warp_boot_gate = match (warp_boot, warp_until) {
-        (false, None) => None,
-        _ if cli.run.is_some() => {
-            anyhow::bail!("--warp-boot/--warp-until cannot combine with --run, which already warp-boots until the program loads");
-        }
-        (true, Some(_)) => {
-            anyhow::bail!("--warp-boot and --warp-until are mutually exclusive: pick the storage-idle heuristic or the fixed timestamp");
-        }
-        (false, Some(secs)) => Some(copperline::warpboot::WarpBootGate::new(
-            copperline::warpboot::WarpBootCondition::Until(secs),
-        )),
-        (true, None) => Some(copperline::warpboot::WarpBootGate::new(
-            copperline::warpboot::WarpBootCondition::StorageIdle(cfg.emulation.warp_boot_idle),
-        )),
-    };
+    // The general warp-boot gate: interactive sessions only, same rule as
+    // the --run gate above (a capture run is already unpaced end to end).
     let warp_boot_gate = if headless_capture {
         None
     } else {
-        warp_boot_gate
+        copperline::warpboot::gate_from_settings(
+            warp_boot,
+            cfg.emulation.warp_boot_idle,
+            warp_until,
+        )
     };
     #[cfg_attr(not(feature = "control"), allow(unused_mut))]
     let mut app = App::new(

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -2343,6 +2343,11 @@ pub struct MachineSetup {
     /// The config screen has no control for run-ahead yet, but must preserve
     /// a value loaded from TOML or the CLI when it rebuilds RawConfig.
     run_ahead_frames: u8,
+    /// No config-screen controls yet either; preserved across the round
+    /// trip like run_ahead_frames (src/warpboot.rs).
+    warp_boot: bool,
+    warp_boot_idle: f64,
+    warp_until: Option<f64>,
     joystick_input_mode: JoystickInputMode,
     mouse_sensitivity: u8,
     mouse_capture: MouseCapture,
@@ -2635,6 +2640,9 @@ impl MachineSetup {
             realtime_priority: cfg.emulation.realtime_priority,
             warp: cfg.emulation.warp_speed,
             run_ahead_frames: cfg.emulation.run_ahead_frames,
+            warp_boot: cfg.emulation.warp_boot,
+            warp_boot_idle: cfg.emulation.warp_boot_idle,
+            warp_until: cfg.emulation.warp_until,
             joystick_input_mode: cfg.joystick_input_mode,
             mouse_sensitivity: cfg.mouse_sensitivity,
             mouse_capture: cfg.mouse_capture,
@@ -3203,6 +3211,15 @@ impl MachineSetup {
         }
         if self.run_ahead_frames != base.emulation.run_ahead_frames {
             raw.emulation.run_ahead_frames = Some(self.run_ahead_frames);
+        }
+        if self.warp_boot != base.emulation.warp_boot {
+            raw.emulation.warp_boot = Some(self.warp_boot);
+        }
+        if self.warp_boot_idle != base.emulation.warp_boot_idle {
+            raw.emulation.warp_boot_idle = Some(self.warp_boot_idle);
+        }
+        if self.warp_until != base.emulation.warp_until {
+            raw.emulation.warp_until = self.warp_until;
         }
         if self.joystick_input_mode != base.joystick_input_mode {
             raw.input.joystick = Some(self.joystick_input_mode.label().to_string());

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -8,6 +8,23 @@ fn run_ahead_frames_survives_the_config_screen_round_trip() {
 }
 
 #[test]
+fn warp_boot_settings_survive_the_config_screen_round_trip() {
+    // No config-screen controls yet, same as run-ahead: a saved default
+    // opening in the launcher must not silently shed them on Run/Save.
+    let raw: RawConfig =
+        toml::from_str("[emulation]\nwarp_boot = true\nwarp_boot_idle = 15.0\n").unwrap();
+    let setup = MachineSetup::from_raw(&raw).unwrap();
+    let out = setup.to_raw();
+    assert_eq!(out.emulation.warp_boot, Some(true));
+    assert_eq!(out.emulation.warp_boot_idle, Some(15.0));
+    assert_eq!(out.emulation.warp_until, None);
+
+    let raw: RawConfig = toml::from_str("[emulation]\nwarp_until = 12.5\n").unwrap();
+    let setup = MachineSetup::from_raw(&raw).unwrap();
+    assert_eq!(setup.to_raw().emulation.warp_until, Some(12.5));
+}
+
+#[test]
 fn ram_initialisation_controls_cycle_and_round_trip() {
     let raw: RawConfig = toml::from_str("[memory]\ninit = \"random:0xBEEF\"\n").unwrap();
     let mut setup = MachineSetup::from_raw(&raw).unwrap();

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1056,6 +1056,11 @@ pub struct App {
     /// LoadSeg observer feeding the warp-launch gate. Only meaningful
     /// while `warp_launch` is Some.
     warp_launch_tracker: crate::amigaos::LibraryTracker,
+    /// Warp boot (`--warp-boot`/`--warp-until`): warp from power-on until
+    /// the storage-idle or timestamp condition holds, then return to
+    /// real-time pacing (src/warpboot.rs). One-shot; None once finished
+    /// or cancelled. Host-side only, never serialized.
+    warp_boot: Option<crate::warpboot::WarpBootGate>,
     /// Live-input recorder: logs every input event that reaches the
     /// emulated machine and writes a --script-replayable file on stop.
     /// None while not recording.
@@ -1869,6 +1874,7 @@ impl App {
         cd_insert_after: Vec<(f32, PathBuf)>,
         record_input: Option<PathBuf>,
         run_warp_target: Option<crate::runprog::WarpLaunch>,
+        warp_boot_gate: Option<crate::warpboot::WarpBootGate>,
         disk_playlists: [Vec<PathBuf>; 4],
         disk_write_protected: [bool; 4],
         overscan: Overscan,
@@ -2023,6 +2029,7 @@ impl App {
             pending_auto_cd_inserts: cd_insert_after,
             warp_launch: run_warp_target,
             warp_launch_tracker: crate::amigaos::LibraryTracker::default(),
+            warp_boot: warp_boot_gate,
             input_recorder: record_input
                 .is_some()
                 .then(|| crate::inputrec::InputRecorder::new(0.0)),
@@ -3452,6 +3459,7 @@ impl ApplicationHandler for App {
         self.request_redraw();
         self.arm_scheduled_events();
         self.engage_warp_launch();
+        self.engage_warp_boot();
     }
 
     fn window_event(
@@ -4726,6 +4734,12 @@ impl ApplicationHandler for App {
                 // The warp-launch gate ends its warp the frame the guest
                 // loads the target program.
                 if self.poll_warp_launch() {
+                    burst_complete = false;
+                    break;
+                }
+                // The warp-boot gate ends its warp the frame its
+                // timestamp or storage-idle condition holds.
+                if self.poll_warp_boot() {
                     burst_complete = false;
                     break;
                 }

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -1480,6 +1480,16 @@ impl App {
         self.powered_on = true;
         self.cpu_halted = false;
         self.paused = false;
+        // The machine's configured warp boot ([emulation] warp_boot /
+        // warp_until) starts fresh with the machine: run_machine is the
+        // launcher path's power-on, so construct and engage the gate here
+        // the way main.rs does for a direct CLI launch.
+        self.warp_boot = crate::warpboot::gate_from_settings(
+            cfg.emulation.warp_boot,
+            cfg.emulation.warp_boot_idle,
+            cfg.emulation.warp_until,
+        );
+        self.engage_warp_boot();
         self.reset_render_pipeline();
         // The last overlay set here is the one that gets drawn, so a shader
         // or sticker folder that failed to load has to travel in this

--- a/src/video/window/app_session.rs
+++ b/src/video/window/app_session.rs
@@ -117,6 +117,82 @@ impl App {
         self.sync_live_audio_suspension();
     }
 
+    /// Start the general warp-boot phase (`--warp-boot`/`--warp-until`,
+    /// src/warpboot.rs): run unpaced with live audio muted until the
+    /// storage-idle or timestamp condition holds. Same contract as the
+    /// `--run` warp launch: a machine that refuses to unpace (a bridged
+    /// physical drive) still runs the gate at normal speed with audio
+    /// live, and the phase is one-shot per session.
+    pub(super) fn engage_warp_boot(&mut self) {
+        let engage = match &self.warp_boot {
+            Some(gate) => self.powered_on && !gate.started(),
+            None => false,
+        };
+        if !engage {
+            return;
+        }
+        self.emu.set_paced(false);
+        let unpaced = !self.emu.paced();
+        let now = self.emu.bus().emulated_seconds();
+        let gate = self.warp_boot.as_mut().expect("checked above");
+        gate.engage(now, unpaced);
+        if unpaced {
+            info!("warp boot: warping {}", gate.describe());
+        } else {
+            info!(
+                "warp boot: physical floppy drive attached; booting at normal speed ({})",
+                gate.describe()
+            );
+        }
+        self.sync_live_audio_suspension();
+    }
+
+    /// One warp-boot poll, once per retired emulated frame (inside the
+    /// warp burst the gate must not lag the condition by a thousand
+    /// frames). Returns true when the boot phase just ended, so the
+    /// burst breaks and pacing takes effect at this frame.
+    pub(super) fn poll_warp_boot(&mut self) -> bool {
+        let Some(gate) = &mut self.warp_boot else {
+            return false;
+        };
+        if !gate.started() {
+            return false;
+        }
+        // Storage activity as the front panel shows it: the floppy LED and
+        // the (non-draining, timestamp-latched) HDD LED. CD-DA playback is
+        // deliberately not activity -- CD data traffic rides the HDD LED,
+        // and a menu's background audio must not hold the warp forever.
+        let panel = self.emu.bus().front_panel_status();
+        let storage_active = panel.fdd_led_on || panel.hdd_led == Some(true);
+        let now = self.emu.bus().emulated_seconds();
+        match gate.note(now, storage_active) {
+            crate::warpboot::WarpBootOutcome::Waiting => false,
+            crate::warpboot::WarpBootOutcome::Done => {
+                info!("warp boot: done at {now:.1}s emulated; real-time pacing resumes");
+                self.finish_warp_boot();
+                self.show_osd("Warp boot: done");
+                true
+            }
+            crate::warpboot::WarpBootOutcome::TimedOut => {
+                warn!(
+                    "warp boot: storage never settled within {:.0} emulated seconds;                      resuming real-time pacing anyway",
+                    crate::warpboot::WARP_BOOT_TIMEOUT_SECS
+                );
+                self.finish_warp_boot();
+                self.show_osd("Warp boot: storage never settled, warp off");
+                true
+            }
+        }
+    }
+
+    /// End the warp-boot phase: back to real-time pacing (set_paced
+    /// re-anchors the pacing clock) and live audio.
+    pub(super) fn finish_warp_boot(&mut self) {
+        self.warp_boot = None;
+        self.emu.set_paced(true);
+        self.sync_live_audio_suspension();
+    }
+
     /// Toggle warp speed: emulation runs unpaced (as fast as the host
     /// allows) until switched back, when pacing re-anchors to "now".
     pub(super) fn toggle_warp(&mut self) {
@@ -126,6 +202,10 @@ impl App {
         if self.warp_launch.take().is_some() {
             self.sync_live_audio_suspension();
             info!("warp launch: cancelled by manual warp toggle");
+        }
+        if self.warp_boot.take().is_some() {
+            self.sync_live_audio_suspension();
+            info!("warp boot: cancelled by manual warp toggle");
         }
         let warp = self.emu.paced();
         self.emu.set_paced(!warp);
@@ -749,7 +829,8 @@ impl App {
         // The warp-launch catch-up is silent: unpaced Paula output is
         // fast-forward noise, and the machine snaps back to live audio
         // the moment the launch finishes (or is cancelled).
-        let warp_launching = self.warp_launch.as_ref().is_some_and(|l| l.engaged);
+        let warp_launching = self.warp_launch.as_ref().is_some_and(|l| l.engaged)
+            || self.warp_boot.as_ref().is_some_and(|g| g.engaged);
         let suspended = !self.powered_on || self.cpu_halted || self.paused || warp_launching;
         self.emu.set_live_audio_suspended(suspended);
     }

--- a/src/video/window/app_session.rs
+++ b/src/video/window/app_session.rs
@@ -175,7 +175,7 @@ impl App {
             }
             crate::warpboot::WarpBootOutcome::TimedOut => {
                 warn!(
-                    "warp boot: storage never settled within {:.0} emulated seconds;                      resuming real-time pacing anyway",
+                    "warp boot: storage never settled within {:.0} emulated seconds; resuming real-time pacing anyway",
                     crate::warpboot::WARP_BOOT_TIMEOUT_SECS
                 );
                 self.finish_warp_boot();
@@ -196,16 +196,26 @@ impl App {
     /// Toggle warp speed: emulation runs unpaced (as fast as the host
     /// allows) until switched back, when pacing re-anchors to "now".
     pub(super) fn toggle_warp(&mut self) {
-        // A manual warp toggle during a warp launch takes the session
-        // back: cancel the launch so one press means normal-speed,
-        // audible emulation, not a fight with the gate.
+        // A manual warp toggle during a warp launch or warp boot takes
+        // the session back: one press means normal-speed, audible
+        // emulation -- a complete action, not a second toggle on top. On
+        // a machine that refused to unpace (a bridged physical drive)
+        // the gate is pending while the emulator is still paced, and
+        // falling through would read that press as "warp on".
+        let mut cancelled = false;
         if self.warp_launch.take().is_some() {
-            self.sync_live_audio_suspension();
             info!("warp launch: cancelled by manual warp toggle");
+            cancelled = true;
         }
         if self.warp_boot.take().is_some() {
-            self.sync_live_audio_suspension();
             info!("warp boot: cancelled by manual warp toggle");
+            cancelled = true;
+        }
+        if cancelled {
+            self.emu.set_paced(true);
+            self.sync_live_audio_suspension();
+            self.show_osd("Warp off");
+            return;
         }
         let warp = self.emu.paced();
         self.emu.set_paced(!warp);
@@ -1001,9 +1011,10 @@ impl App {
             // still holds them, so no permission is asked twice.
             self.attach_configured_host_disks();
             info!("power button: machine powered on (cold boot)");
-            // A --run session that started powered off begins its warp
-            // launch at the first power-on.
+            // A session that started powered off begins its warp launch
+            // (--run) or warp boot at the first power-on.
             self.engage_warp_launch();
+            self.engage_warp_boot();
         }
         self.request_redraw();
     }
@@ -1082,13 +1093,19 @@ impl App {
         // goes, so the cold-boot machine starts with the caps up and
         // nothing latched against the machine that just stopped.
         self.release_keyboard_panel_holds();
-        // A pending warp launch dies with the machine; give the pacing
-        // back so the next power-on runs at normal speed.
+        // A pending warp launch or warp boot dies with the machine; give
+        // the pacing back so the next power-on runs at normal speed.
         if let Some(launch) = self.warp_launch.take() {
             if launch.engaged {
                 self.emu.set_paced(true);
             }
             info!("warp launch: cancelled by power off");
+        }
+        if let Some(gate) = self.warp_boot.take() {
+            if gate.engaged {
+                self.emu.set_paced(true);
+            }
+            info!("warp boot: cancelled by power off");
         }
         self.powered_on = false;
         self.paused = false;

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4165,6 +4165,7 @@ fn test_app_with_audio_cpu_and_program(
         Vec::new(),
         None,
         None,
+        None,
         std::array::from_fn(|_| Vec::new()),
         [true; 4],
         crate::config::Overscan::Full,
@@ -8737,4 +8738,51 @@ fn pacer_counts_a_slip_when_it_reanchors_past_the_catchup_limit() {
         Some(crate::timebase::Instant::now() - crate::timebase::Duration::from_secs(10));
     app.emu.step_frame().expect("step");
     assert_eq!(app.emu.perf_counters().pacer_slips, 1);
+}
+
+/// The general warp-boot gate (src/warpboot.rs) wired through the app:
+/// engaging unpaces the machine and mutes live audio, the poll holds the
+/// warp until the emulated-time condition, and finishing re-paces and
+/// clears the one-shot gate. The pure state machine is covered in
+/// warpboot.rs; this drives the real App plumbing against a live
+/// emulator.
+#[test]
+fn warp_boot_gate_warps_until_the_timestamp_then_repaces() {
+    let mut app = test_app();
+    app.powered_on = true;
+    app.warp_boot = Some(crate::warpboot::WarpBootGate::new(
+        crate::warpboot::WarpBootCondition::Until(0.05),
+    ));
+    app.engage_warp_boot();
+    assert!(!app.emu.paced(), "the boot phase runs unpaced");
+    assert!(
+        !app.poll_warp_boot(),
+        "the gate holds before the target time"
+    );
+
+    while app.emu.bus().emulated_seconds() < 0.05 {
+        app.emu.step_frame().expect("frame");
+    }
+    assert!(app.poll_warp_boot(), "the gate ends at the target time");
+    assert!(app.emu.paced(), "real-time pacing resumes");
+    assert!(app.warp_boot.is_none(), "the gate is one-shot");
+
+    // A second poll after the phase ended is a no-op.
+    assert!(!app.poll_warp_boot());
+}
+
+/// The manual warp toggle cancels a pending warp-boot gate: one press
+/// means normal-speed, audible emulation, not a fight with the gate.
+#[test]
+fn manual_warp_toggle_cancels_the_warp_boot_gate() {
+    let mut app = test_app();
+    app.powered_on = true;
+    app.warp_boot = Some(crate::warpboot::WarpBootGate::new(
+        crate::warpboot::WarpBootCondition::StorageIdle(10.0),
+    ));
+    app.engage_warp_boot();
+    assert!(!app.emu.paced());
+    app.toggle_warp();
+    assert!(app.warp_boot.is_none(), "the toggle cancels the gate");
+    assert!(app.emu.paced(), "one press lands on paced, audible");
 }

--- a/src/warpboot.rs
+++ b/src/warpboot.rs
@@ -58,6 +58,23 @@ pub enum WarpBootOutcome {
     TimedOut,
 }
 
+/// Build the gate a resolved configuration's settings ask for.
+/// `warp_until` wins; the both-set case is rejected by shared config
+/// validation (and the CLI path re-checks the merged flag/TOML combo).
+pub fn gate_from_settings(
+    warp_boot: bool,
+    warp_boot_idle: f64,
+    warp_until: Option<f64>,
+) -> Option<WarpBootGate> {
+    match (warp_boot, warp_until) {
+        (_, Some(secs)) => Some(WarpBootGate::new(WarpBootCondition::Until(secs))),
+        (true, None) => Some(WarpBootGate::new(WarpBootCondition::StorageIdle(
+            warp_boot_idle,
+        ))),
+        (false, None) => None,
+    }
+}
+
 /// The boot-phase state machine: warp from power-on until the condition
 /// holds, then hand back to real-time pacing.
 pub struct WarpBootGate {

--- a/src/warpboot.rs
+++ b/src/warpboot.rs
@@ -1,0 +1,217 @@
+//! General warp boot: run the machine unpaced from power-on until a
+//! condition holds, then hand back to real-time pacing.
+//!
+//! `--run`'s warp launch (src/runprog.rs) does this for one specific
+//! condition -- the guest loading a known executable. This is the same
+//! idea for ordinary configurations that boot from whatever media they
+//! have (a Workbench disk, a hard-disk setup like AmigaVision, a CD):
+//!
+//! - `--warp-until SECS` warps until an absolute emulated timestamp.
+//!   Deterministic: the same config lands at the same place every run,
+//!   so once a user knows their setup shows its menu at 12s they get it
+//!   in a couple of wall seconds, every time.
+//! - `--warp-boot` warps until the boot storage (floppy and hard-disk
+//!   activity, as shown by the front-panel LEDs) has been idle for a
+//!   threshold of emulated seconds (`[emulation] warp_boot_idle`,
+//!   default 10). Overshoot is free: the extra idle seconds pass at warp
+//!   speed, and landing a few emulated seconds after the menu settled is
+//!   invisible. CD audio deliberately does not count as activity -- CD
+//!   *data* traffic rides the HDD LED, while a menu's background CD-DA
+//!   must not hold the warp forever. The idle threshold exists because
+//!   boots have storage-quiet stretches that are not the end of the
+//!   boot: a big-RAM machine's SetPatch MMU table build keeps the disk
+//!   idle for seconds while the CPU walks every page of fitted RAM
+//!   (timing-test/accelprobe.asm measures that walk), so a threshold
+//!   shorter than the longest such stretch would disengage mid-boot.
+//!
+//! Like the warp launch, this is pure bookkeeping over emulated time so
+//! it tests without an emulator; the owner (src/video/window.rs) does
+//! the actual pacing and audio calls, engages the gate at power-on, and
+//! polls it once per retired emulated frame. Headless capture runs are
+//! already unpaced end to end and never carry a gate. The manual warp
+//! toggle cancels the gate, same as it cancels a warp launch: one press
+//! means normal-speed, audible emulation.
+
+/// Hard cap for the storage-idle mode, in emulated seconds from
+/// engagement: a boot that is still churning storage after this long is
+/// one the user should be watching at normal speed to see what is wrong.
+/// The `--warp-until` mode needs no cap -- its condition *is* a time.
+pub const WARP_BOOT_TIMEOUT_SECS: f64 = 600.0;
+
+/// What ends the warp.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum WarpBootCondition {
+    /// Absolute emulated timestamp, in seconds.
+    Until(f64),
+    /// Floppy+HDD idle for this many consecutive emulated seconds.
+    StorageIdle(f64),
+}
+
+/// Why a poll ended the warp (or didn't).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum WarpBootOutcome {
+    /// Keep warping.
+    Waiting,
+    /// The condition holds: resume real-time pacing.
+    Done,
+    /// Storage never went idle within [`WARP_BOOT_TIMEOUT_SECS`].
+    TimedOut,
+}
+
+/// The boot-phase state machine: warp from power-on until the condition
+/// holds, then hand back to real-time pacing.
+pub struct WarpBootGate {
+    condition: WarpBootCondition,
+    /// Emulated time of the last observed storage activity (idle mode).
+    last_active_secs: f64,
+    /// Hard-cap deadline, set at engagement (idle mode only).
+    deadline_secs: Option<f64>,
+    /// Whether [`WarpBootGate::engage`] has run.
+    started: bool,
+    /// Whether the machine actually entered warp (audio is muted only
+    /// while this is true; a machine that refuses to unpace -- a bridged
+    /// physical drive -- still runs the gate at normal speed).
+    pub engaged: bool,
+}
+
+impl WarpBootGate {
+    pub fn new(condition: WarpBootCondition) -> Self {
+        Self {
+            condition,
+            last_active_secs: 0.0,
+            deadline_secs: None,
+            started: false,
+            engaged: false,
+        }
+    }
+
+    pub fn condition(&self) -> WarpBootCondition {
+        self.condition
+    }
+
+    /// A short description for the log and the OSD.
+    pub fn describe(&self) -> String {
+        match self.condition {
+            WarpBootCondition::Until(secs) => format!("until {secs:.1}s emulated"),
+            WarpBootCondition::StorageIdle(idle) => {
+                format!("until storage is idle for {idle:.0}s")
+            }
+        }
+    }
+
+    /// Whether [`WarpBootGate::engage`] has run.
+    pub fn started(&self) -> bool {
+        self.started
+    }
+
+    /// Start the boot phase at `now_secs` of emulated time. `unpaced`
+    /// says whether the machine really went unpaced.
+    pub fn engage(&mut self, now_secs: f64, unpaced: bool) {
+        self.started = true;
+        self.engaged = unpaced;
+        self.last_active_secs = now_secs;
+        if matches!(self.condition, WarpBootCondition::StorageIdle(_)) {
+            self.deadline_secs = Some(now_secs + WARP_BOOT_TIMEOUT_SECS);
+        }
+    }
+
+    /// Feed one poll: the current emulated time and whether the boot
+    /// storage (floppy or hard disk) is active right now.
+    pub fn note(&mut self, now_secs: f64, storage_active: bool) -> WarpBootOutcome {
+        match self.condition {
+            WarpBootCondition::Until(target) => {
+                if now_secs >= target {
+                    WarpBootOutcome::Done
+                } else {
+                    WarpBootOutcome::Waiting
+                }
+            }
+            WarpBootCondition::StorageIdle(threshold) => {
+                if storage_active {
+                    self.last_active_secs = now_secs;
+                }
+                if now_secs - self.last_active_secs >= threshold {
+                    return WarpBootOutcome::Done;
+                }
+                match self.deadline_secs {
+                    Some(deadline) if now_secs >= deadline => WarpBootOutcome::TimedOut,
+                    _ => WarpBootOutcome::Waiting,
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn until_mode_ends_exactly_at_the_target_time() {
+        let mut gate = WarpBootGate::new(WarpBootCondition::Until(12.0));
+        gate.engage(0.5, true);
+        assert!(gate.engaged);
+        assert_eq!(gate.note(0.6, true), WarpBootOutcome::Waiting);
+        assert_eq!(gate.note(11.99, false), WarpBootOutcome::Waiting);
+        assert_eq!(gate.note(12.0, false), WarpBootOutcome::Done);
+    }
+
+    #[test]
+    fn until_mode_already_past_the_target_ends_on_the_first_poll() {
+        // Engaging after the target (a resumed save state, a late gate)
+        // must not warp forever.
+        let mut gate = WarpBootGate::new(WarpBootCondition::Until(1.0));
+        gate.engage(5.0, true);
+        assert_eq!(gate.note(5.0, true), WarpBootOutcome::Done);
+    }
+
+    #[test]
+    fn idle_mode_needs_a_full_quiet_threshold() {
+        let mut gate = WarpBootGate::new(WarpBootCondition::StorageIdle(10.0));
+        gate.engage(0.0, true);
+        // Boot activity keeps re-arming the window.
+        assert_eq!(gate.note(1.0, true), WarpBootOutcome::Waiting);
+        assert_eq!(gate.note(8.0, true), WarpBootOutcome::Waiting);
+        assert_eq!(gate.note(17.9, false), WarpBootOutcome::Waiting);
+        // Ten quiet seconds after the last activity at 8.0.
+        assert_eq!(gate.note(18.0, false), WarpBootOutcome::Done);
+    }
+
+    #[test]
+    fn idle_mode_survives_a_storage_quiet_stretch_shorter_than_threshold() {
+        // The SetPatch MMU-walk shape: disk quiet for seconds mid-boot,
+        // then loading resumes. A threshold longer than the stretch keeps
+        // the warp engaged across it.
+        let mut gate = WarpBootGate::new(WarpBootCondition::StorageIdle(10.0));
+        gate.engage(0.0, true);
+        assert_eq!(gate.note(2.0, true), WarpBootOutcome::Waiting);
+        // 9 quiet seconds -- not enough to disengage.
+        assert_eq!(gate.note(11.0, false), WarpBootOutcome::Waiting);
+        // Activity resumes and re-arms the window.
+        assert_eq!(gate.note(11.5, true), WarpBootOutcome::Waiting);
+        assert_eq!(gate.note(21.4, false), WarpBootOutcome::Waiting);
+        assert_eq!(gate.note(21.5, false), WarpBootOutcome::Done);
+    }
+
+    #[test]
+    fn idle_mode_times_out_rather_than_warping_forever() {
+        let mut gate = WarpBootGate::new(WarpBootCondition::StorageIdle(10.0));
+        gate.engage(0.0, true);
+        // Storage never goes quiet for the threshold.
+        let mut now = 0.0;
+        while now < WARP_BOOT_TIMEOUT_SECS {
+            assert_eq!(gate.note(now, true), WarpBootOutcome::Waiting);
+            now += 5.0;
+        }
+        assert_eq!(gate.note(now, true), WarpBootOutcome::TimedOut);
+    }
+
+    #[test]
+    fn a_machine_that_refuses_to_unpace_still_runs_the_gate() {
+        let mut gate = WarpBootGate::new(WarpBootCondition::Until(2.0));
+        gate.engage(0.0, false);
+        assert!(gate.started());
+        assert!(!gate.engaged);
+        assert_eq!(gate.note(2.5, false), WarpBootOutcome::Done);
+    }
+}


### PR DESCRIPTION
`--run` warp-launches: unpaced with muted audio until the guest loads the program. This generalizes that to configurations that boot from their own media -- a Workbench install, a hard-disk setup like AmigaVision, a CD:

- **`--warp-boot`** / `[emulation] warp_boot`: warp from power-on until the boot storage (the floppy and hard-disk activity the front-panel LEDs show) has been idle for `[emulation] warp_boot_idle` emulated seconds (default 10), then resume real-time pacing and audio. Overshoot is free -- the extra idle seconds pass at warp speed -- but the threshold must outlast the boot's longest storage-quiet stretch: a big-RAM machine's SetPatch MMU table build keeps the disk idle for seconds while the CPU walks every page of fitted RAM (the accelprobe campaign measured that walk). CD audio deliberately does not count as activity (CD *data* traffic rides the HDD LED), so a menu's background CD-DA cannot hold the warp; a boot whose storage never settles gives up after 600 emulated seconds.
- **`--warp-until SECS`** / `[emulation] warp_until`: the deterministic variant -- warp until an absolute emulated timestamp, for a setup whose boot time is known. An AmigaVision 040 machine reaches its menu in a couple of wall-clock seconds either way.

The gate (`src/warpboot.rs`) mirrors the warp launch's shape: a pure state machine over emulated time, polled once per retired frame inside the warp burst, engaged at power-on, one-shot per session, cancelled by the manual warp toggle, audio muted only while genuinely unpaced (a machine with a bridged physical drive still runs the gate at normal speed). The storage-idle condition reads `front_panel_status()`, whose HDD LED is a non-draining timestamp latch, so the gate and the status bar share the signal without stealing each other's events.

Headless captures are already unpaced end to end and drop the gate, same as the `--run` gate. Combining with `--run` (whose own warp ends at a sharper condition), or combining the two modes with each other, is a configuration error with a message saying so.

Covered by: six pure state-machine tests (`warpboot.rs`), two App wiring tests driving a live emulator (engage/poll/finish and the manual-toggle cancel), CLI/TOML validation smoke tests for both error paths, and docs in `docs/guide/configuration.md`, `docs/guide/run.md`, and `copperline.example.toml`. Full suite green, clippy/fmt clean.