### PR TITLE
Per-axis PAR-aware integer scaling under the tv pixel aspect

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -605,12 +605,15 @@ video = "PAL"
 # scanline, so a 320x256 lo-res screen is an exact 640x512 -- handy for
 # pixel-exact comparison against square-pixel emulators). scaling: how that
 # canvas reaches the window. "smooth" (default; fit to the window preserving
-# aspect ratio, interpolated) or "integer" (the largest whole-number multiple
-# of the canvas that fits, centred in black borders and point-sampled, in the
-# spirit of WinUAE/Amiberry integer scaling). Integer covers RTG modes too,
-# at multiples of their own native resolution, and falls back to the smooth
-# fit when the window is too small for even 1x rather than cropping.
-# Pair it with pixel_aspect = "square" for a fully pixel-exact picture.
+# aspect ratio, interpolated) or "integer" (whole-number multiples of the
+# unresampled canvas, centred in black borders and point-sampled, in the
+# spirit of WinUAE/Amiberry integer scaling). Under the tv aspect the two
+# axes take separate whole numbers -- pixels per column and per scan line,
+# chosen for the 4:3 pixel shape, so an NTSC game on a 1080p screen draws
+# at 4:5 pixels (1280x1000 with autocrop) rather than squat square ones;
+# under square pixels the multiple is uniform. Integer covers RTG modes
+# too, at multiples of their own native resolution, and falls back to the
+# smooth fit when the window is too small for even 1x rather than cropping.
 # autocrop: crop the window presentation to the display window the
 # hardware programs (default false), so a game using fewer lines than the
 # full scan fills more of a 16:9/21:9 screen; with integer scaling the

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -727,11 +727,12 @@ flips the mode live without touching the config, and
 a separate question from what the canvas is. The default `"smooth"` fits the
 canvas to the window preserving its aspect ratio and interpolates, so the
 picture always uses the full window height (or width) whatever fraction the
-scale works out to. `"integer"` instead draws the canvas at the largest
-whole-number multiple of itself that fits the window, measured in physical
-device pixels, centred in black borders and point-sampled: every canvas
-pixel becomes the same square block of host pixels, with no row or column
-sampled twice, which is the look WinUAE and Amiberry call integer scaling.
+scale works out to. `"integer"` instead draws the canvas at whole-number
+multiples -- the largest that fits the window, measured in physical device
+pixels, and under the TV aspect a separate whole number per axis (below)
+-- centred in black borders and point-sampled: every canvas pixel becomes
+the same block of host pixels, with no row or column sampled twice, which
+is the look WinUAE and Amiberry call integer scaling.
 The fit is taken in whole canvas pixels against the physical surface --
 the canvas is re-rendered at whatever factor fits, rather than drawn at
 whole multiples of a fixed high-DPI texture -- so every step exists on
@@ -749,16 +750,40 @@ what fits. RTG board modes follow the setting too: their frame is scaled
 from its own native resolution, so a 640x480 board screen is drawn at 1x,
 2x, 3x of *those* pixels inside the display area.
 
