### PR TITLE
Autocrop for programmable (multisync) scans

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -618,8 +618,9 @@ video = "PAL"
 # hardware programs (default false), so a game using fewer lines than the
 # full scan fills more of a 16:9/21:9 screen; with integer scaling the
 # whole-number fit is retaken against the crop. Window-only (captures
-# keep their aperture); composes with the CRT shader presets, and is
-# suspended under a bezel, for RTG scanout and for programmable scans.
+# keep their aperture); composes with the CRT shader presets, crops
+# programmable (multisync) scans through their own sync window, and is
+# suspended under a bezel and for RTG scanout.
 # deinterlace: motion-adaptive weaving of interlaced displays (default
 # true); false line-doubles every field, showing interlace bob/flicker like
 # a bare TV.

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -547,6 +547,8 @@ impl WebEmu {
         let h_shift = self
             .presentation_latch
             .presentation_h_shift(&base, self.overscan);
+        // The browser presents the whole placed field (no autocrop here
+        // yet), so only the placement's row count is used.
         let field_rows = present_common::post_process_rendered_field(
             &mut self.fb,
             geometry,
@@ -556,7 +558,8 @@ impl WebEmu {
             visible_start_vpos,
             h_shift,
             self.overscan,
-        );
+        )
+        .rows;
         let canvas_width = FB_WIDTH * canvas_scale;
         let lace = base.bplcon0 & 0x0004 != 0;
         let double_rows = !geometry.programmable;

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -807,11 +807,17 @@ overlay is cropped away) and the band stays put. A
 window-presentation setting only: screenshots, frame dumps and
 recordings always keep their configured aperture. The CRT shader
 presets compose with it (the scanlines, mask or tube face are drawn
-over the cropped picture). Automatically suspended where it cannot
-apply -- under a monitor bezel (whose fixed opening frames the whole
-glass), for RTG board scanout, and for programmable multisync scans.
-The menu's *Video Settings > Autocrop* toggle flips it live without
-touching the config.
+over the cropped picture). Programmable (ECS/AGA VARBEAMEN) multisync
+scans -- a DblPAL or Multiscan Workbench, a 31 kHz Linux console --
+crop too: their envelope is the same fetched-rows model carried
+through the scan's own sync-anchored window and blanking, so a
+doubled Workbench screen fills the window like a 15 kHz one, at the
+uniform multiple under integer scaling (a progressive scan's rows are
+not woven pairs for the per-axis fit to step by). Automatically
+suspended where it cannot apply -- under a monitor bezel (whose fixed
+opening frames the whole glass) and for RTG board scanout. The menu's
+*Video Settings > Autocrop* toggle flips it live without touching the
+config.
 
 `deinterlace` controls how interlaced (LACE) displays are presented. On
 (the default), a motion-adaptive deinterlacer weaves the two fields into a

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -366,9 +366,10 @@ belongs to the Amiga.
   pinned along the window bottom; an open menu or panel widens the
   picture to the full display area while it is up, and the band stays
   put. Presentation-only (captures keep their aperture); the CRT
-  shader presets compose with it, while a bezel, RTG scanout and
-  programmable scans suspend it. The start-up value is
-  `[display] autocrop` (see [Configuration](configuration.md)).
+  shader presets compose with it, programmable (multisync) scans crop
+  through their own sync-anchored window, and a bezel or RTG scanout
+  suspends it. The start-up value is `[display] autocrop` (see
+  [Configuration](configuration.md)).
 - **Screen Centring**: nudge where the TV picture sits on the glass, the
   H-CENTER/V-CENTER controls a real monitor carried on its front.
   **Picture Left/Right** step one lo-res pixel (up to 16 each way),

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -609,11 +609,24 @@ the display quad samples the content sub-rect of the canvas -- derived
 each frame from the display-window rows that carry fetched bitplane data
 (`RenderResult::content_rect`: the renderer's own per-line window model
 intersected with the captured rows, so a window left open around a
-shorter picture crops to the picture; carried through the same shifts
-`post_process_rendered_field` applies and inverted through the same
-row/column maps the present copy uses) -- and the chrome band (panels and
-status bar) is drawn separately, bottom-anchored at exactly the size the
-classic letterbox gives it, so the band never eats what the crop gains. `AutocropLatch` smooths the per-frame envelope: growth is adopted
+shorter picture crops to the picture, and trimmed to the rows and columns
+the programmable blanking windows or the frame end blacked; carried
+through the same shifts `post_process_rendered_field` applies and
+inverted through the same row/column maps the present copy uses) -- and
+the chrome band (panels and status bar) is drawn separately,
+bottom-anchored at exactly the size the classic letterbox gives it, so
+the band never eats what the crop gains. `post_process_rendered_field`
+returns the `FieldPlacement` it applied, and the envelope follows the
+pixels through it: a standard field's centring and recentring shifts and
+then two woven rows per line; a programmable scan's sync-anchored column
+resample (`stretch_rows_x_window`, scanned against the resampler's own
+taps so a partly blended edge column counts), the vertical window's
+skipped and padded rows, and native rows or woven pairs as the
+deinterlacer left them. So a multisync scan -- DblPAL Workbench, a 31 kHz
+console -- crops like a 15 kHz one; it keeps the uniform multiple under
+integer scaling (its rows are not woven pairs for the per-axis fit), and
+a scan-geometry change resets the latch, the way the deinterlacer drops
+its weave history there. `AutocropLatch` smooths the per-frame envelope: growth is adopted
 immediately, border-only frames hold the previous crop (like the aperture
 latch), and a strictly smaller envelope is adopted only after holding
 steady for its stability window, so screen transitions do not pump the
@@ -626,8 +639,8 @@ bar. The CRT presets compose with the crop: `uniforms_for_rect` aims the
 pass at the layout's display rect and crop sub-rect (the same numbers
 the scaler pass drew), with the beam-line count scaled to the rows the
 crop shows. Only a pass that owns the whole display rect falls back to
-the classic layout -- the bezel's fixed opening, RTG scanout -- along
-with programmable scans; captures never see the crop.
+the classic layout -- the bezel's fixed opening, RTG scanout; captures
+never see the crop.
 
 Integer scaling presents from the square canvas under either aspect
 (`video::square_canvas`): `present_height()` -- the window canvas the
@@ -660,8 +673,9 @@ they do for autocrop, and the two modes compose (autocrop supplies the
 rect, the per-axis fit the factors). A bezel keeps the tv canvas -- its
 opening resamples the whole glass -- and the canvas change it, the
 scaling toggle and the pixel aspect each provoke goes through one path
