### PR TITLE
floppy: frame DSKBYTR from the read shifter and model IPF cell-density profiles

### DIFF
--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -395,6 +395,15 @@ later DSKSYNC match during it, so the sectors after an index wrap on a track
 whose cell count is not a multiple of 16 still land word-aligned (AROS's
 trackdisk.device reads 1.08 revolutions this way and scans the buffer on the
 word grid; Kickstart's reads without WORDSYNC and bit-searches itself).
+DSKBYTR is served by that same read shifter: its byte and DSKBYT come from
+the shifter's bit counter, the one a WORDSYNC match resets whether or not a
+transfer is running, and WORDEQUAL is the comparator's level held until the
+register is read. A reader that waits for WORDEQUAL and then collects bytes
+through DSKBYTR therefore gets them framed from the end of the sync word at
+whatever bit phase the sync sits on the track -- IPF and flux tracks carry
+their syncs at arbitrary phases, and Rob Northen's Copylock reads its key
+sector exactly this way (Lemmings, issue #610), rejecting the read unless the
+first two bytes are the MFM of the sector's first data byte.
 Supported image
 formats: ADF (read/write), gzip ADZ, single file ZIP, DMS (decompressed by
  `dms.rs`), UAE extended ADF, and read-only IPF (decoded by `ipf.rs`) and SCP
@@ -422,12 +431,21 @@ repeated byte or from forward and backward gap streams whose loop samples
 stretch to meet at the write splice in the middle. Each track is checked
 against the bit counts its descriptors declare and then rotated so the
 revolution starts at the index, matching the shape a flux capture already
-has. Two modelling gaps remain: the variable cell-*rate* density profiles
-(Copylock, Speedlock, Brierley) decode with uniform 2 us cells and log a
-warning, and weak bits replay as the one deterministic revolution the file
-stores rather than varying per revolution -- `FloppyTrackImage::RawMfm` can
-already carry both (`bitcell_ns` and multiple revolutions) when the
-per-protection profiles are modelled.
+has. A track's cell-*rate* density model (the IMGE density field) becomes a
+per-track profile of cell-time weights, in per-mille of nominal, following the
+CAPS library's own definitions: Copylock Amiga masters three consecutive key
+sectors at -5.5%, -0.5% and +4.5% (blocks 4-6, or 0-2 on the newer scheme),
+each run starting at the gap before its block; Copylock ST, Speedlock and the
+Brierley models weight single blocks by +-5..15%, and the Brierley density-key
+model takes a bit per block from block 0's gap value. The floppy model scales
+each cell's clock by its run's weight (`TrackRev::prefix_cck`), so a loader
+that reads two key sectors byte by byte through DSKBYTR and compares how often
+it polled between bytes sees the few-per-cent difference the master put
+there -- Copylock's check on Lemmings wants `$8911`'s sector at least 2%
+slower than `$8912`'s (issue #610). One modelling gap remains: weak bits
+replay as the one deterministic revolution the file stores rather than
+varying per revolution -- `FloppyTrackImage::RawMfm` can already carry
+multiple revolutions, so closing it is a decoder change alone.
 
 The synthesized drive sounds ([](../guide/configuration)) are driven by
 this model's real state transitions -- motor spin-up, seeks, the

--- a/docs/internals/chipset.md
+++ b/docs/internals/chipset.md
@@ -397,8 +397,12 @@ trackdisk.device reads 1.08 revolutions this way and scans the buffer on the
 word grid; Kickstart's reads without WORDSYNC and bit-searches itself).
 DSKBYTR is served by that same read shifter: its byte and DSKBYT come from
 the shifter's bit counter, the one a WORDSYNC match resets whether or not a
-transfer is running, and WORDEQUAL is the comparator's level held until the
-register is read. A reader that waits for WORDEQUAL and then collects bytes
+transfer is running, and WORDEQUAL is the comparator's live level -- true for
+the one cell in which the shift register equals DSKSYNC, so a poll that
+arrives a cell late sees nothing and waits for the next revolution, as on
+the hardware; reading the register resets DSKBYT alone, while the DSKSYNC
+interrupt is the latched edge of the same comparator. A reader that waits
+for WORDEQUAL and then collects bytes
 through DSKBYTR therefore gets them framed from the end of the sync word at
 whatever bit phase the sync sits on the track -- IPF and flux tracks carry
 their syncs at arbitrary phases, and Rob Northen's Copylock reads its key

--- a/src/bus/custom_regs.rs
+++ b/src/bus/custom_regs.rs
@@ -73,9 +73,7 @@ impl Bus {
             }
             0x018 => self.paula.read_serdatr(), // SERDATR
             0x01A => {
-                let r = self
-                    .floppy
-                    .read_dskbytr(self.agnus.dmacon, self.paula.adkcon);
+                let r = self.floppy.read_dskbytr(self.agnus.dmacon);
                 if self.floppy.take_sync_irq() {
                     self.paula.intreq |= INT_DSKSYNC;
                 }

--- a/src/floppy/formats.rs
+++ b/src/floppy/formats.rs
@@ -44,7 +44,18 @@ pub(super) enum FloppyTrackImage {
         revolutions: u8,
         legacy_sync: Option<u16>,
         bitcell_ns: Option<Vec<u32>>,
+        /// The cell-rate profile of a mastered protection track (IPF density
+        /// models), as the runs where the rate changes; `None` is uniform.
+        density: Option<Vec<DensitySpan>>,
     },
+}
+
+/// From `start_bit` until the next span (or the index), cells are written at
+/// `permille` / 1000 of the nominal cell time.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct DensitySpan {
+    pub(crate) start_bit: u32,
+    pub(crate) permille: u16,
 }
 
 impl FloppyImage {
@@ -119,12 +130,14 @@ impl FloppyImage {
                         bit_len,
                         revolutions,
                         legacy_sync,
+                        density,
                         ..
                     } => Some(raw_mfm_track_stream(
                         words,
                         *bit_len,
                         *revolutions,
                         legacy_sync.is_some(),
+                        density.as_deref().unwrap_or(&[]),
                     )),
                 }
             }
@@ -151,6 +164,7 @@ pub(super) fn raw_mfm_track_stream(
     bit_len: u32,
     revolutions: u8,
     legacy_sync: bool,
+    density: &[DensitySpan],
 ) -> TrackStream {
     let rev_bits = (bit_len as usize).max(1);
     let words_per_rev = rev_bits.div_ceil(16).max(1);
@@ -172,11 +186,20 @@ pub(super) fn raw_mfm_track_stream(
         let rev_words = words[start..end].to_vec();
         let this_bits = rev_bits.min(rev_words.len() * 16);
         let word_cck = FloppyController::word_cck_for_track_words(rev_words.len());
-        revs.push(TrackRev::new(rev_words, this_bits, word_cck));
+        // The mastered cell-rate profile is a property of the track, so every
+        // captured revolution of it carries the same one.
+        revs.push(TrackRev::with_density(
+            rev_words, this_bits, word_cck, density,
+        ));
     }
     if revs.is_empty() {
         let word_cck = FloppyController::word_cck_for_track_words(words.len());
-        revs.push(TrackRev::new(words.to_vec(), words.len() * 16, word_cck));
+        revs.push(TrackRev::with_density(
+            words.to_vec(),
+            words.len() * 16,
+            word_cck,
+            density,
+        ));
     }
     TrackStream { revs }
 }
@@ -347,6 +370,7 @@ pub(super) fn decode_uae_extended_adf(data: &[u8]) -> Result<FloppyImageData> {
                 revolutions,
                 legacy_sync: None,
                 bitcell_ns: None,
+                density: None,
             }),
             other => {
                 ensure!(
@@ -439,6 +463,7 @@ pub(super) fn decode_uae_legacy_extended_adf(data: &[u8]) -> Result<FloppyImageD
                 revolutions: 1,
                 legacy_sync: Some(sync),
                 bitcell_ns: None,
+                density: None,
             }));
         }
     }
@@ -458,10 +483,21 @@ pub(super) fn decode_ipf_image(data: &[u8]) -> Result<FloppyImageData> {
                 bit_len: track.bit_len,
                 // The format describes one canonical revolution, and its cell
                 // rate is the nominal 2 us that `word_cck_for_track_words`
-                // already paces a raw track at.
+                // already paces a raw track at -- except where the track's
+                // density model marks sectors mastered at another rate.
                 revolutions: 1,
                 legacy_sync: None,
                 bitcell_ns: None,
+                density: (!track.density.is_empty()).then(|| {
+                    track
+                        .density
+                        .iter()
+                        .map(|&(start_bit, permille)| DensitySpan {
+                            start_bit,
+                            permille,
+                        })
+                        .collect()
+                }),
             })
         })
         .collect();
@@ -650,6 +686,7 @@ pub(super) fn decode_scp_track(
         revolutions: decoded_revolutions,
         legacy_sync: None,
         bitcell_ns: Some(all_bitcell_ns),
+        density: None,
     })
 }
 

