### PR TITLE
paths: host data moves out of the hidden config tree and into Documents

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -16,8 +16,8 @@ rom = "kickstart.rom"
 # [paths] -- where Copperline writes what it produces, and where its file
 # dialogs open when the field they were launched from is empty. Every key is
 # optional; the defaults are folders of these names under the host-data
-# directory (~/.config/copperline, %APPDATA%\copperline, or the executable's
-# folder in a portable install). Relative paths hang off `base`, absolute
+# directory (~/Documents/Copperline, %USERPROFILE%\Documents\Copperline, or
+# the executable's folder in a portable install). Relative paths hang off `base`, absolute
 # paths are used as given. Entries naming folders this machine cannot reach
 # are ignored with a log warning and the default is used instead.
 # [paths]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -212,9 +212,9 @@ once something is moved. The launcher edits the same keys on its **A/V &
 Emu -> Paths** page.
 
 Each default is a folder of that name under the host-data directory --
-`~/.config/copperline` on macOS and Linux, `%APPDATA%\copperline` on
-Windows, or the executable's own folder in a [portable
-installation](ui.md#where-files-go). A relative path is taken from
+`~/Documents/Copperline` on macOS and Linux,
+`%USERPROFILE%\Documents\Copperline` on Windows, or the executable's own
+folder in a [portable installation](ui.md#where-files-go). A relative path is taken from
 `base` (itself taken from the host-data directory when relative or unset),
 an absolute path is used as given. Output folders are created on first
 write; the dialog folders are never created, and a dialog only starts in

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -92,7 +92,9 @@ button opens a simplified in-game menu:
 - Save state slots (if enabled in manifest)
 
 User configuration, game saves, NVRAM, and save states are stored in the
-per-game directory (`~/.config/<id>/` on Linux/macOS, `%APPDATA%\<id>` on Windows),
+per-game directory (`~/.config/<id>/` on Linux/macOS, `%APPDATA%\<id>` on
+Windows -- the hidden per-user tree, deliberately: a published game is an
+appliance, and its folder does not belong at the top of Documents),
 or locally inside the application directory in portable mode.
 
 ## Automated bundle verification

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -957,9 +957,9 @@ directory is:
 
 | Host | Location |
 |---|---|
-| Linux/BSD | `$XDG_CONFIG_HOME/copperline/`, else `~/.config/copperline/` |
-| macOS | `~/.config/copperline/` |
-| Windows | `%APPDATA%\copperline\` |
+| Linux/BSD | `~/Documents/Copperline/` |
+| macOS | `~/Documents/Copperline/` |
+| Windows | `%USERPROFILE%\Documents\Copperline\` |
 
 with a folder inside it for each kind of file: `screenshots/`, `states/`
 (named saves and the quick-save slots), `recordings/` (video captures and
@@ -1171,9 +1171,9 @@ holding one hands the panel's Save and Cancel buttons to the pad, so a
 calibration can be finished without the mouse.
 
 Calibrations are saved per controller UUID in
-`~/.config/copperline/gamepads.toml` (`$XDG_CONFIG_HOME` respected;
-`%APPDATA%\copperline\` on Windows, or beside the executable in
-[portable mode](#quick-save-slots)). A calibration recorded by a
+`~/Documents/Copperline/gamepads.toml`
+(`%USERPROFILE%\Documents\Copperline\` on Windows, or beside the
+executable in [portable mode](#quick-save-slots)). A calibration recorded by a
 Copperline version that predates the bundled controller database can
 resolve a stick direction reversed on a database-covered pad; the log
 suggests recalibrating when it loads such a file, and recalibrating
@@ -1207,5 +1207,5 @@ before -- including from the other mapping -- so the two controllers can
 never end up fighting over one key.
 
 Saved maps live next to the gamepad calibrations, in
-`~/.config/copperline/keymap.toml` (same per-platform locations as above).
+`~/Documents/Copperline/keymap.toml` (same per-platform locations as above).
 Deleting the file restores the defaults.

--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -37,12 +37,12 @@ Run "copperline.exe --help" for the full command-line surface.
 Portable data
 -------------
 By default, quick-save slots and host preferences are kept under
-%APPDATA%\copperline so they survive replacing or moving this folder. To keep
-them inside this folder instead, create an empty file named portable.txt next
-to copperline.exe and restart Copperline. Quick-save slots will then be in the
-states subfolder; controller mappings, WHDLoad data and other host preferences
-will also stay here. Delete portable.txt to return to %APPDATA%; existing files
-are not moved automatically.
+%USERPROFILE%\Documents\Copperline so they survive replacing or moving this
+folder. To keep them inside this folder instead, create an empty file named
+portable.txt next to copperline.exe and restart Copperline. Quick-save slots
+will then be in the states subfolder; controller mappings, WHDLoad data and
+other host preferences will also stay here. Delete portable.txt to return to
+Documents; existing files are not moved automatically.
 
 Bridged Ethernet
 ----------------

--- a/src/envcfg.rs
+++ b/src/envcfg.rs
@@ -32,7 +32,7 @@ fn snapshot() -> &'static HashMap<OsString, OsString> {
 
 /// Seal the snapshot with every `COPPERLINE_*` variable absent, so all
 /// diagnostic and debugging knobs read as unset for the life of the process.
-/// The rest of the environment (`HOME`, `APPDATA`, ...) is kept: `paths`
+/// The rest of the environment (`HOME`, `USERPROFILE`, ...) is kept: `paths`
 /// resolves the host-data directory through this module.
 ///
 /// Built for player builds, which call it first thing in `main` so a shipped

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -49,7 +49,7 @@ fn portable_config_dir(
         .find_map(marked_program_dir)
 }
 
-/// The directory name host data lives under: "copperline" for the emulator
+/// The directory name host data lives under: "Copperline" for the emulator
 /// itself, a game's own id for a publisher-kit player build. See
 /// [`set_app_identity`].
 static APP_IDENTITY: std::sync::OnceLock<String> = std::sync::OnceLock::new();
@@ -57,9 +57,9 @@ static APP_IDENTITY: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 /// The resolved host-data directory, cached for the life of the process.
 static DIR: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
 
-/// Adopt a per-application identity, so host data lands under a directory of
-/// that name (`~/.config/<name>/`, `%APPDATA%\<name>\`) instead of
-/// `copperline`. Built for player builds, where each game keeps its own
+/// Adopt a per-application identity, so host data lands under a hidden
+/// per-user directory of that name (`~/.config/<name>/`,
+/// `%APPDATA%\<name>\`) instead of the emulator's own Documents folder. Built for player builds, where each game keeps its own
 /// settings, saves, and gamepad calibration.
 ///
 /// Must be called before anything resolves [`config_dir`]: the directory is
@@ -89,14 +89,20 @@ fn app_identity() -> &'static str {
     APP_IDENTITY
         .get()
         .map(String::as_str)
-        .unwrap_or("copperline")
+        // Capitalised: this folder sits in the user's Documents beside
+        // other applications' folders, and reads as a product name there,
+        // not as a unix binary.
+        .unwrap_or("Copperline")
 }
 
 /// Copperline's host-data directory. An empty `portable.txt` beside the
-/// executable or downloaded AppImage selects that directory; otherwise this is
-/// `$XDG_CONFIG_HOME/copperline`, `%APPDATA%\copperline`, or
-/// `$HOME/.config/copperline`, whichever the host offers first. A player
-/// build's [`set_app_identity`] substitutes the game's id for `copperline`.
+/// executable or downloaded AppImage selects that directory; otherwise this
+/// is the user's Documents folder -- `$HOME/Documents/Copperline`,
+/// `%USERPROFILE%\Documents\Copperline` -- somewhere a person browsing
+/// their own files can find, rather than a hidden config tree. A player
+/// build's [`set_app_identity`] keeps the game's data in the hidden tree
+/// instead (`~/.config/<id>/`, `%APPDATA%\<id>\`), one folder per game,
+/// off the top of the user's Documents.
 ///
 /// Not created here -- writers call [`ensure_parent`].
 pub fn config_dir() -> Option<PathBuf> {
@@ -112,13 +118,36 @@ fn discover_config_dir() -> Option<PathBuf> {
     if let Some(dir) = portable_config_dir(appimage.as_deref(), executable.as_deref()) {
         return Some(dir);
     }
-    for var in ["XDG_CONFIG_HOME", "APPDATA"] {
-        if let Some(dir) = crate::envcfg::var_os(var) {
-            return Some(PathBuf::from(dir).join(app_identity()));
+    // A player build ([`set_app_identity`]) keeps the hidden per-user
+    // tree: a published game is an appliance whose data nobody browses,
+    // and putting every bought game's id at the top of Documents would
+    // strew it with loose folders. Only the emulator's own host data --
+    // the saves, screenshots and configs a person actually goes looking
+    // for -- moves out to Documents.
+    if APP_IDENTITY.get().is_some() {
+        for var in ["XDG_CONFIG_HOME", "APPDATA"] {
+            if let Some(dir) = crate::envcfg::var_os(var) {
+                return Some(PathBuf::from(dir).join(app_identity()));
+            }
         }
+        return crate::envcfg::var_os("HOME")
+            .map(|home| PathBuf::from(home).join(".config").join(app_identity()));
     }
-    crate::envcfg::var_os("HOME")
-        .map(|home| PathBuf::from(home).join(".config").join(app_identity()))
+    // The user's own Documents folder: %USERPROFILE% is the Windows
+    // spelling of a home directory, HOME everyone else's. One chain serves
+    // both -- whichever the host defines names the home.
+    documents_config_dir(
+        ["USERPROFILE", "HOME"]
+            .iter()
+            .find_map(|var| crate::envcfg::var_os(var)),
+    )
+}
+
+/// The host-data directory under a home: `<home>/Documents/<identity>`.
+/// Split out, like [`portable_config_dir`], so the shape is testable
+/// without mutating the process environment `envcfg` snapshots.
+fn documents_config_dir(home: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    home.map(|home| PathBuf::from(home).join("Documents").join(app_identity()))
 }
 
 /// A named file directly inside [`config_dir`], e.g. `gamepads.toml`.
@@ -218,8 +247,8 @@ pub fn whdload_library_cache() -> Option<PathBuf> {
 
 /// The root the launcher takes its library paths from.
 ///
-/// A host with no per-user directory at all -- no `HOME`, no `XDG_CONFIG_HOME`,
-/// no `APPDATA`, which is a bare service account or some CI runners -- has
+/// A host with no per-user directory at all -- no `HOME`, no `USERPROFILE`,
+/// which is a bare service account or some CI runners -- has
 /// nowhere to put these, and every call site reached for
 /// `config_dir().unwrap_or_default()`. That yields an *empty* path, so the
 /// library quietly becomes `whdload/support/launcher.db` relative to
@@ -775,13 +804,28 @@ mod tests {
         );
     }
 
+    /// The home resolves to the user's Documents folder -- somewhere a
+    /// person browsing their own files can find, not a hidden config tree.
+    /// (A player build's overridden identity stays in the hidden tree; see
+    /// `discover_config_dir` -- that branch reads the process environment
+    /// through `envcfg`'s one snapshot, so it is exercised by the player
+    /// crate rather than driven from here.)
+    #[test]
+    fn host_data_lives_in_documents() {
+        assert_eq!(
+            documents_config_dir(Some("/home/lee".into())),
+            Some(PathBuf::from("/home/lee/Documents/Copperline"))
+        );
+        assert_eq!(documents_config_dir(None), None);
+    }
+
     /// The cascade is read through `envcfg`, which snapshots the environment
     /// once per process, so this asserts the shape of whatever the host
     /// offered rather than driving each branch with a mutated environment.
     #[test]
     fn host_data_paths_hang_off_one_directory() {
         let Some(dir) = config_dir() else {
-            return; // A host with no HOME/APPDATA/XDG_CONFIG_HOME.
+            return; // A host with no HOME/USERPROFILE.
         };
         assert_eq!(
             config_file("gamepads.toml").unwrap(),

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -125,29 +125,44 @@ fn discover_config_dir() -> Option<PathBuf> {
     // the saves, screenshots and configs a person actually goes looking
     // for -- moves out to Documents.
     if APP_IDENTITY.get().is_some() {
-        for var in ["XDG_CONFIG_HOME", "APPDATA"] {
-            if let Some(dir) = crate::envcfg::var_os(var) {
-                return Some(PathBuf::from(dir).join(app_identity()));
-            }
-        }
-        return crate::envcfg::var_os("HOME")
-            .map(|home| PathBuf::from(home).join(".config").join(app_identity()));
+        return hidden_config_dir(
+            ["XDG_CONFIG_HOME", "APPDATA"]
+                .iter()
+                .find_map(|var| crate::envcfg::var_os(var)),
+            crate::envcfg::var_os("HOME"),
+        );
     }
     // The user's own Documents folder: %USERPROFILE% is the Windows
-    // spelling of a home directory, HOME everyone else's. One chain serves
-    // both -- whichever the host defines names the home.
-    documents_config_dir(
-        ["USERPROFILE", "HOME"]
-            .iter()
-            .find_map(|var| crate::envcfg::var_os(var)),
-    )
+    // spelling of a home directory, HOME everyone else's. Chosen per
+    // platform, not by precedence -- a unix box that happens to export
+    // USERPROFILE too must not have it outrank the documented $HOME.
+    documents_config_dir(crate::envcfg::var_os(HOME_VAR))
 }
+
+/// The environment variable naming this platform's home directory.
+#[cfg(windows)]
+const HOME_VAR: &str = "USERPROFILE";
+#[cfg(not(windows))]
+const HOME_VAR: &str = "HOME";
 
 /// The host-data directory under a home: `<home>/Documents/<identity>`.
 /// Split out, like [`portable_config_dir`], so the shape is testable
 /// without mutating the process environment `envcfg` snapshots.
 fn documents_config_dir(home: Option<std::ffi::OsString>) -> Option<PathBuf> {
     home.map(|home| PathBuf::from(home).join("Documents").join(app_identity()))
+}
+
+/// A player build's hidden per-user directory: the explicit config base
+/// (`XDG_CONFIG_HOME`/`APPDATA`) with the identity under it, else
+/// `<home>/.config/<identity>`. The same seam-shape as
+/// [`documents_config_dir`], for the same testability reason.
+fn hidden_config_dir(
+    config_base: Option<std::ffi::OsString>,
+    home: Option<std::ffi::OsString>,
+) -> Option<PathBuf> {
+    config_base
+        .map(|base| PathBuf::from(base).join(app_identity()))
+        .or_else(|| home.map(|home| PathBuf::from(home).join(".config").join(app_identity())))
 }
 
 /// A named file directly inside [`config_dir`], e.g. `gamepads.toml`.
@@ -804,12 +819,26 @@ mod tests {
         );
     }
 
+    /// A player build's overridden identity keeps the hidden per-user
+    /// tree. The resolver is pure, so both fallbacks are pinned here --
+    /// with the default identity, since an override is process-global.
+    #[test]
+    fn an_overridden_identity_would_stay_in_the_hidden_tree() {
+        assert_eq!(
+            hidden_config_dir(Some("/home/lee/.config".into()), Some("/home/lee".into())),
+            Some(PathBuf::from("/home/lee/.config/Copperline")),
+            "an explicit config base wins"
+        );
+        assert_eq!(
+            hidden_config_dir(None, Some("/home/lee".into())),
+            Some(PathBuf::from("/home/lee/.config/Copperline")),
+            "no base falls back to ~/.config"
+        );
+        assert_eq!(hidden_config_dir(None, None), None);
+    }
+
     /// The home resolves to the user's Documents folder -- somewhere a
     /// person browsing their own files can find, not a hidden config tree.
-    /// (A player build's overridden identity stays in the hidden tree; see
-    /// `discover_config_dir` -- that branch reads the process environment
-    /// through `envcfg`'s one snapshot, so it is exercised by the player
-    /// crate rather than driven from here.)
     #[test]
     fn host_data_lives_in_documents() {
         assert_eq!(

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -1097,8 +1097,8 @@ impl App {
             return;
         };
         let Some(path) = crate::paths::default_config_file() else {
-            // No host-data directory at all (no HOME, XDG_CONFIG_HOME or
-            // APPDATA), so there is nowhere the next launch would look.
+            // No host-data directory at all (no HOME or USERPROFILE), so
+            // there is nowhere the next launch would look.
             warn!("no host data directory to save a default configuration in");
             self.set_launcher_status(StatusMessage::err(
                 "Failed to set the default config (see log)",

--- a/tests/cd32_fmv_aros.rs
+++ b/tests/cd32_fmv_aros.rs
@@ -102,7 +102,8 @@ fn assert_cannon_fmv(
     let mut command = Command::new(env!("CARGO_BIN_EXE_copperline"));
     command
         .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .env("XDG_CONFIG_HOME", scratch.join("config"))
+        .env("HOME", scratch.join("config"))
+        .env("USERPROFILE", scratch.join("config"))
         .env("RUST_LOG", "copperline::cd32_fmv=trace,copperline=warn");
     if let Some(aros_dir) = aros_dir {
         command.env("COPPERLINE_AROS_DIR", aros_dir);

--- a/tests/cd32_videocd.rs
+++ b/tests/cd32_videocd.rs
@@ -109,7 +109,8 @@ fn open_videocd_library_parses_the_philips_sampler() -> Result<(), Box<dyn std::
 
     let output = Command::new(env!("CARGO_BIN_EXE_copperline"))
         .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .env("XDG_CONFIG_HOME", &config_home)
+        .env("HOME", &config_home)
+        .env("USERPROFILE", &config_home)
         .env("RUST_LOG", "copperline=warn")
         .arg("--factory")
         .arg("--config")
@@ -206,7 +207,8 @@ fn video_cd_autoboot_player_plays_and_aborts_track() -> Result<(), Box<dyn std::
 
     let output = Command::new(env!("CARGO_BIN_EXE_copperline"))
         .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .env("XDG_CONFIG_HOME", &config_home)
+        .env("HOME", &config_home)
+        .env("USERPROFILE", &config_home)
         .env("RUST_LOG", "copperline::cd32_fmv=trace,copperline=warn")
         .arg("--factory")
         .arg("--config")

--- a/tests/image_regression.rs
+++ b/tests/image_regression.rs
@@ -811,8 +811,9 @@ fn hostfs_boot_aros_runs_a_guest_binary_and_writes_to_the_host(
 /// (Startup-Sequence only), the bundled AROS ROM boots it at priority 6,
 /// and the Startup-Sequence CDs to the program volume and runs the guest
 /// probe -- which writes FROM-GUEST next to the binary on the host. The
-/// staging is redirected via XDG_CONFIG_HOME so the invoking user's real
-/// config directory is never touched.
+/// staging is redirected via a scratch HOME (and USERPROFILE, for a
+/// Windows host) so the invoking user's real Documents/Copperline is
+/// never touched.
 #[test]
 #[ignore = "runs the emulator"]
 fn run_flag_boots_and_runs_a_guest_binary() -> Result<(), Box<dyn std::error::Error>> {
@@ -832,7 +833,8 @@ fn run_flag_boots_and_runs_a_guest_binary() -> Result<(), Box<dyn std::error::Er
     let output = Command::new(env!("CARGO_BIN_EXE_copperline"))
         .env("RUST_LOG", "copperline=warn")
         .env("COPPERLINE_AROS_DIR", repo_root().join("assets/aros"))
-        .env("XDG_CONFIG_HOME", &config_home)
+        .env("HOME", &config_home)
+        .env("USERPROFILE", &config_home)
         .arg("--noaudio")
         .arg("--run")
         .arg(prog_dir.join("mkfile"))


### PR DESCRIPTION
## Host data moves into Documents

`~/Documents/Copperline` on macOS and Linux, `%USERPROFILE%\Documents\Copperline` on Windows — somewhere a person browsing their own files can find their saves, screenshots, recordings and configs, rather than a dot-directory built for tools. Capitalised, since the folder sits beside other applications' folders in Documents.

No backwards compatibility, by design: `XDG_CONFIG_HOME`/`APPDATA` are no longer consulted for the emulator, and nothing probes or migrates the old tree — `.config`/`%APPDATA%` were simply where host data used to live. A portable installation (`portable.txt` beside the executable) keeps meaning exactly what it meant.

**Publisher-kit players deliberately stay where they were.** following the same pattern would mean every game would have planted a loose `Documents/<id>/` folder at the top of the user's Documents. That was considered : a published game is an appliance whose data nobody browses, so an overridden identity keeps the hidden per-user tree (`~/.config/<id>/`, `%APPDATA%\<id>`), one folder per game. (`Documents/Copperline Games/<id>/` was also considered.

Docs, the Windows package README, and every in-code reference follow. Note for Flatpak: the manifest's `--filesystem=host` covers this today; if permissions ever narrow, the scoped grant is `xdg-documents`.