-`pixel_aspect = "square"` with `scaling = "integer"` is the fully
-pixel-exact combination: the square-pixel canvas is one host row per woven
-scanline, so a whole-number window scale carries the emulated bitmap to the
-screen untouched. Integer scaling of the default TV aspect is still crisp,
-but crisp pixels of an already-resampled image -- that canvas fits the scan
-onto 537 rows for the 4:3 shape before presentation. The monitor-bezel mode
-(`bezel`) composes with either, but its picture opening is a fraction of
-the window by design and is not itself integer-exact. The menu's *Video
-Settings > Scaling* item switches modes live without touching the config;
-there is no environment-variable override.
+Integer scaling always draws from the unresampled canvas -- one host row
+per woven scanline, the canvas `pixel_aspect = "square"` presents -- so a
+whole-number scale carries the emulated bitmap to the screen untouched
+under either aspect. Under the default TV aspect the two axes take
+separate whole numbers: the picture is the TV aperture, drawn at a whole
+number of device pixels per hi-res column and a whole number per scan
+line, chosen to approximate the pixel shape of the 4:3 glass (the shape
+the smooth TV presentation resamples to: a PAL pixel about 1.08 times
+wider than tall, an NTSC one about 0.85). The choice is the tallest fit
+whose shape stays within a tenth of the glass's, so an NTSC 200-line game
+on a 1080p screen gets two pixels per column and five per line -- the
+4:5 pixel of [amiga.vision's NTSC guide](https://amiga.vision/ntsc), a
+1280x1000 picture -- 6:7 at 1440p and 4:5 again at 4K, while PAL, whose
+glass shape is within a tenth of square, takes the square multiples until
+a display is tall enough for 8:7. The count per scan line may be odd: a
+non-interlaced display's two woven rows per line are identical, so the
+line still lands as one exact block, and only an interlaced display shows
+its two fields' rows at alternating heights then. A window too short for
+even one pixel per line falls back to the smooth fit of the same shape.
+`pixel_aspect = "square"` with `"integer"` keeps the uniform square
+multiples instead, exact in the same way, for side-by-side pixel
+comparison. Pair either with `autocrop` (below): the fit is retaken
+against the picture the hardware draws, which is what earns the extra
+lines a taller shape needs (the uncropped NTSC aperture on a 1080p screen
+only has room for square pixels). The window resizes to the unresampled
+canvas when the TV aspect switches to or from integer scaling, as it does
+for a pixel-aspect change; captures keep the aspect's own shape whatever
+the window draws. The monitor-bezel mode (`bezel`) keeps the resampled TV
+canvas under either scaling: its picture opening is a fraction of the
+window by design and is not itself integer-exact. Programmable (ECS/AGA
+VARBEAMEN) scans and RTG board screens, which present their own geometry,
+take a uniform multiple of the canvas. The menu's *Video Settings >
+Scaling* item switches modes live without touching the config; there is
+no environment-variable override.
 
 `autocrop` (default off) crops the window presentation to the display
 window the hardware actually programs, instead of the fixed TV aperture:

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -343,17 +343,22 @@ belongs to the Amiga.
   (see [Configuration](configuration.md)).
 - **Scaling**: how that canvas is drawn into the window -- **Smooth** (the
   default: fit to the window preserving aspect ratio, interpolated) or
-  **Integer** (the largest whole-number multiple of the canvas that fits,
-  centred in black borders and point-sampled, so every canvas pixel is the
-  same square block of host pixels). The fit is taken in whole canvas
-  pixels, so every step exists on high-DPI and fractional-scale displays
-  alike. Integer scaling applies to RTG board modes too, at multiples of
-  their own native resolution, and gives way to the smooth fit when the
-  window cannot hold even a 1:1 copy rather than cropping the picture. The
-  window never resizes when it changes, and a video recording carries on
-  underneath. The start-up mode is
-  `[display] scaling`, which also notes which pixel-aspect pairing is
-  fully pixel-exact (see [Configuration](configuration.md)).
+  **Integer** (whole-number multiples of the unresampled canvas, centred
+  in black borders and point-sampled, so every canvas pixel is the same
+  block of host pixels). Under the TV aspect the two axes take separate
+  whole numbers -- pixels per column and per scan line -- chosen to
+  approximate the 4:3 pixel shape, so an NTSC game on a 1080p screen is
+  drawn at 4:5 pixels rather than squat square ones; under square pixels
+  the multiple is uniform. The fit is taken in whole canvas pixels, so
+  every step exists on high-DPI and fractional-scale displays alike.
+  Integer scaling applies to RTG board modes too, at multiples of their
+  own native resolution, and gives way to the smooth fit when the window
+  cannot hold even a 1:1 copy rather than cropping the picture. Under the
+  TV aspect the window resizes to the unresampled canvas when the mode
+  changes, as it does for a pixel-aspect change; a video recording carries
+  on underneath either way, at the aspect's own shape. The start-up mode
+  is `[display] scaling`, which describes the per-axis fit and its
+  pairing with autocrop (see [Configuration](configuration.md)).
 - **Autocrop**: crop the presentation to the picture the hardware
   fetches, so a game driving fewer lines than the full scan fills more
   of a wide screen; with integer scaling the whole-number fit is retaken

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -629,6 +629,40 @@ crop shows. Only a pass that owns the whole display rect falls back to
 the classic layout -- the bezel's fixed opening, RTG scanout -- along
 with programmable scans; captures never see the crop.
 
+Integer scaling presents from the square canvas under either aspect
+(`video::square_canvas`): `present_height()` -- the window canvas the
+texture, the tool windows and every overlay size themselves from -- is
+`PRESENT_HEIGHT_SQUARE` for the square aspect and for integer scaling,
+`PRESENT_HEIGHT_TV` otherwise and under a bezel; captures size themselves
+from `capture_height()`, the aspect's own, so a scaling or bezel toggle
+never changes a saved picture. A whole-number draw is only pixel-exact
+from an unresampled canvas, and under the tv aspect the layout then puts
+the 4:3 shape back with a separate whole-number factor per axis.
+`DisplaySrc` (`window/present.rs`) carries the sub-rect to show -- the TV
+aperture's rect on the square canvas (`aperture_canvas_rect`), or the
+autocrop content rect -- and the pixel shape to draw it at: `glass_par`,
+the tv canvas's own resample read back (`FB_WIDTH / TV_CAPTURED_WIDTH`
+wide by `PRESENT_HEIGHT_TV / aperture rows` tall: PAL 1.078, NTSC 0.854;
+the whole field over the glass for full overscan). `per_axis_fit` then
+picks surface pixels per canvas column and per *field line*: the tallest
+fit whose shape is within 11/10 of the glass's, the closest shape among
+those of that height, and the closest shape at the largest size when
+none is inside the tolerance -- exact integer arithmetic, so every host
+agrees. Counting per field line rather than per woven row is what
+reaches 4:5 on a 1080p display: a non-interlaced line's two woven rows
+are identical, so an odd count per line is still one exact block per
+line, and the scaler's sample centres can never coincide with a line
+boundary -- every display rect starts on a woven pair, and the sample
+positions a half-row factor leaves ambiguous fall between the two rows
+of a pair (`display_rects_start_on_field_lines`). The chrome band, the
+cursor mapping and the CRT-preset viewport follow the rect exactly as
+they do for autocrop, and the two modes compose (autocrop supplies the
+rect, the per-axis fit the factors). A bezel keeps the tv canvas -- its
+opening resamples the whole glass -- and the canvas change it, the
+scaling toggle and the pixel aspect each provoke goes through one path
+(`App::resync_canvas_geometry`); RTG board frames and programmable scans
+take the classic uniform multiple of the square canvas.
+
 Every redraw first re-syncs the surface to the host window's current size
 (`resync_surface_size`), rather than trusting the Resized event to have
 arrived first. `pixels` rebuilds its swapchain from the size the last

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -315,8 +315,9 @@ pub struct Config {
     pub pixel_aspect: PixelAspect,
     /// How the presentation canvas is scaled into the window: aspect-fit
     /// with filtering, or whole-number multiples only. See
-    /// [`DisplayScaling`]. Orthogonal to `pixel_aspect`, which decides what
-    /// the canvas itself is.
+    /// [`DisplayScaling`]. A separate question from `pixel_aspect`, which
+    /// decides the shape of the picture; integer scaling draws that shape
+    /// from the unresampled canvas under either aspect.
     pub scaling: DisplayScaling,
     /// Crop the window presentation to the display window the hardware
     /// programs (`[display] autocrop`, default off), so a display using
@@ -485,11 +486,15 @@ pub enum DisplayScaling {
     /// whatever the ratio works out to. The default.
     #[default]
     Smooth,
-    /// Draw the canvas at the largest whole-number multiple of itself that
-    /// fits the window, centred in black borders and point-sampled, so
-    /// every canvas pixel is the same square block of host pixels. Falls
-    /// back to the smooth fit when the window is too small for even 1x,
-    /// which shrinks rather than crops.
+    /// Draw the canvas at whole-number multiples, centred in black borders
+    /// and point-sampled, so every canvas pixel is the same block of host
+    /// pixels. Always from the unresampled (square) canvas: the largest
+    /// uniform multiple under the square aspect, and under the tv aspect a
+    /// separate whole number per axis -- pixels per column and per scan
+    /// line -- chosen to approximate the 4:3 pixel shape
+    /// (`video::window::present::per_axis_fit`). Falls back to the smooth
+    /// fit when the window is too small for even 1x, which shrinks rather
+    /// than crops.
     Integer,
 }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1397,7 +1397,7 @@ impl M68kMachine {
             &fb,
             canvas_width as u32,
             present_rows as u32,
-            (crate::video::present_height() * canvas_scale) as u32,
+            (crate::video::capture_height() * canvas_scale) as u32,
         ) {
             Ok(()) => log::info!("  screenshot: {path}"),
             Err(e) => log::warn!("  screenshot failed ({path}): {e:#}"),

--- a/src/video/mod.rs
+++ b/src/video/mod.rs
@@ -121,8 +121,10 @@ pub fn set_pixel_aspect(aspect: crate::config::PixelAspect) {
 /// How the presentation canvas is scaled into the window
 /// (`[display] scaling`, runtime-toggled by the menu's Scaling item).
 /// Main thread only, like [`SQUARE_PIXEL_ASPECT`]; the atomic only
-/// satisfies `static` safety. Independent of the pixel aspect: that
-/// decides what the canvas is, this decides how it reaches the window.
+/// satisfies `static` safety. The pixel aspect decides the picture's
+/// shape and this decides how it reaches the window -- but integer
+/// scaling draws from the unresampled canvas, so it has a say in the
+/// canvas height too ([`square_canvas`]).
 static INTEGER_SCALING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 pub fn set_display_scaling(scaling: crate::config::DisplayScaling) {
@@ -138,6 +140,22 @@ pub fn display_scaling() -> crate::config::DisplayScaling {
     } else {
         crate::config::DisplayScaling::Smooth
     }
+}
+
+/// Whether a monitor bezel is drawn around the picture (`[display] bezel`,
+/// runtime-toggled by the menu and its shortcut). A mirror of the window's
+/// own style field for the canvas rule below: a bezel's fixed 4:3 opening
+/// keeps the tv canvas under integer scaling, so the canvas height has to
+/// know. Main thread only, like [`SQUARE_PIXEL_ASPECT`]; the atomic only
+/// satisfies `static` safety.
+static BEZEL_SHOWN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+pub fn set_bezel_shown(shown: bool) {
+    BEZEL_SHOWN.store(shown, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn bezel_shown() -> bool {
+    BEZEL_SHOWN.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Whether the window presentation crops to the display window the
@@ -362,14 +380,61 @@ pub fn pixel_aspect() -> crate::config::PixelAspect {
     }
 }
 
-/// Presentation height for the active pixel aspect. The pure
-/// [`present_height_for`] variant is what unit tests target, so they
-/// never have to mutate the process-global mode.
+/// Height of the window's presentation canvas: the display region of the
+/// backing texture, which the window, the tool windows and every overlay
+/// size themselves from. The pure [`present_height_for`] variant is what
+/// unit tests target, so they never have to mutate the process-global
+/// modes.
 pub fn present_height() -> usize {
-    present_height_for(pixel_aspect())
+    present_height_for(pixel_aspect(), display_scaling(), bezel_shown())
 }
 
-pub fn present_height_for(aspect: crate::config::PixelAspect) -> usize {
+/// Whether the window canvas keeps one row per woven scanline
+/// (`PRESENT_HEIGHT_SQUARE`) rather than the 4:3 resample
+/// (`PRESENT_HEIGHT_TV`). The square-pixel aspect asks for that outright.
+/// Integer scaling asks for it too, whatever the aspect: a whole-number
+/// draw is only pixel-exact from an unresampled canvas, and under the tv
+/// aspect the scaler pass then draws the square canvas with a separate
+/// whole-number factor per axis to put the 4:3 shape back
+/// (`window/present.rs`, `per_axis_fit`). A monitor bezel is the exception:
+/// its fixed opening frames the whole glass and shows the aperture
+/// resampled onto it, so it keeps the tv canvas for the tv aspect.
+pub fn square_canvas() -> bool {
+    square_canvas_for(pixel_aspect(), display_scaling(), bezel_shown())
+}
+
+pub fn square_canvas_for(
+    aspect: crate::config::PixelAspect,
+    scaling: crate::config::DisplayScaling,
+    bezel_shown: bool,
+) -> bool {
+    aspect == crate::config::PixelAspect::Square
+        || (scaling == crate::config::DisplayScaling::Integer && !bezel_shown)
+}
+
+pub fn present_height_for(
+    aspect: crate::config::PixelAspect,
+    scaling: crate::config::DisplayScaling,
+    bezel_shown: bool,
+) -> usize {
+    if square_canvas_for(aspect, scaling, bezel_shown) {
+        PRESENT_HEIGHT_SQUARE
+    } else {
+        PRESENT_HEIGHT_TV
+    }
+}
+
+/// Height of the capture canvas: the pixel aspect's own presentation of
+/// the field, which screenshots, frame dumps and video recordings save.
+/// Captures are presentation-independent -- the scaling mode and the
+/// bezel decide how the window draws, never what a saved picture is -- so
+/// this follows the aspect alone, where [`present_height`] follows the
+/// window's canvas rule.
+pub fn capture_height() -> usize {
+    capture_height_for(pixel_aspect())
+}
+
+pub fn capture_height_for(aspect: crate::config::PixelAspect) -> usize {
     match aspect {
         crate::config::PixelAspect::Tv => PRESENT_HEIGHT_TV,
         crate::config::PixelAspect::Square => PRESENT_HEIGHT_SQUARE,
@@ -385,4 +450,37 @@ pub fn blend_rgba(a: u32, b: u32, frac: u32) -> u32 {
     let rb = ((a & 0x00FF_00FF) * inv + (b & 0x00FF_00FF) * frac) >> 8;
     let ag = (((a >> 8) & 0x00FF_00FF) * inv + ((b >> 8) & 0x00FF_00FF) * frac) >> 8;
     (rb & 0x00FF_00FF) | ((ag & 0x00FF_00FF) << 8)
+}
+
+#[cfg(test)]
+mod canvas_rule_tests {
+    use super::*;
+    use crate::config::{DisplayScaling, PixelAspect};
+
+    /// The canvas is square for the square aspect, and for integer
+    /// scaling under either aspect unless a bezel is drawn; captures
+    /// follow the aspect alone.
+    #[test]
+    fn integer_scaling_takes_the_square_canvas_unless_a_bezel_is_drawn() {
+        let tv = PixelAspect::Tv;
+        let square = PixelAspect::Square;
+        let (smooth, integer) = (DisplayScaling::Smooth, DisplayScaling::Integer);
+        assert_eq!(present_height_for(tv, smooth, false), PRESENT_HEIGHT_TV);
+        assert_eq!(
+            present_height_for(tv, integer, false),
+            PRESENT_HEIGHT_SQUARE
+        );
+        assert_eq!(present_height_for(tv, integer, true), PRESENT_HEIGHT_TV);
+        assert_eq!(present_height_for(tv, smooth, true), PRESENT_HEIGHT_TV);
+        for scaling in [smooth, integer] {
+            for bezel in [false, true] {
+                assert_eq!(
+                    present_height_for(square, scaling, bezel),
+                    PRESENT_HEIGHT_SQUARE
+                );
+            }
+        }
+        assert_eq!(capture_height_for(tv), PRESENT_HEIGHT_TV);
+        assert_eq!(capture_height_for(square), PRESENT_HEIGHT_SQUARE);
+    }
 }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1990,6 +1990,11 @@ impl App {
             .run_ahead_frames
             .unwrap_or(0)
             .min(crate::config::RUN_AHEAD_MAX_FRAMES);
+        // The canvas rule reads the bezel through its own mirror
+        // (`present_height`), and the window is sized from the canvas
+        // before the first frame: seed it with the style the window opens
+        // with, as `main` seeds the aspect and the scaling.
+        crate::video::set_bezel_shown(bezel.is_on());
         let mut app = Self {
             emu,
             serial_is_midi,
@@ -3781,11 +3786,11 @@ impl ApplicationHandler for App {
             WindowEvent::CursorMoved { position, .. } => {
                 let previous_cursor_pos = self.cursor_pos;
                 self.last_cursor_phys = Some(position);
-                let autocrop_src = self.autocrop_canvas_src();
+                let display_src = self.display_canvas_src();
                 let pos = self
                     .render
                     .as_ref()
-                    .and_then(|r| main_cursor_position(r, autocrop_src, position));
+                    .and_then(|r| main_cursor_position(r, display_src, position));
                 // A button held on the dial turns it by following the hand
                 // round the face.
                 #[cfg(feature = "mt32")]
@@ -4172,9 +4177,9 @@ impl ApplicationHandler for App {
                 // a redraw, so re-mapping the cached host position here
                 // keeps hover and click hit-testing aligned with the
                 // pixels this frame actually shows.
-                let autocrop_src = self.autocrop_canvas_src();
+                let display_src = self.display_canvas_src();
                 if let (Some(phys), Some(r)) = (self.last_cursor_phys, self.render.as_ref()) {
-                    self.cursor_pos = main_cursor_position(r, autocrop_src, phys);
+                    self.cursor_pos = main_cursor_position(r, display_src, phys);
                 }
                 let status = status_with_latched_fdd_track(
                     self.emu.bus().front_panel_status(),
@@ -4353,8 +4358,14 @@ impl ApplicationHandler for App {
                     );
                     // The corner overlays anchor to the display region the
                     // viewer actually sees: the whole display classically,
-                    // the crop rect while autocrop presents.
-                    let overlay_anchor = autocrop_src.unwrap_or((0, 0, FB_WIDTH, present_height()));
+                    // the sub-rect while autocrop or per-axis scaling
+                    // presents one.
+                    let overlay_anchor = display_src.map(|src| src.rect).unwrap_or((
+                        0,
+                        0,
+                        FB_WIDTH,
+                        present_height(),
+                    ));
                     if recording {
                         // Painted into the presentation texture only, so
                         // the badge never appears in the recorded file.
@@ -4396,21 +4407,27 @@ impl ApplicationHandler for App {
                     // the same display rect, and the cursor mapping inverts
                     // the same layout, so all of them agree by construction.
                     // The branches that draw over the display (RTG, CRT,
-                    // bezel) only run when autocrop is suspended, so their
-                    // layout is the classic whole-texture letterbox.
-                    let layout = main_present_layout(r, autocrop_src);
+                    // bezel) only run when the sub-rect modes are
+                    // suspended, so their layout is the classic
+                    // whole-texture letterbox.
+                    let layout = main_present_layout(r, display_src);
                     // COPPERLINE_DIAG_AUTOCROP: the window half of the
                     // renderer-side envelope trace -- the exact rects the
                     // scaler pass draws this frame, logged when they
                     // change, with the mode spelled out: a classic layout
-                    // must say WHY it is classic (toggle off, or which
-                    // condition suspended the crop), because the envelope
-                    // line prints whether or not the mode is on and the
-                    // difference is invisible from it alone.
+                    // must say WHY it is classic (both modes off, or which
+                    // condition suspended them), because the envelope
+                    // line prints whether or not a mode is on and the
+                    // difference is invisible from it alone. The factors
+                    // are the whole-number draw's pixels per canvas
+                    // column and per field line, and the shape is the
+                    // glass ratio a per-axis draw aims at.
                     if crate::envcfg::flag("COPPERLINE_DIAG_AUTOCROP")
                         && self.last_diag_layout != Some(layout)
                     {
-                        let mode = if !crate::video::autocrop() {
+                        let autocrop = crate::video::autocrop();
+                        let per_axis = per_axis_scaling_requested();
+                        let mode = if !autocrop && !per_axis {
                             "off"
                         } else if self.rtg_present_dims.is_some() {
                             "suspended(rtg)"
@@ -4420,18 +4437,25 @@ impl ApplicationHandler for App {
                             "suspended(canvas-width)"
                         } else if self.bezel.is_on() {
                             "suspended(bezel)"
+                        } else if autocrop && per_axis {
+                            "active(autocrop+per-axis)"
+                        } else if per_axis {
+                            "active(per-axis)"
                         } else {
-                            "active"
+                            "active(autocrop)"
                         };
                         info!(
                             "[DIAG_AUTOCROP] layout mode={} surface={:?} src_canvas={:?} \
-                             display_dst={:?} chrome_dst={:?} filter={:?}",
+                             display_dst={:?} chrome_dst={:?} filter={:?} factors={:?} \
+                             shape={:?}",
                             mode,
                             r.surface_size,
                             layout.src_canvas,
                             layout.display_dst,
                             layout.chrome_dst,
                             layout.filter,
+                            layout.factors,
+                            display_src.map(|src| src.par),
                         );
                         self.last_diag_layout = Some(layout);
                     }
@@ -4505,13 +4529,13 @@ impl ApplicationHandler for App {
                         let kind = self.crt_shader_kind;
                         let strength = self.shader_strength;
                         let bezel_style = self.bezel;
-                        // Under the autocrop layout the preset re-draws the
-                        // crop into the crop's own viewport -- the same
+                        // Under a sub-rect layout the preset re-draws the
+                        // rect into the rect's own viewport -- the same
                         // sub-rect the scaler pass just drew -- with the
-                        // beam-line count scaled to the rows the crop shows.
-                        // The bezel suspends autocrop, so this is never the
-                        // bezel case.
-                        let crt_crop = autocrop_src.map(|_| {
+                        // beam-line count scaled to the rows the rect shows.
+                        // The bezel suspends the sub-rect modes, so this is
+                        // never the bezel case.
+                        let crt_crop = display_src.map(|_| {
                             (
                                 layout.display_dst,
                                 layout.src_canvas,

--- a/src/video/window/app_display.rs
+++ b/src/video/window/app_display.rs
@@ -298,13 +298,29 @@ impl App {
     /// Draw a given monitor front for the rest of the run (the config file
     /// default is unchanged; set `[display] bezel` to make it stick).
     pub(super) fn set_bezel(&mut self, style: BezelStyle) {
+        self.apply_bezel_style(style);
+        info!("monitor bezel: {}", style.label());
+        self.show_osd(format!("Monitor bezel: {}", style.menu_label()));
+        self.request_redraw();
+    }
+
+    /// Adopt a bezel style: the window's own field, the canvas rule's
+    /// mirror of it (`video::set_bezel_shown`), and -- when that moves
+    /// the canvas between the tv and the square geometry, which it does
+    /// under integer scaling of the tv aspect (`video::square_canvas`) --
+    /// the texture and window that follow the canvas. Says nothing on
+    /// screen: the toggle announces itself, a machine start does not.
+    pub(super) fn apply_bezel_style(&mut self, style: BezelStyle) {
+        let was_canvas_sized = self.window_is_canvas_sized();
+        let canvas_before = window_present_height();
         self.bezel = style;
         if style.is_on() {
             self.bezel_last = style;
         }
-        info!("monitor bezel: {}", style.label());
-        self.show_osd(format!("Monitor bezel: {}", style.menu_label()));
-        self.request_redraw();
+        crate::video::set_bezel_shown(style.is_on());
+        if window_present_height() != canvas_before {
+            self.resync_canvas_geometry(was_canvas_sized, canvas_before);
+        }
     }
 
     /// Cmd/Alt+P: toggle the performance overlay for the rest of the run
@@ -445,18 +461,29 @@ impl App {
         let was_canvas_sized = self.window_is_canvas_sized();
         let canvas_before = window_present_height();
         crate::video::set_pixel_aspect(aspect);
+        // The square aspect and integer scaling of the tv aspect share the
+        // square canvas, so the height need not change; the geometry
+        // resync is a no-op then, and the texture is re-planned regardless.
+        self.resync_canvas_geometry(was_canvas_sized, canvas_before);
+        self.request_redraw();
+    }
+
+    /// Follow a change of the canvas height that came from a presentation
+    /// setting -- the pixel aspect, integer scaling under the tv aspect,
+    /// the bezel (`video::present_height`): re-plan the main texture for
+    /// the new canvas (the integer fit and its supersample factor are
+    /// re-decided for it, and the texture resized like a DPI change, see
+    /// `resync_render_scale`), put the tool windows -- whose texture
+    /// layout is the canvas's, panel centring reading the live height --
+    /// on the new size too, and move the window with it
+    /// (`follow_canvas_change`).
+    pub(super) fn resync_canvas_geometry(&mut self, was_canvas_sized: bool, canvas_before: usize) {
         if let Some(r) = self.render.as_mut() {
-            // The canvas height changes with the aspect, so re-plan: the
-            // integer fit (and its supersample factor) is re-decided for the
-            // new canvas, and the texture resized to it.
             let surface = r.window.inner_size();
             if let Err(e) = sync_main_present_scaling(r, (surface.width, surface.height)) {
-                warn!("resize texture buffer for pixel aspect failed: {e}");
+                warn!("resize texture buffer for the canvas change failed: {e}");
             }
         }
-        // Tool windows share the canvas-sized texture layout (panel
-        // centring reads the live canvas height), so their buffers and
-        // windows must follow the new size too.
         let size = LogicalSize::new(FB_WIDTH as f64, window_present_height() as f64);
         for kind in ToolPanelKind::ALL {
             let mut applied = None;
@@ -465,7 +492,7 @@ impl App {
                     texture_width(tool.texture_scale) as u32,
                     texture_height(tool.texture_scale) as u32,
                 ) {
-                    warn!("resize tool texture buffer for pixel aspect failed: {e}");
+                    warn!("resize tool texture buffer for the canvas change failed: {e}");
                 }
                 applied = tool.window.request_inner_size(size);
             }
@@ -475,22 +502,29 @@ impl App {
             }
         }
         self.follow_canvas_change(was_canvas_sized, canvas_before);
-        self.request_redraw();
     }
 
     /// Switch how the presentation canvas is scaled into the window live.
     ///
-    /// The canvas itself never changes -- integer mode may re-render it at a
-    /// different supersample factor, but its pixel content, the window size
-    /// and a video recording (whose frames are the 1x canvas, averaged down
-    /// like any supersample) all carry on -- so unlike a pixel-aspect switch
-    /// there is no recording to refuse and no window to re-size.
+    /// Under the square aspect the canvas itself never changes -- integer
+    /// mode may re-render it at a different supersample factor, but its
+    /// pixel content and the window size carry on -- so only the plan is
+    /// re-taken. Under the tv aspect, integer scaling moves the canvas to
+    /// the square geometry and back (`video::square_canvas`: the
+    /// whole-number draw is only exact from an unresampled canvas), which
+    /// is a pixel-aspect-sized change the texture, the tool windows and
+    /// the window all follow. A video recording carries on either way:
+    /// its frames are the aspect's capture canvas, never the window's.
     pub(super) fn apply_display_scaling(&mut self, scaling: DisplayScaling) {
         if scaling == crate::video::display_scaling() {
             return;
         }
+        let was_canvas_sized = self.window_is_canvas_sized();
+        let canvas_before = window_present_height();
         crate::video::set_display_scaling(scaling);
-        if let Some(r) = self.render.as_mut() {
+        if window_present_height() != canvas_before {
+            self.resync_canvas_geometry(was_canvas_sized, canvas_before);
+        } else if let Some(r) = self.render.as_mut() {
             // A minimized window has no surface to re-plan against; the
             // Resized event that restores it re-plans itself.
             if !r.minimized {
@@ -511,49 +545,79 @@ impl App {
         self.request_redraw();
     }
 
-    /// The rect the autocrop presentation shows of the display region,
-    /// in canvas pixels -- or `None` whenever the classic whole-canvas
-    /// layout must present instead: autocrop off, or a frame the mode
-    /// does not apply to (the bezel frames the whole glass with a fixed
-    /// opening, so it wins while it is on; RTG board frames and
-    /// programmable scans present their own geometry). The CRT presets
-    /// compose: the pass re-draws whatever rect the layout shows.
+    /// The sub-rect of the display region the presentation shows, in
+    /// canvas pixels, with the pixel shape it is drawn at -- or `None`
+    /// whenever the classic whole-canvas layout must present instead.
+    /// Two modes show a sub-rect: autocrop (the content rect the hardware
+    /// fetches), and per-axis integer scaling -- integer scaling of the
+    /// tv aspect, which draws the square canvas with its own whole-number
+    /// factor per axis at the glass's pixel shape (`glass_par`), and
+    /// shows the TV aperture's rect of that canvas (`aperture_canvas_rect`)
+    /// unless autocrop tightens it to the content. Neither applies to a
+    /// frame it cannot draw: the bezel frames the whole glass with a fixed
+    /// opening (and keeps the tv canvas, so there is no per-axis draw to
+    /// make), RTG board frames and programmable scans present their own
+    /// geometry. The CRT presets compose: the pass re-draws whatever rect
+    /// the layout shows.
     ///
-    /// While the mode is on, the layout never falls back to the classic
-    /// letterbox: an open menu or panel, or a session with no content
-    /// yet, widens the rect to the full display region instead. The
-    /// overlays draw into the display region against the full canvas
-    /// mapping, so this keeps them entirely visible -- and it keeps the
-    /// status-bar band pinned to the window bottom, rather than hopping
-    /// between the bottom-anchored band and the letterbox's centred bar
-    /// every time a menu opens.
-    pub(super) fn autocrop_canvas_src(&self) -> Option<(usize, usize, usize, usize)> {
-        if !crate::video::autocrop()
-            || self.rtg_present_dims.is_some()
+    /// While a mode is on, the layout never falls back to the classic
+    /// letterbox: an open menu or panel widens the rect to the full
+    /// display region instead, as does a session with no content yet
+    /// under autocrop alone. The overlays draw into the display region
+    /// against the full canvas mapping, so this keeps them entirely
+    /// visible -- and it keeps the status-bar band pinned to the window
+    /// bottom, rather than hopping between the bottom-anchored band and
+    /// the letterbox's centred bar every time a menu opens.
+    pub(super) fn display_canvas_src(&self) -> Option<DisplaySrc> {
+        if self.rtg_present_dims.is_some()
             || self.present_programmable
             || self.present_width != FB_WIDTH
             || self.bezel.is_on()
         {
             return None;
         }
+        let per_axis = per_axis_scaling_requested();
+        let autocrop = crate::video::autocrop();
+        if !per_axis && !autocrop {
+            return None;
+        }
+        let par = if per_axis {
+            glass_par(
+                self.overscan,
+                self.present_tv_aperture_rows,
+                self.present_rows,
+            )
+        } else {
+            (1, 1)
+        };
         let full = (0, 0, FB_WIDTH, present_height());
         if self.ui.active() {
-            return Some(full);
+            return Some(DisplaySrc { rect: full, par });
         }
-        let Some(content) = self.present_content_rect else {
-            return Some(full);
+        // What the per-axis draw shows with nothing tighter to show: the
+        // aperture the tv canvas fills its glass with, not the pads
+        // around it. (The full-overscan canvas is its own aperture.)
+        let base = match self.present_tv_aperture_rows {
+            Some(rows) if per_axis && self.overscan == Overscan::Tv => aperture_canvas_rect(rows),
+            _ => full,
         };
-        Some(
-            canvas_content_rect(
-                content,
-                self.present_rows,
-                self.overscan,
-                self.tv_centre,
-                self.present_tv_aperture_rows,
-                present_height(),
-            )
-            .unwrap_or(full),
-        )
+        let rect = if autocrop {
+            self.present_content_rect
+                .and_then(|content| {
+                    canvas_content_rect(
+                        content,
+                        self.present_rows,
+                        self.overscan,
+                        self.tv_centre,
+                        self.present_tv_aperture_rows,
+                        present_height(),
+                    )
+                })
+                .unwrap_or(base)
+        } else {
+            base
+        };
+        Some(DisplaySrc { rect, par })
     }
 
     /// Switch the autocrop presentation live. Purely a scaler-pass

--- a/src/video/window/app_display.rs
+++ b/src/video/window/app_display.rs
@@ -298,7 +298,11 @@ impl App {
     /// Draw a given monitor front for the rest of the run (the config file
     /// default is unchanged; set `[display] bezel` to make it stick).
     pub(super) fn set_bezel(&mut self, style: BezelStyle) {
-        self.apply_bezel_style(style);
+        if !self.apply_bezel_style(style) {
+            self.show_osd("Monitor bezel unchanged: the display texture could not be resized");
+            self.request_redraw();
+            return;
+        }
         info!("monitor bezel: {}", style.label());
         self.show_osd(format!("Monitor bezel: {}", style.menu_label()));
         self.request_redraw();
@@ -310,17 +314,26 @@ impl App {
     /// under integer scaling of the tv aspect (`video::square_canvas`) --
     /// the texture and window that follow the canvas. Says nothing on
     /// screen: the toggle announces itself, a machine start does not.
-    pub(super) fn apply_bezel_style(&mut self, style: BezelStyle) {
+    /// False, with the previous style back in force, when the texture
+    /// could not follow the canvas change.
+    pub(super) fn apply_bezel_style(&mut self, style: BezelStyle) -> bool {
         let was_canvas_sized = self.window_is_canvas_sized();
         let canvas_before = window_present_height();
+        let previous = (self.bezel, self.bezel_last);
         self.bezel = style;
         if style.is_on() {
             self.bezel_last = style;
         }
         crate::video::set_bezel_shown(style.is_on());
-        if window_present_height() != canvas_before {
-            self.resync_canvas_geometry(was_canvas_sized, canvas_before);
+        if window_present_height() != canvas_before
+            && !self.resync_canvas_geometry(was_canvas_sized, canvas_before)
+        {
+            (self.bezel, self.bezel_last) = previous;
+            crate::video::set_bezel_shown(self.bezel.is_on());
+            self.replan_main_texture();
+            return false;
         }
+        true
     }
 
     /// Cmd/Alt+P: toggle the performance overlay for the rest of the run
@@ -460,11 +473,17 @@ impl App {
         // note the height that verdict is measured against.
         let was_canvas_sized = self.window_is_canvas_sized();
         let canvas_before = window_present_height();
+        let previous = crate::video::pixel_aspect();
         crate::video::set_pixel_aspect(aspect);
         // The square aspect and integer scaling of the tv aspect share the
         // square canvas, so the height need not change; the geometry
         // resync is a no-op then, and the texture is re-planned regardless.
-        self.resync_canvas_geometry(was_canvas_sized, canvas_before);
+        if !self.resync_canvas_geometry(was_canvas_sized, canvas_before) {
+            crate::video::set_pixel_aspect(previous);
+            self.replan_main_texture();
+            self.show_osd("Pixel aspect unchanged: the display texture could not be resized");
+            return;
+        }
         self.request_redraw();
     }
 
@@ -477,11 +496,24 @@ impl App {
     /// layout is the canvas's, panel centring reading the live height --
     /// on the new size too, and move the window with it
     /// (`follow_canvas_change`).
-    pub(super) fn resync_canvas_geometry(&mut self, was_canvas_sized: bool, canvas_before: usize) {
+    ///
+    /// False when the main texture could not be resized for the new
+    /// canvas, and then nothing else is touched. The draw helpers slice
+    /// the texture by the live canvas height, so a taller canvas over the
+    /// old, shorter texture would index past it on the next redraw: the
+    /// caller must put its setting back and re-plan for the canvas it
+    /// went back to ([`Self::replan_main_texture`]), as the status-bar
+    /// toggle does.
+    pub(super) fn resync_canvas_geometry(
+        &mut self,
+        was_canvas_sized: bool,
+        canvas_before: usize,
+    ) -> bool {
         if let Some(r) = self.render.as_mut() {
             let surface = r.window.inner_size();
             if let Err(e) = sync_main_present_scaling(r, (surface.width, surface.height)) {
                 warn!("resize texture buffer for the canvas change failed: {e}");
+                return false;
             }
         }
         let size = LogicalSize::new(FB_WIDTH as f64, window_present_height() as f64);
@@ -502,6 +534,19 @@ impl App {
             }
         }
         self.follow_canvas_change(was_canvas_sized, canvas_before);
+        true
+    }
+
+    /// Re-plan the main texture for the canvas a reverted setting went
+    /// back to. The plan taken for the canvas that never materialised is
+    /// stale; the texture kept its old extent (`resize_buffer` leaves it
+    /// on failure), so this re-take is what makes texture and canvas
+    /// agree again before the next redraw.
+    pub(super) fn replan_main_texture(&mut self) {
+        if let Some(r) = self.render.as_mut() {
+            let surface = r.window.inner_size();
+            let _ = sync_main_present_scaling(r, (surface.width, surface.height));
+        }
     }
 
     /// Switch how the presentation canvas is scaled into the window live.
@@ -521,9 +566,15 @@ impl App {
         }
         let was_canvas_sized = self.window_is_canvas_sized();
         let canvas_before = window_present_height();
+        let previous = crate::video::display_scaling();
         crate::video::set_display_scaling(scaling);
         if window_present_height() != canvas_before {
-            self.resync_canvas_geometry(was_canvas_sized, canvas_before);
+            if !self.resync_canvas_geometry(was_canvas_sized, canvas_before) {
+                crate::video::set_display_scaling(previous);
+                self.replan_main_texture();
+                self.show_osd("Scaling unchanged: the display texture could not be resized");
+                return;
+            }
         } else if let Some(r) = self.render.as_mut() {
             // A minimized window has no surface to re-plan against; the
             // Resized event that restores it re-plans itself.

--- a/src/video/window/app_input.rs
+++ b/src/video/window/app_input.rs
@@ -106,7 +106,7 @@ impl App {
         if !crate::envcfg::flag("COPPERLINE_DIAG_CURSOR") {
             return;
         }
-        let autocrop_src = self.autocrop_canvas_src();
+        let display_src = self.display_canvas_src();
         let Some(r) = self.render.as_ref() else {
             return;
         };
@@ -114,10 +114,11 @@ impl App {
         let inner = r.window.inner_size();
         let phys = self.last_cursor_phys;
         let context = r.pixels.context();
-        // The rect the display quad is actually drawn into -- the crop's
-        // under autocrop, the classic letterbox otherwise -- so the trace
-        // shows the same mapping the position below went through.
-        let layout = main_present_layout(r, autocrop_src);
+        // The rect the display quad is actually drawn into -- the
+        // sub-rect's under autocrop or per-axis scaling, the classic
+        // letterbox otherwise -- so the trace shows the same mapping the
+        // position below went through.
+        let layout = main_present_layout(r, display_src);
         let clip = layout.display_dst;
         let texture = (context.texture_extent.width, context.texture_extent.height);
         let pos = phys.and_then(|p| layout.cursor_position(p));

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -1401,6 +1401,9 @@ impl App {
         self.overscan = crate::config::resolve_overscan(cfg.overscan);
         self.tv_centre = cfg.tv_centre;
         self.apply_pixel_aspect(crate::config::resolve_pixel_aspect(cfg.pixel_aspect));
+        // The bezel before the scaling: the canvas rule reads both, and
+        // adopting them in this order moves the canvas at most once.
+        self.apply_bezel_style(crate::config::resolve_bezel(cfg.bezel));
         self.apply_display_scaling(cfg.scaling);
         self.apply_autocrop(cfg.autocrop);
         // Apply the configured start-up window state; the runtime toggles
@@ -1470,7 +1473,7 @@ impl App {
             r.crt_shader.clear_custom();
         }
         self.shader_strength = crate::config::resolve_shader_strength(cfg.shader_strength);
-        self.bezel = crate::config::resolve_bezel(cfg.bezel);
+        // The style itself was adopted with the display settings above.
         self.bezel_last = last_bezel_style(self.bezel);
         self.bezel_stickers_path =
             crate::config::resolve_bezel_stickers(cfg.bezel_stickers.clone());

--- a/src/video/window/app_session.rs
+++ b/src/video/window/app_session.rs
@@ -663,7 +663,11 @@ impl App {
     }
 
     pub(super) fn start_recording_to(&mut self, path: PathBuf) {
-        match crate::recorder::VideoRecorder::create(&path, FB_WIDTH, present_height()) {
+        // The capture canvas: a recording is the aspect's own picture,
+        // whatever the window is drawing (integer scaling of the tv aspect
+        // draws from a square canvas the recording never sees).
+        let rows = crate::video::capture_height();
+        match crate::recorder::VideoRecorder::create(&path, FB_WIDTH, rows) {
             Ok(rec) => {
                 // The Paula tap collects the mixed stereo output from this
                 // point on; capture_recorder_output drains it every frame.
@@ -734,7 +738,7 @@ impl App {
                         &self.record_scratch_fb,
                         FB_WIDTH,
                         self.present_rows,
-                        present_height(),
+                        crate::video::capture_height(),
                         &mut self.record_fb,
                     );
                 } else {
@@ -742,7 +746,7 @@ impl App {
                         &self.present_fb,
                         FB_WIDTH,
                         self.present_rows,
-                        present_height(),
+                        crate::video::capture_height(),
                         &mut self.record_fb,
                     );
                 }

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -671,33 +671,219 @@ pub(super) fn main_clip_rect(r: &Render) -> (u32, u32, u32, u32) {
 pub(super) struct PresentLayout {
     /// The canvas sub-rect the display draw samples, in logical canvas
     /// pixels `(x, y, w, h)`. The whole window canvas -- chrome included
-    /// -- in the classic layout; the autocrop rect (display region only)
-    /// when cropping.
+    /// -- in the classic layout; the display region's sub-rect (an
+    /// autocrop content rect, the TV aperture under per-axis integer
+    /// scaling) in a sub-rect layout.
     pub(super) src_canvas: (usize, usize, usize, usize),
     /// Where that lands on the surface, physical pixels.
     pub(super) display_dst: (u32, u32, u32, u32),
     pub(super) filter: scaler::ScaleFilter,
     /// The chrome band's destination when the layout splits it from the
-    /// display (autocrop only): the texture rows below `present_height`
-    /// drawn across the surface bottom.
+    /// display (a sub-rect layout: autocrop, per-axis integer scaling):
+    /// the texture rows below `present_height` drawn across the surface
+    /// bottom.
     pub(super) chrome_dst: Option<(u32, u32, u32, u32)>,
+    /// The whole-number factors of the display draw, as surface pixels
+    /// `(per canvas column, per field line)` -- a uniform multiple `m`
+    /// is `(m, 2 * m)` -- or `None` for a smooth fit.
+    pub(super) factors: Option<(usize, usize)>,
 }
 
-/// The layout for the current frame. `autocrop_src` is the content rect
-/// to crop to, in canvas pixels of the display region, or `None` for the
-/// classic whole-canvas letterbox (autocrop off, suspended, or nothing
-/// to crop to).
-pub(super) fn main_present_layout(
-    r: &Render,
-    autocrop_src: Option<(usize, usize, usize, usize)>,
-) -> PresentLayout {
+/// The sub-rect of the display region the display draw shows, and the
+/// shape its canvas pixels are drawn at. `App::display_canvas_src`
+/// derives it per frame; `None` there means the classic whole-canvas
+/// letterbox.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DisplaySrc {
+    /// The canvas sub-rect `(x, y, w, h)`, in logical canvas pixels of
+    /// the display region.
+    pub(super) rect: (usize, usize, usize, usize),
+    /// The pixel aspect the rect's canvas pixels are drawn at, as the
+    /// `(width, height)` of one canvas pixel in surface units: `(1, 1)`
+    /// when the canvas already has the picture's shape (the tv canvas,
+    /// or the square canvas under the square aspect), the glass ratio
+    /// ([`glass_par`]) for the square canvas under the tv aspect.
+    pub(super) par: (u32, u32),
+}
+
+/// The shape of one square-canvas pixel on the 4:3 glass, as a ratio
+/// `(width, height)`: the tv aspect's own model, read back. The tv
+/// canvas fits the TV aperture -- `TV_CAPTURED_WIDTH` columns by
+/// `tv_aperture_rows` woven rows -- onto the `FB_WIDTH` x
+/// `PRESENT_HEIGHT_TV` glass (`tv_glass_sample`, `tv_aperture_source_row`),
+/// so each captured column widens by FB_WIDTH / TV_CAPTURED_WIDTH and
+/// each woven row by PRESENT_HEIGHT_TV / rows; the full-overscan canvas
+/// puts the whole `present_rows`-row field on the same glass. PAL lands
+/// at 1.078 (a shade over the textbook 16:15), NTSC at 0.854 (6:7, a
+/// shade over the textbook 5:6): the aperture keeps a little less of the
+/// line than of the field, so both come out a few per cent wider than
+/// the window-fills-the-glass figures.
+pub(super) fn glass_par(
+    overscan: Overscan,
+    tv_aperture_rows: Option<usize>,
+    present_rows: usize,
+) -> (u32, u32) {
+    match tv_aperture_rows {
+        Some(rows) if overscan == Overscan::Tv => (
+            (FB_WIDTH * rows) as u32,
+            (crate::video::PRESENT_HEIGHT_TV * TV_CAPTURED_WIDTH) as u32,
+        ),
+        _ => (
+            present_rows.max(1) as u32,
+            crate::video::PRESENT_HEIGHT_TV as u32,
+        ),
+    }
+}
+
+/// The TV aperture's rect on the square canvas: the captured aperture's
+/// columns between the black side pads, its rows between the bezel
+/// bands `tv_aperture_source_row` centres a shorter aperture with. This
+/// is the picture the tv canvas fills its whole glass with, so it is
+/// what the per-axis draw shows when nothing tighter (an autocrop
+/// content rect) is asked for.
+pub(super) fn aperture_canvas_rect(tv_aperture_rows: usize) -> (usize, usize, usize, usize) {
+    let rows = tv_aperture_rows.min(crate::video::PRESENT_HEIGHT_SQUARE);
+    (
+        TV_LIVE_PAD_X,
+        (crate::video::PRESENT_HEIGHT_SQUARE - rows) / 2,
+        TV_CAPTURED_WIDTH,
+        rows,
+    )
+}
+
+/// How far a whole-number pixel shape may stray from the glass ratio
+/// before a taller fit stops being worth it: max(shape/par, par/shape)
+/// at most 11/10. Wide enough that NTSC's 0.854 admits 4:5 (6.8% off)
+/// through 6:7, 7:8 and 12:13 -- the family amiga.vision's NTSC guide
+/// reaches for, 4:5 being its 1080p and 4K answer -- while excluding
+/// 3:4 (14%) and the squat 1:1 (17%); and that PAL's 1.078 admits the
+/// square 1:1 (7.2%) and 8:7 (6%) but not 6:5 (11%).
+const PAR_TOLERANCE: (u64, u64) = (11, 10);
+
+/// The per-axis whole-number fit of a `w` x `h` canvas rect (hi-res
+/// columns by woven rows) into `avail` surface pixels, drawn at the
+/// pixel shape `par`: `(columns, lines)` -- surface pixels per canvas
+/// column, and per *field line*, the scan's own vertical unit. The
+/// woven canvas carries two rows per line so interlaced fields can be
+/// woven; a non-interlaced display's two are identical, so a whole
+/// number of pixels per line is exact for it whether or not the number
+/// is even (an odd count lands as alternate rows of the pair, which is
+/// only visible on an interlaced display). Stepping the vertical factor
+/// by half a woven row is what makes the NTSC shapes reachable on
+/// ordinary displays: 4:5 is two pixels per column and five per line,
+/// 1000 rows for a 200-line display -- the 1080p answer.
+///
+/// The choice is the tallest fit whose shape stays within
+/// [`PAR_TOLERANCE`] of `par` (a bigger picture beats a marginally truer
+/// one), the closest shape among fits of that height, and the widest
+/// among equals; with no fit inside the tolerance, the closest shape at
+/// the largest size. `None` when not even one pixel per column and per
+/// line fits, where the caller falls back to the smooth fit. Exact
+/// integer arithmetic throughout, so every host agrees on the answer.
+pub(super) fn per_axis_fit(
+    avail: (u32, u32),
+    (w, h): (usize, usize),
+    par: (u32, u32),
+) -> Option<(usize, usize)> {
+    if w == 0 || h == 0 || par.0 == 0 || par.1 == 0 {
+        return None;
+    }
+    let max_columns = avail.0 as usize / w;
+    // `h` woven rows are `h / 2` field lines: `lines` pixels per line
+    // puts `h * lines / 2` rows on the surface.
+    let max_lines = 2 * avail.1 as usize / h;
+    if max_columns == 0 || max_lines == 0 {
+        return None;
+    }
+    let (par_w, par_h) = (u64::from(par.0), u64::from(par.1));
+    // A shape's deviation from `par`, as the two cross products ordered
+    // (max, min): their quotient is the symmetric ratio error, and two
+    // deviations compare exactly by cross-multiplying.
+    let deviation = |columns: usize, lines: usize| -> (u64, u64) {
+        let shape = 2 * columns as u64 * par_h;
+        let glass = lines as u64 * par_w;
+        (shape.max(glass), shape.min(glass))
+    };
+    let within = |(hi, lo): (u64, u64)| hi * PAR_TOLERANCE.1 <= lo * PAR_TOLERANCE.0;
+    let compare = |a: (u64, u64), b: (u64, u64)| (a.0 * b.1).cmp(&(b.0 * a.1));
+    // A candidate: its factors, its deviation, and whether that is
+    // within the tolerance.
+    type Candidate = ((usize, usize), (u64, u64), bool);
+    let mut best: Option<Candidate> = None;
+    for lines in 1..=max_lines {
+        for columns in 1..=max_columns {
+            let dev = deviation(columns, lines);
+            let ok = within(dev);
+            let better = match best {
+                None => true,
+                Some((_, _, cand_ok)) if ok != cand_ok => ok,
+                Some((cand, cand_dev, true)) => lines
+                    .cmp(&cand.1)
+                    .then(compare(cand_dev, dev))
+                    .then(columns.cmp(&cand.0))
+                    .is_gt(),
+                Some((cand, cand_dev, false)) => compare(cand_dev, dev)
+                    .then(lines.cmp(&cand.1))
+                    .then(columns.cmp(&cand.0))
+                    .is_gt(),
+            };
+            if better {
+                best = Some(((columns, lines), dev, ok));
+            }
+        }
+    }
+    best.map(|(factors, _, _)| factors)
+}
+
+/// Where a `w` x `h` canvas rect lands in `avail` at whole-number
+/// factors `(columns, lines)`: exactly `w * columns` by `h * lines / 2`,
+/// centred. The rect's rows are whole field lines (an even count) so the
+/// height is exact -- every display rect's are, starting on a woven pair
+/// (`display_rects_start_on_field_lines`).
+fn per_axis_rect(
+    avail: (u32, u32),
+    (w, h): (usize, usize),
+    (columns, lines): (usize, usize),
+) -> (u32, u32, u32, u32) {
+    let dw = ((w * columns) as u32).min(avail.0);
+    let dh = ((h * lines / 2) as u32).min(avail.1);
+    ((avail.0 - dw) / 2, (avail.1 - dh) / 2, dw, dh)
+}
+
+/// The smooth fit of a `w` x `h` canvas rect drawn at pixel shape
+/// `par`: the aspect-preserving letterbox of `w * par` by `h` in
+/// `avail`, `clip_rect_for`'s smooth arithmetic with the shape folded
+/// into the width (at `(1, 1)` it is that fit exactly).
+fn smooth_fit_rect(
+    avail: (u32, u32),
+    (w, h): (usize, usize),
+    par: (u32, u32),
+) -> (u32, u32, u32, u32) {
+    if avail.0 == 0 || avail.1 == 0 || w == 0 || h == 0 {
+        return (0, 0, 0, 0);
+    }
+    let shaped_w = w as f32 * par.0 as f32 / par.1.max(1) as f32;
+    let scale = (avail.0 as f32 / shaped_w).min(avail.1 as f32 / h as f32);
+    let dw = ((shaped_w * scale) as u32).min(avail.0).max(1);
+    let dh = ((h as f32 * scale) as u32).min(avail.1).max(1);
+    ((avail.0 - dw) / 2, (avail.1 - dh) / 2, dw, dh)
+}
+
+/// The layout for the current frame. `src` is the sub-rect of the
+/// display region to show (an autocrop content rect, the TV aperture
+/// under per-axis integer scaling) with the pixel shape to draw it at,
+/// or `None` for the classic whole-canvas letterbox (both modes off or
+/// suspended).
+pub(super) fn main_present_layout(r: &Render, src: Option<DisplaySrc>) -> PresentLayout {
     let surface = (r.surface_size.0.max(1), r.surface_size.1.max(1));
-    let Some(crop) = autocrop_src.filter(|(_, _, w, h)| *w > 0 && *h > 0) else {
+    let Some(src) = src.filter(|src| src.rect.2 > 0 && src.rect.3 > 0) else {
+        let plan = main_present_plan(r);
         return PresentLayout {
             src_canvas: (0, 0, FB_WIDTH, window_present_height()),
             display_dst: main_clip_rect(r),
-            filter: main_present_plan(r).filter(),
+            filter: plan.filter(),
             chrome_dst: None,
+            factors: plan.multiple.map(|m| (m, 2 * m)),
         };
     };
     // The chrome band keeps exactly the size and position the classic
@@ -717,46 +903,63 @@ pub(super) fn main_present_layout(
     // The *requested* setting, not the classic plan's resolved multiple:
     // a surface too small for the whole canvas can still hold a whole
     // multiple of the crop (a 700-wide window around a 640-wide game),
-    // and autocrop_layout takes its own fit against the crop.
-    autocrop_layout(surface, integer_scaling_requested(), crop, chrome_dst)
+    // and display_src_layout takes its own fit against the rect.
+    display_src_layout(surface, integer_scaling_requested(), src, chrome_dst)
 }
 
-/// The autocrop layout, pure of the live globals: `crop` (canvas pixels
-/// of the display region) placed on `surface`, above the already-sized
-/// `chrome_dst` band (panels and status bar; `None` when there is no
-/// chrome to show).
+/// The sub-rect layout, pure of the live globals: `src` (canvas pixels
+/// of the display region, and the shape to draw them at) placed on
+/// `surface`, above the already-sized `chrome_dst` band (panels and
+/// status bar; `None` when there is no chrome to show).
 ///
-/// Integer scaling re-fits against the crop -- a display using fewer
-/// lines earns a larger whole multiple, which is the point of the
-/// feature -- and falls back to the smooth fit of the crop when not
-/// even 1x fits, exactly as the classic layout falls back.
-pub(super) fn autocrop_layout(
+/// Integer scaling re-fits against the rect -- a display using fewer
+/// lines earns a larger whole multiple, which is the point of autocrop
+/// -- as a uniform multiple when the canvas already has the picture's
+/// shape, and as the per-axis fit ([`per_axis_fit`]) when the shape is
+/// the glass's: the square canvas under the tv aspect. Either falls
+/// back to the smooth fit of the rect at its shape when not even 1x
+/// fits, exactly as the classic layout falls back.
+pub(super) fn display_src_layout(
     surface: (u32, u32),
     integer: bool,
-    crop: (usize, usize, usize, usize),
+    src: DisplaySrc,
     chrome_dst: Option<(u32, u32, u32, u32)>,
 ) -> PresentLayout {
     let avail_h = surface.1 - chrome_dst.map_or(0, |(_, _, _, h)| h.min(surface.1));
     let avail = (surface.0, avail_h.max(1));
-    let multiple = integer
-        .then(|| (avail.0 as usize / crop.2).min(avail.1 as usize / crop.3))
-        .filter(|fit| *fit >= 1);
-    let display_dst = scaler::clip_rect_for(avail, (crop.2 as u32, crop.3 as u32), multiple);
+    let (w, h) = (src.rect.2.max(1), src.rect.3.max(1));
+    let factors = if !integer {
+        None
+    } else if src.par.0 == src.par.1 {
+        // The uniform multiple is the per-axis fit's answer for a square
+        // shape, but stated directly: the tolerance that lets a glass
+        // shape prefer a taller near-miss must not apply to a canvas
+        // asked for as square.
+        let fit = (avail.0 as usize / w).min(avail.1 as usize / h);
+        (fit >= 1).then_some((fit, 2 * fit))
+    } else {
+        per_axis_fit(avail, (w, h), src.par)
+    };
+    let display_dst = match factors {
+        Some(factors) => per_axis_rect(avail, (w, h), factors),
+        None => smooth_fit_rect(avail, (w, h), src.par),
+    };
     PresentLayout {
-        src_canvas: crop,
+        src_canvas: src.rect,
         display_dst,
-        filter: if multiple.is_some() {
+        filter: if factors.is_some() {
             scaler::ScaleFilter::Nearest
         } else {
             scaler::ScaleFilter::SharpBilinear
         },
         chrome_dst,
+        factors,
     }
 }
 
 impl PresentLayout {
     /// The scaler-pass draws this layout amounts to. The classic layout
-    /// is one whole-texture draw; the autocrop layout samples the crop's
+    /// is one whole-texture draw; a sub-rect layout samples the rect's
     /// uv sub-rect and adds the chrome band below it.
     pub(super) fn draws(&self) -> Vec<scaler::ScalerDraw> {
         let canvas_h = window_present_height() as f32;
@@ -817,6 +1020,15 @@ impl PresentLayout {
 /// machine's own display follows it; the tool windows are always fitted.
 pub(super) fn integer_scaling_requested() -> bool {
     crate::video::display_scaling() == crate::config::DisplayScaling::Integer
+}
+
+/// Whether the emulator window draws with a whole-number factor per axis:
+/// integer scaling of the tv aspect, which presents the square canvas at
+/// the glass's pixel shape (`glass_par`, `per_axis_fit`). A drawn bezel
+/// keeps the tv canvas and suspends the draw, like the other sub-rect
+/// conditions `App::display_canvas_src` checks per frame.
+pub(super) fn per_axis_scaling_requested() -> bool {
+    integer_scaling_requested() && crate::video::pixel_aspect() == crate::config::PixelAspect::Tv
 }
 
 /// Re-plan the emulator window's presentation for the given surface size
@@ -979,14 +1191,14 @@ pub(super) fn cursor_texture_position(
 /// window is drawn by the scaler pass, not the built-in renderer, so the
 /// rects inverted here are the same [`PresentLayout`] rects the pass
 /// draws into, and the mapping lands directly in logical canvas pixels.
-/// `autocrop_src` must be the same crop the redraw presents
-/// (`App::autocrop_canvas_src`), so clicks land where the picture is.
+/// `src` must be the same sub-rect the redraw presents
+/// (`App::display_canvas_src`), so clicks land where the picture is.
 pub(super) fn main_cursor_position(
     r: &Render,
-    autocrop_src: Option<(usize, usize, usize, usize)>,
+    src: Option<DisplaySrc>,
     position: winit::dpi::PhysicalPosition<f64>,
 ) -> Option<(i32, i32)> {
-    main_present_layout(r, autocrop_src).cursor_position(position)
+    main_present_layout(r, src).cursor_position(position)
 }
 
 /// The pure half of [`cursor_texture_position`]: position and clip rect in
@@ -1643,8 +1855,10 @@ pub(super) fn save_present_frame(
     }
 
     // A double-width (35 ns) canvas saves at double height too, keeping the
-    // 4:3 glass shape at the higher resolution.
-    let out_rows = present_height() * src_width / FB_WIDTH;
+    // 4:3 glass shape at the higher resolution. The capture canvas, not
+    // the window's: a saved picture keeps the aspect's shape whatever
+    // the window is drawing.
+    let out_rows = crate::video::capture_height() * src_width / FB_WIDTH;
     screenshot::save_scaled_y(
         path,
         present_fb,

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -811,7 +811,19 @@ pub(super) fn per_axis_fit(
     type Candidate = ((usize, usize), (u64, u64), bool);
     let mut best: Option<Candidate> = None;
     for lines in 1..=max_lines {
-        for columns in 1..=max_columns {
+        // At a given height the shape grows with the column count, so
+        // only the two counts astride the ideal one (lines * par / 2)
+        // can be the closest -- and the tolerance band, an interval
+        // around the ideal, holds one of them if it holds any. Two
+        // candidates per height instead of every column: a one-line
+        // autocrop rect on a large surface has thousands of both, and
+        // the fit runs on every redraw and cursor move.
+        let ideal = (lines as u64 * par_w / (2 * par_h)) as usize;
+        let astride = [
+            ideal.clamp(1, max_columns),
+            (ideal + 1).clamp(1, max_columns),
+        ];
+        for columns in astride {
             let dev = deviation(columns, lines);
             let ok = within(dev);
             let better = match best {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -8725,17 +8725,21 @@ fn autocrop_latch_grows_fast_and_shrinks_only_when_stable() {
     assert_eq!(latch.resolve(None), None);
 }
 
-/// The autocrop layout splits the chrome band off at the width-fit
+/// The sub-rect layout splits the chrome band off at the width-fit
 /// scale, and integer scaling re-fits its whole multiple against the
-/// crop rather than the full canvas -- the display using fewer lines is
-/// what earns the larger multiple.
+/// rect rather than the full canvas -- the display using fewer lines is
+/// what earns the larger multiple. A square shape (a canvas that already
+/// has the picture's shape) takes the uniform multiple.
 #[test]
-fn autocrop_layout_refits_the_multiple_against_the_crop() {
+fn display_src_layout_refits_the_multiple_against_the_rect() {
+    use super::scaler::ScaleFilter::{Nearest, SharpBilinear};
+    let crop = |rect| super::DisplaySrc { rect, par: (1, 1) };
+    let game = (38, 69, 640, 400);
     // A 200-line lo-res game (400 woven rows, 640 canvas px wide) on a
     // 2000x1200 surface, above a pre-sized 100-row chrome band (the
     // caller sizes the band at the classic letterbox scale).
     let chrome = (30u32, 1100u32, 1940u32, 100u32);
-    let layout = super::autocrop_layout((2000, 1200), true, (38, 69, 640, 400), Some(chrome));
+    let layout = super::display_src_layout((2000, 1200), true, crop(game), Some(chrome));
     // The band passes through untouched, and the crop fits 2x whole
     // (min(2000/640, 1100/400) = 2), centred in the region above it.
     assert_eq!(layout.chrome_dst, Some(chrome));
@@ -8743,8 +8747,10 @@ fn autocrop_layout_refits_the_multiple_against_the_crop() {
         layout.display_dst,
         ((2000 - 1280) / 2, (1100 - 800) / 2, 1280, 800)
     );
-    assert_eq!(layout.filter, super::scaler::ScaleFilter::Nearest);
-    assert_eq!(layout.src_canvas, (38, 69, 640, 400));
+    assert_eq!(layout.filter, Nearest);
+    assert_eq!(layout.src_canvas, game);
+    // Two pixels per column, four per two-row field line.
+    assert_eq!(layout.factors, Some((2, 4)));
 
     // The classic full canvas only fits 1x on the same surface: the crop
     // doubled the picture.
@@ -8754,23 +8760,241 @@ fn autocrop_layout_refits_the_multiple_against_the_crop() {
     );
 
     // Without a whole multiple the crop falls back to its smooth fit.
-    let layout = super::autocrop_layout((600, 500), true, (38, 69, 640, 400), None);
-    assert_eq!(layout.filter, super::scaler::ScaleFilter::SharpBilinear);
+    let layout = super::display_src_layout((600, 500), true, crop(game), None);
+    assert_eq!(layout.filter, SharpBilinear);
+    assert_eq!(layout.factors, None);
     assert!(layout.display_dst.2 <= 600);
 
     // A surface too small for the whole 716-wide canvas still holds a
     // whole multiple of a 640-wide crop: the fit is the crop's own, not
     // an inherited fallback from the classic full-canvas plan.
-    let layout = super::autocrop_layout((700, 500), true, (38, 69, 640, 400), None);
-    assert_eq!(layout.filter, super::scaler::ScaleFilter::Nearest);
+    let layout = super::display_src_layout((700, 500), true, crop(game), None);
+    assert_eq!(layout.filter, Nearest);
     assert_eq!((layout.display_dst.2, layout.display_dst.3), (640, 400));
 
     // Smooth scaling keeps the sharp-bilinear fit of the crop.
-    let layout = super::autocrop_layout((2000, 1200), false, (38, 69, 640, 400), None);
+    let layout = super::display_src_layout((2000, 1200), false, crop(game), None);
     assert_eq!(layout.chrome_dst, None);
-    assert_eq!(layout.filter, super::scaler::ScaleFilter::SharpBilinear);
+    assert_eq!(layout.filter, SharpBilinear);
+    assert_eq!(layout.factors, None);
     // Aspect preserved: 640x400 into 2000x1200 is height-limited.
     assert_eq!(layout.display_dst.3, 1200);
+}
+
+/// The glass ratio is the tv aspect's own model read back: the tv canvas
+/// widens the captured aperture's columns onto the glass width and its
+/// rows onto the glass height, and the ratio of the two is the shape of
+/// a square-canvas pixel on that glass -- PAL a shade wider than tall,
+/// NTSC the 5:6 of a 200-line display on a 4:3 screen. Full overscan
+/// puts the whole woven field on the glass, both standards alike.
+#[test]
+fn glass_par_is_the_tv_canvas_model_read_back() {
+    use crate::video::deinterlace::OUT_HEIGHT;
+    use crate::video::PRESENT_HEIGHT_TV;
+    let ratio = |(w, h): (u32, u32)| f64::from(w) / f64::from(h);
+    let pal = super::glass_par(Overscan::Tv, Some(TV_PAL_PRESENT_HEIGHT), OUT_HEIGHT);
+    let ntsc = super::glass_par(Overscan::Tv, Some(TV_NTSC_PRESENT_HEIGHT), OUT_HEIGHT);
+    assert_eq!(
+        pal,
+        (
+            (FB_WIDTH * TV_PAL_PRESENT_HEIGHT) as u32,
+            (PRESENT_HEIGHT_TV * TV_CAPTURED_WIDTH) as u32
+        )
+    );
+    assert!(
+        (ratio(pal) - 1.0778).abs() < 5e-4,
+        "PAL glass shape {}",
+        ratio(pal)
+    );
+    assert!(
+        (ratio(ntsc) - 0.8543).abs() < 5e-4,
+        "NTSC glass shape {}",
+        ratio(ntsc)
+    );
+    let field = (OUT_HEIGHT as u32, PRESENT_HEIGHT_TV as u32);
+    for rows in [
+        Some(TV_PAL_PRESENT_HEIGHT),
+        Some(TV_NTSC_PRESENT_HEIGHT),
+        None,
+    ] {
+        assert_eq!(super::glass_par(Overscan::Full, rows, OUT_HEIGHT), field);
+    }
+    assert_eq!(super::glass_par(Overscan::Tv, None, OUT_HEIGHT), field);
+}
+
+/// The TV aperture's rect on the square canvas is the aperture between
+/// its side pads and bezel bands, and its first row is the aperture's
+/// first -- an even woven row, the start of a field-line pair -- with a
+/// whole number of lines below it. Every display rect starts on a pair
+/// like this: it is what lets the per-axis draw give a field line an odd
+/// number of surface rows and still land each non-interlaced line, whose
+/// two woven rows are identical, as one exact block (`per_axis_fit`).
+#[test]
+fn display_rects_start_on_field_lines() {
+    use crate::video::PRESENT_HEIGHT_SQUARE;
+    assert_eq!(TV_PRESENT_SOURCE_Y % 2, 0);
+    for rows in [TV_PAL_PRESENT_HEIGHT, TV_NTSC_PRESENT_HEIGHT] {
+        let rect = super::aperture_canvas_rect(rows);
+        assert_eq!(
+            rect,
+            (
+                TV_LIVE_PAD_X,
+                (PRESENT_HEIGHT_SQUARE - rows) / 2,
+                TV_CAPTURED_WIDTH,
+                rows
+            )
+        );
+        assert_eq!(
+            tv_aperture_source_row(rect.1, PRESENT_HEIGHT_SQUARE, 1, rows),
+            Some(0)
+        );
+        assert_eq!(rect.3 % 2, 0);
+    }
+    // A content rect on the square canvas keeps its woven bounds, which
+    // the renderer states in whole field lines.
+    use crate::config::TvCentre;
+    let content = crate::video::bitplane::ContentRect {
+        x0: 52,
+        x1: 692,
+        y0: 2 * 20,
+        y1: 2 * 220,
+    };
+    let rect = super::canvas_content_rect(
+        content,
+        crate::video::deinterlace::OUT_HEIGHT,
+        Overscan::Tv,
+        TvCentre::default(),
+        Some(TV_NTSC_PRESENT_HEIGHT),
+        PRESENT_HEIGHT_SQUARE,
+    )
+    .unwrap();
+    let pad = (PRESENT_HEIGHT_SQUARE - TV_NTSC_PRESENT_HEIGHT) / 2;
+    assert_eq!(rect.1, pad + content.y0 - TV_PRESENT_SOURCE_Y);
+    assert_eq!(rect.3, content.y1 - content.y0);
+}
+
+/// The per-axis fit reaches the NTSC shapes amiga.vision's guide gives
+/// ordinary displays -- 4:5 at 1080p and 4K, 6:7 at 1440p, 5:6 at 5K --
+/// by counting pixels per field line rather than per woven row, prefers
+/// a taller fit within the tolerance to a marginally truer one, settles
+/// for the closest shape when nothing fits inside it, and gives up (to
+/// the smooth fit) only below one pixel per column and per line. PAL's
+/// glass shape is within the tolerance of square, so its fits are the
+/// uniform multiples until the zoom admits a taller near-miss (8:7 with
+/// seven rows per line) or a truer shape (16:15 with fifteen).
+#[test]
+fn per_axis_fit_reaches_the_ntsc_shapes_of_ordinary_displays() {
+    use crate::video::deinterlace::OUT_HEIGHT;
+    let ntsc = super::glass_par(Overscan::Tv, Some(TV_NTSC_PRESENT_HEIGHT), OUT_HEIGHT);
+    let pal = super::glass_par(Overscan::Tv, Some(TV_PAL_PRESENT_HEIGHT), OUT_HEIGHT);
+    let fit = super::per_axis_fit;
+    // A 200-line lo-res display's content rect: 640 columns, 400 woven
+    // rows (200 field lines).
+    let game = (640, 400);
+    // 1080p under a 44-row status bar: two pixels per column, five per
+    // line -- 4:5, 1280x1000.
+    assert_eq!(fit((1920, 1036), game, ntsc), Some((2, 5)));
+    // 1440p with the bar hidden: 6:7 at 1920x1400; under the bar the
+    // 1400 rows do not fit and 4:5 stands.
+    assert_eq!(fit((2560, 1440), game, ntsc), Some((3, 7)));
+    assert_eq!(fit((2560, 1396), game, ntsc), Some((2, 5)));
+    // 4K: 4:5 at 2560x2000.
+    assert_eq!(fit((3840, 2072), game, ntsc), Some((4, 10)));
+    // 5K: thirteen rows per line offers 12:13 inside the tolerance, and
+    // being taller it takes 3840x2600 over the truer 5:6 at 2400 rows;
+    // with the bar hidden the fourteenth row admits 6:7, the truest of
+    // all, at 3840x2800.
+    assert_eq!(fit((5120, 2792), game, ntsc), Some((6, 13)));
+    assert_eq!(fit((5120, 2880), game, ntsc), Some((6, 14)));
+    // Taller beats truer inside the tolerance: room for 16 rows per line
+    // takes 7:8 at 4480x3200 over 5:6 at 2400 rows.
+    assert_eq!(fit((4480, 3200), game, ntsc), Some((7, 16)));
+    // Nothing inside the tolerance: the closest shape, 1:1 at 640x400,
+    // over the 2:3 that would stand taller.
+    assert_eq!(fit((800, 600), game, ntsc), Some((1, 2)));
+    // Below one pixel per column, or per line: no whole-number fit.
+    assert_eq!(fit((600, 300), game, ntsc), None);
+    assert_eq!(fit((700, 199), game, ntsc), None);
+
+    let aperture = (TV_CAPTURED_WIDTH, TV_PAL_PRESENT_HEIGHT);
+    assert_eq!(fit((1920, 1036), aperture, pal), Some((1, 2)));
+    assert_eq!(fit((2560, 1396), aperture, pal), Some((2, 4)));
+    // 4K under the bar: 8:7 at 2672x1890 stands taller than 1:1 at 3x;
+    // with the bar hidden, 1:1 at 4x fills the height.
+    assert_eq!(fit((3840, 2072), aperture, pal), Some((4, 7)));
+    assert_eq!(fit((3840, 2160), aperture, pal), Some((4, 8)));
+    // Fifteen rows per line: 16:15 is truer than 15:15 and takes it.
+    assert_eq!(
+        fit(
+            (
+                16 * TV_CAPTURED_WIDTH as u32,
+                15 * TV_PAL_PRESENT_HEIGHT as u32
+            ),
+            aperture,
+            pal
+        ),
+        Some((16, 30))
+    );
+}
+
+/// Per-axis integer scaling draws the rect at exactly its factors -- the
+/// columns times the horizontal one, the field lines times the vertical
+/// one -- centred and point-sampled, and the cursor mapping inverts that
+/// rect; the chrome band takes its rows off the fit; without a fit the
+/// rect falls back to the smooth fit at the glass shape.
+#[test]
+fn per_axis_layout_draws_the_rect_at_its_factors() {
+    use super::scaler::ScaleFilter::{Nearest, SharpBilinear};
+    use crate::video::deinterlace::OUT_HEIGHT;
+    let ntsc = super::glass_par(Overscan::Tv, Some(TV_NTSC_PRESENT_HEIGHT), OUT_HEIGHT);
+    let src = super::DisplaySrc {
+        rect: (38, 71, 640, 400),
+        par: ntsc,
+    };
+    let layout = super::display_src_layout((1920, 1036), true, src, None);
+    assert_eq!(layout.factors, Some((2, 5)));
+    assert_eq!(
+        layout.display_dst,
+        ((1920 - 1280) / 2, (1036 - 1000) / 2, 1280, 1000)
+    );
+    assert_eq!(layout.filter, Nearest);
+    assert_eq!(layout.src_canvas, src.rect);
+    let (dx, dy, dw, dh) = layout.display_dst;
+    let at = |x: u32, y: u32| {
+        layout.cursor_position(winit::dpi::PhysicalPosition::new(
+            f64::from(x),
+            f64::from(y),
+        ))
+    };
+    assert_eq!(at(dx, dy), Some((38, 71)));
+    assert_eq!(at(dx + dw - 1, dy + dh - 1), Some((38 + 639, 71 + 399)));
+    assert_eq!(at(dx + dw, dy), None);
+
+    // A 100-row chrome band leaves 936 rows: four per line (1:1, the
+    // closest shape with no 4:5 room) at 1280x800, centred above it.
+    let chrome = (0u32, 936u32, 1920u32, 100u32);
+    let layout = super::display_src_layout((1920, 1036), true, src, Some(chrome));
+    assert_eq!(layout.factors, Some((2, 4)));
+    assert_eq!(
+        layout.display_dst,
+        ((1920 - 1280) / 2, (936 - 800) / 2, 1280, 800)
+    );
+    assert_eq!(layout.chrome_dst, Some(chrome));
+
+    // Too small for one pixel per column: the smooth fit, at the glass
+    // shape rather than the rect's own.
+    let shaped = 640.0 * f64::from(ntsc.0) / f64::from(ntsc.1) / 400.0;
+    let layout = super::display_src_layout((600, 500), true, src, None);
+    assert_eq!(layout.factors, None);
+    assert_eq!(layout.filter, SharpBilinear);
+    let (_, _, w, h) = layout.display_dst;
+    assert!(w <= 600 && h <= 500);
+    assert!((f64::from(w) / f64::from(h) - shaped).abs() < 0.01);
+    // Smooth scaling draws the same shape: height-limited here.
+    let layout = super::display_src_layout((2000, 1200), false, src, None);
+    assert_eq!(layout.factors, None);
+    assert_eq!(layout.display_dst.3, 1200);
+    assert!((f64::from(layout.display_dst.2) / 1200.0 - shaped).abs() < 0.01);
 }
 
 /// A redraw that finds the host window at a size the surface was not

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -8937,6 +8937,77 @@ fn per_axis_fit_reaches_the_ntsc_shapes_of_ordinary_displays() {
     );
 }
 
+/// The fit evaluates only the two column counts astride the ideal at
+/// each height, and that loses nothing against trying every column: the
+/// shape is monotone in the count at a fixed height, so the closest count
+/// is one of the two, and the tolerance band holds one of them if it
+/// holds any. Checked against the exhaustive rule over a grid of small
+/// surfaces, rects and shapes; and a one-line autocrop rect on a large
+/// surface, which the exhaustive scan would spend millions of steps on
+/// per redraw, still answers.
+#[test]
+fn per_axis_fit_prunes_to_the_columns_astride_the_ideal() {
+    use crate::video::deinterlace::OUT_HEIGHT;
+    let exhaustive = |avail: (u32, u32), (w, h): (usize, usize), par: (u32, u32)| {
+        let (max_columns, max_lines) = (avail.0 as usize / w, 2 * avail.1 as usize / h);
+        let (pw, ph) = (u64::from(par.0), u64::from(par.1));
+        let dev = |c: usize, l: usize| {
+            let (a, b) = (2 * c as u64 * ph, l as u64 * pw);
+            (a.max(b), a.min(b))
+        };
+        let within = |(hi, lo): (u64, u64)| hi * 10 <= lo * 11;
+        let cmp = |a: (u64, u64), b: (u64, u64)| (a.0 * b.1).cmp(&(b.0 * a.1));
+        type Candidate = ((usize, usize), (u64, u64), bool);
+        let mut best: Option<Candidate> = None;
+        for l in 1..=max_lines {
+            for c in 1..=max_columns {
+                let d = dev(c, l);
+                let ok = within(d);
+                let better = match best {
+                    None => true,
+                    Some((_, _, bok)) if ok != bok => ok,
+                    Some((b, bd, true)) => l.cmp(&b.1).then(cmp(bd, d)).then(c.cmp(&b.0)).is_gt(),
+                    Some((b, bd, false)) => cmp(bd, d).then(l.cmp(&b.1)).then(c.cmp(&b.0)).is_gt(),
+                };
+                if better {
+                    best = Some(((c, l), d, ok));
+                }
+            }
+        }
+        best.map(|(f, _, _)| f)
+    };
+    let shapes = [
+        super::glass_par(Overscan::Tv, Some(TV_PAL_PRESENT_HEIGHT), OUT_HEIGHT),
+        super::glass_par(Overscan::Tv, Some(TV_NTSC_PRESENT_HEIGHT), OUT_HEIGHT),
+        super::glass_par(Overscan::Full, None, OUT_HEIGHT),
+        (1, 3),
+        (3, 1),
+    ];
+    for par in shapes {
+        for (w, h) in [(2, 2), (3, 2), (5, 4), (7, 6), (16, 10), (40, 30)] {
+            for avail in [
+                (1, 1),
+                (7, 5),
+                (40, 30),
+                (97, 61),
+                (160, 90),
+                (200, 200),
+                (300, 120),
+            ] {
+                assert_eq!(
+                    super::per_axis_fit(avail, (w, h), par),
+                    exhaustive(avail, (w, h), par),
+                    "par {par:?} rect {w}x{h} on {avail:?}"
+                );
+            }
+        }
+    }
+    // A one-line, two-column rect on a 4K surface: thousands of counts
+    // on each axis, answered without the cross product.
+    let ntsc = shapes[1];
+    assert!(super::per_axis_fit((3840, 2160), (2, 2), ntsc).is_some());
+}
+
 /// Per-axis integer scaling draws the rect at exactly its factors -- the
 /// columns times the horizontal one, the field lines times the vertical
 /// one -- centred and point-sampled, and the cursor mapping inverts that


### PR DESCRIPTION
Closes #606, the second half of the #591 proposal.

## What changes

`scaling = "integer"` under the default `pixel_aspect = "tv"` used to integer-scale a canvas already resampled onto 537 rows for the 4:3 shape -- crisp blocks of a resampled picture -- so `square` was the only pixel-exact pairing. Integer scaling now presents from the unresampled (square, 570-row) canvas under either aspect, and under the tv aspect the scaler pass draws it with a separate whole-number factor per axis chosen to approximate the 4:3 glass's pixel shape. Square + integer keeps its uniform multiple; captures are untouched.

## Design

- **Canvas rule** (`video::square_canvas`): the window canvas is square for the square aspect or integer scaling, unless a bezel is on (its fixed opening resamples the whole glass, so it keeps the tv canvas). `present_height()` follows the rule; a new `capture_height()` follows the pixel aspect alone and every capture site (window screenshot, recorder, headless/DBG shots) uses it, so a scaling or bezel toggle never changes a saved picture.
- **Pixel shape** (`glass_par`): the tv canvas's own resample read back -- `FB_WIDTH / TV_CAPTURED_WIDTH` wide by `PRESENT_HEIGHT_TV / aperture rows` tall: PAL 1.078, NTSC 0.854; the whole field over the glass for full overscan. No new model, just the existing one stated as a ratio.
- **Per-axis fit** (`per_axis_fit`): surface pixels per hi-res column and per *field line*. Counting per line rather than per woven row is what reaches 4:5 on a 1080p display (two pixels per column, five per line): a non-interlaced line's two woven rows are identical, so an odd count per line still lands as one exact block, and every display rect starts on a woven pair so the scaler's sample centres never sit on a line boundary (pinned by `display_rects_start_on_field_lines`). The rule is the tallest fit whose shape is within 11/10 of the glass's, then the closest, then the closest shape at the largest size; exact integer arithmetic. The tolerance admits NTSC's 4:5 through 7:8 (the amiga.vision family) and PAL's 1:1 and 8:7, and rejects 3:4 and NTSC 1:1.
- **Plumbing**: `DisplaySrc { rect, par }` generalises the autocrop sub-rect (`App::display_canvas_src`, was `autocrop_canvas_src`); autocrop and the per-axis draw compose (autocrop supplies the rect, the fit the factors) and share the chrome band, cursor mapping and CRT-preset viewport. The canvas change the scaling toggle now provokes under the tv aspect goes through the path the pixel-aspect switch already had (`resync_canvas_geometry`), which the bezel toggle uses too; the launcher adopts the bezel before the scaling so the canvas moves at most once. `COPPERLINE_DIAG_AUTOCROP` names the mode (`active(per-axis)`, `active(autocrop+per-axis)`), the factors and the shape.

Outcomes for a 200-line NTSC game with autocrop: 1080p 4:5 (1280x1000), 1440p with the bar hidden 6:7 (1920x1400), 4K 4:5 (2560x2000). PAL aperture: 1x/2x square at 1080p/1440p, 8:7 at 4K under the bar and 1:1 at 4x with it hidden. Without autocrop the NTSC aperture at 1080p only has room for square pixels; the docs recommend the pairing.

Docs: `configuration.md`, `ui.md`, `internals/video.md`, `copperline.example.toml`, the config enum docs.

## Verification

`cargo test` (3092 passed; new `per_axis_fit_reaches_the_ntsc_shapes_of_ordinary_displays`, `per_axis_layout_draws_the_rect_at_its_factors`, `glass_par_is_the_tv_canvas_model_read_back`, `display_rects_start_on_field_lines`, `display_src_layout_refits_the_multiple_against_the_rect`, `integer_scaling_takes_the_square_canvas_unless_a_bezel_is_drawn`), `cargo clippy --all-targets` and `cargo fmt --check` clean. Headless `--screenshot-after` with `scaling = "smooth"` and `"integer"` saves byte-identical 716x540 PNGs.

Not verified in a live window (the GPU present path cannot be exercised headlessly): with `scaling = "integer"`, autocrop on and an NTSC game, `COPPERLINE_DIAG_AUTOCROP=1` should log `mode=active(autocrop+per-axis) factors=Some((2, 5))` on a 1080p surface, and the Scaling and bezel toggles should resize the window as the pixel-aspect toggle does.

## Judgment calls

- The 11/10 tolerance is needed for NTSC 4:5 to qualify; it also lets PAL take 8:7 at 4K under the bar, which is closer to the glass shape than 3x square.
- An odd count per line shows an interlaced display's two fields' rows at alternating heights. Not lace-gated: a program toggling LACE per frame would otherwise flip the factors every frame.
- Programmable scans and RTG board frames take the classic uniform multiple of the square canvas; the web frontend (#608) is untouched.
