### PR TITLE
launcher: Warp boot rows on the A/V & Emu Emulation page

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -434,7 +434,10 @@ carried no information.)
   are mutually exclusive, `--warp-boot`/`--warp-until` set them from the
   command line, the manual warp toggle cancels the phase, headless captures
   (already unpaced end to end) ignore both, and `--run` (whose own warp
-  launch ends at a sharper condition) cannot combine with them.
+  launch ends at a sharper condition) cannot combine with them. The
+  launcher's *Warp boot* and *Warp boot idle* rows (*A/V & Emu*,
+  *Emulation*) edit the storage-idle mode; a `warp_until` loaded from a
+  config shows there as its own *Until Ns* state, which one press clears.
 - `rewind = true` records rewind history from power-on, so `Cmd+Z` / `Alt+Z`
   and the **Rewind** menu item can step the whole machine backward through
   it. It rides the same deterministic snapshot ring as the debugger's reverse

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -714,6 +714,8 @@ pub enum LauncherField {
     PacingBudget,
     RealtimePriority,
     Warp,
+    WarpBoot,
+    WarpBootIdle,
     // Input
     Joystick,
     MouseSensitivity,
@@ -1269,18 +1271,22 @@ const AUDIO_ROWS: [Row; 6] = [
     row(F::FloppyVolume, "Floppy volume", Cycle),
 ];
 #[cfg(not(feature = "game-library"))]
-const EMULATION_ROWS: [Row; 4] = [
+const EMULATION_ROWS: [Row; 6] = [
     row(F::PowerOn, "Power on startup", Cycle),
     row(F::RealtimePriority, "Realtime priority", Cycle),
     row(F::PacingBudget, "Pacing budget", Cycle),
     row(F::Warp, "Warp speed", Cycle),
+    row(F::WarpBoot, "Warp boot", Cycle),
+    row(F::WarpBootIdle, "Warp boot idle", Cycle),
 ];
 #[cfg(feature = "game-library")]
-const EMULATION_ROWS: [Row; 5] = [
+const EMULATION_ROWS: [Row; 7] = [
     row(F::PowerOn, "Power on startup", Cycle),
     row(F::RealtimePriority, "Realtime priority", Cycle),
     row(F::PacingBudget, "Pacing budget", Cycle),
     row(F::Warp, "Warp speed", Cycle),
+    row(F::WarpBoot, "Warp boot", Cycle),
+    row(F::WarpBootIdle, "Warp boot idle", Cycle),
     // Off, the strip loses its WHDLoad entry and the pages behind it stop
     // doing anything at all -- no database read, no cover worker, no scan.
     row(F::WhdloadEnabled, "WHDLoad", Cycle),
@@ -1563,6 +1569,11 @@ const CPUS: [CpuModel; 7] = [
     CpuModel::M68040,
     CpuModel::M68060,
 ];
+/// Storage-idle thresholds for the Warp boot row, in emulated seconds.
+/// The threshold must outlast the boot's longest storage-quiet stretch
+/// (a big-RAM machine's MMU table build keeps the disk idle for seconds),
+/// hence the range up to two minutes.
+const WARP_BOOT_IDLE_PRESETS: [f64; 7] = [5.0, 10.0, 15.0, 20.0, 30.0, 60.0, 120.0];
 const CLOCK_PRESETS: [f64; 10] = [
     7.09, 14.0, 14.18, 25.0, 28.0, 33.0, 40.0, 50.0, 100.0, 200.0,
 ];
@@ -4438,6 +4449,14 @@ impl MachineSetup {
                 PacingBudget::Instructions => "Instructions".to_string(),
             },
             F::Warp => self.warp.label().to_string(),
+            F::WarpBoot => match (self.warp_until, self.warp_boot) {
+                // A warp_until from the TOML shows as its own state; the
+                // panel's own two states are Off and storage-idle.
+                (Some(secs), _) => format!("Until {secs:.0}s"),
+                (None, true) => "Storage idle".to_string(),
+                (None, false) => "Off".to_string(),
+            },
+            F::WarpBootIdle => format!("{:.0}s", self.warp_boot_idle),
             F::Joystick => self.joystick_input_mode.menu_label().to_string(),
             F::MouseSensitivity => crate::config::mouse_sensitivity_label(self.mouse_sensitivity),
             F::MouseCapture => match self.mouse_capture {
@@ -4872,6 +4891,23 @@ impl MachineSetup {
                 self.pacing_budget = cycle_slice(&PACINGS, self.pacing_budget, forward)
             }
             F::Warp => self.warp = cycle_slice(&WARPS, self.warp, forward),
+            F::WarpBoot => {
+                // Two panel states, Off and storage-idle (the boot warps
+                // until the floppy/HDD LEDs have been quiet for the idle
+                // threshold below). A timestamp warp (warp_until, set from
+                // TOML or --warp-until) shows as a third state; the modes
+                // are mutually exclusive, so one press clears it and lands
+                // on Off in either direction.
+                if self.warp_until.take().is_some() {
+                    self.warp_boot = false;
+                } else {
+                    self.warp_boot = !self.warp_boot;
+                }
+            }
+            F::WarpBootIdle => {
+                self.warp_boot_idle =
+                    cycle_floats(&WARP_BOOT_IDLE_PRESETS, self.warp_boot_idle, forward)
+            }
             F::Joystick => {
                 self.joystick_input_mode =
                     cycle_slice(&JOYSTICK_MODES, self.joystick_input_mode, forward)

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -4452,11 +4452,11 @@ impl MachineSetup {
             F::WarpBoot => match (self.warp_until, self.warp_boot) {
                 // A warp_until from the TOML shows as its own state; the
                 // panel's own two states are Off and storage-idle.
-                (Some(secs), _) => format!("Until {secs:.0}s"),
+                (Some(secs), _) => format!("Until {}", format_secs(secs)),
                 (None, true) => "Storage idle".to_string(),
                 (None, false) => "Off".to_string(),
             },
-            F::WarpBootIdle => format!("{:.0}s", self.warp_boot_idle),
+            F::WarpBootIdle => format_secs(self.warp_boot_idle),
             F::Joystick => self.joystick_input_mode.menu_label().to_string(),
             F::MouseSensitivity => crate::config::mouse_sensitivity_label(self.mouse_sensitivity),
             F::MouseCapture => match self.mouse_capture {
@@ -9233,6 +9233,18 @@ fn connected_floppy_bays(connected: &[bool; 4]) -> u8 {
         .rposition(|&connected| connected)
         .map(|idx| idx as u8 + 1)
         .unwrap_or(0)
+}
+
+/// A seconds label that keeps a fractional configured value visible
+/// ("12.5s") while the whole-second presets stay terse ("10s"). The
+/// config accepts arbitrary positive seconds, so the panel must not
+/// round a loaded value into a different-looking timestamp.
+fn format_secs(secs: f64) -> String {
+    if secs.fract().abs() < 1e-6 {
+        format!("{secs:.0}s")
+    } else {
+        format!("{secs}s")
+    }
 }
 
 fn format_mhz(mhz: f64) -> String {

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -22,9 +22,14 @@ fn warp_boot_rows_cycle_and_round_trip() {
 
     // A TOML warp_until shows as its own state; one press clears it (the
     // modes are mutually exclusive) and lands on Off.
-    let raw: RawConfig = toml::from_str("[emulation]\nwarp_until = 12.0\n").unwrap();
+    let raw: RawConfig = toml::from_str("[emulation]\nwarp_until = 12.5\n").unwrap();
     let mut setup = MachineSetup::from_raw(&raw).unwrap();
+    // A fractional configured timestamp is shown as configured, not
+    // rounded into a different-looking one.
+    assert_eq!(setup.value_label(F::WarpBoot), "Until 12.5s");
     setup.cycle(F::WarpBoot, true);
+    assert_eq!(setup.value_label(F::WarpBoot), "Off");
+    assert_eq!(setup.value_label(F::WarpBootIdle), "10s");
     let out = setup.to_raw();
     assert_eq!(out.emulation.warp_until, None);
     assert_eq!(out.emulation.warp_boot, None);

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -8,6 +8,29 @@ fn run_ahead_frames_survives_the_config_screen_round_trip() {
 }
 
 #[test]
+fn warp_boot_rows_cycle_and_round_trip() {
+    let raw: RawConfig = toml::from_str("").unwrap();
+    let mut setup = MachineSetup::from_raw(&raw).unwrap();
+    // Default: off, nothing emitted.
+    assert_eq!(setup.to_raw().emulation.warp_boot, None);
+    setup.cycle(F::WarpBoot, true);
+    assert_eq!(setup.to_raw().emulation.warp_boot, Some(true));
+    setup.cycle(F::WarpBootIdle, true); // 10s -> 15s
+    assert_eq!(setup.to_raw().emulation.warp_boot_idle, Some(15.0));
+    setup.cycle(F::WarpBoot, true); // back to off
+    assert_eq!(setup.to_raw().emulation.warp_boot, None);
+
+    // A TOML warp_until shows as its own state; one press clears it (the
+    // modes are mutually exclusive) and lands on Off.
+    let raw: RawConfig = toml::from_str("[emulation]\nwarp_until = 12.0\n").unwrap();
+    let mut setup = MachineSetup::from_raw(&raw).unwrap();
+    setup.cycle(F::WarpBoot, true);
+    let out = setup.to_raw();
+    assert_eq!(out.emulation.warp_until, None);
+    assert_eq!(out.emulation.warp_boot, None);
+}
+
+#[test]
 fn warp_boot_settings_survive_the_config_screen_round_trip() {
     // No config-screen controls yet, same as run-ahead: a saved default
     // opening in the launcher must not silently shed them on Run/Save.

--- a/src/video/ui/tests.rs
+++ b/src/video/ui/tests.rs
@@ -3180,6 +3180,19 @@ fn panels_render_into_their_rects() {
     draw(&mut frame, scale, &ui, None, None);
     save(&frame, "launcher-av-display");
 
+    // The Emulation category: pacing, warp speed, and the warp-boot rows.
+    let mut frame = vec![0u8; w * h * 4];
+    let mut state = LauncherState::new(launcher::MachineSetup::default());
+    state.tab = LauncherTab::AvEmulation;
+    let ui = UiState {
+        menu_open: false,
+        menu_rows: Vec::new(),
+        menu_nav: menu::MenuNav::default(),
+        panel: Some(Panel::Launcher(Box::new(state))),
+    };
+    draw(&mut frame, scale, &ui, None, None);
+    save(&frame, "launcher-av-emulation");
+
     // The Floppy tab with two drives wired in: each drive is a greyed "DFn:"
     // heading with indented settings; DF2/DF3 are hidden until enabled.
     let mut frame = vec![0u8; w * h * 4];


### PR DESCRIPTION
Follow-up to #598 (merged): the warp-boot settings get launcher controls, as two rows under *Warp speed* on the *A/V & Emu* → *Emulation* page, in the page's existing cycle style:

- **Warp boot**: *Off* ↔ *Storage idle* (the boot warps until the floppy/HDD LEDs have been quiet for the idle threshold below). A `warp_until` loaded from a config file shows as its own *Until Ns* state; the modes are mutually exclusive, so one press clears it and lands on *Off* -- the panel can never produce the invalid both-set combination.
- **Warp boot idle**: preset stepper over 5s-120s (the upper presets exist because the threshold must outlast the boot's longest storage-quiet stretch -- a big-RAM machine's MMU table build keeps the disk idle for seconds).

The Emulation category also gains a UI-preview render alongside its Audio/Video/Display siblings (`COPPERLINE_UI_PREVIEW=1` → `target/ui-preview-launcher-av-emulation.png`), which is how the layout below was verified:

| Row | Value |
|---|---|
| Power on startup | Enabled |
| Realtime priority | Disabled |
| Pacing budget | Cycles |
| Warp speed | Max |
| **Warp boot** | **Off** |
| **Warp boot idle** | **10s** |
| WHDLoad | Enabled |

Row cycling and the round trip through `RawConfig` are covered in the launcher tests, including the `warp_until`-clearing press. Docs: the `configuration.md` warp-boot bullet now names the launcher rows. Full suite green, clippy/fmt clean.

(Housekeeping: a stray push had resurrected the deleted `feat/warp-boot` branch after #598 merged; it has been deleted again and this commit re-based onto main.)