--- a/src/floppy/mod.rs
+++ b/src/floppy/mod.rs
@@ -238,8 +238,6 @@ pub struct FloppyController {
     last_dskdatr: u16,
     last_dskbytr_byte: u8,
     dskbyte_valid: bool,
-    last_dskbytr_pos: Option<DiskBytePos>,
-    last_stream_sync_pos: Option<DiskWordPos>,
     word_equal_latch: bool,
     sync_irq_latch: bool,
     index_pulse_cck: u32,
@@ -318,8 +316,6 @@ impl Default for FloppyController {
             last_dskdatr: 0,
             last_dskbytr_byte: 0,
             dskbyte_valid: false,
-            last_dskbytr_pos: None,
-            last_stream_sync_pos: None,
             word_equal_latch: false,
             sync_irq_latch: false,
             index_pulse_cck: 0,
@@ -1200,6 +1196,7 @@ impl FloppyController {
 
     pub fn write_dsksync(&mut self, val: u16) -> bool {
         self.dsksync = val;
+        self.read_shifter.set_sync(val);
         self.word_equal_latch = false;
         if self.current_disk_word_matches_sync() {
             self.record_sync_match();
@@ -1287,7 +1284,19 @@ impl FloppyController {
         self.last_dskdatr
     }
 
-    pub fn read_dskbytr(&mut self, dmacon: u16, adkcon: u16) -> u16 {
+    /// DSKBYTR. The byte and DSKBYT come from Paula's read shifter on its
+    /// own framing: the bit counter that a DSKSYNC match resets under
+    /// WORDSYNC. After a sync, the bytes a polling reader collects therefore
+    /// start exactly where the sync word ended, whatever bit phase that sync
+    /// has on the track -- an IPF or flux track carries its syncs at any
+    /// phase, and only a synthesised AmigaDOS track keeps them on the word
+    /// grid. (Rob Northen's Copylock reads its key sector this way: it waits
+    /// for WORDEQUAL, then reads the sector byte by byte through DSKBYTR
+    /// while counting poll iterations, and rejects the read unless the first
+    /// two bytes are the MFM of the sector's first data byte.) WORDEQUAL is
+    /// the comparator's level on the last sampled cell, held by a latch
+    /// until read so a polling loop cannot miss it.
+    pub fn read_dskbytr(&mut self, dmacon: u16) -> u16 {
         let mut status = 0u16;
         if self.dma_enabled(dmacon) {
             status |= DMAON;
@@ -1295,54 +1304,19 @@ impl FloppyController {
         if self.dsklen & DSKLEN_WRITE != 0 {
             status |= DISKWRITE;
         }
-        let dskbytr_load_allowed = self.dsklen & (DSKLEN_DMAEN | DSKLEN_WRITE) != DSKLEN_WRITE;
+        // Write mode with the DMA disarmed (DSKLEN WRITE without DMAEN) holds
+        // the byte register: nothing loads until the write bit clears.
+        let load_allowed = self.dsklen & (DSKLEN_DMAEN | DSKLEN_WRITE) != DSKLEN_WRITE;
         let active_write_dma = self.dma.as_ref().is_some_and(|dma| dma.write);
-        let mut current_word = None;
-        let mut new_disk_word = false;
-        if let Some((idx, track)) = self.selected_ready_track() {
-            self.ensure_track(idx, track);
-            let drive = &self.drives[idx];
-            if let Some(rev) = drive.cur_rev() {
-                let bit = drive.rotation_bit;
-                let byte_index = bit / 8;
-                let word_index = bit / 16;
-                let word = rev.word_at(word_index * 16);
-                let byte = rev.byte_at(byte_index * 8);
-                let byte_pos = DiskBytePos {
-                    drive: idx,
-                    track,
-                    word: byte_index,
-                    byte_phase: 0,
-                };
-                let word_pos = DiskWordPos {
-                    drive: idx,
-                    track,
-                    word: word_index,
-                };
-                current_word = Some(word);
-                new_disk_word = self.last_stream_sync_pos != Some(word_pos);
-                self.last_stream_sync_pos = Some(word_pos);
-                if dskbytr_load_allowed && self.last_dskbytr_pos != Some(byte_pos) {
-                    if active_write_dma {
-                        self.last_dskbytr_byte = 0;
-                    } else {
-                        self.last_dskdatr = word;
-                        self.last_dskbytr_byte = byte;
-                    }
-                    self.dskbyte_valid = true;
-                    self.last_dskbytr_pos = Some(byte_pos);
-                }
+        if let Some(byte) = self.read_shifter.take_dskbyt() {
+            if load_allowed {
+                // During a write transfer the shifter is Paula's output path
+                // and the byte register reads as zero.
+                self.last_dskbytr_byte = if active_write_dma { 0 } else { byte };
+                self.dskbyte_valid = true;
             }
-        } else {
-            self.last_dskbytr_pos = None;
-            self.last_stream_sync_pos = None;
         }
-        let current_word_equal = current_word.is_some_and(|word| word == self.dsksync);
-        let sync_irq_allowed = adkcon & ADK_MSBSYNC == 0 && !active_write_dma;
-        if current_word_equal && new_disk_word && sync_irq_allowed {
-            self.record_sync_match();
-        }
-        if self.word_equal_latch || current_word_equal {
+        if self.word_equal_latch || self.read_shifter.sync_matched() {
             status |= WORDEQUAL;
         }
         if self.dskbyte_valid {
@@ -1586,20 +1560,20 @@ impl FloppyController {
                 }
             }
             if comparator_match && sync_enabled && self.adkcon & ADK_WORDSYNC != 0 {
-                if let Some(dma) = read_dma.as_mut() {
-                    if !dma.wait_sync {
-                        // With WORDSYNC set, Paula re-frames the word boundary
-                        // on every DSKSYNC match, not only on the one that
-                        // starts the transfer. A revolution whose cell count
-                        // is not a multiple of 16 otherwise leaves every
-                        // sector after the index wrap off the word grid, and
-                        // a reader that scans its buffer on that grid (AROS
-                        // trackdisk.device) never finds them. Re-framing on
-                        // every matching cell of a run parks the framing at
-                        // the run's end, where the first word after it starts.
-                        self.read_shifter.reframe();
-                    }
-                }
+                // With WORDSYNC set, Paula re-frames the word boundary on
+                // every DSKSYNC match, not only on the one that starts a
+                // transfer. A revolution whose cell count is not a multiple
+                // of 16 otherwise leaves every sector after the index wrap
+                // off the word grid, and a reader that scans its buffer on
+                // that grid (AROS trackdisk.device) never finds them.
+                // Re-framing on every matching cell of a run parks the
+                // framing at the run's end, where the first word after it
+                // starts. The same bit counter frames DSKBYTR, so the reset
+                // applies with no transfer running too: a reader polling
+                // bytes after WORDEQUAL gets them framed from the sync. (A
+                // transfer that was waiting for this sync already realigned
+                // on the edge above; re-framing again is idempotent.)
+                self.read_shifter.reframe();
             }
 
             if self.drives[idx].advance_head_bit() {
@@ -1619,8 +1593,6 @@ impl FloppyController {
                             self.debug_watched_write = Some((self.dskpt, word));
                         }
                         self.last_dskdatr = word;
-                        self.last_dskbytr_byte = (word & 0x00FF) as u8;
-                        self.dskbyte_valid = true;
                         self.advance_dskpt();
                         dma.remaining -= 1;
                         if dma.remaining == 0 {
@@ -1692,6 +1664,11 @@ impl FloppyController {
                     index_pulse = true;
                 }
             }
+            // The shifter is Paula's output path during a write: DSKBYT
+            // still pulses as it clocks bytes out, but the byte register
+            // holds nothing readable.
+            self.last_dskbytr_byte = 0;
+            self.dskbyte_valid = true;
             dma.remaining -= 1;
             if dma.remaining == 0 {
                 irq = true;
@@ -2256,6 +2233,28 @@ impl FloppyController {
         self.ensure_track(idx, track);
         self.peek_head_word(idx)
             .is_some_and(|word| word == self.dsksync)
+    }
+
+    /// Test helper: put the head on a word boundary with a fresh read
+    /// shifter, so the shifter's framing follows the track's word grid from
+    /// here and the cells it samples are exactly the ones ticked from now.
+    #[cfg(test)]
+    fn park_head_at_word(&mut self, idx: usize, word: usize) {
+        self.drives[idx].set_rotation_word(word);
+        self.drives[idx].rotation_acc_cck = 0;
+        self.read_shifter = PaulaDiskReadDpllFifo::new();
+    }
+
+    /// Test helper: advance the platter exactly `cells` MFM cells, one tick
+    /// per cell, returning whether any tick raised DSKBLK.
+    #[cfg(test)]
+    fn tick_cells(&mut self, idx: usize, cells: usize, dmacon: u16) -> bool {
+        let mut irq = false;
+        for _ in 0..cells {
+            let cell = self.drives[idx].head_cell_cck();
+            irq |= self.tick(cell, dmacon, &mut []);
+        }
+        irq
     }
 
     fn record_sync_match(&mut self) {
@@ -3216,6 +3215,13 @@ impl FloppyDrive {
 /// 16-bit word at this revolution's length; per-bit timing is derived so each
 /// aligned 16-bit group sums to exactly `word_cck`, keeping synthetic (ADF)
 /// word cadence identical to the old word-grid model.
+///
+/// `density` is empty for a uniform revolution. Otherwise it lists the runs
+/// of cells written at a rate other than nominal -- the shape a mastering
+/// protection's key track takes, where some sectors are written with cells a
+/// few per cent longer or shorter than 2 us so a loader timing them can tell
+/// the original from a copy -- and every cell's cck scales by its run's
+/// per-mille weight.
 #[derive(Clone, Default, serde::Serialize, serde::Deserialize)]
 struct TrackRev {
     words: Vec<u16>,
@@ -3228,12 +3234,24 @@ struct TrackRev {
     /// and a DSKSYNC change replaces it.
     #[serde(skip)]
     sync_index: std::cell::RefCell<Option<SyncIndex>>,
+    density: Vec<DensityRun>,
 }
 
 #[derive(Clone)]
 struct SyncIndex {
     sync: u16,
     ends: Vec<u32>,
+}
+
+/// A run of cells from `start_bit` to the next run's start (or the index)
+/// written at `permille` / 1000 of the nominal cell time. `weight_before` is
+/// the per-mille weight summed over every cell ahead of the run, so a
+/// cumulative cell time is one multiply from any bit inside it.
+#[derive(Clone, Copy, serde::Serialize, serde::Deserialize)]
+struct DensityRun {
+    start_bit: usize,
+    permille: u32,
+    weight_before: u64,
 }
 
 impl TrackRev {
@@ -3253,6 +3271,7 @@ impl TrackRev {
             bit_len,
             word_cck: word_cck.max(1),
             sync_index: Default::default(),
+            density: Vec::new(),
         }
     }
 
@@ -3263,7 +3282,53 @@ impl TrackRev {
             bit_len,
             word_cck: word_cck.max(1),
             sync_index: Default::default(),
+            density: Vec::new(),
         }
+    }
+
+    /// A revolution whose cells are not all the nominal length: `spans`
+    /// lists, in ascending bit order, where each new cell rate starts. A
+    /// profile that is nominal throughout collapses to the uniform model.
+    fn with_density(
+        words: Vec<u16>,
+        bit_len: usize,
+        word_cck: u32,
+        spans: &[formats::DensitySpan],
+    ) -> Self {
+        let mut rev = Self::new(words, bit_len, word_cck);
+        if spans.iter().all(|span| span.permille == 1000) {
+            return rev;
+        }
+        let mut runs: Vec<DensityRun> = Vec::with_capacity(spans.len() + 1);
+        // The profile starts nominal unless a span says otherwise from bit 0.
+        if spans.first().is_none_or(|span| span.start_bit != 0) {
+            runs.push(DensityRun {
+                start_bit: 0,
+                permille: 1000,
+                weight_before: 0,
+            });
+        }
+        for span in spans {
+            let start_bit = (span.start_bit as usize).min(rev.bit_len);
+            if let Some(last) = runs.last() {
+                if start_bit <= last.start_bit {
+                    continue;
+                }
+            }
+            runs.push(DensityRun {
+                start_bit,
+                permille: u32::from(span.permille).max(1),
+                weight_before: 0,
+            });
+        }
+        let mut weight = 0u64;
+        for i in 0..runs.len() {
+            runs[i].weight_before = weight;
+            let end = runs.get(i + 1).map_or(rev.bit_len, |next| next.start_bit);
+            weight += (end - runs[i].start_bit) as u64 * u64::from(runs[i].permille);
+        }
+        rev.density = runs;
+        rev
     }
 
     fn bit(&self, bit: usize) -> bool {
@@ -3283,20 +3348,26 @@ impl TrackRev {
         value
     }
 
-    /// The 8-bit byte starting at `bit` (MSB-first), wrapping at `bit_len`.
-    fn byte_at(&self, bit: usize) -> u8 {
-        let mut value = 0u8;
-        for offset in 0..8 {
-            value = (value << 1) | u8::from(self.bit(bit + offset));
-        }
-        value
-    }
-
     /// Cumulative cck from the start of the revolution to the start of `bit`.
-    /// `prefix(16k) == k*word_cck` exactly, so aligned word boundaries match
-    /// the old uniform word clock.
+    /// On a uniform revolution `prefix(16k) == k*word_cck` exactly, so aligned
+    /// word boundaries match the old uniform word clock. With a density
+    /// profile each cell is weighted by its run's per-mille rate instead, so a
+    /// sector written with longer cells takes proportionally longer to pass
+    /// the head -- which is what a protection's timing loop measures.
     fn prefix_cck(&self, bit: usize) -> u64 {
-        (bit as u64 * self.word_cck as u64 + 8) / 16
+        if self.density.is_empty() {
+            return (bit as u64 * self.word_cck as u64 + 8) / 16;
+        }
+        let run = self
+            .density
+            .iter()
+            .rev()
+            .find(|run| run.start_bit <= bit)
+            .or(self.density.first())
+            .expect("a density profile has at least one run");
+        let weight =
+            run.weight_before + bit.saturating_sub(run.start_bit) as u64 * u64::from(run.permille);
+        (weight * self.word_cck as u64 + 8000) / 16000
     }
 
     fn cell_cck(&self, bit: usize) -> u32 {
@@ -3482,8 +3553,12 @@ fn apply_extended_adf_write(
             revolutions,
             legacy_sync,
             bitcell_ns,
+            density,
         } => {
+            // A track the guest wrote over carries the drive's own uniform
+            // cell rate, not the mastered profile.
             *bitcell_ns = None;
+            *density = None;
             if legacy_extended_adf || legacy_sync.is_some() {
                 apply_legacy_raw_mfm_write(
                     words,
@@ -3903,21 +3978,6 @@ struct DiskDirectWrite {
     write_start_bit: u8,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-struct DiskBytePos {
-    drive: usize,
-    track: usize,
-    word: usize,
-    byte_phase: u8,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-struct DiskWordPos {
-    drive: usize,
-    track: usize,
-    word: usize,
-}
-
 // Bit-granular accessor over a packed MFM word slice. The live read path uses
 // `TrackRev::word_at`/`byte_at` directly; this remains for the bit-stream and
 // DPLL-FIFO unit tests.
@@ -4084,6 +4144,24 @@ impl PaulaDiskReadDpllFifo {
     /// comparator's level, where `take_sync_irq` reports only its edge.
     fn sync_matched(&self) -> bool {
         self.word_equal
+    }
+
+    /// Re-evaluate the comparator against a freshly written DSKSYNC: it is
+    /// combinational on the shift register, so the level follows the new
+    /// value at once. The edge that raises DSKSYN belongs to the cell that
+    /// completes a match, so it is left to `sample_bit`.
+    fn set_sync(&mut self, sync: u16) {
+        self.word_equal = self.shift_word == sync;
+    }
+
+    /// The byte the shifter last completed, if one has completed since the
+    /// previous call: DSKBYT, cleared by the DSKBYTR read that consumes it.
+    fn take_dskbyt(&mut self) -> Option<u8> {
+        if !self.dskbyt {
+            return None;
+        }
+        self.dskbyt = false;
+        Some(self.dskbytr_byte)
     }
 
     #[cfg(test)]

--- a/src/floppy/mod.rs
+++ b/src/floppy/mod.rs
@@ -238,7 +238,6 @@ pub struct FloppyController {
     last_dskdatr: u16,
     last_dskbytr_byte: u8,
     dskbyte_valid: bool,
-    word_equal_latch: bool,
     sync_irq_latch: bool,
     index_pulse_cck: u32,
     index_flag_sync_cck: u32,
@@ -316,7 +315,6 @@ impl Default for FloppyController {
             last_dskdatr: 0,
             last_dskbytr_byte: 0,
             dskbyte_valid: false,
-            word_equal_latch: false,
             sync_irq_latch: false,
             index_pulse_cck: 0,
             index_flag_sync_cck: 0,
@@ -1197,7 +1195,6 @@ impl FloppyController {
     pub fn write_dsksync(&mut self, val: u16) -> bool {
         self.dsksync = val;
         self.read_shifter.set_sync(val);
-        self.word_equal_latch = false;
         if self.current_disk_word_matches_sync() {
             self.record_sync_match();
             true
@@ -1294,8 +1291,10 @@ impl FloppyController {
     /// for WORDEQUAL, then reads the sector byte by byte through DSKBYTR
     /// while counting poll iterations, and rejects the read unless the first
     /// two bytes are the MFM of the sector's first data byte.) WORDEQUAL is
-    /// the comparator's level on the last sampled cell, held by a latch
-    /// until read so a polling loop cannot miss it.
+    /// the comparator's live level: true for the one cell in which the shift
+    /// register equals DSKSYNC and gone once the next cell shifts in, so a
+    /// polling loop can miss a match and wait a revolution for the next --
+    /// as it does on the hardware. Only DSKBYT is reset by the read.
     pub fn read_dskbytr(&mut self, dmacon: u16) -> u16 {
         let mut status = 0u16;
         if self.dma_enabled(dmacon) {
@@ -1316,14 +1315,13 @@ impl FloppyController {
                 self.dskbyte_valid = true;
             }
         }
-        if self.word_equal_latch || self.read_shifter.sync_matched() {
+        if self.read_shifter.sync_matched() {
             status |= WORDEQUAL;
         }
         if self.dskbyte_valid {
             status |= DSKBYT;
             self.dskbyte_valid = false;
         }
-        self.word_equal_latch = false;
         status | self.last_dskbytr_byte as u16
     }
 
@@ -2258,7 +2256,6 @@ impl FloppyController {
     }
 
     fn record_sync_match(&mut self) {
-        self.word_equal_latch = true;
         self.sync_irq_latch = true;
     }
 

--- a/src/floppy/tests.rs
+++ b/src/floppy/tests.rs
@@ -1634,25 +1634,35 @@ fn dskbytr_wordequal_tracks_current_word() -> Result<()> {
     ctrl.park_head_at_word(0, 0);
     let word_cck = FloppyController::word_cck_for_track_words(raw_words.len());
 
-    // Writing DSKSYNC while the head is inside a matching word latches the
-    // match for the next read; after that read WORDEQUAL follows the
-    // comparator, which has not seen the word's last cell yet.
+    // WORDEQUAL is the comparator's live level. Writing DSKSYNC while the
+    // head is inside a matching word raises the interrupt, but the shift
+    // register has not seen the word's last cell yet, so the level is low.
     assert!(ctrl.write_dsksync(raw_words[0]));
-    let latched = ctrl.read_dskbytr(0);
-    assert_ne!(latched & WORDEQUAL, 0);
+    assert!(ctrl.take_sync_irq());
     assert_eq!(ctrl.read_dskbytr(0) & WORDEQUAL, 0);
 
-    // The word's last cell completes the match, and it holds until the
-    // next word shifts it out.
+    // The word's last cell completes the match: the level is high for that
+    // one cell, and reading the register does not clear it.
     ctrl.tick(word_cck, 0, &mut []);
     let matched = ctrl.read_dskbytr(0);
     assert_ne!(matched & WORDEQUAL, 0);
     let repeat = ctrl.read_dskbytr(0);
     assert_ne!(repeat & WORDEQUAL, 0);
 
-    ctrl.tick(word_cck, 0, &mut []);
-    let next = ctrl.read_dskbytr(0);
-    assert_eq!(next & WORDEQUAL, 0);
+    // The next cell shifts the match out, whether or not anyone read it in
+    // time: a poll that arrives late sees nothing, as on the hardware.
+    ctrl.tick_cells(0, 1, 0);
+    assert_eq!(ctrl.read_dskbytr(0) & WORDEQUAL, 0);
+    // The second word completes fifteen cells on; sixteen carry the match
+    // through and out again before anyone reads it.
+    ctrl.write_dsksync(raw_words[1]);
+    ctrl.tick_cells(0, 16, 0);
+    assert_eq!(ctrl.read_dskbytr(0) & WORDEQUAL, 0);
+    // A revolution later the poll lands on the matching cell itself.
+    ctrl.tick_cells(0, 31, 0);
+    assert_ne!(ctrl.read_dskbytr(0) & WORDEQUAL, 0);
+    ctrl.tick_cells(0, 1, 0);
+    assert_eq!(ctrl.read_dskbytr(0) & WORDEQUAL, 0);
 
     let _ = fs::remove_file(path);
     Ok(())
@@ -2946,11 +2956,17 @@ fn active_read_dma_dsksync_change_updates_dskbytr_wordequal() -> Result<()> {
     assert_eq!(read_chip_word(&chip_ram, 0), raw_words[0]);
     assert!(!ctrl.take_sync_irq());
 
+    // The comparator is live: the new sync word has not shifted in yet...
     assert!(ctrl.write_dsksync(raw_words[1]));
     let status = ctrl.read_dskbytr(dmacon);
     assert_ne!(status & DMAON, 0);
-    assert_ne!(status & WORDEQUAL, 0);
+    assert_eq!(status & WORDEQUAL, 0);
     assert!(ctrl.take_sync_irq());
+
+    // ...and WORDEQUAL reports it once the cell that completes it is in.
+    assert!(!ctrl.tick(word_cck, dmacon, &mut chip_ram));
+    assert_eq!(read_chip_word(&chip_ram, 2), raw_words[1]);
+    assert_ne!(ctrl.read_dskbytr(dmacon) & WORDEQUAL, 0);
 
     let _ = fs::remove_file(path);
     Ok(())

--- a/src/floppy/tests.rs
+++ b/src/floppy/tests.rs
@@ -1311,19 +1311,24 @@ fn dskbytr_byte_valid_tracks_new_rotation_words() -> Result<()> {
     ctrl.tick(MOTOR_READY_CCK, 0, &mut []);
 
     ctrl.ensure_track(0, 0);
-    let first_word = ctrl.drives[0].cached_words()[ctrl.drives[0].rotation_word_index()];
+    ctrl.park_head_at_word(0, 0);
+    let first_word = ctrl.drives[0].cached_words()[0];
     ctrl.write_dsksync(first_word);
 
-    let first = ctrl.read_dskbytr(0, 0);
+    // A whole word shifted in: its low byte is ready and the comparator
+    // sees the word DSKSYNC was set to.
+    ctrl.tick(ctrl.word_cck(), 0, &mut []);
+    let first = ctrl.read_dskbytr(0);
     assert_ne!(first & DSKBYT, 0);
     assert_ne!(first & WORDEQUAL, 0);
 
-    let second = ctrl.read_dskbytr(0, 0);
+    // The read resets DSKBYT; WORDEQUAL holds while no cell has moved.
+    let second = ctrl.read_dskbytr(0);
     assert_eq!(second & DSKBYT, 0);
     assert_ne!(second & WORDEQUAL, 0);
 
     ctrl.tick(ctrl.word_cck(), 0, &mut []);
-    let third = ctrl.read_dskbytr(0, 0);
+    let third = ctrl.read_dskbytr(0);
     assert_ne!(third & DSKBYT, 0);
 
     let _ = fs::remove_file(path);
@@ -1352,31 +1357,101 @@ fn dskbytr_reports_current_disk_byte_phase() -> Result<()> {
     ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
     ctrl.tick(MOTOR_READY_CCK, 0, &mut []);
     ctrl.ensure_track(0, 0);
-    ctrl.drives[0].set_rotation_word(0);
-    ctrl.drives[0].rotation_acc_cck = 0;
+    ctrl.park_head_at_word(0, 0);
     let word_cck = FloppyController::word_cck_for_track_words(raw_words.len());
     let half_word_cck = word_cck.div_ceil(2);
 
-    let high = ctrl.read_dskbytr(0, 0);
+    // Nothing has completed at the word boundary itself: a byte is ready
+    // once its eight cells have shifted through.
+    assert_eq!(ctrl.read_dskbytr(0) & DSKBYT, 0);
+
+    ctrl.tick(half_word_cck, 0, &mut []);
+    let high = ctrl.read_dskbytr(0);
     assert_ne!(high & DSKBYT, 0);
     assert_eq!(high & 0x00FF, 0x12);
 
-    let repeat_high = ctrl.read_dskbytr(0, 0);
+    // The byte stays readable, without DSKBYT, until the next completes.
+    let repeat_high = ctrl.read_dskbytr(0);
     assert_eq!(repeat_high & DSKBYT, 0);
     assert_eq!(repeat_high & 0x00FF, 0x12);
 
-    ctrl.tick(half_word_cck, 0, &mut []);
-    let low = ctrl.read_dskbytr(0, 0);
+    ctrl.tick(word_cck - half_word_cck, 0, &mut []);
+    let low = ctrl.read_dskbytr(0);
     assert_ne!(low & DSKBYT, 0);
     assert_eq!(low & 0x00FF, 0x34);
 
-    ctrl.tick(word_cck - half_word_cck, 0, &mut []);
-    let next_high = ctrl.read_dskbytr(0, 0);
+    ctrl.tick(half_word_cck, 0, &mut []);
+    let next_high = ctrl.read_dskbytr(0);
     assert_ne!(next_high & DSKBYT, 0);
     assert_eq!(next_high & 0x00FF, 0xAB);
 
     let _ = fs::remove_file(path);
     Ok(())
+}
+
+/// A mastered cell-rate profile scales each run's cells by its per-mille
+/// weight: the cells of a sector written 5% slow take 5% longer to pass the
+/// head, so the revolution and everything timed against it stretch with it.
+#[test]
+fn track_rev_density_profile_scales_the_cells_it_covers() {
+    let spans = [
+        DensitySpan {
+            start_bit: 16,
+            permille: 500,
+        },
+        DensitySpan {
+            start_bit: 32,
+            permille: 1000,
+        },
+    ];
+    let rev = TrackRev::with_density(vec![0; 4], 64, 1600, &spans);
+
+    // Nominal cells are 100 cck; the run from bit 16 to 32 halves them.
+    assert_eq!(rev.cell_cck(0), 100);
+    assert_eq!(rev.cell_cck(15), 100);
+    assert_eq!(rev.cell_cck(16), 50);
+    assert_eq!(rev.cell_cck(31), 50);
+    assert_eq!(rev.cell_cck(32), 100);
+    assert_eq!(rev.prefix_cck(16), 1600);
+    assert_eq!(rev.prefix_cck(32), 2400);
+    assert_eq!(rev.rev_cck(), 5600);
+
+    // A profile that is nominal throughout is the uniform revolution.
+    let uniform = TrackRev::with_density(
+        vec![0; 4],
+        64,
+        1600,
+        &[DensitySpan {
+            start_bit: 0,
+            permille: 1000,
+        }],
+    );
+    assert!(uniform.density.is_empty());
+    assert_eq!(uniform.prefix_cck(16), 1600);
+    assert_eq!(uniform.rev_cck(), 6400);
+}
+
+/// A raw track image carrying a density profile hands it to every revolution
+/// it is split into, and a track without one stays uniform.
+#[test]
+fn raw_mfm_track_stream_carries_the_density_profile() {
+    let words = vec![0u16; 8];
+    let spans = [DensitySpan {
+        start_bit: 32,
+        permille: 1050,
+    }];
+    let stream = raw_mfm_track_stream(&words, 64, 2, false, &spans);
+    assert_eq!(stream.revs.len(), 2);
+    for rev in &stream.revs {
+        assert_eq!(rev.cell_cck(0), rev.word_cck / 16);
+        assert!(rev.rev_cck() > u64::from(rev.word_cck) * 4);
+    }
+
+    let uniform = raw_mfm_track_stream(&words, 64, 2, false, &[]);
+    for rev in &uniform.revs {
+        assert!(rev.density.is_empty());
+        assert_eq!(rev.rev_cck(), u64::from(rev.word_cck) * 4);
+    }
 }
 
 #[test]
@@ -1556,21 +1631,27 @@ fn dskbytr_wordequal_tracks_current_word() -> Result<()> {
     ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
     ctrl.tick(MOTOR_READY_CCK, 0, &mut []);
     ctrl.ensure_track(0, 0);
-    ctrl.drives[0].set_rotation_word(0);
-    ctrl.drives[0].rotation_acc_cck = 0;
-    ctrl.write_dsksync(raw_words[0]);
+    ctrl.park_head_at_word(0, 0);
+    let word_cck = FloppyController::word_cck_for_track_words(raw_words.len());
 
-    let first = ctrl.read_dskbytr(0, 0);
-    assert_ne!(first & WORDEQUAL, 0);
-    let repeat = ctrl.read_dskbytr(0, 0);
+    // Writing DSKSYNC while the head is inside a matching word latches the
+    // match for the next read; after that read WORDEQUAL follows the
+    // comparator, which has not seen the word's last cell yet.
+    assert!(ctrl.write_dsksync(raw_words[0]));
+    let latched = ctrl.read_dskbytr(0);
+    assert_ne!(latched & WORDEQUAL, 0);
+    assert_eq!(ctrl.read_dskbytr(0) & WORDEQUAL, 0);
+
+    // The word's last cell completes the match, and it holds until the
+    // next word shifts it out.
+    ctrl.tick(word_cck, 0, &mut []);
+    let matched = ctrl.read_dskbytr(0);
+    assert_ne!(matched & WORDEQUAL, 0);
+    let repeat = ctrl.read_dskbytr(0);
     assert_ne!(repeat & WORDEQUAL, 0);
 
-    ctrl.tick(
-        FloppyController::word_cck_for_track_words(raw_words.len()),
-        0,
-        &mut [],
-    );
-    let next = ctrl.read_dskbytr(0, 0);
+    ctrl.tick(word_cck, 0, &mut []);
+    let next = ctrl.read_dskbytr(0);
     assert_eq!(next & WORDEQUAL, 0);
 
     let _ = fs::remove_file(path);
@@ -1599,10 +1680,15 @@ fn msbsync_dskbytr_keeps_wordequal_without_stream_irq() -> Result<()> {
     ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
     ctrl.tick(MOTOR_READY_CCK, 0, &mut []);
     ctrl.ensure_track(0, 0);
-    ctrl.drives[0].set_rotation_word(0);
-    ctrl.drives[0].rotation_acc_cck = 0;
+    ctrl.park_head_at_word(0, 0);
+    ctrl.set_adkcon(ADK_MSBSYNC);
+    ctrl.tick(
+        FloppyController::word_cck_for_track_words(raw_words.len()),
+        0,
+        &mut [],
+    );
 
-    let first = ctrl.read_dskbytr(0, ADK_MSBSYNC);
+    let first = ctrl.read_dskbytr(0);
     assert_ne!(first & DSKBYT, 0);
     assert_ne!(first & WORDEQUAL, 0);
     assert!(!ctrl.take_sync_irq());
@@ -1633,14 +1719,20 @@ fn write_dma_dskbytr_keeps_wordequal_without_stream_irq() -> Result<()> {
     ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
     ctrl.tick(MOTOR_READY_CCK, 0, &mut []);
     ctrl.ensure_track(0, 0);
-    ctrl.drives[0].set_rotation_word(0);
-    ctrl.drives[0].rotation_acc_cck = 0;
+    ctrl.park_head_at_word(0, 0);
+    // The sync word shifts in with WORDSYNC clear: the comparator level
+    // rises, but it interrupts nothing.
+    ctrl.tick(
+        FloppyController::word_cck_for_track_words(raw_words.len()),
+        0,
+        &mut [],
+    );
 
     let len = DSKLEN_DMAEN | DSKLEN_WRITE | 1;
     assert!(!ctrl.write_dsklen(len, 0));
     assert!(!ctrl.write_dsklen(len, 0));
 
-    let status = ctrl.read_dskbytr(DMACON_DMAEN | DMACON_DISK, 0);
+    let status = ctrl.read_dskbytr(DMACON_DMAEN | DMACON_DISK);
     assert_ne!(status & DSKBYT, 0);
     assert_ne!(status & DMAON, 0);
     assert_ne!(status & DISKWRITE, 0);
@@ -1654,7 +1746,7 @@ fn write_dma_dskbytr_keeps_wordequal_without_stream_irq() -> Result<()> {
 
 #[test]
 fn dskbytr_write_mode_without_dma_suppresses_byte_loads() -> Result<()> {
-    let raw_words = [0x1234, DEFAULT_DSKSYNC];
+    let raw_words = [0x1234, DEFAULT_DSKSYNC, 0xABCD];
     let path = temp_ext2_raw(&raw_words)?;
     let cfg = FloppyConfig {
         bridges: std::array::from_fn(|_| None),
@@ -1674,29 +1766,37 @@ fn dskbytr_write_mode_without_dma_suppresses_byte_loads() -> Result<()> {
     ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
     ctrl.tick(MOTOR_READY_CCK, 0, &mut []);
     ctrl.ensure_track(0, 0);
-    ctrl.drives[0].set_rotation_word(0);
-    ctrl.drives[0].rotation_acc_cck = 0;
+    ctrl.park_head_at_word(0, 0);
+    ctrl.set_adkcon(ADK_WORDSYNC);
+    let word_cck = FloppyController::word_cck_for_track_words(raw_words.len());
+    let half_word_cck = word_cck.div_ceil(2);
 
-    let first = ctrl.read_dskbytr(0, 0);
+    ctrl.tick(half_word_cck, 0, &mut []);
+    let first = ctrl.read_dskbytr(0);
     assert_ne!(first & DSKBYT, 0);
     assert_eq!(first & 0x00FF, 0x12);
 
     assert!(!ctrl.write_dsksync(DEFAULT_DSKSYNC));
     assert!(!ctrl.write_dsklen(DSKLEN_WRITE, 0));
-    let word_cck = FloppyController::word_cck_for_track_words(raw_words.len());
+    // Through the rest of the first word and the whole sync word: the
+    // comparator matches and interrupts, but the byte register does not
+    // load while DSKLEN holds WRITE with the DMA disarmed.
+    ctrl.tick(word_cck - half_word_cck, 0, &mut []);
     ctrl.tick(word_cck, 0, &mut []);
 
-    let write_mode = ctrl.read_dskbytr(0, 0);
+    let write_mode = ctrl.read_dskbytr(0);
     assert_ne!(write_mode & DISKWRITE, 0);
     assert_eq!(write_mode & DSKBYT, 0);
     assert_ne!(write_mode & WORDEQUAL, 0);
     assert_eq!(write_mode & 0x00FF, 0x12);
     assert!(ctrl.take_sync_irq());
 
+    // Loads resume with the next byte to complete once the write bit clears.
     assert!(!ctrl.write_dsklen(0, 0));
-    let resumed = ctrl.read_dskbytr(0, 0);
+    ctrl.tick(half_word_cck, 0, &mut []);
+    let resumed = ctrl.read_dskbytr(0);
     assert_ne!(resumed & DSKBYT, 0);
-    assert_eq!(resumed & 0x00FF, 0x44);
+    assert_eq!(resumed & 0x00FF, 0xAB);
 
     let _ = fs::remove_file(path);
     Ok(())
@@ -1727,11 +1827,11 @@ fn dskbytr_dmaon_waits_for_double_dsklen_arm() -> Result<()> {
     let len = DSKLEN_DMAEN | 1;
     let dmacon = DMACON_DMAEN | DMACON_DISK;
     assert!(!ctrl.write_dsklen(len, 0));
-    assert_eq!(ctrl.read_dskbytr(dmacon, 0) & DMAON, 0);
+    assert_eq!(ctrl.read_dskbytr(dmacon) & DMAON, 0);
 
     assert!(!ctrl.write_dsklen(len, 0));
-    assert_ne!(ctrl.read_dskbytr(dmacon, 0) & DMAON, 0);
-    assert_eq!(ctrl.read_dskbytr(0, 0) & DMAON, 0);
+    assert_ne!(ctrl.read_dskbytr(dmacon) & DMAON, 0);
+    assert_eq!(ctrl.read_dskbytr(0) & DMAON, 0);
 
     let _ = fs::remove_file(path);
     Ok(())
@@ -1765,7 +1865,7 @@ fn dskbytr_dmaon_stays_set_while_armed_dma_waits_for_the_motor() -> Result<()> {
     let dmacon = DMACON_DMAEN | DMACON_DISK;
     assert!(!ctrl.write_dsklen(len, 0));
     assert!(!ctrl.write_dsklen(len, 0));
-    assert_ne!(ctrl.read_dskbytr(dmacon, 0) & DMAON, 0);
+    assert_ne!(ctrl.read_dskbytr(dmacon) & DMAON, 0);
     assert_eq!(ctrl.next_completion_cck(dmacon), None);
     let mut chip_ram = vec![0u8; 4];
     assert!(!ctrl.tick(MOTOR_READY_CCK * 4, dmacon, &mut chip_ram));
@@ -1791,7 +1891,7 @@ fn read_dma_with_no_media_arms_and_pends_until_media_arrives() -> Result<()> {
     let dmacon = DMACON_DMAEN | DMACON_DISK;
     assert!(!ctrl.write_dsklen(len, 0));
     assert!(!ctrl.write_dsklen(len, 0));
-    assert_ne!(ctrl.read_dskbytr(dmacon, 0) & DMAON, 0);
+    assert_ne!(ctrl.read_dskbytr(dmacon) & DMAON, 0);
     assert_eq!(ctrl.next_completion_cck(dmacon), None);
 
     // Several revolutions of waiting deliver nothing.
@@ -1902,7 +2002,7 @@ fn read_dma_started_during_motor_spinup_arms_and_transfers() -> Result<()> {
     assert!(!ctrl.write_dsklen(len, 0));
     let dmacon = DMACON_DMAEN | DMACON_DISK;
 
-    assert_ne!(ctrl.read_dskbytr(dmacon, 0) & DMAON, 0);
+    assert_ne!(ctrl.read_dskbytr(dmacon) & DMAON, 0);
     assert!(ctrl.tick(
         FloppyController::word_cck_for_track_words(raw_words.len()),
         dmacon,
@@ -2223,7 +2323,7 @@ fn motor_off_blocks_read_dma_until_next_spinup() -> Result<()> {
     // pends: no cells pass under the head, so nothing completes.
     assert!(!ctrl.write_dsklen(len, 0));
     assert!(!ctrl.write_dsklen(len, 0));
-    assert_ne!(ctrl.read_dskbytr(dmacon, 0) & DMAON, 0);
+    assert_ne!(ctrl.read_dskbytr(dmacon) & DMAON, 0);
 
     // Leave the motor off long enough for the platter to spin down fully,
     // so the drive must spin back up before data can flow.
@@ -2308,12 +2408,143 @@ fn reset_dsksync_defaults_to_amigados_mfm_sync_word() -> Result<()> {
     ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
     ctrl.tick(MOTOR_READY_CCK, 0, &mut []);
     ctrl.ensure_track(0, 0);
-    ctrl.drives[0].set_rotation_word(0);
-    ctrl.drives[0].rotation_acc_cck = 0;
+    ctrl.park_head_at_word(0, 0);
+    ctrl.set_adkcon(ADK_WORDSYNC);
+    ctrl.tick(
+        FloppyController::word_cck_for_track_words(raw_words.len()),
+        0,
+        &mut [],
+    );
 
-    let status = ctrl.read_dskbytr(0, 0);
+    let status = ctrl.read_dskbytr(0);
     assert_ne!(status & WORDEQUAL, 0);
     assert!(ctrl.take_sync_irq());
+
+    let _ = fs::remove_file(path);
+    Ok(())
+}
+
+/// A raw track whose sync word sits one cell off the word grid, followed
+/// by known data: `0 | 8911 | 2A91 4511 1445 | 0101...`. That is the shape
+/// of an IPF or flux track (Copylock's key track on Lemmings has its
+/// per-sector sync at bit phase 1), where nothing keeps syncs word-aligned.
+fn off_grid_sync_track() -> Vec<u16> {
+    let mut bits = vec![false];
+    for word in [0x8911u16, 0x2A91, 0x4511, 0x1445] {
+        bits.extend((0..16).rev().map(|shift| word & (1 << shift) != 0));
+    }
+    while bits.len() < 128 {
+        bits.push(bits.len() % 2 == 1);
+    }
+    bits.chunks(16)
+        .map(|chunk| {
+            chunk
+                .iter()
+                .fold(0u16, |word, &bit| (word << 1) | u16::from(bit))
+        })
+        .collect()
+}
+
+/// Paula frames DSKBYTR with the bit counter a WORDSYNC match resets, so a
+/// reader that waits for WORDEQUAL and then collects bytes gets them from
+/// the end of the sync word, not from the track's byte grid. Rob Northen's
+/// Copylock reads its key sector this way and rejects the read unless the
+/// first two bytes are the MFM of the sector's first data byte.
+#[test]
+fn dskbytr_bytes_frame_from_the_sync_at_any_bit_phase() -> Result<()> {
+    let raw_words = off_grid_sync_track();
+    let path = temp_ext2_raw(&raw_words)?;
+    let cfg = FloppyConfig {
+        bridges: std::array::from_fn(|_| None),
+        speed: 100,
+        drives: [
+            Some(FloppyDriveConfig {
+                path: path.clone(),
+                write_protected: true,
+            }),
+            None,
+            None,
+            None,
+        ],
+    };
+    let mut ctrl = FloppyController::from_config(&cfg)?;
+    ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
+    ctrl.tick(MOTOR_READY_CCK, 0, &mut []);
+    ctrl.ensure_track(0, 0);
+    ctrl.park_head_at_word(0, 0);
+    ctrl.set_adkcon(ADK_WORDSYNC);
+    assert!(!ctrl.write_dsksync(0x8911));
+
+    // Sixteen cells in, the shifter holds the grid's first word, which is
+    // not the sync: the comparator stays quiet.
+    assert!(!ctrl.tick_cells(0, 16, 0));
+    assert_eq!(ctrl.read_dskbytr(0) & WORDEQUAL, 0);
+    assert!(!ctrl.take_sync_irq());
+
+    // One more cell completes the sync word.
+    assert!(!ctrl.tick_cells(0, 1, 0));
+    assert_ne!(ctrl.read_dskbytr(0) & WORDEQUAL, 0);
+    assert!(ctrl.take_sync_irq());
+
+    // The bytes that follow are framed from the end of the sync.
+    for expected in [0x2Au16, 0x91, 0x45, 0x11, 0x14, 0x45] {
+        ctrl.tick_cells(0, 8, 0);
+        let status = ctrl.read_dskbytr(0);
+        assert_ne!(status & DSKBYT, 0, "DSKBYT for byte {expected:#04X}");
+        assert_eq!(status & 0x00FF, expected);
+        assert_eq!(ctrl.read_dskbytr(0) & DSKBYT, 0);
+    }
+
+    let _ = fs::remove_file(path);
+    Ok(())
+}
+
+/// Copylock's idiom: it arms a zero-length read (DSKLEN=$8000 twice), which
+/// completes on arming with DSKBLK and leaves no transfer behind, then waits
+/// for WORDEQUAL from the free-running comparator and polls the key sector's
+/// bytes through DSKBYTR -- so the framing reset on that match must not
+/// depend on a transfer being in flight.
+#[test]
+fn zero_length_arm_then_polled_bytes_frame_from_the_sync() -> Result<()> {
+    let raw_words = off_grid_sync_track();
+    let path = temp_ext2_raw(&raw_words)?;
+    let cfg = FloppyConfig {
+        bridges: std::array::from_fn(|_| None),
+        speed: 100,
+        drives: [
+            Some(FloppyDriveConfig {
+                path: path.clone(),
+                write_protected: true,
+            }),
+            None,
+            None,
+            None,
+        ],
+    };
+    let mut ctrl = FloppyController::from_config(&cfg)?;
+    ctrl.write_prb(!CIAB_DSKMOTOR & !CIAB_DSKSEL0);
+    ctrl.tick(MOTOR_READY_CCK, 0, &mut []);
+    ctrl.ensure_track(0, 0);
+    ctrl.park_head_at_word(0, 0);
+    ctrl.set_adkcon(ADK_WORDSYNC);
+    assert!(!ctrl.write_dsksync(0x8911));
+    assert!(!ctrl.write_dsklen(DSKLEN_DMAEN, ADK_WORDSYNC));
+    // The zero-length transfer completes on arming: DSKBLK, no DMA pending.
+    assert!(ctrl.write_dsklen(DSKLEN_DMAEN, ADK_WORDSYNC));
+    let dmacon = DMACON_DMAEN | DMACON_DISK;
+    assert_eq!(ctrl.read_dskbytr(dmacon) & DMAON, 0);
+
+    assert!(!ctrl.tick_cells(0, 16, dmacon));
+    assert_eq!(ctrl.read_dskbytr(dmacon) & WORDEQUAL, 0);
+    assert!(!ctrl.tick_cells(0, 1, dmacon));
+    assert_ne!(ctrl.read_dskbytr(dmacon) & WORDEQUAL, 0);
+
+    for expected in [0x2Au16, 0x91] {
+        ctrl.tick_cells(0, 8, dmacon);
+        let status = ctrl.read_dskbytr(dmacon);
+        assert_ne!(status & DSKBYT, 0, "DSKBYT for byte {expected:#04X}");
+        assert_eq!(status & 0x00FF, expected);
+    }
 
     let _ = fs::remove_file(path);
     Ok(())
@@ -2716,7 +2947,7 @@ fn active_read_dma_dsksync_change_updates_dskbytr_wordequal() -> Result<()> {
     assert!(!ctrl.take_sync_irq());
 
     assert!(ctrl.write_dsksync(raw_words[1]));
-    let status = ctrl.read_dskbytr(dmacon, 0);
+    let status = ctrl.read_dskbytr(dmacon);
     assert_ne!(status & DMAON, 0);
     assert_ne!(status & WORDEQUAL, 0);
     assert!(ctrl.take_sync_irq());
@@ -3976,7 +4207,7 @@ fn cpu_dskdat_write_without_dma_overlays_raw_track() -> Result<()> {
     ctrl.drives[0].rotation_acc_cck = 0;
 
     assert!(!ctrl.write_dsklen(DSKLEN_WRITE | 1, 0));
-    let status = ctrl.read_dskbytr(0, 0);
+    let status = ctrl.read_dskbytr(0);
     assert_eq!(status & DMAON, 0);
     assert_ne!(status & DISKWRITE, 0);
 

--- a/src/ipf.rs
+++ b/src/ipf.rs
@@ -98,6 +98,19 @@ const SIGNAL_2US_CELLS: u32 = 1;
 // the track to defeat copiers, and needs a per-protection timing model.
 const DENSITY_NOISE: u32 = 1;
 const DENSITY_AUTO: u32 = 2;
+// The mastered cell-rate profiles: which blocks of the track were written
+// with cells longer or shorter than nominal, and by how much, so a loader
+// timing them can tell an original from a copy. Modelled after the CAPS
+// library's `GenerateCLA`/`GenerateSLA`/`GenerateABA` family, which scales
+// each byte's cell time in per-mille of nominal.
+const DENSITY_COPYLOCK_AMIGA: u32 = 3;
+const DENSITY_COPYLOCK_AMIGA_NEW: u32 = 4;
+const DENSITY_COPYLOCK_ST: u32 = 5;
+const DENSITY_SPEEDLOCK_AMIGA: u32 = 6;
+const DENSITY_SPEEDLOCK_AMIGA_OLD: u32 = 7;
+const DENSITY_BRIERLEY_AMIGA: u32 = 8;
+const DENSITY_BRIERLEY_AMIGA_KEY: u32 = 9;
+const DENSITY_NOMINAL_PERMILLE: i32 = 1000;
 
 // Data-stream sample types.
 const DATA_SYNC: u8 = 1;
@@ -116,11 +129,15 @@ const BLOCK_FLAG_BWGAP: u32 = 1 << 1;
 const BLOCK_FLAG_BIT_LENGTHS: u32 = 1 << 2;
 
 /// One decoded revolution: packed MFM words, MSB first, and the exact bit
-/// length it wraps at.
+/// length it wraps at. `density` is the track's mastered cell-rate profile as
+/// `(start_bit, permille)` spans in ascending bit order, each holding until
+/// the next one: cells from `start_bit` are written at `permille` / 1000 of
+/// the nominal cell time. Empty for a track written at one rate throughout.
 #[derive(Debug)]
 pub struct IpfTrack {
     pub words: Vec<u16>,
     pub bit_len: u32,
+    pub density: Vec<(u32, u16)>,
 }
 
 /// True when `data` opens with the IPF/CAPS file signature.
@@ -166,7 +183,7 @@ pub fn decode(data: &[u8]) -> Result<Vec<Option<IpfTrack>>> {
     ensure!(!images.is_empty(), "IPF image describes no tracks");
 
     let mut tracks: Vec<Option<IpfTrack>> = (0..MAX_TRACKS).map(|_| None).collect();
-    let mut unsupported_density = None;
+    let mut unknown_density = None;
     for imge in &images {
         let index = imge.track_index()?;
         ensure!(
@@ -175,8 +192,8 @@ pub fn decode(data: &[u8]) -> Result<Vec<Option<IpfTrack>>> {
             imge.cylinder,
             imge.head
         );
-        if let Some(density) = imge.unsupported_density() {
-            unsupported_density.get_or_insert(density);
+        if let Some(density) = imge.unknown_density() {
+            unknown_density.get_or_insert(density);
         }
         let area = areas
             .iter()
@@ -187,17 +204,14 @@ pub fn decode(data: &[u8]) -> Result<Vec<Option<IpfTrack>>> {
         })?;
     }
 
-    if let Some(density) = unsupported_density {
+    if let Some(density) = unknown_density {
         // The cells are still decoded, and every byte of them is right; it is
         // only the varying cell *rate* that is missing, so the disk loads and
         // just the timing check of the protection sees the wrong answer.
-        // TODO: model the per-protection density profiles (Copylock,
-        // Speedlock, Brierley) as a per-cell bitcell_ns track profile, which
-        // FloppyTrackImage::RawMfm can already carry.
         warn!(
-            "IPF image uses cell-density model {density}, whose variable cell timing is not \
-             modelled; the track data is decoded with uniform 2 us cells, so a protection \
-             that measures cell timing may not pass"
+            "IPF image uses cell-density model {density}, which Copperline does not know; the \
+             track data is decoded with uniform 2 us cells, so a protection that measures \
+             cell timing may not pass"
         );
     }
 
@@ -389,10 +403,11 @@ impl Imge {
         Ok(index)
     }
 
-    /// The density models past `AUTO` vary the cell rate across the track.
-    fn unsupported_density(&self) -> Option<u32> {
+    /// A density model this decoder has no cell-rate profile for.
+    fn unknown_density(&self) -> Option<u32> {
         match self.density {
             DENSITY_NOISE | DENSITY_AUTO => None,
+            DENSITY_COPYLOCK_AMIGA..=DENSITY_BRIERLEY_AMIGA_KEY => None,
             other => Some(other),
         }
     }
@@ -432,6 +447,9 @@ struct Block {
     gap_offset: usize,
     flags: u32,
     gap_value: u8,
+    /// The whole gap-value word: block 0's doubles as the density key of the
+    /// Brierley density-key model.
+    gap_value_word: u32,
     data_offset: usize,
 }
 
@@ -455,6 +473,7 @@ impl Block {
             },
             // The gap fill value is a byte held in a big-endian word.
             gap_value: d[27],
+            gap_value_word: read_be_u32(&d[24..28]),
             data_offset: read_be_u32(&d[28..32]) as usize,
         })
     }
@@ -506,10 +525,113 @@ fn decode_track(imge: &Imge, area: Option<&[u8]>, info: &Info) -> Result<Option<
         }
     }
 
+    let flags_meaningful = info.block_flags_meaningful();
+    let blocks = (0..imge.block_count as usize)
+        .map(|index| Block::parse(area, index, flags_meaningful))
+        .collect::<Result<Vec<_>>>()?;
+    let density = density_profile(imge, &blocks, start, track_bits);
+
     Ok(Some(IpfTrack {
         words,
         bit_len: imge.track_bits,
+        density,
     }))
+}
+
+/// The track's mastered cell-rate profile as `(start_bit, permille)` spans on
+/// the revolution as rotated to the index, or empty when every cell is
+/// nominal. The profiles are the CAPS library's own (`GenerateCLA`,
+/// `GenerateSLA`, `GenerateABA` and their variants), which weight each block's
+/// cell time in per-mille of nominal:
+///
+/// - Copylock Amiga slows and speeds three consecutive sectors (blocks 4-6 on
+///   the original scheme, 0-2 on the newer one) by -5.5%, -0.5% and +4.5%,
+///   each run starting at the gap that precedes its block. A loader reads
+///   two of them byte by byte, counting how often it polled between bytes,
+///   and passes only if their counts differ by the few per cent the mastered
+///   rates put between them;
+/// - Copylock ST writes block 5 5% slow; Speedlock writes block 1 10% slow
+///   and block 2 10% fast (the older variant block 1 5% slow); Brierley steps
+///   blocks 1, 2, 4, 5 and 6 through +10%, +5%, -5%, -10%, -15%; and the
+///   Brierley density-key model takes a bit per block from block 0's gap
+///   value word, 5% fast where set and 5% slow where clear.
+fn density_profile(
+    imge: &Imge,
+    blocks: &[Block],
+    start: usize,
+    track_bits: usize,
+) -> Vec<(u32, u16)> {
+    // Per affected block: the per-mille delta, and whether the run begins at
+    // the gap that precedes the block rather than at the block itself.
+    let deltas: Vec<(usize, i32, bool)> = match imge.density {
+        DENSITY_COPYLOCK_AMIGA => vec![(4, -55, true), (5, -5, true), (6, 45, true)],
+        DENSITY_COPYLOCK_AMIGA_NEW => vec![(0, -55, true), (1, -5, true), (2, 45, true)],
+        DENSITY_COPYLOCK_ST => vec![(5, 50, false)],
+        DENSITY_SPEEDLOCK_AMIGA => vec![(1, 100, false), (2, -100, false)],
+        DENSITY_SPEEDLOCK_AMIGA_OLD => vec![(1, 50, false)],
+        DENSITY_BRIERLEY_AMIGA => vec![
+            (1, 100, false),
+            (2, 50, false),
+            (4, -50, false),
+            (5, -100, false),
+            (6, -150, false),
+        ],
+        DENSITY_BRIERLEY_AMIGA_KEY => {
+            let key = blocks.first().map_or(0, |block| block.gap_value_word);
+            (1..blocks.len())
+                .map(|blk| {
+                    let mask = 1u32.checked_shl(blk as u32 - 1).unwrap_or(0);
+                    (blk, if key & mask != 0 { -50 } else { 50 }, false)
+                })
+                .collect()
+        }
+        _ => return Vec::new(),
+    };
+    if track_bits == 0 || blocks.is_empty() {
+        return Vec::new();
+    }
+
+    // Where each block begins in the stream as laid out from block 0; its
+    // gap follows it.
+    let mut block_starts = Vec::with_capacity(blocks.len());
+    let mut pos = 0usize;
+    for block in blocks {
+        block_starts.push(pos);
+        pos += block.block_bits + block.gap_bits;
+    }
+    let mut weights = vec![DENSITY_NOMINAL_PERMILLE; track_bits];
+    for (blk, delta, from_preceding_gap) in deltas {
+        let Some(&block_start) = block_starts.get(blk) else {
+            continue;
+        };
+        let lead = if from_preceding_gap {
+            blocks[(blk + blocks.len() - 1) % blocks.len()].gap_bits
+        } else {
+            0
+        };
+        let from = block_start as isize - lead as isize;
+        let to = (block_start + blocks[blk].block_bits) as isize;
+        for i in from..to {
+            weights[i.rem_euclid(track_bits as isize) as usize] += delta;
+        }
+    }
+
+    // Rotate to the index as the cells were, then keep only the changes.
+    let mut spans: Vec<(u32, u16)> = Vec::new();
+    for bit in 0..track_bits {
+        let weight = weights[(bit + track_bits - start) % track_bits];
+        let permille = weight.clamp(1, i32::from(u16::MAX)) as u16;
+        if spans.last().is_none_or(|&(_, last)| last != permille) {
+            spans.push((bit as u32, permille));
+        }
+    }
+    if spans
+        .iter()
+        .all(|&(_, permille)| i32::from(permille) == DENSITY_NOMINAL_PERMILLE)
+    {
+        return Vec::new();
+    }
+    spans
 }
 
 /// Encode every block of a track back to back, returning the cells and the
@@ -1409,6 +1531,120 @@ pub(crate) mod tests {
 
         let err = decode(&image_bytes).expect_err("an HD cell rate is not an Amiga DD disk");
         assert!(format!("{err:#}").contains("signal type"));
+    }
+
+    /// Eleven blocks with a gap after each, in the shape of a mastered
+    /// protection track, under the given density model.
+    fn density_ipf_image(density: u32, gap_bits: usize, start_bit: u32) -> Vec<u8> {
+        let payload: Vec<u8> = (0..SECTOR_BYTES).map(|i| (i % 251) as u8).collect();
+        let mut stream = sample(DATA_GAP, 2, &[0, 0]);
+        stream.extend_from_slice(&sample(DATA_SYNC, 4, &[0x44, 0x89, 0x44, 0x89]));
+        stream.extend_from_slice(&sample(DATA_DATA, SECTOR_BYTES, &payload));
+        stream.push(0);
+
+        let descriptors = SECTORS * BLOCK_DESCRIPTOR_LEN;
+        let mut area = Vec::new();
+        for sector in 0..SECTORS {
+            area.extend_from_slice(&block_descriptor(
+                BLOCK_BITS,
+                gap_bits,
+                0,
+                0,
+                0,
+                descriptors + sector * stream.len(),
+            ));
+        }
+        // Block 0's gap-value word doubles as the Brierley density key: make
+        // it a recognisable bit pattern.
+        area[24..28].copy_from_slice(&0x0000_0155u32.to_be_bytes());
+        for _ in 0..SECTORS {
+            area.extend_from_slice(&stream);
+        }
+
+        let track = Track {
+            density,
+            start_bit,
+            data_bits: (SECTORS * BLOCK_BITS) as u32,
+            gap_bits: (SECTORS * gap_bits) as u32,
+            track_bits: (SECTORS * (BLOCK_BITS + gap_bits)) as u32,
+            blocks: SECTORS as u32,
+            ..Track::default()
+        };
+        image(track, &area, ENCODER_CAPS, 1)
+    }
+
+    /// Copylock's key sectors are mastered at other cell rates: the CAPS
+    /// profile speeds block 4 by 5.5%, block 5 by 0.5% and slows block 6 by
+    /// 4.5%, each run beginning at the gap before its block and ending with
+    /// the block's own cells.
+    #[test]
+    fn copylock_density_profile_covers_the_key_sectors_and_their_leading_gaps() {
+        const GAP: usize = 720;
+        let block = (BLOCK_BITS + GAP) as u32;
+        let track = only_track(&density_ipf_image(DENSITY_COPYLOCK_AMIGA, GAP, 0));
+        assert_eq!(
+            track.density,
+            vec![
+                (0, 1000),
+                (4 * block - GAP as u32, 945),
+                (5 * block - GAP as u32, 995),
+                (6 * block - GAP as u32, 1045),
+                (6 * block + BLOCK_BITS as u32, 1000),
+            ]
+        );
+        // The profile sits on the revolution as rotated to the index, like
+        // the cells do.
+        let rotated = only_track(&density_ipf_image(DENSITY_COPYLOCK_AMIGA, GAP, 1176));
+        assert_eq!(
+            rotated.density,
+            vec![
+                (0, 1000),
+                (4 * block - GAP as u32 + 1176, 945),
+                (5 * block - GAP as u32 + 1176, 995),
+                (6 * block - GAP as u32 + 1176, 1045),
+                (6 * block + BLOCK_BITS as u32 + 1176, 1000),
+            ]
+        );
+    }
+
+    /// The other models weight the block's cells alone; the density-key one
+    /// takes a bit per block from block 0's gap value word.
+    #[test]
+    fn speedlock_and_brierley_density_profiles_weight_the_blocks_alone() {
+        const GAP: usize = 720;
+        let block = (BLOCK_BITS + GAP) as u32;
+        let speedlock = only_track(&density_ipf_image(DENSITY_SPEEDLOCK_AMIGA, GAP, 0));
+        assert_eq!(
+            speedlock.density,
+            vec![
+                (0, 1000),
+                (block, 1100),
+                (block + BLOCK_BITS as u32, 1000),
+                (2 * block, 900),
+                (2 * block + BLOCK_BITS as u32, 1000),
+            ]
+        );
+
+        // Key 0x155 = bits 0, 2, 4, 6, 8 set: blocks 1, 3, 5, 7, 9 fast, the
+        // rest slow.
+        let keyed = only_track(&density_ipf_image(DENSITY_BRIERLEY_AMIGA_KEY, GAP, 0));
+        let mut expected = vec![(0u32, 1000u16)];
+        for blk in 1..SECTORS as u32 {
+            let permille = if blk % 2 == 1 { 950 } else { 1050 };
+            expected.push((blk * block, permille));
+            expected.push((blk * block + BLOCK_BITS as u32, 1000));
+        }
+        assert_eq!(keyed.density, expected);
+    }
+
+    /// A uniform track has no profile, and a density model this decoder does
+    /// not know still decodes -- at the nominal rate throughout.
+    #[test]
+    fn uniform_and_unknown_density_models_decode_without_a_profile() {
+        assert!(only_track(&amigados_ipf_image()).density.is_empty());
+        let unknown = only_track(&density_ipf_image(42, 720, 0));
+        assert!(unknown.density.is_empty());
+        assert_eq!(unknown.bit_len as usize, SECTORS * (BLOCK_BITS + 720));
     }
 
     /// Files the CAPS encoder wrote spend the flags word on other fields, so

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -340,7 +340,13 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      cursor has to travel with the state. `irq_latency_visible_at` replaces
 //      the single IPL-pipe countdown with one delivery deadline per interrupt
 //      source, in absolute colour clocks.
-pub const STATE_VERSION: u32 = 71;
+//  72: the floppy controller lost the DSKBYTR track-grid position tracking
+//      (`last_dskbytr_pos`, `last_stream_sync_pos`): DSKBYTR's byte and
+//      WORDEQUAL now come from Paula's read shifter on the framing a
+//      WORDSYNC match resets, as on hardware. Raw track images
+//      (`FloppyTrackImage::RawMfm`) and cached revolutions (`TrackRev`)
+//      gained the mastered cell-rate profile of IPF density models.
+pub const STATE_VERSION: u32 = 72;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -341,9 +341,10 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      the single IPL-pipe countdown with one delivery deadline per interrupt
 //      source, in absolute colour clocks.
 //  72: the floppy controller lost the DSKBYTR track-grid position tracking
-//      (`last_dskbytr_pos`, `last_stream_sync_pos`): DSKBYTR's byte and
-//      WORDEQUAL now come from Paula's read shifter on the framing a
-//      WORDSYNC match resets, as on hardware. Raw track images
+//      and the WORDEQUAL latch (`last_dskbytr_pos`, `last_stream_sync_pos`,
+//      `word_equal_latch`): DSKBYTR's byte and WORDEQUAL now come from
+//      Paula's read shifter on the framing a WORDSYNC match resets, as on
+//      hardware. Raw track images
 //      (`FloppyTrackImage::RawMfm`) and cached revolutions (`TrackRev`)
 //      gained the mastered cell-rate profile of IPF density models.
 pub const STATE_VERSION: u32 = 72;


### PR DESCRIPTION
Fixes #610 (Lemmings IPF freezes on a black screen just before the disk 2 prompt).

The freeze is Rob Northen Copylock failing on the IPF's key track (cylinder 0 head 1, IPF density model 3). Copylock reads that sector byte by byte through DSKBYTR: it waits for WORDEQUAL, collects the bytes while counting how often it polled between them, rejects the read unless the first two bytes are the MFM of the sector's first data byte (`CMPI.W #$2A91,(A0)` after sync `$8911`), and then times a second sector (`$8912`) against the first, demanding `(count8911 - count8912) * 100 / count8912 >= 2`. Two independent hardware-model defects broke this:

## 1. DSKBYTR byte framing

`read_dskbytr` served bytes from the track's own byte grid (`rotation_bit / 8`), but Paula frames DSKBYTR with the bit counter a WORDSYNC match resets. Syncs on an IPF or flux track sit at any bit phase (phase 1 here), so the bytes came out shifted and Copylock retried every revolution forever. Synthesised AmigaDOS tracks hid this because their syncs are word-aligned.

DSKBYTR's byte, DSKBYT and WORDEQUAL now come from the read shifter (`take_dskbyt` / `sync_matched`), and the shifter reframes on every WORDSYNC match even with no transfer running: Copylock arms a zero-length read (`DSKLEN=$8000` twice), which completes on arming (as in WinUAE), and relies on the free-running comparator from then on. The grid-position fields (`last_dskbytr_pos`, `last_stream_sync_pos`) are gone and `read_dskbytr` lost its unused `adkcon` parameter.

## 2. IPF density profiles

Density models 3..9 decoded with uniform 2 us cells, so the timing ratio was 0%: Copylock handed the game a wrong key, the disk 2 prompt appeared, and the game crashed to garbage once disk 2 loaded. `ipf.rs` now emits the CAPS library's own profiles (cross-checked against capsimg's `GenerateCLA`/`CLA2`/`CLST`/`SLA`/`SLA2`/`ABA`/`ABA2` and Keir Fraser's libdisk `copylock.c`) as per-mille cell-time spans: Copylock Amiga slows/speeds blocks 4-6 by -5.5/-0.5/+4.5% from the preceding gap through the block (the newer scheme blocks 0-2); Copylock ST, Speedlock and the Brierley models weight single blocks; the Brierley density-key model takes a bit per block from block 0's gap value word. `FloppyTrackImage::RawMfm` carries the spans and `TrackRev::prefix_cck` scales each cell's clock by its run's weight; uniform tracks keep the exact old arithmetic. Weak bits remain the one IPF modelling gap.

## State version

`STATE_VERSION` 71 -> 72: the floppy controller's grid fields leave the state and `RawMfm`/`TrackRev` gain the profile.

## Tests

Seven tests that pinned the grid model move to hardware semantics (a byte is ready once its eight cells have shifted through; WORDEQUAL follows the comparator). New: `dskbytr_bytes_frame_from_the_sync_at_any_bit_phase`, `zero_length_arm_then_polled_bytes_frame_from_the_sync`, `track_rev_density_profile_scales_the_cells_it_covers`, `raw_mfm_track_stream_carries_the_density_profile`, and IPF profile tests for Copylock (including the index rotation), Speedlock, the Brierley key model, and unknown models. `cargo test` (3085 passed), `cargo clippy --all-targets` and `cargo fmt --check` are clean.

## Verification

Headless KS 1.3 A500 boot of the IPF set: Copylock passes on its first attempt at 116 s, the "insert disk 2" prompt appears at 130 s, and after `--insert-disk-after 131 df0 Lemmings_Disk2.ipf --click-after 134 left 100` the game loads disk 2 to its main menu (200 s). Before the fix the same run stays black indefinitely.

Noted but not changed: disk 2's cylinder 0 is unformatted in the IPF, and Copperline serves no cells for such tracks where hardware and capsimg deliver noise. The loader's 25-word read there completes anyway, so it is harmless here.