-(`App::resync_canvas_geometry`); RTG board frames and programmable scans
-take the classic uniform multiple of the square canvas.
+(`App::resync_canvas_geometry`); RTG board frames take the classic
+uniform multiple of the square canvas, and programmable scans the
+uniform multiple of their (cropped or whole) glass.
 
 Every redraw first re-syncs the surface to the host window's current size
 (`resync_surface_size`), rather than trusting the Resized event to have

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -166,7 +166,8 @@ fn main() -> Result<()> {
                         visible_start_vpos,
                         0,
                         Overscan::Tv,
-                    );
+                    )
+                    .rows;
                     let base = emu.bus().frame_render_base();
                     let (next_rows, next_width) = deinterlacer.present_field_into(
                         &fb,

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -162,12 +162,7 @@ pub fn stretch_rows_x(fb: &mut [u32], width: usize, rows: usize, src_num: u32, s
         let row = &mut fb[y * width..(y + 1) * width];
         scratch.copy_from_slice(row);
         for (x, out) in row.iter_mut().enumerate() {
-            // Source-pixel centre in 24.8 fixed point:
-            // (x + 0.5) * src_num / src_den - 0.5.
-            let pos = ((2 * x as i64 + 1) * src_num as i64 * 128 / src_den as i64 - 128)
-                .clamp(0, ((width - 1) as i64) << 8) as usize;
-            let src_x0 = pos >> 8;
-            let frac = (pos & 0xFF) as u32;
+            let (src_x0, frac) = stretch_rows_x_source(x, width, src_num, src_den);
             *out = if frac == 0 || src_x0 + 1 >= width {
                 scratch[src_x0]
             } else {
@@ -175,6 +170,21 @@ pub fn stretch_rows_x(fb: &mut [u32], width: usize, rows: usize, src_num: u32, s
             };
         }
     }
+}
+
+/// The source taps output column `x` of [`stretch_rows_x`] reads: the
+/// integer source column and the 8-bit fraction toward its right
+/// neighbour (a zero fraction, or a neighbour past the row end, reads
+/// the one column alone). The resample and the presentation's
+/// content-envelope mapping share this, so a crop follows exactly the
+/// columns the resample painted.
+#[inline]
+pub fn stretch_rows_x_source(x: usize, width: usize, src_num: u32, src_den: u32) -> (usize, u32) {
+    // Source-pixel centre in 24.8 fixed point:
+    // (x + 0.5) * src_num / src_den - 0.5.
+    let pos = ((2 * x as i64 + 1) * src_num as i64 * 128 / src_den as i64 - 128)
+        .clamp(0, ((width - 1) as i64) << 8) as usize;
+    (pos >> 8, (pos & 0xFF) as u32)
 }
 
 /// Like [`stretch_rows_x`], but resampling an explicit source window:
@@ -195,13 +205,7 @@ pub fn stretch_rows_x_window(fb: &mut [u32], width: usize, rows: usize, src_x0: 
         let row = &mut fb[y * width..(y + 1) * width];
         scratch.copy_from_slice(row);
         for (x, out) in row.iter_mut().enumerate() {
-            // Source-pixel centre in 24.8 fixed point:
-            // src_x0 + (x + 0.5) * src_w / width - 0.5.
-            let pos = ((src_x0 as i64) << 8)
-                + ((2 * x as i64 + 1) * src_w as i64 * 128 / width as i64 - 128);
-            let pos = pos.clamp(0, ((width - 1) as i64) << 8) as usize;
-            let src_x0i = pos >> 8;
-            let frac = (pos & 0xFF) as u32;
+            let (src_x0i, frac) = stretch_rows_x_window_source(x, width, src_x0, src_w);
             *out = if frac == 0 || src_x0i + 1 >= width {
                 scratch[src_x0i]
             } else {
@@ -209,6 +213,33 @@ pub fn stretch_rows_x_window(fb: &mut [u32], width: usize, rows: usize, src_x0: 
             };
         }
     }
+}
+
+/// The source taps output column `x` of [`stretch_rows_x_window`] reads,
+/// as [`stretch_rows_x_source`] gives them for the whole-line map.
+#[inline]
+pub fn stretch_rows_x_window_source(
+    x: usize,
+    width: usize,
+    src_x0: i32,
+    src_w: u32,
+) -> (usize, u32) {
+    // Source-pixel centre in 24.8 fixed point:
+    // src_x0 + (x + 0.5) * src_w / width - 0.5.
+    let pos =
+        ((src_x0 as i64) << 8) + ((2 * x as i64 + 1) * src_w as i64 * 128 / width as i64 - 128);
+    let pos = pos.clamp(0, ((width - 1) as i64) << 8) as usize;
+    (pos >> 8, (pos & 0xFF) as u32)
+}
+
+/// Whether an output column with source taps `taps` (from
+/// [`stretch_rows_x_source`] or [`stretch_rows_x_window_source`]) in a
+/// `width`-column row reads any source column in `x0..x1`: the tap
+/// itself, or the right neighbour a non-zero fraction blends in.
+pub fn resampled_column_reads(taps: (usize, u32), width: usize, x0: usize, x1: usize) -> bool {
+    let (src, frac) = taps;
+    let reads = |column: usize| (x0..x1).contains(&column);
+    reads(src) || (frac != 0 && src + 1 < width && reads(src + 1))
 }
 
 /// Pick a default filename for an interactive screenshot grab.
@@ -245,5 +276,55 @@ mod tests {
         let fb = [0x0000_0003, 0x0000_0006, 0x0000_0009];
         downsample_x_into(&fb, 3, 1, 1, &mut out);
         assert_eq!(out, vec![0x0000_0006]);
+    }
+
+    /// The tap helpers describe exactly which source columns each
+    /// resampled column reads: a row carrying one lit column comes out
+    /// lit (fully or blended) in precisely the output columns whose taps
+    /// read it, under both the whole-line map and a sync-anchored window
+    /// that starts left of the buffer.
+    #[test]
+    fn resample_taps_name_the_columns_the_resamplers_read() {
+        const WIDTH: usize = 64;
+        let lit = 0xFFFF_FFFF;
+        let lit_column = 20;
+        let fresh = || {
+            let mut fb = vec![0u32; WIDTH];
+            fb[lit_column] = lit;
+            fb
+        };
+
+        let mut linear = fresh();
+        stretch_rows_x(&mut linear, WIDTH, 1, 130, 227);
+        for (x, px) in linear.iter().enumerate() {
+            let taps = stretch_rows_x_source(x, WIDTH, 130, 227);
+            let reads = resampled_column_reads(taps, WIDTH, lit_column, lit_column + 1);
+            assert_eq!(*px != 0, reads, "linear column {x} taps {taps:?}");
+        }
+
+        let mut window = fresh();
+        stretch_rows_x_window(&mut window, WIDTH, 1, -8, 40);
+        let mut any = false;
+        for (x, px) in window.iter().enumerate() {
+            let taps = stretch_rows_x_window_source(x, WIDTH, -8, 40);
+            let reads = resampled_column_reads(taps, WIDTH, lit_column, lit_column + 1);
+            assert_eq!(*px != 0, reads, "window column {x} taps {taps:?}");
+            any |= reads;
+        }
+        assert!(any);
+
+        // Off the source's left edge the window clamps to column 0, so a
+        // lit edge column is read by every output column the sync tail
+        // covers; a window past the right edge reads the last column.
+        assert!(resampled_column_reads(
+            stretch_rows_x_window_source(0, WIDTH, -8, 40),
+            WIDTH,
+            0,
+            1
+        ));
+        assert_eq!(
+            stretch_rows_x_window_source(WIDTH - 1, WIDTH, 40, 40),
+            (WIDTH - 1, 0)
+        );
     }
 }

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -5579,6 +5579,15 @@ fn render_from_input_with_scratch(
         rows,
     );
     blank_rows_past_frame_end(input.frame_lines, fb, visible_line0, rows);
