### PR TITLE
Web frontend: integer scaling and autocrop

### DIFF
--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -19,8 +19,8 @@ use copperline::audio::AudioSink;
 use copperline::bus::PortDevice;
 use copperline::chipset::agnus::VideoStandard;
 use copperline::config::{
-    machine_profile_defaults, parse_machine_model, parse_video_standard, Config, Overscan,
-    TvCentre, TV_H_CENTRE_RANGE, TV_V_CENTRE_RANGE,
+    machine_profile_defaults, parse_machine_model, parse_video_standard, Config, DisplayScaling,
+    Overscan, TvCentre, TV_H_CENTRE_RANGE, TV_V_CENTRE_RANGE,
 };
 use copperline::emulator::{build_machine, Emulator};
 use copperline::serial::{ChannelSerialHandle, ChannelSerialSink};
@@ -257,6 +257,29 @@ pub struct WebEmu {
     /// previous presentation geometry instead of snapping to the full
     /// framebuffer, so the canvas does not jump at every mode change.
     presentation_latch: present_common::PresentationLatch,
+    /// Presentation scaling, the desktop's `[display] scaling` knob. See
+    /// [`Self::set_scaling`].
+    scaling: DisplayScaling,
+    /// Whether [`Self::present_layout`] crops to the content envelope,
+    /// the desktop's `[display] autocrop`. See [`Self::set_autocrop`].
+    autocrop: bool,
+    /// The autocrop smoothing (the desktop's latch), judging envelopes in
+    /// presentation-buffer pixels: the space the page draws in.
+    autocrop_latch: present_common::AutocropLatch,
+    /// The latched content envelope the presentation shows, in
+    /// presentation-buffer pixels; `None` until content has been seen.
+    present_content_rect: Option<bitplane::ContentRect>,
+    /// The envelope the last rendered field presented with, re-fed to the
+    /// latch on an exactly reused frame so a static screen still lets a
+    /// smaller envelope prove itself stable.
+    last_content_rect: Option<bitplane::ContentRect>,
+    /// Whether the presented scan is programmable (VARBEAMEN), which
+    /// takes the uniform multiple under integer scaling.
+    present_programmable: bool,
+    /// The scan geometry the latch is judging in -- programmable, woven
+    /// rows and width, presented rows and width -- so a switch to another
+    /// coordinate space starts the latch over, as on the desktop.
+    present_scan: Option<(bool, usize, usize, usize, usize)>,
     /// Exact previous-frame reuse, the desktop render cache's detector via
     /// the same path the benchmark uses: a frame whose render input matches
     /// the previous one skips the whole render/present pipeline, since the
@@ -348,6 +371,13 @@ impl WebEmu {
             monitor_bezel: false,
             tv_centre: TvCentre::default(),
             presentation_latch: present_common::PresentationLatch::default(),
+            scaling: DisplayScaling::Smooth,
+            autocrop: false,
+            autocrop_latch: present_common::AutocropLatch::default(),
+            present_content_rect: None,
+            last_content_rect: None,
+            present_programmable: false,
+            present_scan: None,
             repeated_frame_detector: bitplane::RepeatedFrameDetector::default(),
             last_run_core_ms: 0.0,
             last_run_render_ms: 0.0,
@@ -517,25 +547,38 @@ impl WebEmu {
             return;
         }
         let visible_start_vpos = self.emu.bus().frame_visible_start_vpos();
-        if self.deinterlacer.phosphor() == 0.0 {
+        let field_content = if self.deinterlacer.phosphor() == 0.0 {
             // A frame identical to the previous render needs no pipeline at
             // all: the present buffer already shows it, and the detector
             // carries the frame's CLXDAT so collisions still accumulate.
-            if bitplane::render_reusing_previous(
+            match bitplane::render_reusing_previous(
                 self.emu.bus_mut(),
                 &mut self.fb,
                 &mut self.repeated_frame_detector,
             ) {
-                self.last_rendered_frame = Some(emulated_frame);
-                return;
+                bitplane::ReuseRender::Reused => {
+                    self.last_rendered_frame = Some(emulated_frame);
+                    // The autocrop smoothing advances on a reused frame
+                    // too, as on the desktop: a static screen is exactly
+                    // what lets a smaller envelope prove itself stable.
+                    // The envelope is the one the held presentation was
+                    // rendered with, and a crop the latch adopts on it
+                    // must reach the page although the pixels did not
+                    // change: the revision is the page's only redraw cue.
+                    if self.latch_content_rect(self.last_content_rect) {
+                        self.presentation_revision = self.presentation_revision.wrapping_add(1);
+                    }
+                    return;
+                }
+                bitplane::ReuseRender::Rendered(content) => content,
             }
         } else {
             // Phosphor changes the presentation on every field while its
             // trail decays, even when the emulated pixels repeat exactly.
             // Render the field unconditionally so every repeated frame
             // reaches the persistence blend.
-            bitplane::render(self.emu.bus_mut(), &mut self.fb);
-        }
+            bitplane::render(self.emu.bus_mut(), &mut self.fb)
+        };
         let geometry = self.emu.bus().frame_geometry();
         let canvas_scale = self.emu.bus().frame_canvas_scale();
         let base = self.emu.bus().frame_render_base();
@@ -547,9 +590,7 @@ impl WebEmu {
         let h_shift = self
             .presentation_latch
             .presentation_h_shift(&base, self.overscan);
-        // The browser presents the whole placed field (no autocrop here
-        // yet), so only the placement's row count is used.
-        let field_rows = present_common::post_process_rendered_field(
+        let placement = present_common::post_process_rendered_field(
             &mut self.fb,
             geometry,
             canvas_scale,
@@ -558,8 +599,8 @@ impl WebEmu {
             visible_start_vpos,
             h_shift,
             self.overscan,
-        )
-        .rows;
+        );
+        let field_rows = placement.rows;
         let canvas_width = FB_WIDTH * canvas_scale;
         let lace = base.bplcon0 & 0x0004 != 0;
         let double_rows = !geometry.programmable;
@@ -568,6 +609,12 @@ impl WebEmu {
         } else {
             field_rows
         };
+        // The content envelope, followed through the placement onto the
+        // woven field the deinterlacer builds -- the desktop's
+        // `present_content_rect` space -- and below through whichever
+        // copy fills the presentation buffer, into the buffer's own
+        // pixels, which are what the page draws.
+        let woven_content = field_content.and_then(|rect| placement.content_rect(rect, woven_rows));
         let tv_aperture_rows = if self.overscan == Overscan::Tv {
             self.presentation_latch
                 .resolve_tv_aperture(present_common::standard_tv_aperture_frame(
@@ -576,7 +623,7 @@ impl WebEmu {
         } else {
             None
         };
-        if let Some(aperture_rows) = tv_aperture_rows {
+        let present_content = if let Some(aperture_rows) = tv_aperture_rows {
             // Standard 15 kHz display: present the captured TV aperture, the
             // browser counterpart of the desktop's TV-aperture crop. Clipped
             // to real framebuffer columns so the canvas never shows the
@@ -602,8 +649,23 @@ impl WebEmu {
                     present_common::TV_GLASS_PRESENT_ROWS,
                 )
             };
+            // Integer scaling draws the unresampled aperture, as the
+            // desktop draws its unresampled canvas: one buffer row per
+            // woven row, so the page's whole-number factors carry every
+            // scan line to the screen as one exact block. The 50 Hz
+            // aperture already has the glass's row count; this keeps the
+            // 60 Hz one at its own. A drawn bezel suspends the mode (its
+            // fixed opening owns the glass) and keeps the tube view.
+            let destination_rows = if self.scaling == DisplayScaling::Integer && !self.monitor_bezel
+            {
+                source_rows
+            } else {
+                destination_rows
+            };
             let (source_x_offset, source_y_offset) =
                 present_common::tv_centre_source_offset(self.tv_centre);
+            let source_x = present_common::TV_CAPTURED_SOURCE_X as i32 + source_x_offset;
+            let source_y = source_y as i32 + source_y_offset;
             (self.present_rows, self.present_width) =
                 self.deinterlacer.present_field_region_into_elapsed(
                     &self.fb,
@@ -612,8 +674,8 @@ impl WebEmu {
                     lace,
                     base.long_field,
                     double_rows,
-                    present_common::TV_CAPTURED_SOURCE_X as i32 + source_x_offset,
-                    source_y as i32 + source_y_offset,
+                    source_x,
+                    source_y,
                     source_rows,
                     present_common::TV_CAPTURED_WIDTH,
                     destination_rows,
@@ -625,6 +687,16 @@ impl WebEmu {
             // whatever row count it was scaled onto (the desktop's
             // crt_scanline_count, without its bezel-padding rescale).
             self.present_crt_lines = (source_rows / 2).max(1) as f32;
+            woven_content.and_then(|rect| {
+                present_common::region_present_content_rect(
+                    rect,
+                    source_x,
+                    source_y,
+                    source_rows,
+                    present_common::TV_CAPTURED_WIDTH,
+                    destination_rows,
+                )
+            })
         } else {
             (self.present_rows, self.present_width) = self.deinterlacer.present_field_into_elapsed(
                 &self.fb,
@@ -644,9 +716,60 @@ impl WebEmu {
             } else {
                 (woven_rows / 2).max(1) as f32
             };
+            // The whole woven field is the buffer: the envelope needs no
+            // further map.
+            woven_content
+        };
+        self.present_programmable = geometry.programmable;
+        // A different scan geometry is a different coordinate space for
+        // the envelope -- a programmable scan's own rows against the
+        // standard woven field, a 35 ns canvas against the classic one, a
+        // mode's LACE toggling its rows, the aperture switching between
+        // the resampled and native row counts -- so the latch's union and
+        // shrink clock start over across one, as on the desktop. The
+        // screen changes wholesale at such a switch anyway.
+        let scan = (
+            geometry.programmable,
+            woven_rows,
+            canvas_width,
+            self.present_rows,
+            self.present_width,
+        );
+        if self
+            .present_scan
+            .replace(scan)
+            .is_some_and(|previous| previous != scan)
+        {
+            self.autocrop_latch.reset();
         }
+        self.last_content_rect = present_content;
+        self.latch_content_rect(present_content);
         self.last_rendered_frame = Some(emulated_frame);
         self.presentation_revision = self.presentation_revision.wrapping_add(1);
+    }
+
+    /// Advance the autocrop smoothing with a frame's envelope (in
+    /// presentation-buffer pixels) and adopt what it presents; true when
+    /// the presented crop changed.
+    fn latch_content_rect(&mut self, content: Option<bitplane::ContentRect>) -> bool {
+        let smoothed = self.autocrop_latch.resolve(content);
+        if smoothed == self.present_content_rect {
+            return false;
+        }
+        self.present_content_rect = smoothed;
+        true
+    }
+
+    /// Forget the presentation's latched decisions across a discontinuity
+    /// (power cycle, state load, overscan change), like the desktop's
+    /// `reset_render_pipeline`: the aperture latch and the autocrop crop
+    /// start over with the next frame.
+    fn reset_presentation_latches(&mut self) {
+        self.presentation_latch.reset();
+        self.autocrop_latch.reset();
+        self.present_content_rect = None;
+        self.last_content_rect = None;
+        self.present_scan = None;
     }
 
     /// Presentation buffer: RGBA bytes in memory order, `present_width() x
@@ -666,6 +789,11 @@ impl WebEmu {
         self.presentation_revision
     }
 
+    /// Rows of the presentation buffer. The 50 Hz TV aperture's row count
+    /// for a standard scan under the default smooth scaling (a 60 Hz
+    /// aperture is resampled onto it, so both fill the same 4:3 glass),
+    /// the aperture's own woven rows under integer scaling (see
+    /// `set_scaling`), the whole field's rows in full overscan.
     pub fn present_rows(&self) -> u32 {
         self.present_rows as u32
     }
@@ -1066,7 +1194,7 @@ impl WebEmu {
         // stepping the machine. The presentation latch belongs to the old
         // timeline, so it starts over too.
         self.last_rendered_frame = None;
-        self.presentation_latch.reset();
+        self.reset_presentation_latches();
         self.deinterlacer.reset_history();
         // The reuse detector's snapshot belongs to the replaced machine;
         // the repaint below must render, not match against it.
@@ -1087,7 +1215,7 @@ impl WebEmu {
         // fresh one, and the presentation latch starts over with it.
         self.mouse_remainder = (0.0, 0.0);
         self.mouse_pending = (0, 0);
-        self.presentation_latch.reset();
+        self.reset_presentation_latches();
         self.deinterlacer.reset_history();
         self.repeated_frame_detector = bitplane::RepeatedFrameDetector::default();
         Ok(())
@@ -1123,7 +1251,7 @@ impl WebEmu {
         // latched under the old one. The reuse detector resets with it:
         // the frame's content has not changed, but its presentation has,
         // so the repaint below must run the pipeline, not match.
-        self.presentation_latch.reset();
+        self.reset_presentation_latches();
         self.last_rendered_frame = None;
         self.repeated_frame_detector = bitplane::RepeatedFrameDetector::default();
         self.render_completed_frame();
@@ -1150,7 +1278,12 @@ impl WebEmu {
         // The frame's content has not changed, but its presentation has,
         // so the repaint below must run the pipeline, not match the reuse
         // detector. The latch keeps its decisions: the nudge translates
-        // the same aperture, it is not a new geometry judgement.
+        // the same aperture, it is not a new geometry judgement. The
+        // autocrop crop, judged in the nudged buffer's own pixels, moves
+        // with the picture at once rather than growing to the union of
+        // the two positions first.
+        self.autocrop_latch.reset();
+        self.present_content_rect = None;
         self.last_rendered_frame = None;
         self.repeated_frame_detector = bitplane::RepeatedFrameDetector::default();
         self.render_completed_frame();
@@ -1179,6 +1312,124 @@ impl WebEmu {
         self.last_rendered_frame = None;
         self.repeated_frame_detector = bitplane::RepeatedFrameDetector::default();
         self.render_completed_frame();
+    }
+
+    /// Presentation scaling, the desktop's `[display] scaling` knob:
+    /// "smooth" (the default) or "integer" -- whole-number device pixels
+    /// per buffer column and per scan line, centred in black, the look
+    /// WinUAE and Amiberry call integer scaling. Unknown names are
+    /// ignored, like `set_overscan`. The page draws the picture, so the
+    /// setting mostly shapes `present_layout`'s answer; it also changes
+    /// the buffer itself for a standard 60 Hz scan, whose captured
+    /// aperture is presented at its own woven rows rather than resampled
+    /// onto the 50 Hz aperture's row count (the desktop draws its
+    /// unresampled canvas under integer scaling the same way), so the
+    /// factors carry every scan line to the screen as one exact block.
+    /// The last completed frame is re-presented under the new setting,
+    /// like `set_overscan`, so a paused page repaints without stepping
+    /// the machine.
+    pub fn set_scaling(&mut self, mode: &str) {
+        let scaling = match mode.trim().to_ascii_lowercase().as_str() {
+            "smooth" => DisplayScaling::Smooth,
+            "integer" => DisplayScaling::Integer,
+            _ => return,
+        };
+        if scaling == self.scaling {
+            return;
+        }
+        self.scaling = scaling;
+        // The frame's content has not changed, but its presentation may
+        // have (the 60 Hz aperture's row count), so the repaint below must
+        // run the pipeline, not match the reuse detector. The latches keep
+        // their decisions; a changed buffer shape starts the crop over on
+        // its own (`present_scan`).
+        self.last_rendered_frame = None;
+        self.repeated_frame_detector = bitplane::RepeatedFrameDetector::default();
+        self.render_completed_frame();
+    }
+
+    /// The desktop's `[display] autocrop` (default off): `present_layout`
+    /// crops the presentation to the display window the hardware actually
+    /// programs -- the rows and columns that carry fetched bitplane data,
+    /// smoothed across frames exactly as the desktop smooths its crop --
+    /// instead of the fixed TV aperture, so a 200-line game fills far
+    /// more of a 16:9 screen, and under integer scaling earns the larger
+    /// whole multiple the cropped picture fits. A layout setting alone:
+    /// the buffer, screenshots and `present_content_rect` are unchanged,
+    /// so the page redraws its held picture rather than re-presenting.
+    pub fn set_autocrop(&mut self, autocrop: bool) {
+        self.autocrop = autocrop;
+    }
+
+    /// The latched autocrop envelope in presentation-buffer pixels, as
+    /// `[x, y, width, height]`, or empty while no content has been seen
+    /// since the last presentation discontinuity. Tracked whether or not
+    /// autocrop is on (it is what `present_layout` crops to), and it can
+    /// change between frames like `present_width`: it grows at once when
+    /// a program opens a larger display and tightens only after a smaller
+    /// one has held steady for about half a second.
+    pub fn present_content_rect(&self) -> Vec<u32> {
+        match self.present_content_rect {
+            Some(rect) => vec![
+                rect.x0 as u32,
+                rect.y0 as u32,
+                (rect.x1 - rect.x0) as u32,
+                (rect.y1 - rect.y0) as u32,
+            ],
+            None => Vec::new(),
+        }
+    }
+
+    /// Where the presentation buffer lands on an `avail_w` x `avail_h`
+    /// device-pixel viewport under the scaling and autocrop settings, for
+    /// a page that draws the buffer itself: `[sx, sy, sw, sh, dx, dy, dw,
+    /// dh, columns, lines]` -- the buffer sub-rect to show (the autocrop
+    /// envelope, or the whole buffer), where to draw it (the viewport
+    /// outside it is black), and the whole-number factors of an integer
+    /// draw as device pixels per buffer column and per scan line (0, 0
+    /// for a smooth fit). Empty until a frame has been presented.
+    ///
+    /// The buffer's pixel shape is the 4:3 glass's, read off the buffer
+    /// itself (the page shows the whole buffer in a 4:3 element): drawn
+    /// smooth, the whole buffer fills such a viewport exactly as the
+    /// page's stretch does, and a crop keeps that shape in a letterbox;
+    /// drawn integer, a standard scan takes a whole number per axis
+    /// approximating that shape -- the desktop's per-axis fit, 4:5 pixels
+    /// for a 200-line NTSC game on a 1080p screen -- and a programmable
+    /// scan the uniform multiple. The page decides when to ask: the
+    /// hosted page keeps its plain stretch while both settings are off,
+    /// and while a bezel mode's fixed opening owns the glass.
+    pub fn present_layout(&self, avail_w: u32, avail_h: u32) -> Vec<u32> {
+        if self.present_rows == 0 || self.present_width == 0 {
+            return Vec::new();
+        }
+        let content = if self.autocrop {
+            self.present_content_rect
+        } else {
+            None
+        };
+        let layout = present_common::buffer_layout(
+            (avail_w.max(1), avail_h.max(1)),
+            (self.present_width, self.present_rows),
+            self.present_programmable,
+            self.scaling == DisplayScaling::Integer,
+            content,
+        );
+        let (sx, sy, sw, sh) = layout.src;
+        let (dx, dy, dw, dh) = layout.dst;
+        let (columns, lines) = layout.factors.unwrap_or((0, 0));
+        vec![
+            sx as u32,
+            sy as u32,
+            sw as u32,
+            sh as u32,
+            dx,
+            dy,
+            dw,
+            dh,
+            columns as u32,
+            lines as u32,
+        ]
     }
 
     /// Enable motion-adaptive LACE field merging. The browser defaults this
@@ -1295,6 +1546,56 @@ mod tests {
     fn web_constructor_accepts_no_floppy_drives() {
         let web = WebEmu::new(Some("A500".into()), Some("PAL".into()), Some(0.0)).unwrap();
         assert!((0..4).all(|idx| !web.emu.bus().floppy.drive_connected(idx)));
+    }
+
+    /// Step a machine on a synthetic wall clock until a frame has been
+    /// presented; the page's animation loop, without the page.
+    fn present_first_frame(web: &mut WebEmu) {
+        let mut now = 0.0;
+        web.run(now, 1).unwrap();
+        while web.present_rows() == 0 {
+            now += 20.0;
+            assert!(now < 5000.0, "no frame presented");
+            web.run(now, 4).unwrap();
+        }
+    }
+
+    #[test]
+    fn present_layout_follows_the_scaling_and_autocrop_settings() {
+        let mut web = WebEmu::new(Some("A500".into()), Some("NTSC".into()), Some(1.0)).unwrap();
+        assert!(web.present_layout(1440, 1080).is_empty());
+        present_first_frame(&mut web);
+        // Smooth: the 60 Hz aperture is resampled onto the 50 Hz aperture's
+        // row count, and the whole buffer fills a 4:3 viewport exactly --
+        // the page's stretch.
+        assert_eq!((web.present_width(), web.present_rows()), (668, 540));
+        assert_eq!(
+            web.present_layout(1440, 1080),
+            vec![0, 0, 668, 540, 0, 0, 1440, 1080, 0, 0]
+        );
+        // Integer: the aperture at its own woven rows, drawn per axis at
+        // the NTSC glass shape -- two pixels per column, five per line on
+        // a 1080p screen -- and re-presented on the spot.
+        let revision = web.presentation_revision();
+        web.set_scaling("integer");
+        assert_ne!(web.presentation_revision(), revision);
+        assert_eq!((web.present_width(), web.present_rows()), (668, 428));
+        assert_eq!(
+            web.present_layout(1920, 1080),
+            vec![0, 0, 668, 428, 292, 5, 1336, 1070, 2, 5]
+        );
+        // Unknown names are ignored; the smooth buffer comes back.
+        web.set_scaling("nearest");
+        assert_eq!(web.present_rows(), 428);
+        web.set_scaling("smooth");
+        assert_eq!(web.present_rows(), 540);
+        // Autocrop alone changes only the layout, never the buffer: with no
+        // content seen on this ROM-less machine it shows the whole buffer.
+        let revision = web.presentation_revision();
+        web.set_autocrop(true);
+        assert_eq!(web.presentation_revision(), revision);
+        assert!(web.present_content_rect().is_empty());
+        assert_eq!(&web.present_layout(1440, 1080)[..4], &[0, 0, 668, 540]);
     }
 
     #[test]

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -2548,6 +2548,9 @@ function enterCssFullscreen() {
   setStyles(canvas, fsCanvasStyles(), true);
   document.documentElement.style.overflow = 'hidden';
   updateFsUi();
+  // No window resize accompanies the pinned fallback: redraw for the
+  // element's new size now (the observer would follow, a frame later).
+  redrawForElementSize();
 }
 
 function exitCssFullscreen() {
@@ -2559,6 +2562,7 @@ function exitCssFullscreen() {
   // Clearing the border shorthand above also cleared the monitor path's
   // border hiding; put the windowed chrome back the way the mode wants.
   syncShellChrome();
+  redrawForElementSize();
 }
 
 function exitFullscreen() {
@@ -2603,6 +2607,7 @@ document.addEventListener('fullscreenchange', () => {
   syncEscapeLock();
   updateFsUi();
   syncShellChrome();
+  redrawForElementSize();
 });
 
 // --- on-screen keyboard ----------------------------------------------------
@@ -2898,6 +2903,8 @@ function ensureKeyboard() {
 function publishKbdHeight(px) {
   document.documentElement.style.setProperty('--cl-kbd-h', `${px}px`);
   placeOsd();
+  // In fullscreen the strip takes its share of the element's box.
+  redrawForElementSize();
 }
 
 function buildKeyCap(grid, spec, x, y) {
@@ -3851,13 +3858,20 @@ function togglePause() {
 // buffer read and puts it back -- each flip re-presents the held frame
 // in place without stepping the machine, and blobOf's executor reads
 // the buffer synchronously (only the canvas encode is async), so the
-// flip is invisible to the page.
+// flip is invisible to the page. Integer scaling is dropped the same
+// way: it presents a 60 Hz aperture at its own woven rows for the draw's
+// sake, and a capture keeps the smooth presentation's shape whatever
+// the page draws, as the desktop's captures keep the aspect's own shape
+// whatever its window draws.
 function withTvAperture(f) {
   const bezel = monitorBezelOn();
+  const integer = layoutSupported && scalingMode === 'integer';
   if (bezel) emu.set_monitor_bezel?.(false);
+  if (integer) emu.set_scaling?.('smooth');
   try {
     return f();
   } finally {
+    if (integer) emu.set_scaling?.('integer');
     if (bezel) emu.set_monitor_bezel?.(true);
   }
 }
@@ -4989,8 +5003,10 @@ overscanSel.addEventListener('change', () => setOverscanMode(overscanSel.value, 
 // presentation-only choices remembered per browser like overscan, never
 // observable by the guest, and both stand down while a bezel mode's
 // fixed opening owns the glass, as the desktop's do. Hidden on a bundle
-// with no layout to ask for (the class methods exist as soon as the
-// module is imported).
+// with no layout to ask for, and shown explicitly on one that has (the
+// class methods exist as soon as the module is imported): a shell ships
+// the hooks hidden, like #devkeyboard, so a page deployed ahead of the
+// glue never shows a dead control.
 const SCALING_STORAGE_KEY = 'copperline-scaling';
 const SCALING_MODES = ['smooth', 'integer'];
 const SCALING_LABELS = { smooth: 'Smooth', integer: 'Integer' };
@@ -5015,10 +5031,8 @@ const autocropToggle = autocropShellToggle ?? buildToggleControl('autocrop', 'Au
 autocropToggle.checked = false;
 autocropToggle.title =
   'Crop to the display the program actually draws instead of the full TV aperture.';
-if (!layoutSupported) {
-  (scalingShellSel ?? scalingSel.parentElement).hidden = true;
-  (autocropShellToggle ?? autocropToggle.parentElement).hidden = true;
-}
+(scalingShellSel ?? scalingSel.parentElement).hidden = !layoutSupported;
+(autocropShellToggle ?? autocropToggle.parentElement).hidden = !layoutSupported;
 let scalingMode = 'smooth';
 let autocropOn = false;
 
@@ -6679,13 +6693,25 @@ presentMonitorOff();
 window.addEventListener('load', () => {
   if (!emu) presentMonitorOff();
 });
-window.addEventListener('resize', () => {
-  // The 2D fallback's plain blit is the page's CSS scaling and needs no
-  // redraw; its layout draw follows the element like the monitor path.
+// Redraw the held picture whenever the element changes size: the monitor
+// path's backing store and a layout draw follow the element, so a stale
+// store would be CSS-stretched over the new size -- and an integer draw
+// would no longer be pixel-exact -- until the next changed frame, which a
+// paused or static screen never sends. The window's own resize is one
+// such change; the element also changes size without one (the CSS
+// fullscreen fallback pinning it to the viewport, the on-screen keyboard
+// strip taking its share, the shell's sidebar opening beside it), which
+// the observer catches -- the page's own fullscreen and keyboard paths
+// also call this directly, so they redraw at once rather than a frame
+// later. The 2D fallback's plain blit is the page's CSS scaling and
+// needs no redraw; its layout draw follows the element too.
+function redrawForElementSize() {
   if (!monitorGl && !subRectModeActive()) return;
   if (!emu) presentMonitorOff();
   else if (running) presentFrame(true);
-});
+}
+window.addEventListener('resize', redrawForElementSize);
+new ResizeObserver(redrawForElementSize).observe(canvas);
 
 // --- status bar --------------------------------------------------------
 // Front-panel status strip mirroring the desktop status bar's LED block:

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -144,6 +144,12 @@ let lastStatUpdate = 0;
 // path the canvas backing store is display-resolution, so pointer scaling
 // reads the emulated size from here rather than from the canvas.
 let presentSize = { width: 0, rows: 0 };
+// The layout the last draw placed the picture with under the scaling and
+// autocrop modes (the display: scaling section): the presentation
+// sub-rect shown and where it landed, in backing-store (device) pixels.
+// Null while the plain stretch draws the whole buffer into the whole
+// element, which is what pointer scaling assumes without one.
+let lastLayout = null;
 
 // Transient caption over the screen, the page's version of the desktop's
 // on-screen display. It exists because the shell's status line lives inside
@@ -832,6 +838,8 @@ async function boot() {
     if (floppySpeed !== null) machine.set_floppy_speed(floppySpeed);
     if (overscanMode !== null) machine.set_overscan?.(overscanMode);
     machine.set_monitor_bezel?.(monitorBezelOn());
+    machine.set_scaling?.(scalingMode);
+    machine.set_autocrop?.(autocropOn);
     machine.set_deinterlace?.(deinterlaceEnabled);
     machine.set_phosphor?.(phosphorPersistence);
     emu = machine;
@@ -995,10 +1003,6 @@ function presentFrame(force = false) {
     presentFrameMonitor(width, rows, changed || !hasPresentationRevision);
   } else {
     const uploadStart = performance.now();
-    if (canvas.width !== width || canvas.height !== rows) {
-      canvas.width = width;
-      canvas.height = rows;
-    }
     // The view must be rebuilt after every changed presentation: wasm memory
     // may grow and the present buffer may reallocate. A forced 2D redraw
     // (resize while paused) needs the same copy even when the revision held.
@@ -1007,11 +1011,71 @@ function presentFrame(force = false) {
       emu.present_ptr(),
       width * rows * 4,
     );
-    ctx2d.putImageData(new ImageData(view, width, rows), 0, 0);
+    const [w, h] = canvasDeviceSize();
+    const lay = subRectModeActive() ? presentLayoutFor(w, h) : null;
+    lastLayout = lay;
+    if (lay) {
+      presentFrame2dLayout(view, width, rows, w, h, lay);
+    } else {
+      if (canvas.width !== width || canvas.height !== rows) {
+        canvas.width = width;
+        canvas.height = rows;
+      }
+      ctx2d.putImageData(new ImageData(view, width, rows), 0, 0);
+    }
     uploadMsThisSecond += performance.now() - uploadStart;
   }
   if (hasPresentationRevision) lastPresentationRevision = revision;
   return changed;
+}
+
+// The element's backing-store size at device resolution, which both the
+// monitor path and a 2D layout draw give the canvas: the whole-number
+// factors of integer scaling are real device pixels only then.
+function canvasDeviceSize() {
+  const dpr = window.devicePixelRatio || 1;
+  return [
+    Math.max(1, Math.round(canvas.clientWidth * dpr)),
+    Math.max(1, Math.round(canvas.clientHeight * dpr)),
+  ];
+}
+
+// The 2D fallback's draw of a layout. putImageData cannot scale, so the
+// presentation goes through a staging canvas at its own size and is drawn
+// from there into the layout's rect of a device-resolution backing store,
+// point-sampled at whole-number factors and filtered for a smooth fit;
+// the store outside the rect is black. The plain stretch keeps the old
+// present-sized store and the page's CSS scaling.
+let stage2d = null;
+function presentFrame2dLayout(view, width, rows, w, h, lay) {
+  if (!stage2d) {
+    const canvas = document.createElement('canvas');
+    stage2d = { canvas, ctx: canvas.getContext('2d') };
+  }
+  if (stage2d.canvas.width !== width || stage2d.canvas.height !== rows) {
+    stage2d.canvas.width = width;
+    stage2d.canvas.height = rows;
+  }
+  stage2d.ctx.putImageData(new ImageData(view, width, rows), 0, 0);
+  if (canvas.width !== w || canvas.height !== h) {
+    canvas.width = w;
+    canvas.height = h;
+  }
+  ctx2d.fillStyle = '#000';
+  ctx2d.fillRect(0, 0, w, h);
+  ctx2d.imageSmoothingEnabled = !lay.factors;
+  ctx2d.imageSmoothingQuality = 'high';
+  ctx2d.drawImage(
+    stage2d.canvas,
+    lay.sx,
+    lay.sy,
+    lay.sw,
+    lay.sh,
+    lay.dx,
+    lay.dy,
+    lay.dw,
+    lay.dh,
+  );
 }
 
 // Advance the machine to nowMs and ship what it produced (audio, serial):
@@ -1866,6 +1930,16 @@ let lastPos = null;
 // with the bezel on the picture fills only the frame's opening, so a CSS
 // pixel of the element covers proportionally more of the picture.
 const cssToEmu = () => {
+  if (lastLayout) {
+    // A layout draw: the picture's sub-rect occupies its destination
+    // rect of the backing store, in device pixels, and a CSS pixel is a
+    // device-pixel-ratio's worth of those.
+    const dpr = window.devicePixelRatio || 1;
+    return {
+      x: lastLayout.sw / (lastLayout.dw / dpr),
+      y: lastLayout.sh / (lastLayout.dh / dpr),
+    };
+  }
   const scale = monitorPictureScale();
   return {
     x: (presentSize.width || canvas.width) / (canvas.clientWidth * scale),
@@ -2440,6 +2514,30 @@ const CSS_FS_CANVAS = {
   objectFit: 'fill',
 };
 
+// The same letterbox with the element spanning the whole viewport: what
+// fullscreen gives the canvas while a layout draw is placing the picture
+// (integer scaling or autocrop without a bezel). The draw letterboxes
+// inside the element itself, at the picture's shape rather than the
+// monitor's, so a cropped picture can take the screen's full width or
+// height -- the point of autocrop on a 16:9 laptop or TV -- and the
+// whole-number fit is taken against every device pixel there is.
+const CSS_FS_CANVAS_FILL = {
+  ...CSS_FS_CANVAS,
+  width: '100dvw',
+  height: 'calc(100dvh - var(--cl-kbd-h, 0px))',
+};
+
+function fsCanvasStyles() {
+  return subRectModeActive() ? CSS_FS_CANVAS_FILL : CSS_FS_CANVAS;
+}
+
+// Re-apply the fullscreen letterbox after a display-mode change while
+// fullscreen is up: the two style sets share their keys, so setting the
+// other one over the old is the whole switch.
+function syncFsCanvasStyles() {
+  if (isFullscreen()) setStyles(canvas, fsCanvasStyles(), true);
+}
+
 function setStyles(el, styles, on) {
   for (const k of Object.keys(styles)) el.style[k] = on ? styles[k] : '';
 }
@@ -2447,7 +2545,7 @@ function setStyles(el, styles, on) {
 function enterCssFullscreen() {
   cssFullscreen = true;
   setStyles(shell, CSS_FS_SHELL, true);
-  setStyles(canvas, CSS_FS_CANVAS, true);
+  setStyles(canvas, fsCanvasStyles(), true);
   document.documentElement.style.overflow = 'hidden';
   updateFsUi();
 }
@@ -2501,7 +2599,7 @@ function syncEscapeLock() {
 // chrome (the monitor path's border hiding); entering it is a no-op
 // there, since fullscreen owns the shell's styles.
 document.addEventListener('fullscreenchange', () => {
-  setStyles(canvas, CSS_FS_CANVAS, document.fullscreenElement !== null);
+  setStyles(canvas, fsCanvasStyles(), document.fullscreenElement !== null);
   syncEscapeLock();
   updateFsUi();
   syncShellChrome();
@@ -4014,6 +4112,8 @@ function restoreState(bytes, source) {
   if (floppySpeed !== null) emu.set_floppy_speed(floppySpeed);
   if (overscanMode !== null) emu.set_overscan?.(overscanMode);
   emu.set_monitor_bezel?.(monitorBezelOn());
+  emu.set_scaling?.(scalingMode);
+  emu.set_autocrop?.(autocropOn);
   emu.set_deinterlace?.(deinterlaceEnabled);
   emu.set_phosphor?.(phosphorPersistence);
   // Port fittings live on the machine, so the pads plugged into the host go
@@ -4876,6 +4976,106 @@ function setOverscanMode(mode, remember) {
 }
 overscanSel.addEventListener('change', () => setOverscanMode(overscanSel.value, true));
 
+// --- display: scaling and autocrop -----------------------------------------
+// The desktop's `[display] scaling` and `autocrop` knobs for the page.
+// "integer" draws the picture at whole-number device pixels per buffer
+// column and per scan line, centred in black; autocrop crops it to the
+// display window the hardware actually programs instead of the fixed TV
+// aperture. Either way the page stops stretching the buffer over the
+// whole element and asks the wasm where the picture lands
+// (present_layout, the desktop's own fit and crop smoothing), then draws
+// that rect -- through the monitor shaders' picture sub-rect on the GL
+// path, or through a staging canvas on the 2D fallback. Both are
+// presentation-only choices remembered per browser like overscan, never
+// observable by the guest, and both stand down while a bezel mode's
+// fixed opening owns the glass, as the desktop's do. Hidden on a bundle
+// with no layout to ask for (the class methods exist as soon as the
+// module is imported).
+const SCALING_STORAGE_KEY = 'copperline-scaling';
+const SCALING_MODES = ['smooth', 'integer'];
+const SCALING_LABELS = { smooth: 'Smooth', integer: 'Integer' };
+const AUTOCROP_STORAGE_KEY = 'copperline-autocrop';
+const layoutSupported = typeof WebEmu.prototype?.present_layout === 'function';
+
+const scalingShellSel = $('scaling');
+const scalingSel = scalingShellSel ?? buildSettingControl('scaling', 'Scaling');
+if (!scalingSel.options.length) {
+  for (const mode of SCALING_MODES) {
+    const option = document.createElement('option');
+    option.value = mode;
+    option.textContent = SCALING_LABELS[mode];
+    scalingSel.appendChild(option);
+  }
+}
+scalingSel.title =
+  'Integer draws whole device pixels per column and scan line, centred in black; ' +
+  'Smooth fits the picture to the monitor.';
+const autocropShellToggle = $('autocrop');
+const autocropToggle = autocropShellToggle ?? buildToggleControl('autocrop', 'Autocrop');
+autocropToggle.checked = false;
+autocropToggle.title =
+  'Crop to the display the program actually draws instead of the full TV aperture.';
+if (!layoutSupported) {
+  (scalingShellSel ?? scalingSel.parentElement).hidden = true;
+  (autocropShellToggle ?? autocropToggle.parentElement).hidden = true;
+}
+let scalingMode = 'smooth';
+let autocropOn = false;
+
+function setScalingMode(mode, remember) {
+  if (!SCALING_MODES.includes(mode)) return;
+  scalingMode = mode;
+  scalingSel.value = mode;
+  if (remember) storePref(SCALING_STORAGE_KEY, mode);
+  syncFsCanvasStyles();
+  // The wasm re-presents the held frame under the new setting (a 60 Hz
+  // aperture changes its row count); the redraw picks it up even while
+  // paused, with the layout the setting asks for.
+  emu?.set_scaling?.(mode);
+  if (emu && running) presentFrame(true);
+}
+scalingSel.addEventListener('change', () => setScalingMode(scalingSel.value, true));
+
+function setAutocrop(on, remember) {
+  autocropOn = !!on;
+  autocropToggle.checked = autocropOn;
+  if (remember) storePref(AUTOCROP_STORAGE_KEY, autocropOn ? 'on' : 'off');
+  syncFsCanvasStyles();
+  // A layout setting alone: the held picture is redrawn where the crop
+  // puts it, nothing is re-presented.
+  emu?.set_autocrop?.(autocropOn);
+  if (emu && running) presentFrame(true);
+}
+autocropToggle.addEventListener('change', () => setAutocrop(autocropToggle.checked, true));
+
+// Whether the draw places the picture through the wasm's layout rather
+// than stretching the buffer over the element: a mode is on, the bundle
+// can answer, and no bezel is framing the glass.
+function subRectModeActive() {
+  return layoutSupported && (scalingMode === 'integer' || autocropOn) && !monitorBezelOn();
+}
+
+// Where the picture lands on a `w` x `h` device-pixel viewport under the
+// modes: the presentation sub-rect to show, its destination rect, and the
+// whole-number factors (device pixels per buffer column and per scan
+// line) of an integer draw, or null for a smooth fit. Null with no frame
+// to place.
+function presentLayoutFor(w, h) {
+  const l = emu?.present_layout?.(w, h);
+  if (!l || l.length < 10) return null;
+  return {
+    sx: l[0],
+    sy: l[1],
+    sw: l[2],
+    sh: l[3],
+    dx: l[4],
+    dy: l[5],
+    dw: l[6],
+    dh: l[7],
+    factors: l[8] > 0 ? [l[8], l[9]] : null,
+  };
+}
+
 // Motion-adaptive deinterlacing and phosphor decay both retain and process
 // frame history. They are useful CRT presentation effects, but opt-in in the
 // browser so the default path keeps maximum emulation headroom. Ordinary
@@ -5122,6 +5322,7 @@ void main() {
 precision highp int;
 uniform sampler2D u_tex;
 uniform vec4 u_size;   // xy: viewport size in px, zw: source size in texels
+uniform vec4 u_src;    // picture sub-rect of the texture in UV: xy origin, zw size
 uniform int u_tint;    // 0 none, 1 bw, 2 green, 3 amber, 4 sepia
 in vec2 v_uv;
 out vec4 fragColor;
@@ -5168,13 +5369,19 @@ vec3 apply_tint(vec3 c) {
   return clamp(c * TINT_HUE_M8, 0.0, 1.0);
 }
 
-// Sample the picture. Unlike the desktop's backing texture the source
-// carries no status bar, so the desktop's src_rect collapses to the whole
-// texture and the edge clamp is the sampler's. The tint applies in sRGB
-// before the pass's own arithmetic, like the desktop's tint LUT on the
-// present buffer.
+// Sample the picture: the u_src sub-rect of the texture, the desktop's
+// src_rect (crt.wgsl sample_display) -- the whole texture for the plain
+// stretch, the picture's crop under a layout draw (integer scaling,
+// autocrop) -- with the edge clamp half a texel inside the rect, so a
+// linear sample on a crop boundary never blends in the far side (u_size.zw
+// is the rect's own size in texels). The tint applies in sRGB before the
+// pass's own arithmetic, like the desktop's tint LUT on the present buffer.
 vec3 sample_display(vec2 uv) {
-  vec3 c = texture(u_tex, clamp(uv, 0.0, 1.0)).rgb;
+  vec2 half_texel = 0.5 * u_src.zw / max(u_size.zw, vec2(1.0));
+  vec2 lo = u_src.xy + half_texel;
+  vec2 hi = u_src.xy + u_src.zw - half_texel;
+  vec2 tc = clamp(u_src.xy + clamp(uv, 0.0, 1.0) * u_src.zw, lo, hi);
+  vec3 c = texture(u_tex, tc).rgb;
   if (u_tint != 0) c = srgb_decode(apply_tint(srgb_encode(c)));
   return c;
 }
@@ -6174,21 +6381,31 @@ function monitorDraw(width, rows, crtLines) {
   // Draw a pass over a viewport rect given in canvas coordinates (origin
   // top-left, like everything else on the page); GL viewports measure
   // from the bottom-left.
-  const draw = (p, vx, vy, vw, vh, setUniforms) => {
+  // The picture sub-rect a pass shows (`src`, texels) is the whole texture
+  // unless a layout draw crops it; the source size the shaders see follows
+  // the rect, like the desktop's uniforms_for_rect.
+  const draw = (p, vx, vy, vw, vh, setUniforms, src) => {
+    const [sx, sy, sw, sh] = src ?? [0, 0, width, rows];
     gl.useProgram(p.prog);
     gl.viewport(vx, canvas.height - vy - vh, vw, vh);
     gl.uniform1i(p.u.u_tex, 0);
     gl.uniform1i(p.u.u_tint, tint);
-    gl.uniform4f(p.u.u_size, vw, vh, width, rows);
+    gl.uniform4f(p.u.u_size, vw, vh, sw, sh);
+    gl.uniform4f(p.u.u_src, sx / width, sy / rows, sw / width, sh / rows);
     setUniforms?.(p);
     gl.drawArrays(gl.TRIANGLES, 0, 3);
   };
-  const crtUniforms = (p) => {
-    gl.uniform4f(p.u.u_params, 1.0, crtLines, 1.0, MONITOR_CRT_CURVATURE);
+  // The scanline count is the beam lines across the rect drawn, not the
+  // whole display: a crop carries its share of them.
+  const crtUniformsFor = (lines) => (p) => {
+    gl.uniform4f(p.u.u_params, 1.0, lines, 1.0, MONITOR_CRT_CURVATURE);
     gl.uniform4f(p.u.u_params2, MONITOR_CRT_VIGNETTE, 0, 0, 0);
   };
+  const crtUniforms = crtUniformsFor(crtLines);
 
   if (bezelStyle) {
+    // A drawn front's fixed opening owns the glass: no layout draw here.
+    lastLayout = null;
     // The desktop composition (window.rs): with the preset on it paints
     // the picture into the opening's bounding box first, and the bezel
     // follows in frame-only mode, clipping the preset's square viewport
@@ -6283,10 +6500,29 @@ function monitorDraw(width, rows, crtLines) {
       // Leave the picture texture bound, as every other path here does.
       gl.bindTexture(gl.TEXTURE_2D, monitorGl.tex);
     }
-  } else if (crtOn) {
-    draw(monitorGl.crt, 0, 0, w, h, crtUniforms);
   } else {
-    draw(monitorGl.plain, 0, 0, w, h);
+    // No bezel: the picture is the element, stretched over it as the
+    // page always did -- or, under integer scaling or autocrop, placed
+    // where the wasm's layout puts its rect, the element black around it
+    // (the clear covers the whole store; a viewport does not bound it).
+    const lay = emu && running && subRectModeActive() ? presentLayoutFor(w, h) : null;
+    lastLayout = lay;
+    if (lay) {
+      gl.viewport(0, 0, w, h);
+      gl.clearColor(0, 0, 0, 1);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      const src = [lay.sx, lay.sy, lay.sw, lay.sh];
+      if (crtOn) {
+        const lines = crtLines * (lay.sh / Math.max(rows, 1));
+        draw(monitorGl.crt, lay.dx, lay.dy, lay.dw, lay.dh, crtUniformsFor(lines), src);
+      } else {
+        draw(monitorGl.plain, lay.dx, lay.dy, lay.dw, lay.dh, undefined, src);
+      }
+    } else if (crtOn) {
+      draw(monitorGl.crt, 0, 0, w, h, crtUniforms);
+    } else {
+      draw(monitorGl.plain, 0, 0, w, h);
+    }
   }
 }
 
@@ -6406,6 +6642,9 @@ function setMonitorMode(mode, remember) {
   monitorSel.value = mode;
   if (remember) storePref(MONITOR_STORAGE_KEY, mode);
   syncShellChrome();
+  // A bezel suspends the layout modes, which changes what fullscreen
+  // gives the element.
+  syncFsCanvasStyles();
   // A drawn frame widens the emulated presentation to the tube aperture;
   // the wasm re-presents the held frame under the new crop on the spot,
   // so the redraw below picks it up even while paused.
@@ -6441,7 +6680,9 @@ window.addEventListener('load', () => {
   if (!emu) presentMonitorOff();
 });
 window.addEventListener('resize', () => {
-  if (!monitorGl) return;
+  // The 2D fallback's plain blit is the page's CSS scaling and needs no
+  // redraw; its layout draw follows the element like the monitor path.
+  if (!monitorGl && !subRectModeActive()) return;
   if (!emu) presentMonitorOff();
   else if (running) presentFrame(true);
 });
@@ -6829,6 +7070,18 @@ function bugReportHref() {
       `present = "${presentSize.width}x${presentSize.rows}"`,
       `canvas = "${canvas.width}x${canvas.height}"`,
       `monitor = ${toml(monitorGl ? monitorMode : '2d fallback')}`,
+      `scaling = ${toml(scalingMode)}`,
+      `autocrop = ${autocropOn}`,
+      // The layout draw's rects when one is placing the picture: the
+      // presentation sub-rect shown, where it landed (device pixels), and
+      // the whole-number factors per column and scan line.
+      `layout = ${toml(
+        lastLayout
+          ? `${lastLayout.sw}x${lastLayout.sh}@${lastLayout.sx},${lastLayout.sy}` +
+              ` -> ${lastLayout.dw}x${lastLayout.dh}@${lastLayout.dx},${lastLayout.dy}` +
+              (lastLayout.factors ? ` x${lastLayout.factors[0]},${lastLayout.factors[1]}` : '')
+          : 'stretch',
+      )}`,
       `deinterlace = ${deinterlaceEnabled}`,
       `phosphor = ${phosphorPersistence}`,
       `running = ${running}`,
@@ -6965,6 +7218,10 @@ const pageParams = new URLSearchParams(location.search);
 //     "monitor": "plain",            starting monitor presentation
 //                                    (1084|classic|crt|cabinet|bezel|plain,
 //                                    default 1084); same visitor rule
+//     "scaling": "integer",          starting presentation scaling
+//                                    (smooth|integer); same visitor rule
+//     "autocrop": true,              crop to the display the program draws;
+//                                    off by default, same visitor rule
 //     "deinterlace": true,           motion-adaptive LACE field merging;
 //                                    off by default for throughput
 //     "phosphor": 0.4,               CRT persistence (0.0..0.95); off by
@@ -7069,6 +7326,14 @@ async function startup() {
     storedPref(MONITOR_STORAGE_KEY) ??
     (typeof cfg.monitor === 'string' ? cfg.monitor.trim() : null);
   if (monitorPref) setMonitorMode(monitorPref, false);
+  // Scaling and autocrop, the desktop's display knobs, the same rule.
+  const scalingPref =
+    storedPref(SCALING_STORAGE_KEY) ??
+    (typeof cfg.scaling === 'string' ? cfg.scaling.trim() : null);
+  if (scalingPref) setScalingMode(scalingPref, false);
+  const autocropPref = storedPref(AUTOCROP_STORAGE_KEY);
+  if (autocropPref !== null) setAutocrop(autocropPref === 'on', false);
+  else if (typeof cfg.autocrop === 'boolean') setAutocrop(cfg.autocrop, false);
   // History-dependent display effects are opt-in for browser throughput.
   // A visitor's saved choice wins over the site's suggested starting point.
   const deinterlacePref = storedPref(DEINTERLACE_STORAGE_KEY);

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -26,6 +26,20 @@ The web version runs at [copperline.dev/try](https://copperline.dev/try/):
   - **Monitor presentation:** Select CRT shader and bezel frames (**1084**, **Classic**,
     **CRT filter**, or **Plain**).
   - **View (Overscan):** Crop to standard TV aperture or view full overscan border areas.
+  - **Scaling:** **Smooth** (the default) fits the picture to the monitor. **Integer** is
+    the desktop's `[display] scaling = "integer"`: the picture is drawn at whole device
+    pixels per hi-res column and per scan line, a separate whole number per axis chosen to
+    approximate the 4:3 glass shape (4:5 pixels for a 200-line NTSC game on a 1080p screen,
+    square multiples for PAL), centred in black. It takes the fit against every device pixel
+    the element has, so fullscreen on a 16:9 laptop or TV is where it gains the most.
+  - **Autocrop:** The desktop's `[display] autocrop`: crop the picture to the display window
+    the program actually draws (the rows and columns carrying fetched bitplane data, smoothed
+    across frames so screen transitions do not pump the zoom) instead of the fixed TV aperture.
+    With **Integer** scaling the whole-number fit is retaken against the crop, so a 200-line
+    game usually earns a full multiple more. In fullscreen the picture may use the whole
+    screen rather than a 4:3 box. Both settings stand down while a monitor bezel is drawn
+    (the frame's fixed opening owns the glass), as on the desktop, and never affect
+    screenshots, which capture the presentation buffer.
   - **Screen tint:** Monochrome simulation presets (Black & White, Green, Amber, Sepia).
   - **Deinterlacing:** Motion-adaptive field merging for interlaced display modes.
   - **Phosphor persistence:** Simulates CRT phosphor decay trails.
@@ -152,6 +166,21 @@ requestAnimationFrame(renderLoop);
 - `set_port_device(port, device)`: Configure controller port device (`port` 1 or 2, e.g., `"mouse"`, `"joystick"`, `"cd32"`, `"analogue"`, `"none"`).
 - `save_state()`: Export full machine state as `Uint8Array`.
 - `load_state(stateBytes)`: Restore machine state from `Uint8Array`.
+- `set_overscan(mode)`: `"tv"` (default) or `"full"` presentation overscan.
+- `set_scaling(mode)`: `"smooth"` (default) or `"integer"`. Under `"integer"` a 60 Hz
+  standard scan presents its captured aperture at its own woven rows (`present_rows()`
+  follows) instead of resampled onto the 50 Hz aperture's row count, so whole-number factors
+  carry every scan line to the screen as one block.
+- `set_autocrop(on)`: Crop `present_layout()` to the content envelope.
+- `present_content_rect()`: The latched content envelope as `[x, y, width, height]` in
+  presentation-buffer pixels, or an empty array before any content has been seen.
+- `present_layout(availWidth, availHeight)`: Where the presentation buffer lands on a
+  viewport of that many device pixels under the scaling and autocrop settings:
+  `[sx, sy, sw, sh, dx, dy, dw, dh, columns, lines]` -- the buffer sub-rect to draw, its
+  destination rect (paint the rest black), and the whole-number factors of an integer draw
+  (`0, 0` for a smooth fit). Empty until a frame has been presented. A page that draws the
+  buffer itself asks for this instead of stretching the buffer over its element; the bundled
+  `try.js` does so whenever either setting is on and no bezel is drawn.
 
 ### HTML element hooks in `try.js`
 
@@ -162,6 +191,8 @@ When using the bundled `try.js` harness, standard UI elements can be connected b
 - `#floppy-speed`: `<select>` for floppy drive speed multiplier (`100`, `200`, `400`, `800`, `0` for turbo).
 - `#monitor`: `<select>` for CRT shader and bezel style.
 - `#overscan`: `<select>` for TV aperture vs. full overscan view.
+- `#scaling`: `<select>` for smooth vs. integer scaling (`smooth` / `integer`).
+- `#autocrop`: `<input type="checkbox">` for the autocrop presentation.
 - `#df0list` / `#kicklist`: `<select>` elements populated from remote disk/ROM manifests.
 - `#pause`, `#screenshot`, `#keyboard`: Action button triggers.
 
@@ -178,9 +209,15 @@ You can provide default settings via a `config.json` file in the web root:
   "autoboot": true,
   "floppy_speed": 400,
   "monitor": "1084",
+  "scaling": "integer",
+  "autocrop": true,
   "background_run": true
 }
 ```
+
+Display choices (`overscan`, `tint`, `monitor`, `scaling`, `autocrop`, `deinterlace`,
+`phosphor`) are starting points for first-time visitors: a visitor's own remembered choice
+wins.
 
 ## Serial port over WebSockets
 

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -38,8 +38,10 @@ The web version runs at [copperline.dev/try](https://copperline.dev/try/):
     With **Integer** scaling the whole-number fit is retaken against the crop, so a 200-line
     game usually earns a full multiple more. In fullscreen the picture may use the whole
     screen rather than a 4:3 box. Both settings stand down while a monitor bezel is drawn
-    (the frame's fixed opening owns the glass), as on the desktop, and never affect
-    screenshots, which capture the presentation buffer.
+    (the frame's fixed opening owns the glass), as on the desktop. Screenshots capture the
+    presentation buffer at its smooth shape: the capture drops integer scaling (and a drawn
+    bezel) around the buffer read, as the desktop's captures keep the aspect's own shape
+    whatever its window draws.
   - **Screen tint:** Monochrome simulation presets (Black & White, Green, Amber, Sepia).
   - **Deinterlacing:** Motion-adaptive field merging for interlaced display modes.
   - **Phosphor persistence:** Simulates CRT phosphor decay trails.
@@ -192,14 +194,16 @@ When using the bundled `try.js` harness, standard UI elements can be connected b
 - `#monitor`: `<select>` for CRT shader and bezel style.
 - `#overscan`: `<select>` for TV aperture vs. full overscan view.
 - `#scaling`: `<select>` for smooth vs. integer scaling (`smooth` / `integer`).
-- `#autocrop`: `<input type="checkbox">` for the autocrop presentation.
+- `#autocrop`: `<input type="checkbox">` for the autocrop presentation. A shell can ship
+  both with the `hidden` attribute; the glue un-hides them on a bundle that supports them.
 - `#df0list` / `#kicklist`: `<select>` elements populated from remote disk/ROM manifests.
 - `#pause`, `#screenshot`, `#keyboard`: Action button triggers.
 
 (browser-page-config)=
-### Page configuration file (`config.json`)
+### Page configuration file (`copperline.json`)
 
-You can provide default settings via a `config.json` file in the web root:
+You can provide default settings via a `copperline.json` file next to the page (the glue
+fetches `./copperline.json`):
 
 ```json
 {

--- a/docs/internals/video.md
+++ b/docs/internals/video.md
@@ -487,6 +487,27 @@ changes such as a resize, tint, monitor mode or WebGL context restoration can
 force a draw of the held texture without pretending the emulated picture
 changed.
 
+The browser's integer scaling and autocrop reuse the desktop's machinery
+rather than re-deriving it in JavaScript. `present_common` carries the
+pure pieces both frontends need: the autocrop smoothing (`AutocropLatch`),
+the per-axis whole-number fit and its smooth fallback (`per_axis_fit`,
+`sub_rect_fit`), and the two maps that follow the renderer's content
+envelope into presentation-buffer pixels -- `FieldPlacement::content_rect`
+onto the woven field, then `region_present_content_rect`, the inverse of
+the deinterlacer's aperture copy, onto the buffer the page draws. The
+wrapper latches that rect per frame (a reused frame re-feeds the previous
+envelope, so a static screen can still prove a smaller crop stable) and
+answers `present_layout` from `buffer_layout`, which reads the glass pixel
+shape off the buffer itself (`buffer_glass_par`: the page shows the buffer
+in a 4:3 element, so a 668 x 540 PAL aperture states the same 1.078 shape
+the desktop's `glass_par` derives from its tv canvas). Under integer
+scaling the wrapper presents a 60 Hz aperture at its own woven rows rather
+than resampled onto the 50 Hz row count -- the browser's equivalent of the
+desktop drawing its unresampled canvas -- so the factors are exact per
+scan line. The page draws the answer: the GL monitor passes take the
+sub-rect through a `u_src` uniform mirroring `crt.wgsl`'s `src_rect`, and
+the 2D fallback scales a staging canvas into a device-resolution store.
+
 For a progressive frame without phosphor persistence, presentation writes
 directly into the frontend-owned buffer instead of first filling the
 deinterlacer's full woven buffer. The browser's standard-TV path goes one step

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -150,7 +150,7 @@ fn main() -> Result<()> {
                     emu.bus_mut(),
                     &mut fb,
                     &mut repeated_frame_detector,
-                );
+                ) == bitplane::ReuseRender::Reused;
                 if reused {
                     reused_frames += 1;
                     render_skipped_frames += 1;

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -4428,16 +4428,29 @@ pub fn render(bus: &mut Bus, fb: &mut [u32]) -> Option<ContentRect> {
     })
 }
 
-/// Synchronous render wrapper with exact previous-frame reuse. Returns true
-/// when `fb` already contains the identical progressive frame and no render
-/// was needed. This is primarily the frontend-free benchmark companion to the
-/// threaded window cache; [`render`] preserves its always-render contract.
+/// What [`render_reusing_previous`] did with the frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReuseRender {
+    /// `fb` already held the identical progressive frame; nothing was
+    /// rendered.
+    Reused,
+    /// The frame was rendered, with its playfield content envelope (see
+    /// [`ContentRect`]), as [`render`] reports it.
+    Rendered(Option<ContentRect>),
+}
+
+/// Synchronous render wrapper with exact previous-frame reuse. Reports
+/// [`ReuseRender::Reused`] when `fb` already contains the identical
+/// progressive frame and no render was needed, and the fresh render's
+/// content envelope otherwise. This is primarily the frontend-free
+/// benchmark companion to the threaded window cache; [`render`] preserves
+/// its always-render contract.
 #[doc(hidden)]
 pub fn render_reusing_previous(
     bus: &mut Bus,
     fb: &mut [u32],
     detector: &mut RepeatedFrameDetector,
-) -> bool {
+) -> ReuseRender {
     thread_local! {
         static REUSED_RENDER_INPUT_SCRATCH: std::cell::RefCell<Option<RenderInput>> =
             const { std::cell::RefCell::new(None) };
@@ -4455,7 +4468,7 @@ pub fn render_reusing_previous(
                 .as_mut()
                 .expect("scratch render input present")
                 .release_shared_frame_data();
-            return true;
+            return ReuseRender::Reused;
         }
         let mut result = if detector.should_track_read_dependencies(input) {
             render_from_input_tracking_reuse(input, fb)
@@ -4469,7 +4482,7 @@ pub fn render_reusing_previous(
             .as_mut()
             .expect("scratch render input present")
             .release_shared_frame_data();
-        false
+        ReuseRender::Rendered(result.content_rect)
     })
 }
 

--- a/src/video/present_common.rs
+++ b/src/video/present_common.rs
@@ -705,6 +705,388 @@ pub fn standard_tv_aperture_frame(
     }
 }
 
+/// Presentation smoothing for the autocrop rect. Per-frame content
+/// envelopes jitter -- loaders blank the screen, screen transitions
+/// rebuild the copper list over a frame or two, games flip between
+/// differently-sized displays -- and the presented crop must not pump
+/// with them. The latch grows immediately (content must never be cut)
+/// to the union of the old and new envelopes, holds through border-only
+/// frames like the aperture latch does, and shrinks only after the
+/// smaller envelope has held steady for [`Self::SHRINK_STABLE_FRAMES`]
+/// consecutive rendered frames. Shared by the desktop window (in woven
+/// presentation space) and the browser wrapper (in its presentation
+/// buffer's space); the envelope's coordinate space is the caller's.
+#[derive(Default, Debug)]
+pub struct AutocropLatch {
+    active: Option<bitplane::ContentRect>,
+    candidate: Option<bitplane::ContentRect>,
+    stable_frames: u32,
+}
+
+impl AutocropLatch {
+    /// Rendered frames a strictly-smaller envelope must persist for
+    /// before the presentation tightens onto it: about half a second of
+    /// PAL frames, long enough to sit out a screen transition.
+    pub const SHRINK_STABLE_FRAMES: u32 = 25;
+
+    pub fn resolve(
+        &mut self,
+        frame: Option<bitplane::ContentRect>,
+    ) -> Option<bitplane::ContentRect> {
+        let Some(frame) = frame else {
+            // Border-only frame: keep presenting the previous crop, and
+            // keep any shrink candidate's clock running from zero again
+            // once content returns.
+            self.candidate = None;
+            self.stable_frames = 0;
+            return self.active;
+        };
+        let Some(active) = self.active else {
+            self.active = Some(frame);
+            return self.active;
+        };
+        let contained = frame.x0 >= active.x0
+            && frame.x1 <= active.x1
+            && frame.y0 >= active.y0
+            && frame.y1 <= active.y1;
+        if !contained {
+            self.active = Some(bitplane::ContentRect {
+                x0: active.x0.min(frame.x0),
+                x1: active.x1.max(frame.x1),
+                y0: active.y0.min(frame.y0),
+                y1: active.y1.max(frame.y1),
+            });
+            self.candidate = None;
+            self.stable_frames = 0;
+        } else if frame != active {
+            if self.candidate == Some(frame) {
+                self.stable_frames += 1;
+                if self.stable_frames >= Self::SHRINK_STABLE_FRAMES {
+                    self.active = Some(frame);
+                    self.candidate = None;
+                    self.stable_frames = 0;
+                }
+            } else {
+                self.candidate = Some(frame);
+                self.stable_frames = 1;
+            }
+        } else {
+            self.candidate = None;
+            self.stable_frames = 0;
+        }
+        self.active
+    }
+
+    /// Forget the crop across a presentation discontinuity (power cycle,
+    /// RTG entry), like `PresentationLatch::reset`.
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// How far a whole-number pixel shape may stray from the glass ratio
+/// before a taller fit stops being worth it: max(shape/par, par/shape)
+/// at most 11/10. Wide enough that NTSC's 0.854 admits 4:5 (6.8% off)
+/// through 6:7, 7:8 and 12:13 -- the family amiga.vision's NTSC guide
+/// reaches for, 4:5 being its 1080p and 4K answer -- while excluding
+/// 3:4 (14%) and the squat 1:1 (17%); and that PAL's 1.078 admits the
+/// square 1:1 (7.2%) and 8:7 (6%) but not 6:5 (11%).
+const PAR_TOLERANCE: (u64, u64) = (11, 10);
+
+/// The per-axis whole-number fit of a `w` x `h` canvas rect (hi-res
+/// columns by woven rows) into `avail` surface pixels, drawn at the
+/// pixel shape `par`: `(columns, lines)` -- surface pixels per canvas
+/// column, and per *field line*, the scan's own vertical unit. The
+/// woven canvas carries two rows per line so interlaced fields can be
+/// woven; a non-interlaced display's two are identical, so a whole
+/// number of pixels per line is exact for it whether or not the number
+/// is even (an odd count lands as alternate rows of the pair, which is
+/// only visible on an interlaced display). Stepping the vertical factor
+/// by half a woven row is what makes the NTSC shapes reachable on
+/// ordinary displays: 4:5 is two pixels per column and five per line,
+/// 1000 rows for a 200-line display -- the 1080p answer.
+///
+/// The choice is the tallest fit whose shape stays within
+/// [`PAR_TOLERANCE`] of `par` (a bigger picture beats a marginally truer
+/// one), the closest shape among fits of that height, and the widest
+/// among equals; with no fit inside the tolerance, the closest shape at
+/// the largest size. `None` when not even one pixel per column and per
+/// line fits, where the caller falls back to the smooth fit. Exact
+/// integer arithmetic throughout, so every host agrees on the answer.
+pub fn per_axis_fit(
+    avail: (u32, u32),
+    (w, h): (usize, usize),
+    par: (u32, u32),
+) -> Option<(usize, usize)> {
+    if w == 0 || h == 0 || par.0 == 0 || par.1 == 0 {
+        return None;
+    }
+    let max_columns = avail.0 as usize / w;
+    // `h` woven rows are `h / 2` field lines: `lines` pixels per line
+    // puts `h * lines / 2` rows on the surface.
+    let max_lines = 2 * avail.1 as usize / h;
+    if max_columns == 0 || max_lines == 0 {
+        return None;
+    }
+    let (par_w, par_h) = (u64::from(par.0), u64::from(par.1));
+    // A shape's deviation from `par`, as the two cross products ordered
+    // (max, min): their quotient is the symmetric ratio error, and two
+    // deviations compare exactly by cross-multiplying.
+    let deviation = |columns: usize, lines: usize| -> (u64, u64) {
+        let shape = 2 * columns as u64 * par_h;
+        let glass = lines as u64 * par_w;
+        (shape.max(glass), shape.min(glass))
+    };
+    let within = |(hi, lo): (u64, u64)| hi * PAR_TOLERANCE.1 <= lo * PAR_TOLERANCE.0;
+    let compare = |a: (u64, u64), b: (u64, u64)| (a.0 * b.1).cmp(&(b.0 * a.1));
+    // A candidate: its factors, its deviation, and whether that is
+    // within the tolerance.
+    type Candidate = ((usize, usize), (u64, u64), bool);
+    let mut best: Option<Candidate> = None;
+    for lines in 1..=max_lines {
+        // At a given height the shape grows with the column count, so
+        // only the two counts astride the ideal one (lines * par / 2)
+        // can be the closest -- and the tolerance band, an interval
+        // around the ideal, holds one of them if it holds any. Two
+        // candidates per height instead of every column: a one-line
+        // autocrop rect on a large surface has thousands of both, and
+        // the fit runs on every redraw and cursor move.
+        let ideal = (lines as u64 * par_w / (2 * par_h)) as usize;
+        let astride = [
+            ideal.clamp(1, max_columns),
+            (ideal + 1).clamp(1, max_columns),
+        ];
+        for columns in astride {
+            let dev = deviation(columns, lines);
+            let ok = within(dev);
+            let better = match best {
+                None => true,
+                Some((_, _, cand_ok)) if ok != cand_ok => ok,
+                Some((cand, cand_dev, true)) => lines
+                    .cmp(&cand.1)
+                    .then(compare(cand_dev, dev))
+                    .then(columns.cmp(&cand.0))
+                    .is_gt(),
+                Some((cand, cand_dev, false)) => compare(cand_dev, dev)
+                    .then(lines.cmp(&cand.1))
+                    .then(columns.cmp(&cand.0))
+                    .is_gt(),
+            };
+            if better {
+                best = Some(((columns, lines), dev, ok));
+            }
+        }
+    }
+    best.map(|(factors, _, _)| factors)
+}
+
+/// Where a `w` x `h` canvas rect lands in `avail` at whole-number
+/// factors `(columns, lines)`: exactly `w * columns` by `h * lines / 2`,
+/// centred. The rect's rows are whole field lines (an even count) so the
+/// height is exact -- every display rect's are, starting on a woven pair
+/// (`display_rects_start_on_field_lines`).
+pub fn per_axis_rect(
+    avail: (u32, u32),
+    (w, h): (usize, usize),
+    (columns, lines): (usize, usize),
+) -> (u32, u32, u32, u32) {
+    let dw = ((w * columns) as u32).min(avail.0);
+    let dh = ((h * lines / 2) as u32).min(avail.1);
+    ((avail.0 - dw) / 2, (avail.1 - dh) / 2, dw, dh)
+}
+
+/// The smooth fit of a `w` x `h` canvas rect drawn at pixel shape
+/// `par`: the aspect-preserving letterbox of `w * par` by `h` in
+/// `avail`, the classic letterbox (`clip_rect_for`'s smooth fit) with
+/// the shape folded into the width (at `(1, 1)` it is that fit). Exact
+/// integer arithmetic, so a rect whose shape is the viewport's fills it
+/// to the pixel: the browser draws its whole presentation buffer into a
+/// 4:3 element this way, where a truncated last column would show as a
+/// black seam.
+pub fn smooth_fit_rect(
+    avail: (u32, u32),
+    (w, h): (usize, usize),
+    par: (u32, u32),
+) -> (u32, u32, u32, u32) {
+    if avail.0 == 0 || avail.1 == 0 || w == 0 || h == 0 || par.0 == 0 || par.1 == 0 {
+        return (0, 0, 0, 0);
+    }
+    // The rect's shape on the surface is `w * par.0 : h * par.1`; the
+    // fit is width-limited when the viewport is narrower than that
+    // shape at the viewport's own height.
+    let (avail_w, avail_h) = (u64::from(avail.0), u64::from(avail.1));
+    let shaped_w = w as u64 * u64::from(par.0);
+    let shaped_h = h as u64 * u64::from(par.1);
+    let (dw, dh) = if avail_w * shaped_h <= avail_h * shaped_w {
+        (avail_w, avail_w * shaped_h / shaped_w)
+    } else {
+        (avail_h * shaped_w / shaped_h, avail_h)
+    };
+    let dw = (dw as u32).clamp(1, avail.0);
+    let dh = (dh as u32).clamp(1, avail.1);
+    ((avail.0 - dw) / 2, (avail.1 - dh) / 2, dw, dh)
+}
+
+/// A sub-rect draw's fit ([`sub_rect_fit`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SubRectFit {
+    /// The whole-number factors of an integer draw, as surface pixels
+    /// `(per column, per field line)` -- a uniform multiple `m` is
+    /// `(m, 2 * m)` -- or `None` for a smooth fit.
+    pub factors: Option<(usize, usize)>,
+    /// Where the rect lands, `(x, y, w, h)` in surface pixels.
+    pub dst: (u32, u32, u32, u32),
+}
+
+/// The whole-number factors and the destination of a sub-rect draw: the
+/// `rect` (`(x, y, w, h)` in canvas or buffer pixels) drawn at the pixel
+/// shape `par` into `avail` surface pixels. Under `integer` the fit is
+/// retaken against the rect -- a display using fewer lines earns a
+/// larger whole multiple, which is the point of autocrop -- as a
+/// uniform multiple when the pixels are asked for as square, and as the
+/// per-axis fit ([`per_axis_fit`]) at a glass shape; either falls back
+/// to the smooth fit of the rect at its shape ([`smooth_fit_rect`])
+/// when not even 1x fits. The desktop's `display_src_layout` and the
+/// browser's [`buffer_layout`] both draw with this.
+pub fn sub_rect_fit(
+    avail: (u32, u32),
+    integer: bool,
+    rect: (usize, usize, usize, usize),
+    par: (u32, u32),
+) -> SubRectFit {
+    let (w, h) = (rect.2.max(1), rect.3.max(1));
+    let factors = if !integer {
+        None
+    } else if par.0 == par.1 {
+        // The uniform multiple is the per-axis fit's answer for a square
+        // shape, but stated directly: the tolerance that lets a glass
+        // shape prefer a taller near-miss must not apply to a canvas
+        // asked for as square.
+        let fit = (avail.0 as usize / w).min(avail.1 as usize / h);
+        (fit >= 1).then_some((fit, 2 * fit))
+    } else {
+        per_axis_fit(avail, (w, h), par)
+    };
+    let dst = match factors {
+        Some(factors) => per_axis_rect(avail, (w, h), factors),
+        None => smooth_fit_rect(avail, (w, h), par),
+    };
+    SubRectFit { factors, dst }
+}
+
+/// The shape of one pixel of a `width` x `rows` presentation buffer
+/// drawn to fill a 4:3 glass, as a ratio `(width, height)` in lowest
+/// terms. The browser's glass model: the page shows whatever buffer the
+/// wrapper presents in a 4:3 element, so the buffer's own dimensions
+/// state its pixel shape. It is the desktop's tv canvas read back
+/// (`window::present::glass_par`) -- the captured TV aperture,
+/// `TV_CAPTURED_WIDTH` columns by its woven rows, lands at PAL 1.078
+/// and NTSC 0.854, and the full-overscan field at `rows` /
+/// `PRESENT_HEIGHT_TV` (the glass is `FB_WIDTH` by `PRESENT_HEIGHT_TV`,
+/// itself 4:3).
+pub fn buffer_glass_par(width: usize, rows: usize) -> (u32, u32) {
+    let (w, h) = (4 * rows.max(1) as u64, 3 * width.max(1) as u64);
+    let g = gcd(w, h);
+    ((w / g) as u32, (h / g) as u32)
+}
+
+fn gcd(mut a: u64, mut b: u64) -> u64 {
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a
+}
+
+/// Follow a content envelope stated in woven presentation-field space
+/// through the deinterlacer's region copy
+/// (`Deinterlacer::present_field_region_into`): the rows and columns of
+/// the `destination_width` x `destination_rows` buffer that show any of
+/// it. The copy reads woven column `source_x + x` for buffer column `x`,
+/// and woven row `source_y + scaled_source_row(y)` for buffer row `y`
+/// (`screenshot::scaled_source_row`, the centre-aligned resample of
+/// `source_rows` onto `destination_rows`). The rows are scanned against
+/// that map rather than derived in closed form, like the desktop's
+/// `canvas_content_rect`: a few hundred iterations per rendered frame,
+/// and immune to drifting out of agreement with the copy it mirrors.
+/// `None` when nothing of the envelope reaches the buffer.
+pub fn region_present_content_rect(
+    rect: bitplane::ContentRect,
+    source_x: i32,
+    source_y: i32,
+    source_rows: usize,
+    destination_width: usize,
+    destination_rows: usize,
+) -> Option<bitplane::ContentRect> {
+    let x0 = (rect.x0 as i64 - i64::from(source_x)).clamp(0, destination_width as i64);
+    let x1 = (rect.x1 as i64 - i64::from(source_x)).clamp(x0, destination_width as i64);
+    if x1 <= x0 {
+        return None;
+    }
+    let (mut y_min, mut y_max) = (None, None);
+    for y in 0..destination_rows {
+        let woven = i64::from(source_y)
+            + screenshot::scaled_source_row(y, source_rows, destination_rows) as i64;
+        if (rect.y0 as i64..rect.y1 as i64).contains(&woven) {
+            y_min.get_or_insert(y);
+            y_max = Some(y);
+        }
+    }
+    Some(bitplane::ContentRect {
+        x0: x0 as usize,
+        x1: x1 as usize,
+        y0: y_min?,
+        y1: y_max? + 1,
+    })
+}
+
+/// Where a presentation buffer lands on a viewport: the browser
+/// wrapper's answer to the desktop's `display_src_layout`, for a page
+/// that draws the wrapper's `width` x `rows` buffer itself.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BufferLayout {
+    /// The buffer sub-rect shown, `(x, y, w, h)` in buffer pixels.
+    pub src: (usize, usize, usize, usize),
+    /// Where it lands, `(x, y, w, h)` in viewport pixels; the viewport
+    /// outside it is black.
+    pub dst: (u32, u32, u32, u32),
+    /// The whole-number factors of an integer draw, as viewport pixels
+    /// `(per buffer column, per field line)` -- a uniform multiple `m`
+    /// is `(m, 2 * m)` -- or `None` for a smooth fit.
+    pub factors: Option<(usize, usize)>,
+}
+
+/// The layout of a `width` x `rows` presentation buffer on an `avail`
+/// viewport under the browser's display settings: `content` is the
+/// autocrop rect to show (the latched envelope in buffer pixels), or
+/// `None` to show the whole buffer; `integer` asks for whole-number
+/// factors. The buffer's pixel shape is the 4:3 glass's
+/// ([`buffer_glass_par`]): drawn smooth, the whole buffer fills a 4:3
+/// viewport exactly as the page's plain stretch did, and a crop keeps
+/// that shape in a letterbox; drawn integer, a standard scan takes the
+/// per-axis fit at that shape, while a `programmable` scan takes the
+/// uniform multiple (its rows are not woven pairs for the per-line
+/// factor to step by), as on the desktop.
+pub fn buffer_layout(
+    avail: (u32, u32),
+    (width, rows): (usize, usize),
+    programmable: bool,
+    integer: bool,
+    content: Option<bitplane::ContentRect>,
+) -> BufferLayout {
+    let full = (0, 0, width, rows);
+    let src = content
+        .map(|rect| (rect.x0, rect.y0, rect.x1 - rect.x0, rect.y1 - rect.y0))
+        .filter(|rect| rect.2 > 0 && rect.3 > 0)
+        .unwrap_or(full);
+    let par = if programmable && integer {
+        (1, 1)
+    } else {
+        buffer_glass_par(width, rows)
+    };
+    let SubRectFit { factors, dst } = sub_rect_fit(avail, integer, src, par);
+    BufferLayout { src, dst, factors }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1186,5 +1568,209 @@ mod tests {
             4
         );
         assert_eq!(fb[0], 1);
+    }
+
+    #[test]
+    fn smooth_fit_rect_fills_a_viewport_of_the_rects_own_shape_exactly() {
+        // The browser's whole-buffer draw: every buffer the wrapper presents
+        // -- the 50 Hz aperture, the 60 Hz aperture at its own rows, a full
+        // overscan field, the square canvas -- fills a 4:3 viewport to the
+        // pixel at the glass shape read off the buffer, at any size. The
+        // f32 fit this replaces could truncate the last column away.
+        for (w, h) in [(668, 540), (668, 428), (716, 626), (716, 570)] {
+            let par = buffer_glass_par(w, h);
+            for avail in [
+                (1440, 1080),
+                (2880, 2160),
+                (1024, 768),
+                (716, 537),
+                (3840, 2880),
+            ] {
+                assert_eq!(
+                    smooth_fit_rect(avail, (w, h), par),
+                    (0, 0, avail.0, avail.1),
+                    "{w}x{h} in {avail:?}"
+                );
+            }
+        }
+        // A rect narrower than the viewport at its shape is height-limited
+        // and centred: 640 x 400 of the native NTSC aperture (0.854 pixels)
+        // on a 16:9 screen.
+        let ntsc = buffer_glass_par(668, 428);
+        assert_eq!(
+            smooth_fit_rect((1920, 1080), (640, 400), ntsc),
+            (222, 0, 1476, 1080)
+        );
+        assert_eq!(smooth_fit_rect((0, 10), (640, 400), ntsc), (0, 0, 0, 0));
+    }
+
+    #[test]
+    fn buffer_glass_par_is_the_4_3_glass_read_off_the_buffer() {
+        // The PAL and NTSC apertures land at the desktop's glass shapes
+        // (`glass_par`: 1.078 and 0.854), in lowest terms.
+        let ratio = |(w, h): (u32, u32)| f64::from(w) / f64::from(h);
+        let pal = buffer_glass_par(TV_CAPTURED_WIDTH, TV_PAL_PRESENT_HEIGHT);
+        let ntsc = buffer_glass_par(TV_CAPTURED_WIDTH, TV_NTSC_PRESENT_HEIGHT);
+        assert_eq!(pal, (180, 167));
+        assert!((ratio(pal) - 1.0778).abs() < 5e-4, "PAL {}", ratio(pal));
+        assert!((ratio(ntsc) - 0.8543).abs() < 5e-4, "NTSC {}", ratio(ntsc));
+        // The full-overscan field: rows over PRESENT_HEIGHT_TV, the glass
+        // being FB_WIDTH x PRESENT_HEIGHT_TV (itself 4:3).
+        assert_eq!(
+            buffer_glass_par(FB_WIDTH, OUT_HEIGHT),
+            (
+                OUT_HEIGHT as u32 / 3,
+                crate::video::PRESENT_HEIGHT_TV as u32 / 3
+            )
+        );
+        assert_eq!(buffer_glass_par(0, 0), (4, 3));
+    }
+
+    #[test]
+    fn region_present_content_rect_inverts_the_aperture_copy() {
+        use crate::video::bitplane::ContentRect;
+        // A 640-wide standard window, 200 lines woven to rows 64..464 of
+        // the field, presented through the 50 Hz aperture copy: the
+        // capture starts TV_CAPTURED_MARGIN_X left of the window and its
+        // rows are the identity from woven row TV_PRESENT_SOURCE_Y.
+        let x0 = bitplane::STANDARD_VISIBLE_X0;
+        let rect = ContentRect {
+            x0,
+            x1: x0 + 640,
+            y0: 64,
+            y1: 464,
+        };
+        let (source_x, source_y) = (TV_CAPTURED_SOURCE_X as i32, TV_PRESENT_SOURCE_Y as i32);
+        assert_eq!(
+            region_present_content_rect(rect, source_x, source_y, 540, TV_CAPTURED_WIDTH, 540),
+            Some(ContentRect {
+                x0: TV_CAPTURED_MARGIN_X,
+                x1: TV_CAPTURED_MARGIN_X + 640,
+                y0: 46,
+                y1: 446,
+            })
+        );
+        // A tv-centre nudge moves the capture, so the buffer rect moves the
+        // other way.
+        let nudged = region_present_content_rect(
+            rect,
+            source_x - 8,
+            source_y + 4,
+            540,
+            TV_CAPTURED_WIDTH,
+            540,
+        )
+        .unwrap();
+        assert_eq!(
+            (nudged.x0, nudged.x1),
+            (TV_CAPTURED_MARGIN_X + 8, TV_CAPTURED_MARGIN_X + 648)
+        );
+        assert_eq!((nudged.y0, nudged.y1), (42, 442));
+        // The 60 Hz aperture resampled onto the 50 Hz row count (428 -> 540,
+        // the smooth presentation): rows 64..364 land on the buffer rows
+        // whose centre-aligned source falls inside them, 58..437; at its
+        // own rows (the integer presentation) the map is the identity.
+        let ntsc = ContentRect { y1: 364, ..rect };
+        let resampled =
+            region_present_content_rect(ntsc, source_x, source_y, 428, TV_CAPTURED_WIDTH, 540)
+                .unwrap();
+        assert_eq!((resampled.y0, resampled.y1), (58, 437));
+        let native =
+            region_present_content_rect(ntsc, source_x, source_y, 428, TV_CAPTURED_WIDTH, 428)
+                .unwrap();
+        assert_eq!((native.y0, native.y1), (46, 346));
+        // Off the buffer entirely: above the aperture, or left of the capture.
+        let above = ContentRect {
+            y0: 0,
+            y1: 10,
+            ..rect
+        };
+        assert_eq!(
+            region_present_content_rect(above, source_x, source_y, 540, TV_CAPTURED_WIDTH, 540),
+            None
+        );
+        let left = ContentRect {
+            x0: 0,
+            x1: 4,
+            ..rect
+        };
+        assert_eq!(
+            region_present_content_rect(left, source_x, source_y, 540, TV_CAPTURED_WIDTH, 540),
+            None
+        );
+        // Partly off: the shown part, clipped.
+        let wide = ContentRect {
+            x0: 0,
+            x1: FB_WIDTH,
+            ..rect
+        };
+        let shown =
+            region_present_content_rect(wide, source_x, source_y, 540, TV_CAPTURED_WIDTH, 540)
+                .unwrap();
+        assert_eq!((shown.x0, shown.x1), (0, TV_CAPTURED_WIDTH));
+    }
+
+    #[test]
+    fn buffer_layout_places_the_browser_buffer() {
+        use crate::video::bitplane::ContentRect;
+        // Smooth, whole buffer: the 4:3 element, exactly -- the page's
+        // plain stretch, so the modes' draw path shows the same picture.
+        let pal = (TV_CAPTURED_WIDTH, TV_PAL_PRESENT_HEIGHT);
+        assert_eq!(
+            buffer_layout((1440, 1080), pal, false, false, None),
+            BufferLayout {
+                src: (0, 0, 668, 540),
+                dst: (0, 0, 1440, 1080),
+                factors: None,
+            }
+        );
+        // Integer, the PAL aperture on a 1080p screen: two pixels per
+        // column and four per line (square, within a tenth of PAL's
+        // 1.078), 1336 x 1080 centred.
+        let layout = buffer_layout((1440, 1080), pal, false, true, None);
+        assert_eq!(layout.factors, Some((2, 4)));
+        assert_eq!(layout.dst, (52, 0, 1336, 1080));
+        // Integer with autocrop, a 640 x 400 NTSC display of the native-row
+        // aperture on a 1080p screen: amiga.vision's 4:5 pixel, 1280 x 1000.
+        let ntsc = (TV_CAPTURED_WIDTH, TV_NTSC_PRESENT_HEIGHT);
+        let content = ContentRect {
+            x0: 14,
+            x1: 654,
+            y0: 14,
+            y1: 414,
+        };
+        let layout = buffer_layout((1920, 1080), ntsc, false, true, Some(content));
+        assert_eq!(layout.src, (14, 14, 640, 400));
+        assert_eq!(layout.factors, Some((2, 5)));
+        assert_eq!(layout.dst, (320, 40, 1280, 1000));
+        // Smooth with autocrop: the crop at the glass shape, letterboxed.
+        let layout = buffer_layout((1920, 1080), ntsc, false, false, Some(content));
+        assert_eq!(layout.factors, None);
+        assert_eq!(layout.dst, (222, 0, 1476, 1080));
+        // A programmable scan (a 716 x 552 DblPAL field) under integer
+        // scaling takes the uniform multiple, its rows not being woven
+        // pairs; drawn smooth it fills the glass like any buffer.
+        let layout = buffer_layout((1440, 1080), (716, 552), true, true, None);
+        assert_eq!(layout.factors, Some((1, 2)));
+        assert_eq!(layout.dst, (362, 264, 716, 552));
+        assert_eq!(
+            buffer_layout((1440, 1080), (716, 552), true, false, None).dst,
+            (0, 0, 1440, 1080)
+        );
+        // Too small for one pixel per column: the smooth fit of the same shape.
+        let layout = buffer_layout((600, 500), pal, false, true, None);
+        assert_eq!(layout.factors, None);
+        assert_eq!(layout.dst, (0, 25, 600, 450));
+        // An empty envelope shows the whole buffer.
+        let empty = ContentRect {
+            x0: 10,
+            x1: 10,
+            y0: 0,
+            y1: 5,
+        };
+        assert_eq!(
+            buffer_layout((1440, 1080), pal, false, false, Some(empty)).src,
+            (0, 0, 668, 540)
+        );
     }
 }

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -266,83 +266,6 @@ pub(super) fn canvas_content_rect(
     Some((x0, y0, x1 + 1 - x0, y1 + 1 - y0))
 }
 
-/// Presentation smoothing for the autocrop rect. Per-frame content
-/// envelopes jitter -- loaders blank the screen, screen transitions
-/// rebuild the copper list over a frame or two, games flip between
-/// differently-sized displays -- and the presented crop must not pump
-/// with them. The latch grows immediately (content must never be cut)
-/// to the union of the old and new envelopes, holds through border-only
-/// frames like the aperture latch does, and shrinks only after the
-/// smaller envelope has held steady for [`Self::SHRINK_STABLE_FRAMES`]
-/// consecutive rendered frames.
-#[derive(Default)]
-pub(super) struct AutocropLatch {
-    active: Option<bitplane::ContentRect>,
-    candidate: Option<bitplane::ContentRect>,
-    stable_frames: u32,
-}
-
-impl AutocropLatch {
-    /// Rendered frames a strictly-smaller envelope must persist for
-    /// before the presentation tightens onto it: about half a second of
-    /// PAL frames, long enough to sit out a screen transition.
-    pub(super) const SHRINK_STABLE_FRAMES: u32 = 25;
-
-    pub(super) fn resolve(
-        &mut self,
-        frame: Option<bitplane::ContentRect>,
-    ) -> Option<bitplane::ContentRect> {
-        let Some(frame) = frame else {
-            // Border-only frame: keep presenting the previous crop, and
-            // keep any shrink candidate's clock running from zero again
-            // once content returns.
-            self.candidate = None;
-            self.stable_frames = 0;
-            return self.active;
-        };
-        let Some(active) = self.active else {
-            self.active = Some(frame);
-            return self.active;
-        };
-        let contained = frame.x0 >= active.x0
-            && frame.x1 <= active.x1
-            && frame.y0 >= active.y0
-            && frame.y1 <= active.y1;
-        if !contained {
-            self.active = Some(bitplane::ContentRect {
-                x0: active.x0.min(frame.x0),
-                x1: active.x1.max(frame.x1),
-                y0: active.y0.min(frame.y0),
-                y1: active.y1.max(frame.y1),
-            });
-            self.candidate = None;
-            self.stable_frames = 0;
-        } else if frame != active {
-            if self.candidate == Some(frame) {
-                self.stable_frames += 1;
-                if self.stable_frames >= Self::SHRINK_STABLE_FRAMES {
-                    self.active = Some(frame);
-                    self.candidate = None;
-                    self.stable_frames = 0;
-                }
-            } else {
-                self.candidate = Some(frame);
-                self.stable_frames = 1;
-            }
-        } else {
-            self.candidate = None;
-            self.stable_frames = 0;
-        }
-        self.active
-    }
-
-    /// Forget the crop across a presentation discontinuity (power cycle,
-    /// RTG entry), like `PresentationLatch::reset`.
-    pub(super) fn reset(&mut self) {
-        *self = Self::default();
-    }
-}
-
 pub(super) fn presentation_pixels_equal(
     current: &[u32],
     current_rows: usize,
@@ -731,136 +654,6 @@ pub(super) fn aperture_canvas_rect(tv_aperture_rows: usize) -> (usize, usize, us
     )
 }
 
-/// How far a whole-number pixel shape may stray from the glass ratio
-/// before a taller fit stops being worth it: max(shape/par, par/shape)
-/// at most 11/10. Wide enough that NTSC's 0.854 admits 4:5 (6.8% off)
-/// through 6:7, 7:8 and 12:13 -- the family amiga.vision's NTSC guide
-/// reaches for, 4:5 being its 1080p and 4K answer -- while excluding
-/// 3:4 (14%) and the squat 1:1 (17%); and that PAL's 1.078 admits the
-/// square 1:1 (7.2%) and 8:7 (6%) but not 6:5 (11%).
-const PAR_TOLERANCE: (u64, u64) = (11, 10);
-
-/// The per-axis whole-number fit of a `w` x `h` canvas rect (hi-res
-/// columns by woven rows) into `avail` surface pixels, drawn at the
-/// pixel shape `par`: `(columns, lines)` -- surface pixels per canvas
-/// column, and per *field line*, the scan's own vertical unit. The
-/// woven canvas carries two rows per line so interlaced fields can be
-/// woven; a non-interlaced display's two are identical, so a whole
-/// number of pixels per line is exact for it whether or not the number
-/// is even (an odd count lands as alternate rows of the pair, which is
-/// only visible on an interlaced display). Stepping the vertical factor
-/// by half a woven row is what makes the NTSC shapes reachable on
-/// ordinary displays: 4:5 is two pixels per column and five per line,
-/// 1000 rows for a 200-line display -- the 1080p answer.
-///
-/// The choice is the tallest fit whose shape stays within
-/// [`PAR_TOLERANCE`] of `par` (a bigger picture beats a marginally truer
-/// one), the closest shape among fits of that height, and the widest
-/// among equals; with no fit inside the tolerance, the closest shape at
-/// the largest size. `None` when not even one pixel per column and per
-/// line fits, where the caller falls back to the smooth fit. Exact
-/// integer arithmetic throughout, so every host agrees on the answer.
-pub(super) fn per_axis_fit(
-    avail: (u32, u32),
-    (w, h): (usize, usize),
-    par: (u32, u32),
-) -> Option<(usize, usize)> {
-    if w == 0 || h == 0 || par.0 == 0 || par.1 == 0 {
-        return None;
-    }
-    let max_columns = avail.0 as usize / w;
-    // `h` woven rows are `h / 2` field lines: `lines` pixels per line
-    // puts `h * lines / 2` rows on the surface.
-    let max_lines = 2 * avail.1 as usize / h;
-    if max_columns == 0 || max_lines == 0 {
-        return None;
-    }
-    let (par_w, par_h) = (u64::from(par.0), u64::from(par.1));
-    // A shape's deviation from `par`, as the two cross products ordered
-    // (max, min): their quotient is the symmetric ratio error, and two
-    // deviations compare exactly by cross-multiplying.
-    let deviation = |columns: usize, lines: usize| -> (u64, u64) {
-        let shape = 2 * columns as u64 * par_h;
-        let glass = lines as u64 * par_w;
-        (shape.max(glass), shape.min(glass))
-    };
-    let within = |(hi, lo): (u64, u64)| hi * PAR_TOLERANCE.1 <= lo * PAR_TOLERANCE.0;
-    let compare = |a: (u64, u64), b: (u64, u64)| (a.0 * b.1).cmp(&(b.0 * a.1));
-    // A candidate: its factors, its deviation, and whether that is
-    // within the tolerance.
-    type Candidate = ((usize, usize), (u64, u64), bool);
-    let mut best: Option<Candidate> = None;
-    for lines in 1..=max_lines {
-        // At a given height the shape grows with the column count, so
-        // only the two counts astride the ideal one (lines * par / 2)
-        // can be the closest -- and the tolerance band, an interval
-        // around the ideal, holds one of them if it holds any. Two
-        // candidates per height instead of every column: a one-line
-        // autocrop rect on a large surface has thousands of both, and
-        // the fit runs on every redraw and cursor move.
-        let ideal = (lines as u64 * par_w / (2 * par_h)) as usize;
-        let astride = [
-            ideal.clamp(1, max_columns),
-            (ideal + 1).clamp(1, max_columns),
-        ];
-        for columns in astride {
-            let dev = deviation(columns, lines);
-            let ok = within(dev);
-            let better = match best {
-                None => true,
-                Some((_, _, cand_ok)) if ok != cand_ok => ok,
-                Some((cand, cand_dev, true)) => lines
-                    .cmp(&cand.1)
-                    .then(compare(cand_dev, dev))
-                    .then(columns.cmp(&cand.0))
-                    .is_gt(),
-                Some((cand, cand_dev, false)) => compare(cand_dev, dev)
-                    .then(lines.cmp(&cand.1))
-                    .then(columns.cmp(&cand.0))
-                    .is_gt(),
-            };
-            if better {
-                best = Some(((columns, lines), dev, ok));
-            }
-        }
-    }
-    best.map(|(factors, _, _)| factors)
-}
-
-/// Where a `w` x `h` canvas rect lands in `avail` at whole-number
-/// factors `(columns, lines)`: exactly `w * columns` by `h * lines / 2`,
-/// centred. The rect's rows are whole field lines (an even count) so the
-/// height is exact -- every display rect's are, starting on a woven pair
-/// (`display_rects_start_on_field_lines`).
-fn per_axis_rect(
-    avail: (u32, u32),
-    (w, h): (usize, usize),
-    (columns, lines): (usize, usize),
-) -> (u32, u32, u32, u32) {
-    let dw = ((w * columns) as u32).min(avail.0);
-    let dh = ((h * lines / 2) as u32).min(avail.1);
-    ((avail.0 - dw) / 2, (avail.1 - dh) / 2, dw, dh)
-}
-
-/// The smooth fit of a `w` x `h` canvas rect drawn at pixel shape
-/// `par`: the aspect-preserving letterbox of `w * par` by `h` in
-/// `avail`, `clip_rect_for`'s smooth arithmetic with the shape folded
-/// into the width (at `(1, 1)` it is that fit exactly).
-fn smooth_fit_rect(
-    avail: (u32, u32),
-    (w, h): (usize, usize),
-    par: (u32, u32),
-) -> (u32, u32, u32, u32) {
-    if avail.0 == 0 || avail.1 == 0 || w == 0 || h == 0 {
-        return (0, 0, 0, 0);
-    }
-    let shaped_w = w as f32 * par.0 as f32 / par.1.max(1) as f32;
-    let scale = (avail.0 as f32 / shaped_w).min(avail.1 as f32 / h as f32);
-    let dw = ((shaped_w * scale) as u32).min(avail.0).max(1);
-    let dh = ((h as f32 * scale) as u32).min(avail.1).max(1);
-    ((avail.0 - dw) / 2, (avail.1 - dh) / 2, dw, dh)
-}
-
 /// The layout for the current frame. `src` is the sub-rect of the
 /// display region to show (an autocrop content rect, the TV aperture
 /// under per-axis integer scaling) with the pixel shape to draw it at,
@@ -919,23 +712,10 @@ pub(super) fn display_src_layout(
 ) -> PresentLayout {
     let avail_h = surface.1 - chrome_dst.map_or(0, |(_, _, _, h)| h.min(surface.1));
     let avail = (surface.0, avail_h.max(1));
-    let (w, h) = (src.rect.2.max(1), src.rect.3.max(1));
-    let factors = if !integer {
-        None
-    } else if src.par.0 == src.par.1 {
-        // The uniform multiple is the per-axis fit's answer for a square
-        // shape, but stated directly: the tolerance that lets a glass
-        // shape prefer a taller near-miss must not apply to a canvas
-        // asked for as square.
-        let fit = (avail.0 as usize / w).min(avail.1 as usize / h);
-        (fit >= 1).then_some((fit, 2 * fit))
-    } else {
-        per_axis_fit(avail, (w, h), src.par)
-    };
-    let display_dst = match factors {
-        Some(factors) => per_axis_rect(avail, (w, h), factors),
-        None => smooth_fit_rect(avail, (w, h), src.par),
-    };
+    let SubRectFit {
+        factors,
+        dst: display_dst,
+    } = sub_rect_fit(avail, integer, src.rect, src.par);
     PresentLayout {
         src_canvas: src.rect,
         display_dst,

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -8936,6 +8936,24 @@ fn glass_par_is_the_tv_canvas_model_read_back() {
     ] {
         assert_eq!(super::glass_par(Overscan::Full, rows, OUT_HEIGHT), field);
     }
+    // The browser reads the same shapes off its presentation buffer
+    // (`buffer_glass_par`): the captured aperture at its woven rows, or the
+    // whole field, shown in a 4:3 element.
+    let same_shape = |a: (u32, u32), b: (u32, u32)| {
+        u64::from(a.0) * u64::from(b.1) == u64::from(b.0) * u64::from(a.1)
+    };
+    assert!(same_shape(
+        pal,
+        super::buffer_glass_par(TV_CAPTURED_WIDTH, TV_PAL_PRESENT_HEIGHT)
+    ));
+    assert!(same_shape(
+        ntsc,
+        super::buffer_glass_par(TV_CAPTURED_WIDTH, TV_NTSC_PRESENT_HEIGHT)
+    ));
+    assert!(same_shape(
+        field,
+        super::buffer_glass_par(FB_WIDTH, OUT_HEIGHT)
+    ));
     assert_eq!(super::glass_par(Overscan::Tv, None, OUT_HEIGHT), field);
 }
 


### PR DESCRIPTION
Closes #608, the browser follow-up to #593 / #606 / #607.

## What changes

The browser build stretched its presentation buffer over a 4:3 element and had neither `[display] scaling = "integer"` nor `autocrop`. Both now port onto the desktop's own machinery: the page asks the wasm where the picture lands (`present_layout`) and draws that rect, so the desktop's per-axis fit and crop smoothing answer for the browser too. Two new controls on the hosted page (**Scaling**: Smooth / Integer, and **Autocrop**), remembered per browser and seeded from `copperline.json`; both stand down while a bezel mode is drawn, as on the desktop. Fullscreen on a 16:9 laptop or TV is where it gains the most: the element spans the viewport while a mode is on and the draw letterboxes the cropped picture inside it.

## Design

- **Shared core** (`present_common.rs`, compiled for wasm): `AutocropLatch`, `per_axis_fit`, `per_axis_rect` and `smooth_fit_rect` move out of `window/present.rs`; the new `sub_rect_fit` (`SubRectFit { factors, dst }`) is the factors/destination core of `display_src_layout`, which now calls it. `smooth_fit_rect` is exact u64 arithmetic now (was f32): a rect of the viewport's own shape fills it to the pixel, which the browser's whole-buffer draw relies on. Desktop tests unchanged.
- **Envelope into buffer pixels**: `FieldPlacement::content_rect` onto the woven field, then `region_present_content_rect`, the inverse of `Deinterlacer::present_field_region_into`'s row/column map, scanned against `scaled_source_row` like the desktop's `canvas_content_rect`. `bitplane::render_reusing_previous` reports the fresh render's envelope (`ReuseRender`); `bench.rs` adapted.
- **Glass shape off the buffer**: `buffer_glass_par(width, rows)` = `4 rows : 3 width` in lowest terms. The page shows whatever buffer the wrapper presents in a 4:3 element, so the buffer states its own pixel shape; it agrees with the desktop's `glass_par` for the PAL/NTSC apertures (1.078 / 0.854) and the full field (cross-check test added). `buffer_layout` composes the two; a programmable scan takes the uniform multiple under integer scaling, as on the desktop.
- **WebEmu**: `set_scaling("smooth"|"integer")`, `set_autocrop(bool)`, `present_content_rect()`, `present_layout(w, h)` -> `[sx, sy, sw, sh, dx, dy, dw, dh, columns, lines]`. The latch runs per frame in buffer pixels, is re-fed with the previous envelope on an exactly reused frame (a static screen is what lets a smaller crop prove itself stable; a crop adopted there bumps the presentation revision, the page's only redraw cue) and resets across a scan-geometry change. **Under integer scaling a 60 Hz aperture is presented at its own woven rows (668x428) instead of resampled onto the 50 Hz row count** -- the browser's equivalent of the desktop drawing its unresampled canvas -- so the factors are exact per scan line. The default smooth path is byte-identical to before.
- **try.js**: a `u_src` picture sub-rect uniform in the shared GLSL prologue, mirroring `crt.wgsl`'s `src_rect` with the half-texel clamp (whole texture by default: the old look); the non-bezel passes clear and draw the layout rect (the CRT scanline count scaled to the crop's share); the 2D fallback scales a staging canvas into a device-resolution store; `cssToEmu` follows the layout; fullscreen switches the element to span the viewport while a mode is on; the settings are re-applied on machine rebuild and state load; the bug-report line gains `scaling` / `autocrop` / `layout`.
- Docs: `guide/browser.md` (options, API, hooks, config keys), `internals/video.md`.

## Verification

- `cargo test` 3103 passed. New `present_common` tests: the exact smooth fit, `buffer_glass_par`, `region_present_content_rect` (identity, resampled, nudged, off-buffer, clipped) and `buffer_layout` (PAL 2x4 at 1080p, the NTSC 640x400 crop at 2x5 = 1280x1000, smooth letterbox, programmable uniform multiple, too-small fallback, empty envelope).
- Web crate: 4 native tests incl. `present_layout_follows_the_scaling_and_autocrop_settings` (NTSC 668x540 smooth -> 668x428 integer, layout `[0,0,668,428, 292,5,1336,1070, 2,5]` on 1920x1080, re-presentation on the setting change); `cargo check --target wasm32-unknown-unknown --locked`, `cargo fmt --check`, `npm test`.
- `cargo clippy --all-targets` and `cargo fmt --check` clean.
- Live in Chrome against a staged site with the fresh bundle: AROS boots; the content rect latches to `(14, 14, 640, 512)`; on the 2804x2104 device canvas the layout is 2560x2048 at 4x8. A readback of 4000 device-pixel blocks over the AROS logo found none straddling a texel (pixel-exact and correctly aligned) and the letterbox column fully black. Smooth+autocrop (a 2804x2081 letterbox), autocrop off (the full stretch), bezel suspension (buffer back to the 570-row tube view), an NTSC rebuild (668x428, 4x9) and the fullscreen fill fallback (5x10 on 4640x2726) all matched hand-computed values; no console errors.

Not machine-verifiable: gesture-driven real fullscreen and pointer feel (the CSS fallback shares the geometry, and `cssToEmu` follows the layout).

## Judgment calls

- The glass shape comes from the 4:3 model rather than the element's measured shape: every shell gives the canvas 4:3 (the hosted page's CSS, `CSS_FS_CANVAS`), as the desktop's glass is.
- A programmable scan drawn smooth keeps the glass shape (fills the element as today); under integer it takes the uniform multiple, like the desktop.
- The hosted page's `try/index.html` does not host `#scaling` / `#autocrop` yet, so the glue self-inserts unthemed rows until the site PR lands; that one should follow after this is published, since an older glue would leave a hosted select empty.
