### PR TITLE
Feature/auto launch

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -49,6 +49,12 @@ rom = "kickstart.rom"
 # that cold test-screen state.
 power_on = true
 
+# When true, the launcher runs this configuration the moment it opens it:
+# starting Copperline with this file as the saved default boots straight
+# into the machine, and Load... in the launcher does the same. Only the
+# launcher reads it -- command-line launches are unaffected.
+auto_launch = false
+
 # Real-mode pacing budget. "cycles" (default) clocks the CPU by each
 # instruction's actual m68k cycle cost plus chip-bus waits, matching real
 # 68000 speed (the core's 68000 cycle counts are now accurate).

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -376,6 +376,7 @@ section uses the same Rev 6A defaults; select `A500OCS` or set
 ```toml
 [emulation]
 power_on = true            # false = start powered off at the test screen
+auto_launch = false        # true = the launcher runs this file at once
 pacing_budget = "cycles"   # "cycles" (hardware-accurate) or "instructions"
 realtime_priority = false  # true = raise the pacer/audio thread priority
 warp_speed = "max"         # turbo limit: "2x", "4x", "8x", "16x", or "max"
@@ -398,6 +399,12 @@ carried no information.)
   until you click the status-bar power button -- useful for arming video
   capture first. The power button cold-boots (reinitialising RAM according to
   `[memory] init`).
+- `auto_launch = true` makes the launcher run this configuration the moment
+  it opens it -- starting Copperline with it as the saved default boots the
+  machine with no configuration screen first, and the launcher's **Load...**
+  button does the same. The launcher's **A/V & Emu -> Emulation -> Run on
+  startup** row sets it. It only concerns the launcher: a machine given on
+  the command line never shows the screen this key skips.
 - `pacing_budget` selects how real-time pacing budgets CPU work per frame:
   `"cycles"` (default) charges each instruction its actual 68000 cycle cost
   plus chip-bus waits, matching real hardware speed; `"instructions"` uses a

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -655,7 +655,9 @@ The layout is:
   shader and shader strength), **Display** -- the host window (start
   fullscreen, status bar, perf overlay, menu size),
   **Emulation**
-  (power-on, realtime priority, pacing, warp speed),
+  (power-on, run on startup -- `[emulation] auto_launch`, the launcher
+  running an opened configuration at once -- realtime priority, pacing,
+  warp speed),
   and **Paths** -- opening on Audio, and switched freely between the five.
   The Paths page edits the `[paths]` section of the configuration (see
   [](configuration.md)): the base folder on top, then one row per folder.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1252,6 +1252,12 @@ pub struct Emulation {
     /// the status-bar power button is clicked -- handy for arming video
     /// capture beforehand. The power button cold-boots the machine.
     pub power_on: bool,
+    /// Whether opening this configuration in the launcher runs it at once,
+    /// skipping the configuration screen (default false). Read only by the
+    /// launcher -- at startup for the default configuration, and by its
+    /// Load... button -- never by a machine started from the command line,
+    /// which was never going to show the screen anyway.
+    pub auto_launch: bool,
     /// How real-mode pacing debits its per-frame instruction budget. See
     /// `PacingBudget`. The `COPPERLINE_REAL_PACING_BUDGET` env var overrides
     /// this for one run.
@@ -2296,6 +2302,7 @@ impl Default for Config {
             cpu_jit: false,
             emulation: Emulation {
                 power_on: true,
+                auto_launch: false,
                 pacing_budget: PacingBudget::Cycles,
                 realtime_priority: false,
                 warp_speed: WarpSpeed::default(),

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -1048,6 +1048,12 @@ pub(crate) struct RawEmulation {
     pub(crate) speed: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) power_on: Option<bool>,
+    /// Skip the configuration screen when this file is opened in the
+    /// launcher and run the machine at once (default false). Only the
+    /// launcher reads it; a machine started from the command line is
+    /// already past the screen this key skips.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) auto_launch: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) pacing_budget: Option<String>,
     /// Best-effort realtime-like thread priority for the pacer and audio

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -120,6 +120,10 @@ impl TryFrom<RawConfig> for Config {
                 .emulation
                 .power_on
                 .unwrap_or(defaults.emulation.power_on),
+            auto_launch: raw
+                .emulation
+                .auto_launch
+                .unwrap_or(defaults.emulation.auto_launch),
             pacing_budget: match raw.emulation.pacing_budget.as_deref() {
                 None => defaults.emulation.pacing_budget,
                 Some(s) => parse_pacing_budget(s)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1228,6 +1228,9 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         copperline::sampler::SamplerRequest::default(),
     );
     app.open_launcher();
+    // `[emulation] auto_launch` in the configuration the launcher opened
+    // showing: straight to the machine, no configuration screen first.
+    app.auto_launch_if_asked();
     app.run()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -729,16 +729,27 @@ fn main() -> Result<()> {
     // The modem's stored profile (AT&W/ATZ) is the frontend's to ask for
     // too, same promise as the synth's battery-backed memory above.
     copperline::modem::profile::set_persistence(!cli.factory);
+    // With nothing specified, open the configuration screen instead of
+    // booting a default machine. Decided before the config is validated --
+    // not just before the bundled ROM resolves -- so the launcher opens
+    // even when no Kickstart/AROS is present *and* when the saved default
+    // no longer validates (a floppy image gone missing, say): the screen
+    // is where such a config gets fixed, and its Run button is where the
+    // error shows. An auto-launching default rides the same rule -- its
+    // failed run lands back on the open screen rather than exiting. (A
+    // bare launcher start has no --rom to fold in: launcher_requested
+    // requires its absence.)
+    if launcher_requested(&cli) {
+        return run_configuration_screen(load_raw_config(
+            cli.config_path.as_deref(),
+            &cli.overrides,
+            cli.factory,
+        )?);
+    }
+
     let (cfg, mut raw_cfg) = load_config(cli.config_path.as_deref(), &cli.overrides, cli.factory)?;
     if let Some(p) = &cli.rom_path {
         raw_cfg.rom = Some(p.to_string_lossy().into_owned());
-    }
-
-    // With nothing specified, open the configuration screen instead of booting
-    // a default machine. Decided before resolving the bundled ROM so the
-    // launcher opens even when no Kickstart/AROS is present.
-    if launcher_requested(&cli) {
-        return run_configuration_screen(raw_cfg);
     }
 
     let mut cfg = cfg.with_rom_override(cli.rom_path.clone());
@@ -1379,6 +1390,21 @@ fn load_config(
     overrides: &ConfigOverrides,
     factory: bool,
 ) -> Result<(Config, config::RawConfig)> {
+    let raw = load_raw_config(explicit, overrides, factory)?;
+    let cfg = Config::try_from(raw.clone())?;
+    Ok((cfg, raw))
+}
+
+/// The raw half of [`load_config`]: find and parse the file, put its
+/// `[paths]` in force, validate nothing. The configuration screen starts
+/// from this -- validation belongs to its Run button, where a missing
+/// floppy image is a status line to fix rather than an exit before the
+/// screen that could fix it ever opens.
+fn load_raw_config(
+    explicit: Option<&Path>,
+    overrides: &ConfigOverrides,
+    factory: bool,
+) -> Result<config::RawConfig> {
     // Resolve which file (if any) backs the config: the explicit --config
     // path, then ./copperline.toml if present, then the configuration saved
     // with Save default, otherwise the built-in defaults. CLI overrides
@@ -1405,14 +1431,13 @@ fn load_config(
         None
     };
     let raw = Config::load_raw(path, overrides)?;
-    // Before the conversion, not after: `Config::try_from` resolves the
-    // implicit battery-RAM backing files through the paths in force, so
-    // adopting afterwards would site this run's NVRAM by the previous
-    // answer. Whatever this host cannot reach is dropped here and inherits
+    // Before any conversion: `Config::try_from` resolves the implicit
+    // battery-RAM backing files through the paths in force, so adopting
+    // afterwards would site this run's NVRAM by the previous answer.
+    // Whatever this host cannot reach is dropped here and inherits
     // instead, so a config naming somebody else's memory stick still starts.
     copperline::paths::adopt(raw.paths());
-    let cfg = Config::try_from(raw.clone())?;
-    Ok((cfg, raw))
+    Ok(raw)
 }
 
 #[cfg(test)]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -711,6 +711,7 @@ pub enum LauncherField {
     FloppySounds,
     FloppyVolume,
     PowerOn,
+    AutoLaunch,
     PacingBudget,
     RealtimePriority,
     Warp,
@@ -1271,8 +1272,9 @@ const AUDIO_ROWS: [Row; 6] = [
     row(F::FloppyVolume, "Floppy volume", Cycle),
 ];
 #[cfg(not(feature = "game-library"))]
-const EMULATION_ROWS: [Row; 6] = [
+const EMULATION_ROWS: [Row; 7] = [
     row(F::PowerOn, "Power on startup", Cycle),
+    row(F::AutoLaunch, "Run on startup", Cycle),
     row(F::RealtimePriority, "Realtime priority", Cycle),
     row(F::PacingBudget, "Pacing budget", Cycle),
     row(F::Warp, "Warp speed", Cycle),
@@ -1280,8 +1282,9 @@ const EMULATION_ROWS: [Row; 6] = [
     row(F::WarpBootIdle, "Warp boot idle", Cycle),
 ];
 #[cfg(feature = "game-library")]
-const EMULATION_ROWS: [Row; 7] = [
+const EMULATION_ROWS: [Row; 8] = [
     row(F::PowerOn, "Power on startup", Cycle),
+    row(F::AutoLaunch, "Run on startup", Cycle),
     row(F::RealtimePriority, "Realtime priority", Cycle),
     row(F::PacingBudget, "Pacing budget", Cycle),
     row(F::Warp, "Warp speed", Cycle),
@@ -2350,6 +2353,7 @@ pub struct MachineSetup {
     floppy_sounds: bool,
     floppy_volume: u8,
     power_on: bool,
+    auto_launch: bool,
     pacing_budget: PacingBudget,
     realtime_priority: bool,
     warp: WarpSpeed,
@@ -2654,6 +2658,7 @@ impl MachineSetup {
             floppy_sounds: cfg.audio.floppy_sounds,
             floppy_volume: cfg.audio.floppy_sounds_volume,
             power_on: cfg.emulation.power_on,
+            auto_launch: cfg.emulation.auto_launch,
             pacing_budget: cfg.emulation.pacing_budget,
             realtime_priority: cfg.emulation.realtime_priority,
             warp: cfg.emulation.warp_speed,
@@ -2720,6 +2725,14 @@ impl MachineSetup {
 
     pub fn midi_out_is_csynth(&self) -> bool {
         crate::config::midi_out_is_csynth(self.midi_out.as_deref())
+    }
+
+    /// Whether this configuration asks the launcher to run it the moment
+    /// it is opened -- `[emulation] auto_launch`. The command line never
+    /// consults it: a machine given on the command line was never going to
+    /// see the configuration screen this skips.
+    pub fn auto_launch(&self) -> bool {
+        self.auto_launch
     }
 
     pub fn serial_mode(&self) -> SerialMode {
@@ -3222,6 +3235,9 @@ impl MachineSetup {
         if self.power_on != base.emulation.power_on {
             raw.emulation.power_on = Some(self.power_on);
         }
+        if self.auto_launch != base.emulation.auto_launch {
+            raw.emulation.auto_launch = Some(self.auto_launch);
+        }
         if self.pacing_budget != base.emulation.pacing_budget {
             raw.emulation.pacing_budget = Some(pacing_name(self.pacing_budget).to_string());
         }
@@ -3524,6 +3540,7 @@ impl MachineSetup {
         self.floppy_sounds = base.audio.floppy_sounds;
         self.floppy_volume = base.audio.floppy_sounds_volume;
         self.power_on = base.emulation.power_on;
+        self.auto_launch = base.emulation.auto_launch;
         self.pacing_budget = base.emulation.pacing_budget;
         self.realtime_priority = base.emulation.realtime_priority;
         self.warp = base.emulation.warp_speed;
@@ -3877,6 +3894,7 @@ impl MachineSetup {
             #[cfg(feature = "midi")]
             F::SerialTelnet => self.serial_telnet,
             F::PowerOn => self.power_on,
+            F::AutoLaunch => self.auto_launch,
             F::RealtimePriority => self.realtime_priority,
             F::Toccata => self.toccata,
             #[cfg(feature = "mhi")]
@@ -4418,6 +4436,7 @@ impl MachineSetup {
             F::Deinterlace => enabled_label(self.deinterlace),
             F::FloppySounds => enabled_label(self.floppy_sounds),
             F::PowerOn => enabled_label(self.power_on),
+            F::AutoLaunch => enabled_label(self.auto_launch),
             F::RealtimePriority => enabled_label(self.realtime_priority),
             F::Toccata => enabled_label(self.toccata),
             #[cfg(feature = "mhi")]
@@ -4903,6 +4922,7 @@ impl MachineSetup {
             F::Deinterlace => self.deinterlace = !self.deinterlace,
             F::FloppySounds => self.floppy_sounds = !self.floppy_sounds,
             F::PowerOn => self.power_on = !self.power_on,
+            F::AutoLaunch => self.auto_launch = !self.auto_launch,
             F::RealtimePriority => self.realtime_priority = !self.realtime_priority,
             F::Toccata => self.toccata = !self.toccata,
             #[cfg(feature = "mhi")]

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -4496,10 +4496,11 @@ impl MachineSetup {
             F::Warp => self.warp.label().to_string(),
             F::WarpBoot => match (self.warp_until, self.warp_boot) {
                 // A warp_until from the TOML shows as its own state; the
-                // panel's own two states are Off and storage-idle.
+                // panel's own two states are Disabled -- the word every
+                // other toggle on the page uses -- and storage-idle.
                 (Some(secs), _) => format!("Until {}", format_secs(secs)),
                 (None, true) => "Storage idle".to_string(),
-                (None, false) => "Off".to_string(),
+                (None, false) => "Disabled".to_string(),
             },
             F::WarpBootIdle => format_secs(self.warp_boot_idle),
             F::Joystick => self.joystick_input_mode.menu_label().to_string(),

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -28,7 +28,7 @@ fn warp_boot_rows_cycle_and_round_trip() {
     // rounded into a different-looking one.
     assert_eq!(setup.value_label(F::WarpBoot), "Until 12.5s");
     setup.cycle(F::WarpBoot, true);
-    assert_eq!(setup.value_label(F::WarpBoot), "Off");
+    assert_eq!(setup.value_label(F::WarpBoot), "Disabled");
     assert_eq!(setup.value_label(F::WarpBootIdle), "10s");
     let out = setup.to_raw();
     assert_eq!(out.emulation.warp_until, None);

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -3696,6 +3696,35 @@ fn scsi_rows_hidden_until_a_controller_is_chosen() {
 }
 
 #[test]
+fn auto_launch_round_trips_and_defaults_off() {
+    use LauncherField as F;
+    // Off by default, and an untouched setup writes no key.
+    let s = MachineSetup::default();
+    assert!(!s.auto_launch());
+    assert!(s.to_raw().emulation.auto_launch.is_none());
+
+    // Toggled on, it survives the round trip.
+    let mut s = s;
+    s.cycle(F::AutoLaunch, true);
+    assert!(s.auto_launch());
+    let raw = s.to_raw();
+    assert_eq!(raw.emulation.auto_launch, Some(true));
+    assert!(MachineSetup::from_raw(&raw).unwrap().auto_launch());
+
+    // And the row sits directly below Power on startup on the Emulation
+    // page, as its sibling.
+    let page = rows(
+        LauncherTab::AvEmulation,
+        ParallelDevice::None,
+        SerialMode::default(),
+        false,
+        false,
+    );
+    let power = page.iter().position(|r| r.field == F::PowerOn).unwrap();
+    assert_eq!(page[power + 1].field, F::AutoLaunch);
+}
+
+#[test]
 fn floppy_rows_hidden_until_wired() {
     use LauncherField as F;
     let with_drives = |n: u8| {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -993,6 +993,11 @@ pub struct App {
     /// the machine sits powered off until the status-bar power button
     /// is clicked. Distinct from the emulated (CIA-driven) power LED.
     powered_on: bool,
+    /// Whether the next `run_machine` keeps the configuration's own
+    /// `power_on` rather than the Run button's power-it-on. Set around the
+    /// two automatic launches (`auto_launch_if_asked`, Load...): nobody
+    /// pressed Run there, so nobody overrode the file.
+    run_honors_power_on: bool,
     /// Host-level pause state. When true the emulator does not step but
     /// stays powered on, so the last rendered frame is held on screen and
     /// emulation resumes from the same point when unpaused.
@@ -1999,6 +2004,7 @@ impl App {
             render_recycle_input: None,
             cpu_halted: false,
             powered_on,
+            run_honors_power_on: false,
             paused: false,
             auto_shot: Vec::new(),
             pending_auto_shot: screenshot_after,

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -1070,7 +1070,9 @@ impl App {
         }
         self.finish_host_io_pause();
         if run_at_once {
+            self.run_honors_power_on = true;
             self.launcher_run();
+            self.run_honors_power_on = false;
         }
     }
 
@@ -1236,23 +1238,29 @@ impl App {
         self.finish_host_io_pause();
     }
 
-    /// Build and start the configured machine (the Run button). Validation,
-    /// WHDLoad staging, AROS resolution, audio-device and
-    /// machine-construction errors all stay in the panel as a status line;
-    /// only success swaps the live machine.
     /// Run the opened configuration at once when it asks for that --
     /// `[emulation] auto_launch` in the file the launcher opened showing.
     /// Called once at startup, after the launcher opens: the screen is
     /// skipped, and if the run fails the launcher is still there under it
     /// with the error on its status line. Command-line launches never come
     /// this way at all.
+    ///
+    /// An automatic run keeps the file's own `power_on`: nobody pressed
+    /// Run, so nobody overrode a configuration that wants to start at the
+    /// test screen.
     pub fn auto_launch_if_asked(&mut self) {
         let asked = self.launcher_state().is_some_and(|s| s.setup.auto_launch());
         if asked {
+            self.run_honors_power_on = true;
             self.launcher_run();
+            self.run_honors_power_on = false;
         }
     }
 
+    /// Build and start the configured machine (the Run button). Validation,
+    /// WHDLoad staging, AROS resolution, audio-device and
+    /// machine-construction errors all stay in the panel as a status line;
+    /// only success swaps the live machine.
     pub(super) fn launcher_run(&mut self) {
         // Capture a name/option typed but not yet committed with Enter. A
         // value the commit refuses keeps the focus and blocks the run,
@@ -1499,19 +1507,28 @@ impl App {
         }
         self.ui.menu_open = false;
         self.ui.panel = None;
-        self.powered_on = true;
+        // Pressing Run is a statement -- start it -- so the button powers
+        // on whatever `power_on` says. An automatic launch pressed nothing:
+        // it keeps the configuration's own power state, the same one a
+        // command-line start of the same file would have.
+        self.powered_on = !self.run_honors_power_on || cfg.emulation.power_on;
         self.cpu_halted = false;
         self.paused = false;
         // The machine's configured warp boot ([emulation] warp_boot /
         // warp_until) starts fresh with the machine: run_machine is the
         // launcher path's power-on, so construct and engage the gate here
-        // the way main.rs does for a direct CLI launch.
+        // the way main.rs does for a direct CLI launch. A machine starting
+        // powered off keeps the gate armed instead; the power button's
+        // first press engages it, exactly as it does for a CLI start.
         self.warp_boot = crate::warpboot::gate_from_settings(
             cfg.emulation.warp_boot,
             cfg.emulation.warp_boot_idle,
             cfg.emulation.warp_until,
         );
-        self.engage_warp_boot();
+        if self.powered_on {
+            self.engage_warp_boot();
+        }
+        self.sync_live_audio_suspension();
         self.reset_render_pipeline();
         // The last overlay set here is the one that gets drawn, so a shader
         // or sticker folder that failed to load has to travel in this

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -1029,10 +1029,16 @@ impl App {
             .set_title("Load configuration")
             .add_filter("Copperline config", &["toml"])
             .pick_file();
+        let mut run_at_once = false;
         if let Some(path) = picked {
             match MachineSetup::load_from(&path) {
                 Ok(setup) => {
                     if let Some(state) = self.launcher_state_mut() {
+                        // `[emulation] auto_launch`: the file asks to run
+                        // the moment it is opened, configuration screen
+                        // skipped. Loaded first so a failed run leaves the
+                        // launcher showing the loaded setup and the error.
+                        run_at_once = setup.auto_launch();
                         state.setup = setup;
                         // The page being looked at may not exist under the
                         // loaded machine (the second boot page, emptied).
@@ -1063,6 +1069,9 @@ impl App {
             }
         }
         self.finish_host_io_pause();
+        if run_at_once {
+            self.launcher_run();
+        }
     }
 
     /// Open or put away the Save menu. Every other click while it is up
@@ -1231,6 +1240,19 @@ impl App {
     /// WHDLoad staging, AROS resolution, audio-device and
     /// machine-construction errors all stay in the panel as a status line;
     /// only success swaps the live machine.
+    /// Run the opened configuration at once when it asks for that --
+    /// `[emulation] auto_launch` in the file the launcher opened showing.
+    /// Called once at startup, after the launcher opens: the screen is
+    /// skipped, and if the run fails the launcher is still there under it
+    /// with the error on its status line. Command-line launches never come
+    /// this way at all.
+    pub fn auto_launch_if_asked(&mut self) {
+        let asked = self.launcher_state().is_some_and(|s| s.setup.auto_launch());
+        if asked {
+            self.launcher_run();
+        }
+    }
+
     pub(super) fn launcher_run(&mut self) {
         // Capture a name/option typed but not yet committed with Enter. A
         // value the commit refuses keeps the focus and blocks the run,

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4763,6 +4763,48 @@ fn auto_launch_runs_only_when_the_config_asks() {
             "auto_launch should have attempted the run"
         );
     }
+    assert!(
+        !app.run_honors_power_on,
+        "the one-shot intent must not leak into a later manual Run"
+    );
+}
+
+#[test]
+fn an_automatic_run_keeps_the_configured_power_state() {
+    use crate::video::launcher::LauncherField;
+
+    // power_on = false + auto_launch: the machine starts, but sits powered
+    // off at the test screen -- the same state a command-line start of the
+    // same file gives -- with the warp-boot gate armed for the power button
+    // rather than engaged.
+    let mut app = test_app();
+    app.open_launcher();
+    if let Some(Panel::Launcher(state)) = app.ui.panel.as_mut() {
+        state.setup.cycle(LauncherField::AutoLaunch, true);
+        state.setup.cycle(LauncherField::PowerOn, true); // on -> off
+        state.setup.cycle(LauncherField::WarpBoot, true); // off -> storage idle
+    }
+    app.auto_launch_if_asked();
+    assert!(
+        app.ui.panel.is_none(),
+        "the automatic run should have started the machine"
+    );
+    assert!(!app.powered_on, "power_on = false was overridden");
+    let gate = app.warp_boot.as_ref().expect("warp-boot gate constructed");
+    assert!(
+        !gate.engaged,
+        "the gate belongs to the first power-on, not to a powered-off machine"
+    );
+
+    // The manual Run button keeps its meaning: pressing it IS the power-on.
+    let mut app = test_app();
+    app.open_launcher();
+    if let Some(Panel::Launcher(state)) = app.ui.panel.as_mut() {
+        state.setup.cycle(LauncherField::PowerOn, true); // on -> off
+    }
+    app.launcher_run();
+    assert!(app.ui.panel.is_none());
+    assert!(app.powered_on, "the Run button powers on regardless");
 }
 
 #[test]

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4771,24 +4771,22 @@ fn auto_launch_runs_only_when_the_config_asks() {
 
 #[test]
 fn an_automatic_run_keeps_the_configured_power_state() {
-    use crate::video::launcher::LauncherField;
+    // Exercised at run_machine, below the staging that needs a live audio
+    // device (which CI has none of): the launcher's two automatic paths
+    // set `run_honors_power_on` around launcher_run, and run_machine is
+    // where the flag lands.
+    let mut raw = crate::config::RawConfig::default();
+    raw.emulation.power_on = Some(false);
+    raw.emulation.warp_boot = Some(true);
+    let cfg = crate::config::Config::try_from(raw.clone()).expect("config");
 
-    // power_on = false + auto_launch: the machine starts, but sits powered
-    // off at the test screen -- the same state a command-line start of the
-    // same file gives -- with the warp-boot gate armed for the power button
-    // rather than engaged.
+    // An automatic run keeps power_on = false: the machine sits at the
+    // test screen -- the state a command-line start of the same file gives
+    // -- with the warp-boot gate armed for the power button, not engaged.
     let mut app = test_app();
-    app.open_launcher();
-    if let Some(Panel::Launcher(state)) = app.ui.panel.as_mut() {
-        state.setup.cycle(LauncherField::AutoLaunch, true);
-        state.setup.cycle(LauncherField::PowerOn, true); // on -> off
-        state.setup.cycle(LauncherField::WarpBoot, true); // off -> storage idle
-    }
-    app.auto_launch_if_asked();
-    assert!(
-        app.ui.panel.is_none(),
-        "the automatic run should have started the machine"
-    );
+    let emu = test_emulator(Box::new(NullSink), crate::config::CpuModel::M68000, &[]);
+    app.run_honors_power_on = true;
+    app.run_machine(emu, &cfg, raw.clone());
     assert!(!app.powered_on, "power_on = false was overridden");
     let gate = app.warp_boot.as_ref().expect("warp-boot gate constructed");
     assert!(
@@ -4796,15 +4794,13 @@ fn an_automatic_run_keeps_the_configured_power_state() {
         "the gate belongs to the first power-on, not to a powered-off machine"
     );
 
-    // The manual Run button keeps its meaning: pressing it IS the power-on.
+    // The manual Run button keeps its meaning: pressing it IS the power-on,
+    // and the gate engages with the machine it starts.
     let mut app = test_app();
-    app.open_launcher();
-    if let Some(Panel::Launcher(state)) = app.ui.panel.as_mut() {
-        state.setup.cycle(LauncherField::PowerOn, true); // on -> off
-    }
-    app.launcher_run();
-    assert!(app.ui.panel.is_none());
+    let emu = test_emulator(Box::new(NullSink), crate::config::CpuModel::M68000, &[]);
+    app.run_machine(emu, &cfg, raw);
     assert!(app.powered_on, "the Run button powers on regardless");
+    assert!(app.warp_boot.as_ref().is_some_and(|g| g.engaged));
 }
 
 #[test]

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4757,12 +4757,11 @@ fn auto_launch_runs_only_when_the_config_asks() {
             .set_path(LauncherField::Df0Image, PathBuf::from("/no/such/disk.adf"));
     }
     app.auto_launch_if_asked();
-    match &app.ui.panel {
-        Some(Panel::Launcher(state)) => assert!(
+    if let Some(Panel::Launcher(state)) = &app.ui.panel {
+        assert!(
             state.status.as_ref().is_some(),
             "auto_launch should have attempted the run"
-        ),
-        _ => {}
+        );
     }
 }
 

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4728,6 +4728,45 @@ fn a_rejected_serial_address_blocks_the_control_it_interrupted() {
 }
 
 #[test]
+fn auto_launch_runs_only_when_the_config_asks() {
+    use crate::video::launcher::LauncherField;
+
+    // Off (the default): opening the launcher and asking leaves it open,
+    // exactly as today.
+    let mut app = test_app();
+    app.powered_on = false;
+    app.open_launcher();
+    app.auto_launch_if_asked();
+    assert!(
+        matches!(&app.ui.panel, Some(Panel::Launcher(_))),
+        "an ordinary config must still show the configuration screen"
+    );
+    assert!(!app.powered_on);
+
+    // On: the ask runs the machine at once. The test machine's config
+    // fails validation the same way a bad Run click would, which is the
+    // observable half we can assert headlessly: the run was *attempted*
+    // (an error status appears) rather than the screen simply sitting.
+    let mut app = test_app();
+    app.powered_on = false;
+    app.open_launcher();
+    if let Some(Panel::Launcher(state)) = app.ui.panel.as_mut() {
+        state.setup.cycle(LauncherField::AutoLaunch, true);
+        state
+            .setup
+            .set_path(LauncherField::Df0Image, PathBuf::from("/no/such/disk.adf"));
+    }
+    app.auto_launch_if_asked();
+    match &app.ui.panel {
+        Some(Panel::Launcher(state)) => assert!(
+            state.status.as_ref().is_some(),
+            "auto_launch should have attempted the run"
+        ),
+        _ => {}
+    }
+}
+
+#[test]
 fn launcher_run_keeps_panel_open_on_error() {
     use crate::video::launcher::LauncherField;
 


### PR DESCRIPTION
## A configuration can ask to run the moment it opens

`[emulation] auto_launch`, off by default — nothing changes while it stays off. On, the launcher runs the configuration as soon as it opens it: a bare start with it saved as the default boots straight into the machine with no configuration screen first, and **Load...** does the same for the file it picks. A failed run leaves the launcher open with the error on its status line, so a broken auto-launching default cannot lock you out.

The row is **A/V & Emu → Emulation → Run on startup**, directly under Power on startup. Only the launcher reads the key: a machine given on the command line was never going to see the screen this skips, so CLI behaviour is untouched.

Paired with `warp_boot`, a saved default takes Copperline from double-click to a settled Workbench in a couple of seconds, no clicks in between.

Also along for the ride, a consistency nit: the launcher's **Warp boot** row said "Off" where every other toggle says "Disabled" -- it says Disabled now. Just the launcher label; the config keys are unchanged.