+    let content_rect = content_rect.and_then(|rect| {
+        trim_content_rect_to_blanking(
+            rect,
+            input.programmable_vertical_blank,
+            input.programmable_horizontal_blank,
+            input.frame_lines,
+            visible_line0,
+        )
+    });
     maybe_log_frame_pixel_samples(
         "final",
         input.emulated_seconds,
@@ -5606,11 +5615,11 @@ fn render_from_input_with_scratch(
     scratch.h_window_rows = h_window_rows;
     scratch.ham_select_pixels = ham_select_pixels;
     // COPPERLINE_DIAG_AUTOCROP: log the per-frame content envelope the
-    // autocrop presentation feeds on, in field canvas coordinates. The
-    // tool for judging what a title's crop will be from a headless run;
-    // `programmable` says when the presentation will decline to crop
-    // however good the envelope looks (multisync scans present their
-    // own window in full).
+    // autocrop presentation feeds on, in field canvas coordinates (x at
+    // the hi-res pitch, y in rendered rows). The tool for judging what a
+    // title's crop will be from a headless run; `programmable` says which
+    // window model the presentation will carry it through (a multisync
+    // scan's sync-anchored glass, else the standard centring).
     if crate::envcfg::flag("COPPERLINE_DIAG_AUTOCROP") {
         log::info!(
             "[DIAG_AUTOCROP] secs={:.3} programmable={} content_rect={:?}",
@@ -5701,6 +5710,72 @@ fn blank_rows_past_frame_end(frame_lines: u32, fb: &mut [u32], visible_line0: i3
     fb[first_blank_row * out_w..rows * out_w].fill(BLANK_RGBA);
 }
 
+/// Whether beam position `pos` lies inside a programmable blank window:
+/// blank asserts at the STRT match and clears at the STOP match, so a
+/// window with STRT >= STOP wraps through the frame/line origin.
+fn blank_window_contains(pos: u32, strt: u32, stop: u32) -> bool {
+    if strt < stop {
+        pos >= strt && pos < stop
+    } else {
+        pos >= strt || pos < stop
+    }
+}
+
+/// The colour clock a framebuffer column sits in, as
+/// [`apply_programmable_blanking`] tests it against HBSTRT/HBSTOP: one
+/// colour clock spans two lo-res DIW positions, i.e. four hi-res
+/// framebuffer pixels.
+fn framebuffer_column_cck(x: usize) -> u32 {
+    let diw_pos = DIW_HSTART_FB0 + (x as i32) / 2;
+    (diw_pos / 2).max(0) as u32
+}
+
+/// Trim the content envelope to what the blanking left showing: rows the
+/// programmable vertical blank or the frame end blacked, and columns the
+/// programmable horizontal blank blacked, are border to the eye whatever
+/// the display window said of them (a programmable scan's VBSTRT/VBSTOP
+/// routinely cross a window Kickstart leaves open past the picture).
+/// Edges only: a blank cutting through the middle of a picture is not a
+/// shape one crop can follow, and the pixels are already black there.
+fn trim_content_rect_to_blanking(
+    rect: ContentRect,
+    programmable_vertical_blank: Option<(u32, u32)>,
+    programmable_horizontal_blank: Option<(u32, u32)>,
+    frame_lines: u32,
+    visible_line0: i32,
+) -> Option<ContentRect> {
+    let row_blanked = |y: usize| {
+        let vpos = visible_line0 + y as i32;
+        vpos >= frame_lines as i32
+            || programmable_vertical_blank
+                .is_some_and(|(strt, stop)| blank_window_contains(vpos.max(0) as u32, strt, stop))
+    };
+    let column_blanked = |x: usize| {
+        programmable_horizontal_blank.is_some_and(|(strt, stop)| {
+            blank_window_contains(framebuffer_column_cck(x), strt, stop)
+        })
+    };
+    let ContentRect {
+        mut x0,
+        mut x1,
+        mut y0,
+        mut y1,
+    } = rect;
+    while y0 < y1 && row_blanked(y0) {
+        y0 += 1;
+    }
+    while y1 > y0 && row_blanked(y1 - 1) {
+        y1 -= 1;
+    }
+    while x0 < x1 && column_blanked(x0) {
+        x0 += 1;
+    }
+    while x1 > x0 && column_blanked(x1 - 1) {
+        x1 -= 1;
+    }
+    (x1 > x0 && y1 > y0).then_some(ContentRect { x0, x1, y0, y1 })
+}
+
 /// ECS programmable blanking (plan 1.2): force the composite blank windows
 /// to black on the finished frame. Vertical blanking follows VBSTRT/VBSTOP
 /// under BEAMCON0.VARVBEN; horizontal blanking follows HBSTRT/HBSTOP under
@@ -5720,13 +5795,7 @@ fn apply_programmable_blanking(
     rows: usize,
 ) {
     const BLANK_RGBA: u32 = 0xFF00_0000;
-    let in_window = |pos: u32, strt: u32, stop: u32| {
-        if strt < stop {
-            pos >= strt && pos < stop
-        } else {
-            pos >= strt || pos < stop
-        }
-    };
+    let in_window = blank_window_contains;
 
     let canvas_scale = active_canvas_scale();
     let out_w = FB_WIDTH * canvas_scale;
@@ -5745,9 +5814,7 @@ fn apply_programmable_blanking(
         let mut blank_cols = [false; FB_WIDTH];
         let mut any = false;
         for (x, blank) in blank_cols.iter_mut().enumerate() {
-            let diw_pos = DIW_HSTART_FB0 + (x as i32) / 2;
-            let cck = (diw_pos / 2).max(0) as u32;
-            if in_window(cck, strt, stop) {
+            if in_window(framebuffer_column_cck(x), strt, stop) {
                 *blank = true;
                 any = true;
             }

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -258,6 +258,56 @@ fn programmable_blanking_blanks_vbstrt_vbstop_rows_under_varvben() {
     assert_eq!(row(&fb, 0x24), FILL);
 }
 
+/// The content envelope the autocrop presentation feeds on stops at the
+/// blanking: rows inside the programmable vertical blank (or past the
+/// frame end) and columns inside the horizontal blank are trimmed off
+/// its edges, exactly the rows and columns `apply_programmable_blanking`
+/// and `blank_rows_past_frame_end` paint black. A blank through the
+/// middle leaves the envelope alone, and an envelope blanked entirely
+/// is no envelope.
+#[test]
+fn content_rect_trims_to_the_blanking_the_frame_shows() {
+    let rect = ContentRect {
+        x0: 0x40,
+        x1: 0x200,
+        y0: 0x26,
+        y1: 0x100,
+    };
+    // Vertical blank over beam lines 0x50..0x58 = rows 0x24..0x2C: the
+    // envelope's first rows fall inside it.
+    let vblank = Some((0x50u32, 0x58u32));
+    let trimmed = trim_content_rect_to_blanking(rect, vblank, None, 312, PAL_VISIBLE_LINE0)
+        .expect("envelope survives");
+    assert_eq!((trimmed.y0, trimmed.y1), (0x2C, 0x100));
+    assert_eq!((trimmed.x0, trimmed.x1), (0x40, 0x200));
+    // Horizontal blank over colour clocks 0x40..0x48 = framebuffer
+    // columns 0x3E..0x5E: the envelope's left edge is inside it.
+    let hblank = Some((0x40u32, 0x48u32));
+    let trimmed = trim_content_rect_to_blanking(rect, None, hblank, 312, PAL_VISIBLE_LINE0)
+        .expect("envelope survives");
+    assert_eq!(trimmed.x0, ((0x90 - DIW_HSTART_FB0) * 2) as usize);
+    assert_eq!(trimmed.x1, 0x200);
+    // The frame end: a 263-line scan shows rows up to beam line 262.
+    let trimmed = trim_content_rect_to_blanking(rect, None, None, 263, PAL_VISIBLE_LINE0)
+        .expect("envelope survives");
+    assert_eq!(trimmed.y1, (263 - PAL_VISIBLE_LINE0) as usize);
+    // A blank through the middle (rows 0x40..0x48) trims nothing.
+    let middle = Some((
+        PAL_VISIBLE_LINE0 as u32 + 0x80,
+        PAL_VISIBLE_LINE0 as u32 + 0x88,
+    ));
+    assert_eq!(
+        trim_content_rect_to_blanking(rect, middle, None, 312, PAL_VISIBLE_LINE0),
+        Some(rect)
+    );
+    // A blank covering every row of the envelope leaves none.
+    let all = Some((PAL_VISIBLE_LINE0 as u32, PAL_VISIBLE_LINE0 as u32 + 0x200));
+    assert_eq!(
+        trim_content_rect_to_blanking(rect, all, None, 312, PAL_VISIBLE_LINE0),
+        None
+    );
+}
+
 #[test]
 fn programmable_blanking_blanks_hbstrt_hbstop_columns_under_blanken() {
     use crate::chipset::agnus::{

--- a/src/video/present_common.rs
+++ b/src/video/present_common.rs
@@ -179,6 +179,11 @@ pub fn tv_glass_sample(row: &[u32], out_x: usize, source_x_offset: i32) -> u32 {
     crate::video::blend_rgba(row[i], row[(i + 1).min(FB_WIDTH - 1)], frac)
 }
 
+/// Turn a rendered field into a presentable frame in place, and report
+/// how it was placed ([`FieldPlacement`]). Returns the placement rather
+/// than only its row count so a coordinate stated in field space -- the
+/// autocrop content envelope -- can follow the pixels through the same
+/// maps, and the two cannot disagree.
 pub fn post_process_rendered_field(
     fb: &mut [u32],
     geometry: FrameGeometry,
@@ -188,7 +193,7 @@ pub fn post_process_rendered_field(
     visible_start_vpos: u32,
     h_shift: usize,
     overscan: Overscan,
-) -> usize {
+) -> FieldPlacement {
     let canvas_width = FB_WIDTH * canvas_scale;
     let field_rows = geometry.visible_lines.min(fb.len() / canvas_width);
     // Vertical centring, optional full-overscan horizontal recentring, and the
@@ -204,29 +209,222 @@ pub fn post_process_rendered_field(
         if overscan == Overscan::Tv {
             mask_present_frame_to_tv(fb, h_shift, standard_window_top_row(visible_start_vpos));
         }
-        return field_rows;
+        return FieldPlacement {
+            rows: field_rows,
+            canvas_scale,
+            map: PlacementMap::Standard {
+                y_offset: presentation_source_y_offset(visible_start_vpos),
+                h_shift,
+            },
+        };
     }
-    if let Some((src_x0, src_w)) = presentation_h_window {
+    let columns = if let Some((src_x0, src_w)) = presentation_h_window {
         // A multisync monitor locks its horizontal deflection to the
         // programmed sync pulse: the glass shows the line from the sync
         // trailing edge to the next pulse, centring the picture the way
         // the mode's own porches place it. The window is computed in
         // classic-canvas pixels; scale it to this frame's pitch.
-        screenshot::stretch_rows_x_window(
-            fb,
-            canvas_width,
-            field_rows,
-            src_x0 * canvas_scale as i32,
-            src_w * canvas_scale as u32,
-        );
+        let (src_x0, src_w) = (src_x0 * canvas_scale as i32, src_w * canvas_scale as u32);
+        screenshot::stretch_rows_x_window(fb, canvas_width, field_rows, src_x0, src_w);
+        ColumnMap::Window { src_x0, src_w }
     } else if geometry.line_cck != 227 {
         // No programmed sync to anchor on: fall back to the time-linear
         // whole-line map (each colour clock of this scan's shorter/longer
         // line covers 227/line_cck of the glass a standard line's clock
         // would).
         screenshot::stretch_rows_x(fb, canvas_width, field_rows, geometry.line_cck, 227);
+        ColumnMap::Linear {
+            src_num: geometry.line_cck,
+            src_den: 227,
+        }
+    } else {
+        ColumnMap::Identity
+    };
+    let rows =
+        presentation_v_window_placement(field_rows, fb.len() / canvas_width, presentation_v_window);
+    place_presentation_v_window(fb, canvas_width, field_rows, rows);
+    FieldPlacement {
+        rows: rows.rows,
+        canvas_scale,
+        map: PlacementMap::Programmable { columns, rows },
     }
-    apply_presentation_v_window(fb, canvas_width, field_rows, presentation_v_window)
+}
+
+/// How [`post_process_rendered_field`] placed a rendered field on the
+/// presentation buffer: the rows it left, and the maps it moved the
+/// pixels through. Built by the function from what it did, so a
+/// field-space coordinate mapped through it ([`Self::content_rect`])
+/// lands exactly where the pixels went.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FieldPlacement {
+    /// Rows of the placed field.
+    pub rows: usize,
+    /// The canvas pitch the field was rendered at
+    /// (`bitplane::canvas_scale_for`): 1, or 2 for a 35 ns canvas.
+    canvas_scale: usize,
+    map: PlacementMap,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PlacementMap {
+    /// A standard scan: rows moved down by the vertical centring, columns
+    /// left by the full-overscan recentring shift.
+    Standard { y_offset: usize, h_shift: usize },
+    /// A programmable scan: columns resampled onto the glass width, rows
+    /// placed inside the sync-anchored vertical window.
+    Programmable {
+        columns: ColumnMap,
+        rows: VerticalPlacement,
+    },
+}
+
+/// The horizontal resample a programmable scan's line takes onto the
+/// glass width.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ColumnMap {
+    /// A standard-length line with no programmed sync: columns stay put.
+    Identity,
+    /// [`screenshot::stretch_rows_x_window`], the sync-anchored window.
+    Window { src_x0: i32, src_w: u32 },
+    /// [`screenshot::stretch_rows_x`], the time-linear whole-line map.
+    Linear { src_num: u32, src_den: u32 },
+}
+
+impl ColumnMap {
+    /// The source taps output column `x` of a `width`-column row reads.
+    fn source(self, x: usize, width: usize) -> (usize, u32) {
+        match self {
+            Self::Identity => (x, 0),
+            Self::Window { src_x0, src_w } => {
+                screenshot::stretch_rows_x_window_source(x, width, src_x0, src_w)
+            }
+            Self::Linear { src_num, src_den } => {
+                screenshot::stretch_rows_x_source(x, width, src_num, src_den)
+            }
+        }
+    }
+}
+
+impl FieldPlacement {
+    /// A standard placement, for callers that present a field the
+    /// classic way without the post-process pass.
+    pub fn standard(rows: usize, visible_start_vpos: u32, h_shift: usize) -> Self {
+        Self {
+            rows,
+            canvas_scale: 1,
+            map: PlacementMap::Standard {
+                y_offset: presentation_source_y_offset(visible_start_vpos),
+                h_shift,
+            },
+        }
+    }
+
+    /// Follow a content envelope the renderer stated in field canvas
+    /// space (`x` in hi-res-pitch pixels, `y` in rendered field rows)
+    /// through this placement and onto the `present_rows`-row buffer the
+    /// deinterlacer built from the placed field: the buffer rows and
+    /// columns that show any of the envelope. A standard field takes the
+    /// centring and recentring shifts, then two woven rows per field row;
+    /// a programmable field's columns are scanned against the resample's
+    /// own taps (so a partially blended edge column counts, and the
+    /// sync tail left of the capture, which clamps to the edge column,
+    /// counts when that column is picture), its rows are the captured
+    /// rows the vertical window kept, and the deinterlacer's row count
+    /// says whether the placed rows were woven (LACE) or passed through
+    /// at native height. `None` when nothing of the envelope reaches the
+    /// buffer -- a picture entirely off the glass.
+    pub fn content_rect(
+        &self,
+        rect: bitplane::ContentRect,
+        present_rows: usize,
+    ) -> Option<bitplane::ContentRect> {
+        let width = FB_WIDTH * self.canvas_scale;
+        // The renderer's x is the hi-res pitch; a 35 ns canvas fans each
+        // logical pixel out to `canvas_scale` columns.
+        let (x0, x1) = (rect.x0 * self.canvas_scale, rect.x1 * self.canvas_scale);
+        let (x0, x1, y0, y1) = match self.map {
+            PlacementMap::Standard { y_offset, h_shift } => {
+                let x0 = x0.saturating_sub(h_shift).min(width);
+                let x1 = x1.saturating_sub(h_shift).clamp(x0, width);
+                let y0 = (rect.y0 + y_offset).min(self.rows);
+                let y1 = (rect.y1 + y_offset).clamp(y0, self.rows);
+                (x0, x1, y0, y1)
+            }
+            PlacementMap::Programmable { columns, rows } => {
+                let mut shown = (0..width).filter(|&x| {
+                    screenshot::resampled_column_reads(columns.source(x, width), width, x0, x1)
+                });
+                let first = shown.next()?;
+                let last = shown.next_back().unwrap_or(first);
+                let kept = rows.skip_top..rows.skip_top + rows.content_rows;
+                let y0 = rect.y0.max(kept.start);
+                let y1 = rect.y1.min(kept.end);
+                if y1 <= y0 {
+                    return None;
+                }
+                let placed = |y: usize| y - rows.skip_top + rows.pad_top;
+                (first, last + 1, placed(y0), placed(y1))
+            }
+        };
+        // The deinterlacer wove or line-doubled the placed rows onto the
+        // buffer (two per row), or passed a programmable progressive field
+        // through at native height.
+        let row_scale = if present_rows >= 2 * self.rows { 2 } else { 1 };
+        let y0 = (row_scale * y0).min(present_rows);
+        let y1 = (row_scale * y1).clamp(y0, present_rows);
+        (x1 > x0 && y1 > y0).then_some(bitplane::ContentRect { x0, x1, y0, y1 })
+    }
+}
+
+/// Where [`apply_presentation_v_window`] puts the captured rows of a
+/// `field_rows`-row field: the rows it skips off the glass top, the
+/// blanked rows it pads above them, how many captured rows it keeps, and
+/// the rows of the result. Without a programmed vertical sync, or with a
+/// glass no taller than the field, the field is left as it is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VerticalPlacement {
+    pub skip_top: usize,
+    pub pad_top: usize,
+    pub content_rows: usize,
+    pub rows: usize,
+}
+
+pub fn presentation_v_window_placement(
+    field_rows: usize,
+    buf_rows: usize,
+    presentation_v_window: Option<(i32, u32)>,
+) -> VerticalPlacement {
+    let unplaced = VerticalPlacement {
+        skip_top: 0,
+        pad_top: 0,
+        content_rows: field_rows,
+        rows: field_rows,
+    };
+    let Some((v_offset, glass_rows)) = presentation_v_window else {
+        return unplaced;
+    };
+    let glass_rows = (glass_rows as usize).min(buf_rows).max(1);
+    if glass_rows <= field_rows {
+        return unplaced;
+    }
+    // Rows the sync-anchored glass top cuts off the capture (offset < 0)
+    // vs. blanked glass rows above the captured window (offset > 0).
+    let skip_top = (-v_offset).max(0) as usize;
+    let pad_top = (v_offset).max(0) as usize;
+    if skip_top >= field_rows || pad_top >= glass_rows {
+        return VerticalPlacement {
+            skip_top,
+            pad_top,
+            content_rows: 0,
+            rows: glass_rows,
+        };
+    }
+    VerticalPlacement {
+        skip_top,
+        pad_top,
+        content_rows: (field_rows - skip_top).min(glass_rows - pad_top),
+        rows: glass_rows,
+    }
 }
 
 /// Vertical counterpart of the sync-anchored horizontal window: place the
@@ -240,24 +438,34 @@ pub fn apply_presentation_v_window(
     field_rows: usize,
     presentation_v_window: Option<(i32, u32)>,
 ) -> usize {
-    let Some((v_offset, glass_rows)) = presentation_v_window else {
-        return field_rows;
-    };
-    let buf_rows = fb.len() / canvas_width;
-    let glass_rows = (glass_rows as usize).min(buf_rows).max(1);
+    let placement =
+        presentation_v_window_placement(field_rows, fb.len() / canvas_width, presentation_v_window);
+    place_presentation_v_window(fb, canvas_width, field_rows, placement);
+    placement.rows
+}
+
+/// Move a `field_rows`-row field's pixels where
+/// [`presentation_v_window_placement`] decided.
+fn place_presentation_v_window(
+    fb: &mut [u32],
+    canvas_width: usize,
+    field_rows: usize,
+    placement: VerticalPlacement,
+) {
+    let VerticalPlacement {
+        skip_top,
+        pad_top,
+        content_rows,
+        rows: glass_rows,
+    } = placement;
     if glass_rows <= field_rows {
-        return field_rows;
+        return;
     }
-    // Rows the sync-anchored glass top cuts off the capture (offset < 0)
-    // vs. blanked glass rows above the captured window (offset > 0).
-    let skip_top = (-v_offset).max(0) as usize;
-    let pad_top = (v_offset).max(0) as usize;
     let black = rgba(0, 0, 0);
-    if skip_top >= field_rows || pad_top >= glass_rows {
+    if content_rows == 0 {
         fb[..glass_rows * canvas_width].fill(black);
-        return glass_rows;
+        return;
     }
-    let content_rows = (field_rows - skip_top).min(glass_rows - pad_top);
     if pad_top > skip_top {
         for row in (0..content_rows).rev() {
             let src = (skip_top + row) * canvas_width;
@@ -273,7 +481,6 @@ pub fn apply_presentation_v_window(
     }
     fb[..pad_top * canvas_width].fill(black);
     fb[(pad_top + content_rows) * canvas_width..glass_rows * canvas_width].fill(black);
-    glass_rows
 }
 
 /// `[display] overscan = "tv"`: black out the deep-overscan margins like the
@@ -799,6 +1006,173 @@ mod tests {
         for row in 2..10 {
             assert_eq!(fb[row * FB_WIDTH], black, "row {row}");
         }
+    }
+
+    /// The placement a programmable field reports carries its content
+    /// envelope exactly where the pixels went: columns through the
+    /// sync-anchored resample's own taps (a window starting left of the
+    /// capture pushes the picture right and widens it onto the glass),
+    /// rows through the vertical window's skip and pad, and the
+    /// deinterlacer's row count decides between native rows and woven
+    /// pairs.
+    #[test]
+    fn programmable_placement_maps_the_content_envelope_through_its_windows() {
+        use crate::video::bitplane::ContentRect;
+        let geometry = FrameGeometry {
+            programmable: true,
+            visible_start_vpos: 20,
+            visible_lines: 100,
+            line_cck: 130,
+            frame_lines: 140,
+            lace: false,
+        };
+        let mut fb = vec![0u32; FB_WIDTH * 120];
+        let lit = 0xFFFF_FFFF;
+        let content = ContentRect {
+            x0: 100,
+            x1: 300,
+            y0: 10,
+            y1: 60,
+        };
+        for y in content.y0..content.y1 {
+            fb[y * FB_WIDTH + content.x0..y * FB_WIDTH + content.x1].fill(lit);
+        }
+        // A sync-anchored window from 40 columns left of the capture, 400
+        // wide, and a glass of 120 rows whose top sits 5 captured rows
+        // down.
+        let placement = post_process_rendered_field(
+            &mut fb,
+            geometry,
+            1,
+            Some((-40, 400)),
+            Some((-5, 120)),
+            geometry.visible_start_vpos,
+            0,
+            Overscan::Tv,
+        );
+        assert_eq!(placement.rows, 120);
+        let mapped = placement
+            .content_rect(content, placement.rows)
+            .expect("content reaches the glass");
+        // Every lit output pixel (any colour in it: a blended edge counts,
+        // the opaque black padding does not) lies inside the mapped rect,
+        // and the rect's edge columns and rows carry lit pixels (no
+        // slack).
+        let is_lit = |px: u32| px & 0x00FF_FFFF != 0;
+        for y in 0..placement.rows {
+            for x in 0..FB_WIDTH {
+                if is_lit(fb[y * FB_WIDTH + x]) {
+                    assert!(
+                        (mapped.x0..mapped.x1).contains(&x) && (mapped.y0..mapped.y1).contains(&y),
+                        "lit pixel ({x}, {y}) outside {mapped:?}"
+                    );
+                }
+            }
+        }
+        let lit_in_column = |x: usize| (0..placement.rows).any(|y| is_lit(fb[y * FB_WIDTH + x]));
+        let lit_in_row = |y: usize| (0..FB_WIDTH).any(|x| is_lit(fb[y * FB_WIDTH + x]));
+        assert!(lit_in_column(mapped.x0) && lit_in_column(mapped.x1 - 1));
+        assert!(lit_in_row(mapped.y0) && lit_in_row(mapped.y1 - 1));
+        // Rows: captured rows 10..60 minus the 5 skipped, at the glass top.
+        assert_eq!((mapped.y0, mapped.y1), (5, 55));
+        // Columns: source 100..300 of a 400-wide window at -40 spans
+        // (140..340) * 716 / 400 of the glass, give or take the blend.
+        assert!((248..=252).contains(&mapped.x0), "{mapped:?}");
+        assert!((606..=612).contains(&mapped.x1), "{mapped:?}");
+
+        // Woven (LACE) presentation doubles the rows.
+        let woven = placement.content_rect(content, 2 * placement.rows).unwrap();
+        assert_eq!((woven.y0, woven.y1), (10, 110));
+
+        // Content entirely above the glass top maps to nothing.
+        let above = ContentRect {
+            x0: 100,
+            x1: 300,
+            y0: 0,
+            y1: 5,
+        };
+        assert_eq!(placement.content_rect(above, placement.rows), None);
+        // Content entirely left of the sync-anchored window (the sync
+        // tail clamps to the edge column, which is border here) maps
+        // to nothing either.
+        let mut fb = vec![0u32; FB_WIDTH * 120];
+        let placement = post_process_rendered_field(
+            &mut fb,
+            geometry,
+            1,
+            Some((300, 400)),
+            None,
+            geometry.visible_start_vpos,
+            0,
+            Overscan::Tv,
+        );
+        let left = ContentRect {
+            x0: 100,
+            x1: 200,
+            y0: 10,
+            y1: 60,
+        };
+        assert_eq!(placement.content_rect(left, placement.rows), None);
+        // Without a programmed vertical sync the rows stay as captured,
+        // and a standard-length line without programmed horizontal sync
+        // keeps its columns.
+        let native = FrameGeometry {
+            line_cck: 227,
+            ..geometry
+        };
+        let placement = post_process_rendered_field(
+            &mut fb,
+            native,
+            1,
+            None,
+            None,
+            geometry.visible_start_vpos,
+            0,
+            Overscan::Tv,
+        );
+        assert_eq!(placement.rows, 100);
+        assert_eq!(placement.content_rect(left, 100), Some(left));
+    }
+
+    /// A 35 ns canvas fans each hi-res-pitch column of the envelope out
+    /// to two buffer columns before the window resample.
+    #[test]
+    fn programmable_placement_scales_the_envelope_to_the_canvas_pitch() {
+        use crate::video::bitplane::ContentRect;
+        let geometry = FrameGeometry {
+            programmable: true,
+            visible_start_vpos: 20,
+            visible_lines: 50,
+            line_cck: 227,
+            frame_lines: 80,
+            lace: false,
+        };
+        let mut fb = vec![0u32; 2 * FB_WIDTH * 50];
+        let placement = post_process_rendered_field(
+            &mut fb,
+            geometry,
+            2,
+            None,
+            None,
+            geometry.visible_start_vpos,
+            0,
+            Overscan::Tv,
+        );
+        let content = ContentRect {
+            x0: 100,
+            x1: 300,
+            y0: 10,
+            y1: 40,
+        };
+        assert_eq!(
+            placement.content_rect(content, 50),
+            Some(ContentRect {
+                x0: 200,
+                x1: 600,
+                y0: 10,
+                y1: 40
+            })
+        );
     }
 
     #[test]

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1613,9 +1613,10 @@ struct RenderWorkerResult {
     /// frames keep the previous geometry.
     tv_aperture: TvApertureFrame,
     programmable: bool,
-    /// Playfield content envelope in woven presentation-buffer space (x
-    /// in framebuffer pixels, y in woven rows), for the autocrop
-    /// presentation; `None` for border-only or programmable frames.
+    /// Playfield content envelope in presentation-buffer space (x in
+    /// buffer columns, y in buffer rows: the woven field of a standard
+    /// scan, the sync-anchored glass of a programmable one), for the
+    /// autocrop presentation; `None` for a border-only frame.
     content_rect: Option<bitplane::ContentRect>,
     /// The job's frame snapshot, handed back for buffer reuse.
     input: bitplane::RenderInput,
@@ -4420,8 +4421,11 @@ impl ApplicationHandler for App {
                     // line prints whether or not a mode is on and the
                     // difference is invisible from it alone. The factors
                     // are the whole-number draw's pixels per canvas
-                    // column and per field line, and the shape is the
-                    // glass ratio a per-axis draw aims at.
+                    // column and per field line, the shape is the glass
+                    // ratio a per-axis draw aims at, and the scan says
+                    // which window model the envelope came through (a
+                    // programmable scan crops too, at the uniform
+                    // multiple).
                     if crate::envcfg::flag("COPPERLINE_DIAG_AUTOCROP")
                         && self.last_diag_layout != Some(layout)
                     {
@@ -4431,10 +4435,6 @@ impl ApplicationHandler for App {
                             "off"
                         } else if self.rtg_present_dims.is_some() {
                             "suspended(rtg)"
-                        } else if self.present_programmable {
-                            "suspended(programmable)"
-                        } else if self.present_width != FB_WIDTH {
-                            "suspended(canvas-width)"
                         } else if self.bezel.is_on() {
                             "suspended(bezel)"
                         } else if autocrop && per_axis {
@@ -4445,10 +4445,15 @@ impl ApplicationHandler for App {
                             "active(autocrop)"
                         };
                         info!(
-                            "[DIAG_AUTOCROP] layout mode={} surface={:?} src_canvas={:?} \
-                             display_dst={:?} chrome_dst={:?} filter={:?} factors={:?} \
-                             shape={:?}",
+                            "[DIAG_AUTOCROP] layout mode={} scan={} surface={:?} \
+                             src_canvas={:?} display_dst={:?} chrome_dst={:?} filter={:?} \
+                             factors={:?} shape={:?}",
                             mode,
+                            if self.present_programmable {
+                                "programmable"
+                            } else {
+                                "standard"
+                            },
                             r.surface_size,
                             layout.src_canvas,
                             layout.display_dst,

--- a/src/video/window/app_debugger.rs
+++ b/src/video/window/app_debugger.rs
@@ -707,7 +707,8 @@ impl App {
             visible_start_vpos,
             h_shift,
             self.overscan,
-        );
+        )
+        .rows;
         let base = self.emu.bus().frame_render_base();
         let (rows, width) = self.deinterlacer.present_field_into(
             &self.fb,

--- a/src/video/window/app_display.rs
+++ b/src/video/window/app_display.rs
@@ -607,9 +607,12 @@ impl App {
     /// unless autocrop tightens it to the content. Neither applies to a
     /// frame it cannot draw: the bezel frames the whole glass with a fixed
     /// opening (and keeps the tv canvas, so there is no per-axis draw to
-    /// make), RTG board frames and programmable scans present their own
-    /// geometry. The CRT presets compose: the pass re-draws whatever rect
-    /// the layout shows.
+    /// make), and RTG board frames present their own geometry. A
+    /// programmable (multisync) scan crops like a standard one -- its
+    /// envelope arrives mapped through the scan's own sync-anchored
+    /// window -- but takes the uniform multiple rather than the per-axis
+    /// glass shape. The CRT presets compose: the pass re-draws whatever
+    /// rect the layout shows.
     ///
     /// While a mode is on, the layout never falls back to the classic
     /// letterbox: an open menu or panel widens the rect to the full
@@ -620,19 +623,27 @@ impl App {
     /// bottom, rather than hopping between the bottom-anchored band and
     /// the letterbox's centred bar every time a menu opens.
     pub(super) fn display_canvas_src(&self) -> Option<DisplaySrc> {
-        if self.rtg_present_dims.is_some()
-            || self.present_programmable
-            || self.present_width != FB_WIDTH
-            || self.bezel.is_on()
-        {
+        self.display_canvas_src_for(per_axis_scaling_requested(), crate::video::autocrop())
+    }
+
+    /// [`Self::display_canvas_src`] for the given mode requests, pure of
+    /// the live globals.
+    pub(super) fn display_canvas_src_for(
+        &self,
+        per_axis: bool,
+        autocrop: bool,
+    ) -> Option<DisplaySrc> {
+        if self.rtg_present_dims.is_some() || self.bezel.is_on() {
             return None;
         }
-        let per_axis = per_axis_scaling_requested();
-        let autocrop = crate::video::autocrop();
         if !per_axis && !autocrop {
             return None;
         }
-        let par = if per_axis {
+        // A programmable scan's glass is the whole canvas, with no woven
+        // pairs for a per-line factor to step by half a row: it keeps
+        // the uniform multiple of the square canvas, so only the tv
+        // canvas of a standard scan asks for the glass shape.
+        let par = if per_axis && !self.present_programmable {
             glass_par(
                 self.overscan,
                 self.present_tv_aperture_rows,
@@ -658,6 +669,7 @@ impl App {
                     canvas_content_rect(
                         content,
                         self.present_rows,
+                        self.present_width,
                         self.overscan,
                         self.tv_centre,
                         self.present_tv_aperture_rows,
@@ -797,6 +809,30 @@ impl App {
         self.present_width = width;
     }
 
+    /// A different scan geometry is a different coordinate space for the
+    /// content envelope -- a programmable scan's own glass rows against
+    /// the standard woven field, a 35 ns canvas against the classic one,
+    /// a mode's LACE toggling its rows -- so the latch's union and shrink
+    /// clock start over across one, the way the deinterlacer drops its
+    /// weave history there. The screen changes wholesale at such a switch
+    /// anyway; there is no zoom to hold steady through it.
+    fn reset_autocrop_latch_across_scan_change(
+        &mut self,
+        programmable: bool,
+        present_rows: usize,
+        present_width: usize,
+    ) {
+        if (programmable, present_rows, present_width)
+            != (
+                self.present_programmable,
+                self.present_rows,
+                self.present_width,
+            )
+        {
+            self.autocrop_latch.reset();
+        }
+    }
+
     pub(super) fn reset_render_pipeline(&mut self) {
         self.render_generation = self.render_generation.wrapping_add(1);
         self.last_rendered_emulated_frame = None;
@@ -827,6 +863,11 @@ impl App {
         // envelope prove itself stable. A change to the *presented* crop
         // must repaint even when the pixels themselves are unchanged
         // (the shrink adoption fires on the Nth identical frame).
+        self.reset_autocrop_latch_across_scan_change(
+            result.programmable,
+            result.present_rows,
+            result.present_width,
+        );
         let smoothed = self.autocrop_latch.resolve(result.content_rect);
         if smoothed != self.present_content_rect {
             self.present_content_rect = smoothed;
@@ -1051,7 +1092,7 @@ impl App {
         let field_content = bitplane::render(self.emu.bus_mut(), &mut self.fb);
         let geometry = self.emu.bus().frame_geometry();
         let canvas_scale = self.emu.bus().frame_canvas_scale();
-        let field_rows = post_process_rendered_field(
+        let placement = post_process_rendered_field(
             &mut self.fb,
             geometry,
             canvas_scale,
@@ -1067,21 +1108,17 @@ impl App {
         let mut next_present_fb = std::mem::take(&mut self.render_recycle_fb);
         let (rows, width) = self.deinterlacer.present_field_into(
             &self.fb,
-            field_rows,
+            placement.rows,
             FB_WIDTH * canvas_scale,
             base.bplcon0 & 0x0004 != 0,
             base.long_field,
             !geometry.programmable,
             &mut next_present_fb,
         );
-        let smoothed = self.autocrop_latch.resolve(woven_content_rect(
-            field_content,
-            geometry.programmable,
-            visible_start_vpos,
-            h_shift,
-            FB_WIDTH * canvas_scale,
-            rows,
-        ));
+        self.reset_autocrop_latch_across_scan_change(geometry.programmable, rows, width);
+        let smoothed = self
+            .autocrop_latch
+            .resolve(field_content.and_then(|rect| placement.content_rect(rect, rows)));
         if smoothed != self.present_content_rect {
             self.present_content_rect = smoothed;
             self.main_presentation_dirty = true;

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -139,7 +139,7 @@ pub(super) fn render_job_to_presentation(
     let canvas_scale = input.canvas_scale();
     let canvas_width = FB_WIDTH * canvas_scale;
     let visible_start_vpos = input.visible_start_vpos();
-    let field_rows = post_process_rendered_field(
+    let placement = post_process_rendered_field(
         fb,
         geometry,
         canvas_scale,
@@ -152,21 +152,16 @@ pub(super) fn render_job_to_presentation(
     let base = input.render_base();
     let (present_rows, present_width) = deinterlacer.present_field_into(
         fb,
-        field_rows,
+        placement.rows,
         canvas_width,
         base.bplcon0 & 0x0004 != 0,
         base.long_field,
         !geometry.programmable,
         &mut presentation_fb,
     );
-    let content_rect = woven_content_rect(
-        render_result.content_rect,
-        geometry.programmable,
-        visible_start_vpos,
-        h_shift,
-        canvas_width,
-        present_rows,
-    );
+    let content_rect = render_result
+        .content_rect
+        .and_then(|rect| placement.content_rect(rect, present_rows));
     let metadata = RepeatedPresentationMetadata {
         present_rows,
         present_width,
@@ -190,38 +185,13 @@ pub(super) fn render_job_to_presentation(
     }
 }
 
-/// Map the renderer's field-space content envelope into woven
-/// presentation-buffer space: the same shifts
-/// `post_process_rendered_field` applied to the pixels (vertical
-/// centring, horizontal recentring), then each field row onto its two
-/// woven rows. Programmable scans present their own window in full and
-/// never autocrop, so they map to `None`.
-pub(super) fn woven_content_rect(
-    rect: Option<bitplane::ContentRect>,
-    programmable: bool,
-    visible_start_vpos: u32,
-    h_shift: usize,
-    canvas_width: usize,
-    present_rows: usize,
-) -> Option<bitplane::ContentRect> {
-    rect.filter(|_| !programmable)
-        .map(|rect| {
-            let y_off = presentation_source_y_offset(visible_start_vpos);
-            let x0 = rect.x0.saturating_sub(h_shift).min(canvas_width);
-            let x1 = rect.x1.saturating_sub(h_shift).clamp(x0, canvas_width);
-            let y0 = (2 * (rect.y0 + y_off)).min(present_rows);
-            let y1 = (2 * (rect.y1 + y_off)).clamp(y0, present_rows);
-            bitplane::ContentRect { x0, x1, y0, y1 }
-        })
-        .filter(|rect| rect.x1 > rect.x0 && rect.y1 > rect.y0)
-}
-
-/// Map a woven-space content envelope into canvas coordinates -- the
-/// space of the texture's display region -- by inverting the same row
-/// and column mapping `copy_window_present_frame` used for this frame's
-/// branch. Returns `(x, y, w, h)` in canvas pixels, or `None` when no
-/// canvas pixel shows content (crop everything away and there is nothing
-/// to present).
+/// Map a presentation-buffer content envelope (`src_rows` x `src_width`
+/// pixels: the woven field of a standard scan, a programmable scan's
+/// glass) into canvas coordinates -- the space of the texture's display
+/// region -- by inverting the same row and column mapping
+/// `copy_window_present_frame` used for this frame's branch. Returns
+/// `(x, y, w, h)` in canvas pixels, or `None` when no canvas pixel shows
+/// content (crop everything away and there is nothing to present).
 ///
 /// The inversion scans the canvas axes against the copy's forward maps
 /// rather than deriving closed forms: a few hundred iterations, run only
@@ -230,6 +200,7 @@ pub(super) fn woven_content_rect(
 pub(super) fn canvas_content_rect(
     content: bitplane::ContentRect,
     src_rows: usize,
+    src_width: usize,
     overscan: Overscan,
     tv_centre: TvCentre,
     tv_aperture_rows: Option<usize>,
@@ -278,8 +249,17 @@ pub(super) fn canvas_content_rect(
                     y_max = Some(y);
                 }
             }
-            x_min = Some(content.x0.min(FB_WIDTH - 1));
-            x_max = Some(content.x1.saturating_sub(1).min(FB_WIDTH - 1));
+            // The plain copy keeps the classic canvas's columns as they
+            // are and folds a wider (35 ns) canvas onto them by nearest
+            // sample: canvas column x reads source column
+            // x * src_width / FB_WIDTH, so a content column lands on the
+            // canvas column that far back. Inclusive at both ends -- the
+            // crop must never cut a content column, whichever of a
+            // group's sources the texture scale in force samples.
+            let src_width = src_width.max(1);
+            let canvas_x = |x: usize| (x * FB_WIDTH / src_width).min(FB_WIDTH - 1);
+            x_min = Some(canvas_x(content.x0));
+            x_max = Some(canvas_x(content.x1.saturating_sub(1)));
         }
     }
     let (x0, x1, y0, y1) = (x_min?, x_max?, y_min?, y_max?);

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -8556,14 +8556,14 @@ fn integer_scaling_fits_in_whole_canvas_pixels() {
     assert_eq!(plan(false, 1.0, (3024, 1964)), (1, None));
 }
 
-/// The renderer's field-space content envelope reaches presentation
-/// space through the exact shifts the pixels took: vertical centring by
+/// The content envelope follows a standard field through the exact
+/// shifts the pixels took: vertical centring by
 /// `presentation_source_y_offset`, horizontal recentring by `h_shift`,
-/// then each field row onto its two woven rows. Programmable scans never
-/// map (they present their own window in full).
+/// then each field row onto its two woven rows.
 #[test]
-fn woven_content_rect_applies_the_post_process_shifts_and_weaves() {
+fn standard_placement_applies_the_post_process_shifts_and_weaves() {
     use crate::video::bitplane::ContentRect;
+    use crate::video::present_common::FieldPlacement;
     let rect = ContentRect {
         x0: 100,
         x1: 500,
@@ -8572,20 +8572,11 @@ fn woven_content_rect_applies_the_post_process_shifts_and_weaves() {
     };
     let y_off = super::presentation_source_y_offset(0x2C);
 
-    let woven = super::woven_content_rect(Some(rect), false, 0x2C, 10, FB_WIDTH, 570)
+    let woven = FieldPlacement::standard(crate::video::FB_HEIGHT, 0x2C, 10)
+        .content_rect(rect, 570)
         .expect("standard frame maps");
     assert_eq!((woven.x0, woven.x1), (90, 490));
     assert_eq!((woven.y0, woven.y1), (2 * (30 + y_off), 2 * (230 + y_off)));
-
-    // Programmable scans and border-only frames give nothing to crop to.
-    assert_eq!(
-        super::woven_content_rect(Some(rect), true, 0x2C, 0, FB_WIDTH, 570),
-        None
-    );
-    assert_eq!(
-        super::woven_content_rect(None, false, 0x2C, 0, FB_WIDTH, 570),
-        None
-    );
 
     // The woven rows clamp to the frame actually presented, and a rect
     // shifted entirely off the canvas collapses to None rather than an
@@ -8597,7 +8588,7 @@ fn woven_content_rect_applies_the_post_process_shifts_and_weaves() {
         y1: 285,
     };
     assert_eq!(
-        super::woven_content_rect(Some(low), false, 0x2C, 8, FB_WIDTH, 570),
+        FieldPlacement::standard(crate::video::FB_HEIGHT, 0x2C, 8).content_rect(low, 570),
         None
     );
 }
@@ -8620,6 +8611,7 @@ fn canvas_content_rect_inverts_the_tv_aperture_mapping() {
     let (x, y, w, h) = super::canvas_content_rect(
         content,
         570,
+        FB_WIDTH,
         Overscan::Tv,
         crate::config::TvCentre::default(),
         Some(aperture_rows),
@@ -8655,6 +8647,7 @@ fn canvas_content_rect_inverts_the_tv_aperture_mapping() {
     let (px, py, pw, ph) = super::canvas_content_rect(
         content,
         570,
+        FB_WIDTH,
         Overscan::Full,
         crate::config::TvCentre::default(),
         None,
@@ -8675,6 +8668,7 @@ fn canvas_content_rect_inverts_the_tv_aperture_mapping() {
         super::canvas_content_rect(
             off_glass,
             570,
+            FB_WIDTH,
             Overscan::Tv,
             crate::config::TvCentre::default(),
             Some(aperture_rows),
@@ -8682,6 +8676,129 @@ fn canvas_content_rect_inverts_the_tv_aperture_mapping() {
         ),
         None
     );
+}
+
+/// A programmable scan's glass presents through the plain copy: its rows
+/// rescale onto the canvas height, and a 35 ns canvas folds two buffer
+/// columns onto each canvas column, so the envelope's columns come back
+/// halved and its rows follow the row map -- content at the glass edges
+/// reaches the canvas edges.
+#[test]
+fn canvas_content_rect_folds_a_programmable_glass_onto_the_canvas() {
+    use crate::video::bitplane::ContentRect;
+    let glass_rows = 552;
+    let canvas_rows = crate::video::PRESENT_HEIGHT_SQUARE;
+    let content = ContentRect {
+        x0: 200,
+        x1: 1000,
+        y0: 40,
+        y1: 500,
+    };
+    let (x, y, w, h) = super::canvas_content_rect(
+        content,
+        glass_rows,
+        2 * FB_WIDTH,
+        Overscan::Tv,
+        crate::config::TvCentre::default(),
+        None,
+        canvas_rows,
+    )
+    .expect("glass content maps");
+    assert_eq!((x, w), (100, 400));
+    // Forward-map the returned row range like the plain copy does.
+    for canvas_y in y..y + h {
+        let src = crate::screenshot::scaled_source_row(canvas_y, glass_rows, canvas_rows);
+        assert!((content.y0..content.y1).contains(&src), "row {canvas_y}");
+    }
+    assert!(
+        !(content.y0..content.y1).contains(&crate::screenshot::scaled_source_row(
+            y - 1,
+            glass_rows,
+            canvas_rows
+        ))
+    );
+    assert!(
+        !(content.y0..content.y1).contains(&crate::screenshot::scaled_source_row(
+            y + h,
+            glass_rows,
+            canvas_rows
+        ))
+    );
+
+    // The whole glass is the whole canvas.
+    let whole = ContentRect {
+        x0: 0,
+        x1: 2 * FB_WIDTH,
+        y0: 0,
+        y1: glass_rows,
+    };
+    assert_eq!(
+        super::canvas_content_rect(
+            whole,
+            glass_rows,
+            2 * FB_WIDTH,
+            Overscan::Tv,
+            crate::config::TvCentre::default(),
+            None,
+            canvas_rows,
+        ),
+        Some((0, 0, FB_WIDTH, canvas_rows))
+    );
+}
+
+/// Autocrop presents a programmable (multisync) scan's content the way
+/// it presents a standard one's: the display source is the content
+/// rect on the canvas, at the uniform pixel shape (a programmable
+/// scan's rows are not woven pairs for the per-axis fit to step by
+/// half a row), and the same suspensions -- a bezel, RTG scanout --
+/// still apply.
+#[test]
+fn display_canvas_src_crops_a_programmable_scan() {
+    use crate::video::bitplane::ContentRect;
+    let mut app = test_app();
+    app.present_programmable = true;
+    app.present_rows = 552;
+    app.present_width = FB_WIDTH;
+    app.present_tv_aperture_rows = None;
+    app.present_content_rect = Some(ContentRect {
+        x0: 40,
+        x1: 680,
+        y0: 20,
+        y1: 532,
+    });
+    let expected = super::canvas_content_rect(
+        app.present_content_rect.unwrap(),
+        552,
+        FB_WIDTH,
+        app.overscan,
+        app.tv_centre,
+        None,
+        present_height(),
+    )
+    .unwrap();
+
+    let src = app
+        .display_canvas_src_for(false, true)
+        .expect("autocrop crops the programmable scan");
+    assert_eq!(src.rect, expected);
+    assert_eq!(src.par, (1, 1));
+
+    // Per-axis integer scaling keeps the uniform multiple on a
+    // programmable scan, cropped or not.
+    let per_axis = app.display_canvas_src_for(true, true).unwrap();
+    assert_eq!(per_axis, src);
+    let uncropped = app.display_canvas_src_for(true, false).unwrap();
+    assert_eq!(uncropped.rect, (0, 0, FB_WIDTH, present_height()));
+    assert_eq!(uncropped.par, (1, 1));
+
+    // Both modes off: the classic layout.
+    assert_eq!(app.display_canvas_src_for(false, false), None);
+    // A standard scan under per-axis scaling asks for the glass shape.
+    app.present_programmable = false;
+    app.present_rows = crate::video::deinterlace::OUT_HEIGHT;
+    app.present_tv_aperture_rows = Some(TV_PAL_PRESENT_HEIGHT);
+    let standard = app.display_canvas_src_for(true, false).unwrap();
+    assert_ne!(standard.par, (1, 1));
 }
 
 /// The autocrop latch grows immediately (content must never be cut),
@@ -8862,6 +8979,7 @@ fn display_rects_start_on_field_lines() {
     let rect = super::canvas_content_rect(
         content,
         crate::video::deinterlace::OUT_HEIGHT,
+        FB_WIDTH,
         Overscan::Tv,
         TvCentre::default(),
         Some(TV_NTSC_PRESENT_HEIGHT),


### PR DESCRIPTION
Closes #607, the programmable-scan follow-up to #593.

## What changes

`[display] autocrop` derived its envelope from the standard 15 kHz presentation and suspended itself for programmable (ECS/AGA VARBEAMEN) scans -- the diag trace reported `mode=suspended(programmable)` on a DblPAL or Multiscan Workbench and on amifb's 31 kHz console. Those scans now crop and refit like a 15 kHz one: the envelope is the same fetched-rows model, carried through the scan's own sync-anchored window and blanking. The renderer already computed the envelope for these frames; only the presentation threw it away.

## Design

- **Placement, not re-derivation** (`present_common.rs`): `post_process_rendered_field` returns the `FieldPlacement` it applied -- a standard field's centring/recentring shifts, or a programmable scan's sync-anchored column resample (`stretch_rows_x_window` / time-linear `stretch_rows_x` / identity) plus the vertical window's skipped and padded rows -- and `FieldPlacement::content_rect` follows the envelope through it onto the presentation buffer. The pixels and the crop go through one description, so they cannot disagree. Replaces `woven_content_rect`.
- **Columns by the resampler's own taps** (`screenshot.rs`): `stretch_rows_x_source` / `stretch_rows_x_window_source` are factored out of the two resamplers (pixel-identical) and `resampled_column_reads` names the source columns each output column blends. The programmable envelope's columns come from scanning the glass against those taps, so a partly blended edge column counts and a sync tail that clamps to an edge column counts only when that column is picture. Rows: the captured rows the vertical window kept; the deinterlacer's row count says whether they were woven (LACE) or passed through at native height.
- **Blanking trim** (`bitplane.rs`): `trim_content_rect_to_blanking` trims the envelope's *edges* by VBSTRT/VBSTOP, HBSTRT/HBSTOP and the frame end, using the same predicates `apply_programmable_blanking` paints with (`blank_window_contains`, `framebuffer_column_cck`). Kickstart leaves the display window open across the blank on these modes; those rows are black to the eye. Edges only -- a blank through the middle is not a shape one crop can follow.
- **35 ns canvas**: `canvas_content_rect` takes the buffer width and folds a super-hi-res canvas onto the canvas columns (floor at both ends: never cut a content column whichever of a group the texture scale samples), so the `present_width != FB_WIDTH` suspension goes too.
- **Presentation**: `App::display_canvas_src` drops the programmable and canvas-width guards (`display_canvas_src_for(per_axis, autocrop)` is the same decision pure of the live globals). A programmable scan keeps the **uniform multiple** under per-axis integer scaling: its rows are not woven pairs for a per-line factor to step by half a row, and an odd count would band a progressive scan. Bezel and RTG scanout still suspend. The `AutocropLatch` resets across a scan-geometry change (programmable flag, rows, width) the way the deinterlacer drops its weave history -- the two spaces have nothing to union. `COPPERLINE_DIAG_AUTOCROP`'s layout line names `scan=standard|programmable` in place of the two suspensions.

Docs: `configuration.md`, `ui.md`, `internals/video.md`, `copperline.example.toml`.

## Verification

- `cargo test` 3099 passed. New: `programmable_placement_maps_the_content_envelope_through_its_windows` (window/skip/pad/LACE/off-glass), `programmable_placement_scales_the_envelope_to_the_canvas_pitch`, `content_rect_trims_to_the_blanking_the_frame_shows`, `canvas_content_rect_folds_a_programmable_glass_onto_the_canvas`, `display_canvas_src_crops_a_programmable_scan`, `resample_taps_name_the_columns_the_resamplers_read`; `standard_placement_applies_the_post_process_shifts_and_weaves` carries the old standard-branch assertions.
- `probe_golden` 44/44 byte-exact: the resampler and vertical-window refactors are pixel-neutral, and the standard-scan envelope is unchanged.
- Ignored `dblpal_boot_presents_full_programmable_scan` passes. A headless DblPAL Workbench boot (KS3.1) with `COPPERLINE_DIAG_AUTOCROP=1` logs a stable envelope of x 58..378 (hi-res pitch), rows 20..532 of the 552-row glass -- the crop removes the black blanking bands and the unfetched sides.
- `cargo clippy --all-targets` and `cargo fmt --check` clean.

Not verified in a live window (the GPU present path cannot be exercised headlessly): a DblPAL Workbench with autocrop on should log `mode=active(autocrop) scan=programmable` with a `src_canvas` narrower than the full canvas, and switching between a standard and a DblPAL screen should adopt the new crop immediately (latch reset) rather than holding the union.

## Judgment calls

- Programmable scans take par `(1, 1)` under per-axis scaling rather than the 4:3 glass ratio; giving them the glass shape needs an even-`lines` rule so a progressive scan's rows stay uniform, left for a follow-up.
- The blanking trim also runs on standard scans, where it only matters on the no-capture re-fetch path (rows past a 263-line frame end); with captured rows those rows were never counted.
- The web frontend (#608) is untouched.
