### PR TITLE
control: MCP server mode for copperline-ctl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,14 @@ copperline-ctl --info /tmp/ccp.json --repl
 events.subscribe {"events":["frame","serial","interrupt","media"],"frame_interval":50}
 ```
 
+An MCP-capable agent (Claude Code, Cursor, ...) gets the same protocol as
+tools: `claude mcp add copperline -- copperline-ctl --mcp` (or an `.mcp.json`
+entry), then `session_launch {"config": "my.toml"}` or `session_attach
+{"info_file": "/tmp/ccp.json"}`, `break_add`, `continue {"wait_ms": 5000}`
+(the bridge pauses the machine when the wait expires), `capture_screenshot`
+(returned as an image), `events_next`. Tool names are the method names with
+dots as underscores; see the "MCP server" section of the reference.
+
 The event streams are bounded, so check their drop counts when observations
 must be complete. The same session can use `trace.start`/`trace.stop` and
 `waveform.start`/`waveform.stop` to bracket file-backed diagnostics at runtime

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,8 +134,10 @@ net-nat = ["dep:smoltcp"]
 # copperline-net-helper when an unprivileged open is denied), macOS uses the
 # system libpcap, and Windows loads an installed Npcap at runtime.
 net-bridge = ["dep:pcap", "dep:libloading"]
-# The `copperline-ctl` command-line client for the control protocol.
-ctl-bin = ["dep:serde_json"]
+# The `copperline-ctl` command-line client for the control protocol, and
+# its `--mcp` mode (src/control/mcp.rs), an MCP server over stdio that
+# exposes the protocol as tools for coding agents.
+ctl-bin = ["dep:serde_json", "control"]
 # The `copperline-import-uae` converter for WinUAE/Amiberry/FS-UAE
 # configuration files.
 import-uae-bin = ["dep:toml_edit"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It boots out of the box with the bundled open-source AROS Kickstart replacement,
 - **Storage and media**: Floppy disk images (ADF, ADZ, DMS, IPF, SCP), physical floppy drives via Greaseweazle (FluxBridge), IDE (Gayle/A4000), SCSI (A2091, A3000, A4091), CD-ROM, and host directory filesystem mounting.
 - **Audio and video**: 4-channel Paula audio, RTG graphics cards (Picasso II/II+, Z3660), host MIDI in/out bridging, and built-in Roland MT-32 and General MIDI synthesis.
 - **Expansion and networking**: Zorro II/III autoconfig, A2065 Ethernet, host-backed bsdsocket.library, and sandboxed WebAssembly expansion plugins.
-- **Debugging and automation**: In-window interactive debugger with reverse stepping, signal waveform export (VCD), GDB remote stub, deterministic save states, headless scripting, and a JSON-RPC control protocol (`copperline-ctl`).
+- **Debugging and automation**: In-window interactive debugger with reverse stepping, signal waveform export (VCD), GDB remote stub, deterministic save states, headless scripting, and a JSON-RPC control protocol (`copperline-ctl`, also served as MCP tools for coding agents by `copperline-ctl --mcp`).
 - **Direct launching**: Boot directly into WHDLoad game packages (`--whdload`) or host-built Amiga executables (`--run`), with a WinUAE-compatible `uaelib` trap so cross-compiler workflows can toggle warp, log, and register debug resources from the guest.
 - **WebAssembly build**: Run directly in modern web browsers at [copperline.dev/try](https://copperline.dev/try/).
 

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -41,6 +41,121 @@ copperline-ctl --info /tmp/ccp.json continue
 copperline-ctl --info /tmp/ccp.json --repl
 ```
 
+(mcp-server)=
+## MCP server
+
+`copperline-ctl --mcp` turns the same client into a
+[Model Context Protocol](https://modelcontextprotocol.io) server over stdio,
+so an agent in Claude Code, Cursor, or any other MCP client drives a live
+machine through tools instead of a REPL. Every control-protocol method is a
+tool, and a few bridge-owned tools manage the session.
+
+```sh
+# Unattached: the agent launches or attaches a session with the session tools.
+copperline-ctl --mcp
+
+# Attached at startup to a running control server:
+copperline-ctl --mcp --info /tmp/ccp.json
+copperline-ctl --mcp --connect 127.0.0.1:7710 --token HEX
+```
+
+Claude Code registers it with one command:
+
+```sh
+claude mcp add copperline -- copperline-ctl --mcp
+```
+
+or, checked into a project, `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "copperline": {
+      "command": "copperline-ctl",
+      "args": ["--mcp"],
+      "env": {"COPPERLINE_BIN": "/path/to/copperline"}
+    }
+  }
+}
+```
+
+`initialize` returns an `instructions` summary of the workflow, and
+`tools/list` carries a description, a JSON Schema and the parameter
+conventions for every tool, so the agent needs nothing else from this
+chapter.
+
+### Tool names
+
+MCP tool names allow only `[a-zA-Z0-9_-]`, so a method's tool is the method
+with dots replaced by underscores: `warp.get` is `warp_get`,
+`media.floppy.insert` is `media_floppy_insert`, `capture.screenshot` is
+`capture_screenshot`; methods without dots (`status`, `run_until`) keep their
+names. The arguments are the method's params, addresses included
+(integers or hex strings), and the text result is the method's result. A
+control-protocol error is returned as a tool result with `isError` set and
+the error code and message in the text, never as a transport failure.
+`hello` and `auth` are the bridge's own handshake and are not tools.
+
+### Session tools
+
+The bridge holds one session at a time:
+
+- `session_launch {"config", "model", "run", "whdload", "factory", "args",
+  "binary", "cwd", "timeout_ms"}` spawns a headless emulator as
+  `copperline --control :0 --control-info TMP --noaudio` plus `--config`,
+  `--model`, `--run`, `--whdload`, `--factory` and any further flags given
+  verbatim in `args`, waits for the endpoint, connects and authenticates.
+  The binary is `binary`, else `$COPPERLINE_BIN`, else the `copperline` next
+  to `copperline-ctl`, else the `PATH`. The emulator's own output goes to a
+  log file named in the result, which also carries the pid, the address and
+  the initial `status`. The machine starts paused at power-on.
+- `session_attach {"info_file"}` or `session_attach {"listen", "token"}`
+  attaches to a running `--control` or `--control-gui` server.
+- `session_status` reports the bridge's state: attached, address, the pid and
+  log of a launched emulator, whether the connection is still open, and the
+  event queue's depth and drop count.
+- `session_close` disconnects (the server drops the session's breakpoints
+  and subscriptions) and shuts down an emulator this server launched,
+  killing it after 3 s if it does not exit. Closing the server's stdin does
+  the same, so no emulator outlives its agent.
+
+### Blocking and `wait_ms`
+
+The resume verbs reply with the eventual stop event, and MCP serves one
+request at a time, so a `continue` with no breakpoint would block the server
+for good. `continue`, `run_until`, `step`, `step_over`, `step_out`,
+`step_copper` and `step_frame` therefore take an extra `wait_ms`: if the
+machine has not stopped within that many host milliseconds the bridge sends
+`pause` and returns the resulting stop event with `bridge.paused_after_ms`
+set. A stop that arrives in time is returned as it is. Without `wait_ms` the
+call blocks until the machine stops on its own.
+
+### Events
+
+A reader thread owns the socket and queues `event.*` notifications (bounded
+to 1024, drops counted) while requests are in flight, so a subscription made
+with `events_subscribe` keeps collecting during a long `run_until`.
+`events_next {"timeout_ms"}` blocks until the next event or the timeout
+(default 1 s) and returns `{method, params}` or `timed_out`;
+`events_drain` returns everything queued. Both report the queue depth and
+the drop count.
+
+### Screenshots
+
+`capture_screenshot` returns the PNG as an MCP image content block
+(`{"type": "image", "mimeType": "image/png"}`) alongside the text result, so
+the model can look at the screen. With no `path` the file is temporary and
+deleted after it is read; with a `path` it is kept there.
+
+### Protocol subset
+
+MCP 2025-06-18 over stdio, newline-delimited JSON-RPC 2.0: `initialize`
+(an earlier revision the client names is echoed; the served subset is the
+same), `notifications/initialized`, `ping`, `tools/list`, `tools/call`.
+Unknown methods get a JSON-RPC error; unknown notifications are ignored;
+stdout carries protocol messages only and diagnostics go to stderr. The
+server exits on stdin EOF.
+
 ## Protocol overview
 
 - **Wire format:** Newline-delimited JSON-RPC 2.0 over TCP.

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -145,16 +145,23 @@ the drop count.
 `capture_screenshot` returns the PNG as an MCP image content block
 (`{"type": "image", "mimeType": "image/png"}`) alongside the text result, so
 the model can look at the screen. With no `path` the file is temporary and
-deleted after it is read; with a `path` it is kept there.
+deleted after it is read; with a `path` it is kept there. A relative `path`
+is resolved against `copperline-ctl`'s working directory (not the
+emulator's, which can differ) and forwarded absolute, and the text result
+carries that absolute path. A PNG the emulator wrote but the bridge cannot
+read back is reported as a tool error, not as a result without its image.
 
 ### Protocol subset
 
 MCP 2025-06-18 over stdio, newline-delimited JSON-RPC 2.0: `initialize`
 (an earlier revision the client names is echoed; the served subset is the
 same), `notifications/initialized`, `ping`, `tools/list`, `tools/call`.
-Unknown methods get a JSON-RPC error; unknown notifications are ignored;
-stdout carries protocol messages only and diagnostics go to stderr. The
-server exits on stdin EOF.
+A message that is not a JSON-RPC 2.0 request (no `"jsonrpc": "2.0"`, an
+`id` that is not a string or an integer, a missing method) is answered with
+`-32600`, unparseable input with `-32700`, and unknown methods with
+`-32601`; unknown notifications (a method and no `id`) are ignored; stdout
+carries protocol messages only and diagnostics go to stderr. The server
+exits on stdin EOF.
 
 ## Protocol overview
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ Spaceballs' *State of the Art* (1992) running in Copperline.
 - [](zorro.md) -- Expansion bus specification and custom Zorro II/III plugin definitions.
 - [](debugger/window), [](debugger/headless), and [](debugger/gdb) -- Interactive,
   command-line, headless, and GDB debugging tools.
-- [](debugger/control) -- JSON-RPC control protocol (`copperline-ctl`) for automation.
+- [](debugger/control) -- JSON-RPC control protocol (`copperline-ctl`) for automation, with an MCP server mode for coding agents.
 - [](internals/architecture) -- Emulator internals and subsystem architecture.
 
 ## Core design principles

--- a/src/bin/copperline-ctl.rs
+++ b/src/bin/copperline-ctl.rs
@@ -11,12 +11,18 @@
 //! REPL (one `METHOD [JSON-PARAMS]` per line on stdin):
 //!   copperline-ctl --info /tmp/ccp.json --repl
 //!
+//! MCP server over stdio (docs/debugger/control.md, "MCP server"), for
+//! coding agents; with no connection arguments the agent launches or
+//! attaches a session through the session_* tools:
+//!   copperline-ctl --mcp [--info FILE | --connect ADDR --token TOKEN]
+//!
 //! Responses print to stdout as one JSON object per line; server
 //! notifications (event.*) print as they arrive. Exit status is nonzero
 //! when a one-shot request returns a JSON-RPC error.
 //!
-//! Deliberately std + serde_json only, so it stays a trivially portable
-//! sidecar for scripts and agents.
+//! Deliberately std + serde_json only (the MCP mode is the library's
+//! hand-rolled `control::mcp`, no async runtime), so it stays a trivially
+//! portable sidecar for scripts and agents.
 
 use serde_json::{json, Value};
 use std::io::{BufRead, BufReader, Write};
@@ -27,19 +33,22 @@ struct Options {
     connect: Option<String>,
     token: Option<String>,
     repl: bool,
+    mcp: bool,
     method: Option<String>,
     params: Value,
 }
 
 fn usage() -> &'static str {
     "usage: copperline-ctl (--info FILE | --connect ADDR --token TOKEN) \
-     [--repl | METHOD [JSON-PARAMS]]"
+     [--repl | METHOD [JSON-PARAMS]]\n       \
+     copperline-ctl --mcp [--info FILE | --connect ADDR --token TOKEN]"
 }
 
 fn parse_options() -> Result<Options, String> {
     let mut connect = None;
     let mut token = None;
     let mut repl = false;
+    let mut mcp = false;
     let mut method = None;
     let mut params = Value::Null;
     let mut args = std::env::args().skip(1);
@@ -69,6 +78,7 @@ fn parse_options() -> Result<Options, String> {
                     .or(token);
             }
             "--repl" => repl = true,
+            "--mcp" => mcp = true,
             "-h" | "--help" => return Err(usage().to_string()),
             _ if method.is_none() && !arg.starts_with('-') => method = Some(arg),
             _ if method.is_some() && params.is_null() => {
@@ -78,16 +88,26 @@ fn parse_options() -> Result<Options, String> {
             other => return Err(format!("unexpected argument {other:?}\n{}", usage())),
         }
     }
-    if connect.is_none() {
-        return Err(format!("no server address\n{}", usage()));
-    }
-    if !repl && method.is_none() {
-        return Err(format!("no method\n{}", usage()));
+    if mcp {
+        if repl || method.is_some() {
+            return Err(format!("--mcp takes no method or --repl\n{}", usage()));
+        }
+        if connect.is_some() && token.is_none() {
+            return Err(format!("--mcp --connect needs --token\n{}", usage()));
+        }
+    } else {
+        if connect.is_none() {
+            return Err(format!("no server address\n{}", usage()));
+        }
+        if !repl && method.is_none() {
+            return Err(format!("no method\n{}", usage()));
+        }
     }
     Ok(Options {
         connect,
         token,
         repl,
+        mcp,
         method,
         params,
     })
@@ -279,6 +299,29 @@ fn read_repl_messages(
     }
 }
 
+/// `--mcp`: serve MCP on stdin/stdout, attached to the session named on
+/// the command line if there is one.
+fn run_mcp(options: &Options) -> ExitCode {
+    use copperline::control::bridge::Bridge;
+    let attach = match (&options.connect, &options.token) {
+        (Some(addr), Some(token)) => match Bridge::connect(addr, token) {
+            Ok(bridge) => Some(bridge),
+            Err(message) => {
+                eprintln!("copperline-ctl: {message}");
+                return ExitCode::FAILURE;
+            }
+        },
+        _ => None,
+    };
+    match copperline::control::mcp::run_stdio(attach) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("copperline-ctl: mcp transport: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
 fn main() -> ExitCode {
     let options = match parse_options() {
         Ok(options) => options,
@@ -287,6 +330,9 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+    if options.mcp {
+        return run_mcp(&options);
+    }
     let addr = options.connect.as_deref().expect("checked in parsing");
     let mut client = match Client::connect(addr) {
         Ok(client) => client,

--- a/src/control.rs
+++ b/src/control.rs
@@ -21,9 +21,11 @@
 //!
 //! [`Emulator`]: crate::emulator::Emulator
 
+pub mod bridge;
 pub mod catalogue;
 pub mod exec;
 pub mod headless;
+pub mod mcp;
 pub mod observe;
 pub mod proto;
 pub mod session;

--- a/src/control.rs
+++ b/src/control.rs
@@ -138,17 +138,26 @@ pub fn announce(
     Ok(())
 }
 
-/// Write `contents` to `path` readable by the owner only (0600 on unix),
-/// truncating any previous file.
-fn write_private_file(path: &PathBuf, contents: &[u8]) -> std::io::Result<()> {
+/// Open options that create a file readable by the owner only (0600 on
+/// unix, the platform default elsewhere), for the files that carry a
+/// session token: the `--control-info` file, and the log the MCP bridge
+/// points a launched emulator's stderr at. The mode is set as the file is
+/// created, never by a chmod afterwards.
+pub(crate) fn owner_only_create() -> std::fs::OpenOptions {
     let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
+    opts.write(true).create(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt as _;
         opts.mode(0o600);
     }
-    let mut f = opts.open(path)?;
+    opts
+}
+
+/// Write `contents` to `path` readable by the owner only (0600 on unix),
+/// truncating any previous file.
+fn write_private_file(path: &PathBuf, contents: &[u8]) -> std::io::Result<()> {
+    let mut f = owner_only_create().truncate(true).open(path)?;
     f.write_all(contents)?;
     f.flush()
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -21,6 +21,7 @@
 //!
 //! [`Emulator`]: crate::emulator::Emulator
 
+pub mod catalogue;
 pub mod exec;
 pub mod headless;
 pub mod observe;

--- a/src/control/bridge.rs
+++ b/src/control/bridge.rs
@@ -414,7 +414,13 @@ pub fn launch(spec: &LaunchSpec) -> Result<(Bridge, Launched), String> {
     let info_path = std::env::temp_dir().join(format!("{stamp}.json"));
     let log_path = std::env::temp_dir().join(format!("{stamp}.log"));
     let _ = std::fs::remove_file(&info_path);
-    let log = std::fs::File::create(&log_path)
+    // The emulator announces its token on stderr, so the log is readable
+    // by the owner only from the moment it exists, like the info file,
+    // and is never an existing file: a symlink planted under the
+    // predictable name in a shared temp dir would carry the token away.
+    let log = super::owner_only_create()
+        .create_new(true)
+        .open(&log_path)
         .map_err(|e| format!("creating {}: {e}", log_path.display()))?;
     let log_err = log
         .try_clone()
@@ -680,6 +686,16 @@ mod tests {
         assert!(err.contains("exited"), "{err}");
         assert!(err.contains("boot failure"), "{err}");
         assert!(err.contains("--control :0"), "{err}");
+        // The log the emulator's stderr went to (where a real emulator
+        // announces its token) is readable by the owner only.
+        let log = err
+            .split("; log ")
+            .nth(1)
+            .and_then(|rest| rest.split("):").next())
+            .expect("the report names the log");
+        let mode = std::fs::metadata(log).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "{log}");
+        std::fs::remove_file(log).ok();
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/control/bridge.rs
+++ b/src/control/bridge.rs
@@ -21,6 +21,7 @@ use std::io::{BufReader, Write as _};
 use std::net::{Shutdown, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -413,29 +414,48 @@ pub fn resolve_binary(explicit: Option<&Path>) -> PathBuf {
     PathBuf::from(name)
 }
 
+/// Per-process launch counter, so launches issued in the same
+/// millisecond (parallel tests, agents opening several sessions at once)
+/// never share a temp-file name.
+static LAUNCH_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Pick the `--control-info` path and create the log file for one launch.
+///
+/// The emulator announces its token on stderr, so the log is readable by
+/// the owner only from the moment it exists, like the info file, and is
+/// never an existing file: a symlink planted under a predictable name in a
+/// shared temp dir would carry the token away. A name that already exists
+/// is simply skipped for the next one in the sequence.
+fn create_launch_files() -> Result<(PathBuf, PathBuf, std::fs::File), String> {
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let mut last_err = None;
+    for _ in 0..64 {
+        let seq = LAUNCH_SEQ.fetch_add(1, Ordering::Relaxed);
+        let stamp = format!("copperline-mcp-{}-{millis}-{seq}", std::process::id());
+        let info_path = std::env::temp_dir().join(format!("{stamp}.json"));
+        let log_path = std::env::temp_dir().join(format!("{stamp}.log"));
+        match super::owner_only_create().create_new(true).open(&log_path) {
+            Ok(log) => {
+                let _ = std::fs::remove_file(&info_path);
+                return Ok((info_path, log_path, log));
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                last_err = Some(format!("creating {}: {e}", log_path.display()));
+            }
+            Err(e) => return Err(format!("creating {}: {e}", log_path.display())),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| "creating the launch log: no free name".into()))
+}
+
 /// Start a headless emulator with a control server on an ephemeral
 /// loopback port, wait for its endpoint, connect and authenticate.
 pub fn launch(spec: &LaunchSpec) -> Result<(Bridge, Launched), String> {
     let binary = resolve_binary(spec.binary.as_deref());
-    let stamp = format!(
-        "copperline-mcp-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis())
-            .unwrap_or(0)
-    );
-    let info_path = std::env::temp_dir().join(format!("{stamp}.json"));
-    let log_path = std::env::temp_dir().join(format!("{stamp}.log"));
-    let _ = std::fs::remove_file(&info_path);
-    // The emulator announces its token on stderr, so the log is readable
-    // by the owner only from the moment it exists, like the info file,
-    // and is never an existing file: a symlink planted under the
-    // predictable name in a shared temp dir would carry the token away.
-    let log = super::owner_only_create()
-        .create_new(true)
-        .open(&log_path)
-        .map_err(|e| format!("creating {}: {e}", log_path.display()))?;
+    let (info_path, log_path, log) = create_launch_files()?;
     let log_err = log
         .try_clone()
         .map_err(|e| format!("cloning the log handle: {e}"))?;
@@ -457,9 +477,14 @@ pub fn launch(spec: &LaunchSpec) -> Result<(Bridge, Launched), String> {
     let command_line: Vec<String> = std::iter::once(binary.display().to_string())
         .chain(command.get_args().map(|a| a.to_string_lossy().into_owned()))
         .collect();
-    let child = command
-        .spawn()
-        .map_err(|e| format!("starting {}: {e}", binary.display()))?;
+    let child = match command.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            // Nothing ran, so nothing was logged: leave no empty file behind.
+            let _ = std::fs::remove_file(&log_path);
+            return Err(format!("starting {}: {e}", binary.display()));
+        }
+    };
     let mut launched = Launched {
         child,
         command: command_line,
@@ -731,6 +756,28 @@ mod tests {
             .unwrap_err()
             .contains("reading"));
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn launches_in_the_same_millisecond_get_distinct_private_files() {
+        // The unit suite runs launch tests in parallel threads of one
+        // process; the temp-file names carry a per-process sequence so
+        // two launches in the same millisecond never race on one path.
+        let (info_a, log_a, _file_a) = create_launch_files().unwrap();
+        let (info_b, log_b, _file_b) = create_launch_files().unwrap();
+        assert_ne!(log_a, log_b);
+        assert_ne!(info_a, info_b);
+        assert!(log_a.is_file() && log_b.is_file());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            for log in [&log_a, &log_b] {
+                let mode = std::fs::metadata(log).unwrap().permissions().mode() & 0o777;
+                assert_eq!(mode, 0o600, "{}", log.display());
+            }
+        }
+        std::fs::remove_file(&log_a).ok();
+        std::fs::remove_file(&log_b).ok();
     }
 
     #[test]

--- a/src/control/bridge.rs
+++ b/src/control/bridge.rs
@@ -208,6 +208,18 @@ impl Bridge {
         self.wait(id, None)
     }
 
+    /// Stop waiting for `id`: its pending entry is dropped, so a reply
+    /// that arrives later is discarded by the reader rather than kept for
+    /// a waiter that never comes. A no-op once the reply has been taken.
+    pub fn forget(&self, id: u64) {
+        self.shared.lock().pending.remove(&id);
+    }
+
+    /// Requests sent and neither answered nor forgotten.
+    pub fn outstanding(&self) -> usize {
+        self.shared.lock().pending.len()
+    }
+
     /// The next queued notification, waiting up to `timeout` for one.
     pub fn next_event(&self, timeout: Duration) -> Option<Value> {
         let deadline = Instant::now() + timeout;
@@ -291,6 +303,8 @@ fn read_loop(mut reader: BufReader<TcpStream>, shared: Arc<Shared>) {
             }
             state.events.push_back(msg);
         } else if let Some(id) = msg.get("id").and_then(Value::as_u64) {
+            // A reply to a forgotten id (a wait that timed out) has no
+            // taker and is dropped here rather than parked in the map.
             if let Some(slot) = state.pending.get_mut(&id) {
                 *slot = Some(msg);
             }
@@ -498,16 +512,18 @@ pub fn launch(spec: &LaunchSpec) -> Result<(Bridge, Launched), String> {
     }
 }
 
+/// Scripted control servers for the bridge's and the MCP server's tests.
 #[cfg(test)]
-mod tests {
+pub(crate) mod test_support {
     use super::*;
     use std::io::{BufRead, Write};
     use std::net::TcpListener;
 
-    /// A scripted server: answers hello, then replies to each request
-    /// per `script` (id -> reply line builder), interleaving the given
-    /// notifications before the reply.
-    fn scripted_server(
+    /// A scripted server on `listener`: `respond` maps each request to
+    /// the lines to send back (replies and notifications, in order, or
+    /// nothing) until the client closes. Token `ok` authenticates; see
+    /// [`hello_reply`].
+    pub(crate) fn scripted_server(
         listener: TcpListener,
         respond: impl Fn(&Value) -> Vec<String> + Send + 'static,
     ) -> JoinHandle<()> {
@@ -528,7 +544,9 @@ mod tests {
         })
     }
 
-    fn hello_reply(req: &Value) -> Option<String> {
+    /// The `hello` reply for a scripted server, `None` for any other
+    /// request.
+    pub(crate) fn hello_reply(req: &Value) -> Option<String> {
         (req["method"] == "hello").then(|| {
             proto::ok_line(
                 &req["id"],
@@ -536,6 +554,13 @@ mod tests {
             )
         })
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::{hello_reply, scripted_server};
+    use super::*;
+    use std::net::TcpListener;
 
     #[test]
     fn connects_authenticates_and_routes_replies_and_events() {
@@ -583,6 +608,61 @@ mod tests {
             Reply::TimedOut
         );
         assert!(bridge.next_event(Duration::from_millis(10)).is_none());
+        bridge.close();
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn a_forgotten_request_s_late_reply_is_dropped() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // `slow` is never answered on its own: its reply goes out late,
+        // ahead of the next request's, once the waiter has given up.
+        let held = Mutex::new(None::<Value>);
+        let server = scripted_server(listener, move |req| {
+            if let Some(hello) = hello_reply(req) {
+                return vec![hello];
+            }
+            let mut held = held.lock().unwrap();
+            match req["method"].as_str() {
+                Some("slow") => {
+                    *held = Some(req["id"].clone());
+                    vec![]
+                }
+                Some("status") => {
+                    let mut lines = Vec::new();
+                    if let Some(id) = held.take() {
+                        lines.push(proto::ok_line(&id, json!({"late": true})));
+                    }
+                    lines.push(proto::ok_line(&req["id"], json!({"frame": 3})));
+                    lines
+                }
+                _ => vec![],
+            }
+        });
+        let mut bridge = Bridge::connect(&addr.to_string(), "ok").unwrap();
+        for round in 0..3 {
+            let id = bridge.send("slow", Value::Null).unwrap();
+            assert_eq!(
+                bridge.wait(id, Some(Duration::from_millis(10))).unwrap(),
+                Reply::TimedOut
+            );
+            assert_eq!(bridge.outstanding(), 1, "round {round}");
+            bridge.forget(id);
+            assert_eq!(bridge.outstanding(), 0, "round {round}");
+            assert_eq!(
+                bridge.call("status", Value::Null).unwrap(),
+                Reply::Ok(json!({"frame": 3}))
+            );
+            assert_eq!(
+                bridge.outstanding(),
+                0,
+                "round {round}: the late reply must not be kept"
+            );
+        }
+        // Forgetting an answered or unknown id is harmless.
+        bridge.forget(9999);
+        assert_eq!(bridge.outstanding(), 0);
         bridge.close();
         server.join().unwrap();
     }

--- a/src/control/bridge.rs
+++ b/src/control/bridge.rs
@@ -1,0 +1,695 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! A control-protocol client for the MCP server: one authenticated
+//! connection, a reader thread that owns the socket's receive side and
+//! routes replies by id, and a bounded queue for the `event.*`
+//! notifications that arrive between and during requests.
+//!
+//! The split matters because a resume verb's reply is the eventual stop
+//! event: while `continue` is outstanding, frame and serial events keep
+//! streaming and must not sit in the socket buffer behind it. The reader
+//! thread drains everything as it arrives; the request thread waits on a
+//! condition variable for its own id, with or without a timeout.
+//!
+//! Also the launcher for a headless emulator process, since an agent
+//! attaching through MCP usually has no emulator running yet.
+
+use super::proto;
+use serde_json::{json, Value};
+use std::collections::{HashMap, VecDeque};
+use std::io::{BufReader, Write as _};
+use std::net::{Shutdown, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+/// Notifications kept between `events_next` / `events_drain` calls;
+/// beyond this the oldest is dropped and counted.
+pub const EVENT_QUEUE_CAPACITY: usize = 1024;
+
+/// How long `launch` waits for the emulator to announce its endpoint
+/// unless the caller says otherwise.
+pub const DEFAULT_LAUNCH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The outcome of one request.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Reply {
+    /// The `result` of a successful reply.
+    Ok(Value),
+    /// The server's JSON-RPC error.
+    Err { code: i64, message: String },
+    /// No reply within the wait; the request is still outstanding and
+    /// `wait` can be called again for it.
+    TimedOut,
+}
+
+impl Reply {
+    fn from_envelope(msg: Value) -> Self {
+        if let Some(err) = msg.get("error") {
+            return Reply::Err {
+                code: err.get("code").and_then(Value::as_i64).unwrap_or(0),
+                message: err
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("error")
+                    .to_string(),
+            };
+        }
+        Reply::Ok(msg.get("result").cloned().unwrap_or(Value::Null))
+    }
+}
+
+#[derive(Default)]
+struct State {
+    /// Outstanding request ids, and the reply once it has arrived.
+    pending: HashMap<u64, Option<Value>>,
+    events: VecDeque<Value>,
+    dropped: u64,
+    /// Why the connection ended, once it has.
+    closed: Option<String>,
+}
+
+struct Shared {
+    state: Mutex<State>,
+    cv: Condvar,
+}
+
+impl Shared {
+    fn lock(&self) -> MutexGuard<'_, State> {
+        self.state.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+/// One authenticated control-protocol connection.
+pub struct Bridge {
+    writer: TcpStream,
+    next_id: u64,
+    shared: Arc<Shared>,
+    reader: Option<JoinHandle<()>>,
+    listen: String,
+    hello: Value,
+}
+
+impl Bridge {
+    /// Connect to `addr` and authenticate with `token`.
+    pub fn connect(addr: &str, token: &str) -> Result<Self, String> {
+        let stream = TcpStream::connect(addr).map_err(|e| format!("connecting to {addr}: {e}"))?;
+        stream.set_nodelay(true).ok();
+        let read_side = stream
+            .try_clone()
+            .map_err(|e| format!("cloning the connection: {e}"))?;
+        let shared = Arc::new(Shared {
+            state: Mutex::new(State::default()),
+            cv: Condvar::new(),
+        });
+        let reader_shared = Arc::clone(&shared);
+        let reader = std::thread::Builder::new()
+            .name("copperline-mcp-read".into())
+            .spawn(move || read_loop(BufReader::new(read_side), reader_shared))
+            .map_err(|e| format!("starting the reader thread: {e}"))?;
+        let mut bridge = Self {
+            writer: stream,
+            next_id: 1,
+            shared,
+            reader: Some(reader),
+            listen: addr.to_string(),
+            hello: Value::Null,
+        };
+        match bridge.call("hello", json!({"token": token}))? {
+            Reply::Ok(hello) if hello["authed"] == Value::Bool(true) => bridge.hello = hello,
+            Reply::Ok(hello) => return Err(format!("auth failed: {hello}")),
+            Reply::Err { message, .. } => return Err(format!("auth failed: {message}")),
+            Reply::TimedOut => unreachable!("hello is waited without a timeout"),
+        }
+        Ok(bridge)
+    }
+
+    /// Connect using the `{"listen", "token"}` file `--control-info` wrote.
+    pub fn connect_info_file(path: &Path) -> Result<Self, String> {
+        let (listen, token) = read_info_file(path)?;
+        Self::connect(&listen, &token)
+    }
+
+    /// The address this bridge connected to.
+    pub fn listen(&self) -> &str {
+        &self.listen
+    }
+
+    /// The server's `hello` reply (`proto`, `emulator`).
+    pub fn hello(&self) -> &Value {
+        &self.hello
+    }
+
+    /// Why the connection ended, if it has.
+    pub fn closed(&self) -> Option<String> {
+        self.shared.lock().closed.clone()
+    }
+
+    /// Send a request and return its id without waiting.
+    pub fn send(&mut self, method: &str, params: Value) -> Result<u64, String> {
+        if let Some(reason) = self.closed() {
+            return Err(format!("session lost: {reason}"));
+        }
+        let id = self.next_id;
+        self.next_id += 1;
+        self.shared.lock().pending.insert(id, None);
+        let msg = json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        let line = format!("{msg}\n");
+        if let Err(e) = self
+            .writer
+            .write_all(line.as_bytes())
+            .and_then(|_| self.writer.flush())
+        {
+            self.shared.lock().pending.remove(&id);
+            return Err(format!("sending {method}: {e}"));
+        }
+        Ok(id)
+    }
+
+    /// Wait for the reply to `id`, up to `timeout` (forever when `None`).
+    pub fn wait(&self, id: u64, timeout: Option<Duration>) -> Result<Reply, String> {
+        let deadline = timeout.map(|t| Instant::now() + t);
+        let mut state = self.shared.lock();
+        loop {
+            if let Some(Some(_)) = state.pending.get(&id) {
+                let msg = state.pending.remove(&id).flatten().expect("checked above");
+                return Ok(Reply::from_envelope(msg));
+            }
+            if let Some(reason) = state.closed.clone() {
+                state.pending.remove(&id);
+                return Err(format!("session lost: {reason}"));
+            }
+            state = match deadline {
+                None => self
+                    .shared
+                    .cv
+                    .wait(state)
+                    .unwrap_or_else(|e| e.into_inner()),
+                Some(deadline) => {
+                    let now = Instant::now();
+                    if now >= deadline {
+                        return Ok(Reply::TimedOut);
+                    }
+                    self.shared
+                        .cv
+                        .wait_timeout(state, deadline - now)
+                        .unwrap_or_else(|e| e.into_inner())
+                        .0
+                }
+            };
+        }
+    }
+
+    /// One request-reply round trip with no timeout.
+    pub fn call(&mut self, method: &str, params: Value) -> Result<Reply, String> {
+        let id = self.send(method, params)?;
+        self.wait(id, None)
+    }
+
+    /// The next queued notification, waiting up to `timeout` for one.
+    pub fn next_event(&self, timeout: Duration) -> Option<Value> {
+        let deadline = Instant::now() + timeout;
+        let mut state = self.shared.lock();
+        loop {
+            if let Some(event) = state.events.pop_front() {
+                return Some(event);
+            }
+            if state.closed.is_some() {
+                return None;
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                return None;
+            }
+            state = self
+                .shared
+                .cv
+                .wait_timeout(state, deadline - now)
+                .unwrap_or_else(|e| e.into_inner())
+                .0;
+        }
+    }
+
+    /// Every queued notification, oldest first.
+    pub fn drain_events(&self) -> Vec<Value> {
+        self.shared.lock().events.drain(..).collect()
+    }
+
+    /// (queued, dropped so far).
+    pub fn event_counts(&self) -> (usize, u64) {
+        let state = self.shared.lock();
+        (state.events.len(), state.dropped)
+    }
+
+    /// Shut the connection and join the reader. The server tears down
+    /// session-owned breakpoints and subscriptions on disconnect.
+    pub fn close(mut self) {
+        self.shutdown_socket();
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+    }
+
+    fn shutdown_socket(&mut self) {
+        let _ = self.writer.shutdown(Shutdown::Both);
+    }
+}
+
+impl Drop for Bridge {
+    fn drop(&mut self) {
+        self.shutdown_socket();
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+    }
+}
+
+/// The reader thread: every reply goes to its waiter, every
+/// notification to the event queue, and the end of the stream closes
+/// the bridge for everyone waiting.
+fn read_loop(mut reader: BufReader<TcpStream>, shared: Arc<Shared>) {
+    let reason = loop {
+        let line = match proto::read_msg_line(&mut reader) {
+            Ok(Some(line)) => line,
+            Ok(None) => break "server closed the connection".to_string(),
+            Err(e) => break format!("reading from the server: {e}"),
+        };
+        let msg: Value = match serde_json::from_str(&line) {
+            Ok(msg) => msg,
+            Err(e) => {
+                eprintln!("copperline-mcp: ignoring a non-JSON server line: {e}");
+                continue;
+            }
+        };
+        let mut state = shared.lock();
+        if msg.get("method").is_some() {
+            if state.events.len() >= EVENT_QUEUE_CAPACITY {
+                state.events.pop_front();
+                state.dropped += 1;
+            }
+            state.events.push_back(msg);
+        } else if let Some(id) = msg.get("id").and_then(Value::as_u64) {
+            if let Some(slot) = state.pending.get_mut(&id) {
+                *slot = Some(msg);
+            }
+        }
+        drop(state);
+        shared.cv.notify_all();
+    };
+    shared.lock().closed = Some(reason);
+    shared.cv.notify_all();
+}
+
+/// Parse a `--control-info` file into (listen address, token).
+pub fn read_info_file(path: &Path) -> Result<(String, String), String> {
+    let body =
+        std::fs::read_to_string(path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let info: Value = serde_json::from_str(body.trim())
+        .map_err(|e| format!("parsing {}: {e}", path.display()))?;
+    let listen = info
+        .get("listen")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("{} has no listen address", path.display()))?;
+    let token = info
+        .get("token")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("{} has no token", path.display()))?;
+    Ok((listen.to_string(), token.to_string()))
+}
+
+// ---------------------------------------------------------------------
+// Launching an emulator
+
+/// What to launch: the binary, extra arguments, and where.
+#[derive(Debug, Clone, Default)]
+pub struct LaunchSpec {
+    /// The emulator binary; `None` resolves `COPPERLINE_BIN`, then a
+    /// `copperline` next to the running executable, then the PATH.
+    pub binary: Option<PathBuf>,
+    pub args: Vec<String>,
+    pub cwd: Option<PathBuf>,
+    pub timeout: Duration,
+}
+
+/// A headless emulator this bridge started, with its log.
+pub struct Launched {
+    pub child: Child,
+    pub command: Vec<String>,
+    pub log_path: PathBuf,
+}
+
+impl Launched {
+    pub fn pid(&self) -> u32 {
+        self.child.id()
+    }
+
+    /// Wait up to `timeout` for the process to exit, then kill it. Returns
+    /// whether it had to be killed.
+    pub fn finish(&mut self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return false,
+                Ok(None) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                _ => break,
+            }
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        true
+    }
+
+    /// The last lines of the process log, for an error report.
+    pub fn log_tail(&self, lines: usize) -> String {
+        let body = std::fs::read_to_string(&self.log_path).unwrap_or_default();
+        let all: Vec<&str> = body.lines().collect();
+        let start = all.len().saturating_sub(lines);
+        all[start..].join("\n")
+    }
+}
+
+/// Resolve the emulator binary: the explicit path, `COPPERLINE_BIN`, a
+/// sibling of the running executable, or the bare name for the PATH.
+pub fn resolve_binary(explicit: Option<&Path>) -> PathBuf {
+    if let Some(path) = explicit {
+        return path.to_path_buf();
+    }
+    if let Some(env) = std::env::var_os("COPPERLINE_BIN") {
+        if !env.is_empty() {
+            return PathBuf::from(env);
+        }
+    }
+    let name = if cfg!(windows) {
+        "copperline.exe"
+    } else {
+        "copperline"
+    };
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let sibling = dir.join(name);
+            if sibling.is_file() {
+                return sibling;
+            }
+        }
+    }
+    PathBuf::from(name)
+}
+
+/// Start a headless emulator with a control server on an ephemeral
+/// loopback port, wait for its endpoint, connect and authenticate.
+pub fn launch(spec: &LaunchSpec) -> Result<(Bridge, Launched), String> {
+    let binary = resolve_binary(spec.binary.as_deref());
+    let stamp = format!(
+        "copperline-mcp-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0)
+    );
+    let info_path = std::env::temp_dir().join(format!("{stamp}.json"));
+    let log_path = std::env::temp_dir().join(format!("{stamp}.log"));
+    let _ = std::fs::remove_file(&info_path);
+    let log = std::fs::File::create(&log_path)
+        .map_err(|e| format!("creating {}: {e}", log_path.display()))?;
+    let log_err = log
+        .try_clone()
+        .map_err(|e| format!("cloning the log handle: {e}"))?;
+
+    let mut command = Command::new(&binary);
+    command
+        .arg("--control")
+        .arg(":0")
+        .arg("--control-info")
+        .arg(&info_path)
+        .arg("--noaudio")
+        .args(&spec.args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(log_err));
+    if let Some(cwd) = &spec.cwd {
+        command.current_dir(cwd);
+    }
+    let command_line: Vec<String> = std::iter::once(binary.display().to_string())
+        .chain(command.get_args().map(|a| a.to_string_lossy().into_owned()))
+        .collect();
+    let child = command
+        .spawn()
+        .map_err(|e| format!("starting {}: {e}", binary.display()))?;
+    let mut launched = Launched {
+        child,
+        command: command_line,
+        log_path,
+    };
+
+    let timeout = if spec.timeout.is_zero() {
+        DEFAULT_LAUNCH_TIMEOUT
+    } else {
+        spec.timeout
+    };
+    let deadline = Instant::now() + timeout;
+    let endpoint = loop {
+        if let Ok(Some(status)) = launched.child.try_wait() {
+            let tail = launched.log_tail(40);
+            let _ = std::fs::remove_file(&info_path);
+            return Err(format!(
+                "the emulator exited with {status} before announcing its control endpoint \
+                 (command: {}; log {}):\n{tail}",
+                launched.command.join(" "),
+                launched.log_path.display()
+            ));
+        }
+        if info_path.is_file() {
+            if let Ok(endpoint) = read_info_file(&info_path) {
+                break endpoint;
+            }
+        }
+        if Instant::now() >= deadline {
+            launched.finish(Duration::ZERO);
+            let tail = launched.log_tail(40);
+            let _ = std::fs::remove_file(&info_path);
+            return Err(format!(
+                "the emulator did not announce its control endpoint within {} ms (command: \
+                 {}; log {}):\n{tail}",
+                timeout.as_millis(),
+                launched.command.join(" "),
+                launched.log_path.display()
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    let _ = std::fs::remove_file(&info_path);
+    match Bridge::connect(&endpoint.0, &endpoint.1) {
+        Ok(bridge) => Ok((bridge, launched)),
+        Err(e) => {
+            launched.finish(Duration::ZERO);
+            Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, Write};
+    use std::net::TcpListener;
+
+    /// A scripted server: answers hello, then replies to each request
+    /// per `script` (id -> reply line builder), interleaving the given
+    /// notifications before the reply.
+    fn scripted_server(
+        listener: TcpListener,
+        respond: impl Fn(&Value) -> Vec<String> + Send + 'static,
+    ) -> JoinHandle<()> {
+        std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut writer = stream;
+            let mut line = String::new();
+            while reader.read_line(&mut line).unwrap() > 0 {
+                let req: Value = serde_json::from_str(line.trim()).unwrap();
+                for out in respond(&req) {
+                    writer.write_all(out.as_bytes()).unwrap();
+                    writer.write_all(b"\n").unwrap();
+                }
+                writer.flush().unwrap();
+                line.clear();
+            }
+        })
+    }
+
+    fn hello_reply(req: &Value) -> Option<String> {
+        (req["method"] == "hello").then(|| {
+            proto::ok_line(
+                &req["id"],
+                json!({"proto": 1, "emulator": "test", "authed": req["params"]["token"] == "ok"}),
+            )
+        })
+    }
+
+    #[test]
+    fn connects_authenticates_and_routes_replies_and_events() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = scripted_server(listener, |req| {
+            if let Some(hello) = hello_reply(req) {
+                return vec![hello];
+            }
+            match req["method"].as_str() {
+                Some("status") => vec![
+                    proto::event_line("event.frame", json!({"frame": 1})),
+                    proto::event_line("event.frame", json!({"frame": 2})),
+                    proto::ok_line(&req["id"], json!({"frame": 2})),
+                ],
+                Some("bad") => vec![proto::err_line(
+                    &req["id"],
+                    &proto::CtlError::invalid_params("missing addr"),
+                )],
+                _ => vec![],
+            }
+        });
+        let mut bridge = Bridge::connect(&addr.to_string(), "ok").unwrap();
+        assert_eq!(bridge.hello()["emulator"], "test");
+        assert_eq!(
+            bridge.call("status", Value::Null).unwrap(),
+            Reply::Ok(json!({"frame": 2}))
+        );
+        assert_eq!(
+            bridge.call("bad", Value::Null).unwrap(),
+            Reply::Err {
+                code: proto::INVALID_PARAMS,
+                message: "missing addr".into()
+            }
+        );
+        let first = bridge.next_event(Duration::from_secs(1)).unwrap();
+        assert_eq!(first["method"], "event.frame");
+        assert_eq!(first["params"]["frame"], 1);
+        assert_eq!(bridge.drain_events().len(), 1);
+        assert_eq!(bridge.event_counts(), (0, 0));
+        // A request nobody answers times out and stays outstanding.
+        let id = bridge.send("silent", Value::Null).unwrap();
+        assert_eq!(
+            bridge.wait(id, Some(Duration::from_millis(20))).unwrap(),
+            Reply::TimedOut
+        );
+        assert!(bridge.next_event(Duration::from_millis(10)).is_none());
+        bridge.close();
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn wrong_token_is_refused() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = scripted_server(listener, |req| hello_reply(req).into_iter().collect());
+        let Err(err) = Bridge::connect(&addr.to_string(), "wrong") else {
+            panic!("a wrong token must not authenticate");
+        };
+        assert!(err.contains("auth failed"), "{err}");
+        drop(server);
+    }
+
+    #[test]
+    fn a_closed_connection_fails_waiters_and_bounds_the_queue() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = scripted_server(listener, |req| {
+            if let Some(hello) = hello_reply(req) {
+                return vec![hello];
+            }
+            // Flood, then drop the connection without replying.
+            let mut lines: Vec<String> = (0..EVENT_QUEUE_CAPACITY + 5)
+                .map(|n| proto::event_line("event.serial", json!({"n": n})))
+                .collect();
+            lines.push(String::new());
+            lines
+        });
+        let mut bridge = Bridge::connect(&addr.to_string(), "ok").unwrap();
+        let id = bridge.send("status", Value::Null).unwrap();
+        // The scripted server returns from its loop only when we close,
+        // so wait for the flood to land, then close our side to end it.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while bridge.event_counts().1 < 5 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(bridge.event_counts(), (EVENT_QUEUE_CAPACITY, 5));
+        bridge.shutdown_socket();
+        let err = bridge.wait(id, None).unwrap_err();
+        assert!(err.contains("session lost"), "{err}");
+        assert!(bridge.closed().is_some());
+        bridge.close();
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn info_file_parses_and_reports_missing_fields() {
+        let dir = std::env::temp_dir().join(format!("ccp-bridge-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("info.json");
+        std::fs::write(
+            &path,
+            "{\"listen\":\"127.0.0.1:1\",\"token\":\"t\",\"proto\":1}\n",
+        )
+        .unwrap();
+        assert_eq!(
+            read_info_file(&path).unwrap(),
+            ("127.0.0.1:1".to_string(), "t".to_string())
+        );
+        std::fs::write(&path, "{\"listen\":\"127.0.0.1:1\"}").unwrap();
+        assert!(read_info_file(&path).unwrap_err().contains("no token"));
+        assert!(read_info_file(&dir.join("absent.json"))
+            .unwrap_err()
+            .contains("reading"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn launch_reports_a_binary_that_cannot_start() {
+        let spec = LaunchSpec {
+            binary: Some(PathBuf::from("/nonexistent/copperline-mcp-test-binary")),
+            timeout: Duration::from_millis(500),
+            ..Default::default()
+        };
+        let Err(err) = launch(&spec) else {
+            panic!("a missing binary must not launch");
+        };
+        assert!(err.contains("starting"), "{err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn launch_reports_a_process_that_exits_without_announcing() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = std::env::temp_dir().join(format!("ccp-launch-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let script = dir.join("fake-copperline");
+        std::fs::write(&script, "#!/bin/sh\necho boot failure >&2\nexit 3\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let spec = LaunchSpec {
+            binary: Some(script),
+            timeout: Duration::from_secs(5),
+            ..Default::default()
+        };
+        let Err(err) = launch(&spec) else {
+            panic!("a failing process must not launch");
+        };
+        assert!(err.contains("exited"), "{err}");
+        assert!(err.contains("boot failure"), "{err}");
+        assert!(err.contains("--control :0"), "{err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_binary_prefers_the_explicit_path() {
+        assert_eq!(
+            resolve_binary(Some(Path::new("/x/copperline"))),
+            PathBuf::from("/x/copperline")
+        );
+        let resolved = resolve_binary(None);
+        assert!(resolved.file_name().is_some());
+    }
+}

--- a/src/control/catalogue.rs
+++ b/src/control/catalogue.rs
@@ -1,0 +1,1289 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The control protocol as a tool catalogue: one entry per CCP method,
+//! with the description, JSON Schema, and example that an MCP client
+//! (or any other tool-calling agent) needs to call it without reading
+//! the protocol reference.
+//!
+//! The entries mirror `exec::parse_method` (and the `shutdown` verb the
+//! drivers answer themselves); the tests pin the two to each other, so a
+//! method added to the parser without a catalogue entry fails the suite,
+//! and every example here must parse.
+//!
+//! Tool names: MCP and the model-side tool namespaces only allow
+//! `[a-zA-Z0-9_-]`, so a method's tool name is the method with dots
+//! replaced by underscores (`warp.get` -> `warp_get`). The mapping back
+//! is a table lookup, never a string edit, because method names such as
+//! `run_until` carry underscores of their own.
+
+use serde_json::{json, Map, Value};
+use std::sync::OnceLock;
+
+/// One control-protocol method as a tool.
+#[derive(Debug, Clone)]
+pub struct ToolDef {
+    /// The wire method name (`capture.screenshot`).
+    pub method: &'static str,
+    /// The tool name (`capture_screenshot`).
+    pub name: String,
+    /// One paragraph for the model: what it does, what it returns, and
+    /// whether it blocks.
+    pub description: String,
+    /// JSON Schema (draft 2020-12 subset) for the params object.
+    pub schema: Value,
+    /// Example params that parse and are valid against `schema`.
+    pub example: Value,
+    /// The tool takes the MCP bridge's `wait_ms` (a resume verb whose
+    /// reply is the eventual stop event); the bridge strips it before
+    /// forwarding.
+    pub wait_ms: bool,
+}
+
+/// The tool name for a method: dots become underscores.
+pub fn tool_name(method: &str) -> String {
+    method.replace('.', "_")
+}
+
+/// The whole catalogue, in reference order.
+pub fn catalogue() -> &'static [ToolDef] {
+    static TABLE: OnceLock<Vec<ToolDef>> = OnceLock::new();
+    TABLE.get_or_init(build)
+}
+
+/// Look a tool up by its tool name.
+pub fn find(name: &str) -> Option<&'static ToolDef> {
+    catalogue().iter().find(|def| def.name == name)
+}
+
+/// Look a tool up by its wire method name.
+pub fn find_method(method: &str) -> Option<&'static ToolDef> {
+    catalogue().iter().find(|def| def.method == method)
+}
+
+// ---------------------------------------------------------------------
+// Schema helpers
+
+const ADDR_NOTE: &str =
+    "an integer, or a hex string with a 0x or $ prefix (\"0xDFF096\", \"$C00000\")";
+
+/// A 32-bit address or value: integer or hex string.
+fn addr(desc: &str) -> Value {
+    json!({"type": ["integer", "string"], "description": format!("{desc}: {ADDR_NOTE}")})
+}
+
+/// An unsigned integer with optional bounds. The parser also accepts a
+/// hex string for these, so the schema allows both.
+fn uint(desc: &str, min: Option<u64>, max: Option<u64>) -> Value {
+    let mut v = json!({"type": ["integer", "string"], "description": desc});
+    if let Some(min) = min {
+        v["minimum"] = json!(min);
+    }
+    if let Some(max) = max {
+        v["maximum"] = json!(max);
+    }
+    v
+}
+
+/// A plain (decimal-only) integer.
+fn int(desc: &str, min: Option<i64>, max: Option<i64>) -> Value {
+    let mut v = json!({"type": "integer", "description": desc});
+    if let Some(min) = min {
+        v["minimum"] = json!(min);
+    }
+    if let Some(max) = max {
+        v["maximum"] = json!(max);
+    }
+    v
+}
+
+fn number(desc: &str) -> Value {
+    json!({"type": "number", "description": desc})
+}
+
+fn boolean(desc: &str) -> Value {
+    json!({"type": "boolean", "description": desc})
+}
+
+fn string(desc: &str) -> Value {
+    json!({"type": "string", "description": desc})
+}
+
+fn enumeration(desc: &str, values: &[&str]) -> Value {
+    json!({"type": "string", "enum": values, "description": desc})
+}
+
+fn port(desc: &str) -> Value {
+    json!({"type": "integer", "enum": [1, 2], "description": desc})
+}
+
+fn at_seconds() -> Value {
+    number(
+        "Emulated time (absolute seconds) at which to apply the input; absent or in the past \
+         applies it now",
+    )
+}
+
+/// An object schema from `(name, schema)` pairs and the required names.
+fn object(props: Vec<(&str, Value)>, required: &[&str]) -> Value {
+    let mut map = Map::new();
+    for (name, schema) in props {
+        map.insert(name.to_string(), schema);
+    }
+    let mut v = json!({"type": "object", "properties": Value::Object(map)});
+    if !required.is_empty() {
+        v["required"] = json!(required);
+    }
+    v
+}
+
+fn no_params() -> Value {
+    json!({"type": "object", "properties": {}})
+}
+
+fn collect() -> (&'static str, Value) {
+    (
+        "collect",
+        json!({
+            "type": "array",
+            "description": "Read-only methods evaluated at the stop and returned as `collect` \
+                            on the stop event, so one round trip both runs and inspects. Each \
+                            item is {\"method\": ..., \"params\": ...} naming an inspection \
+                            method (status, regs.get, mem.read, disasm, custom.read, \
+                            custom.dump, beam.get, cia.get, copper.list, capture.digest...).",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "method": {"type": "string"},
+                    "params": {"type": "object"}
+                },
+                "required": ["method"]
+            }
+        }),
+    )
+}
+
+fn wait_ms() -> (&'static str, Value) {
+    (
+        "wait_ms",
+        int(
+            "MCP bridge option: host milliseconds to wait for the stop. If the machine has \
+             not stopped by then the bridge sends `pause` and returns the resulting stop \
+             event, with `bridge.paused_after_ms` set. Without it the call blocks until the \
+             machine stops on its own, which for a run with no stop condition is forever.",
+            Some(1),
+            None,
+        ),
+    )
+}
+
+const STOP_EVENT: &str = "Returns the stop event: {reason, detail, pc, frame, vpos, hpos, cck, \
+                          seconds, retired_instructions} plus `collect` results if requested. \
+                          Reasons include breakpoint, watch, step, target, pause, catch, \
+                          loadseg, budget, double_fault.";
+
+// ---------------------------------------------------------------------
+// The table
+
+struct Entry {
+    method: &'static str,
+    description: String,
+    schema: Value,
+    example: Value,
+    wait_ms: bool,
+}
+
+fn entry(
+    method: &'static str,
+    description: impl Into<String>,
+    schema: Value,
+    example: Value,
+) -> Entry {
+    Entry {
+        method,
+        description: description.into(),
+        schema,
+        example,
+        wait_ms: false,
+    }
+}
+
+fn resume_entry(
+    method: &'static str,
+    description: impl Into<String>,
+    mut props: Vec<(&str, Value)>,
+    required: &[&str],
+    example: Value,
+) -> Entry {
+    props.push(collect());
+    props.push(wait_ms());
+    Entry {
+        method,
+        description: description.into(),
+        schema: object(props, required),
+        example,
+        wait_ms: true,
+    }
+}
+
+fn build() -> Vec<ToolDef> {
+    let entries: Vec<Entry> = vec![
+        // Session
+        entry(
+            "status",
+            "Report the emulation state: `state` (paused/running), `pc`, `frame`, `vpos`, \
+             `hpos`, `cck` (colour clocks), `seconds` (emulated), `retired_instructions`, \
+             `cpu`, `paced`/`warp`, `tt_armed` (reverse execution available), \
+             `double_faulted`, and host counters (`host_busy_ms`, `pacer_slips`, audio lead \
+             and underruns). Cheap and side-effect free; call it to orient before stepping.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "shutdown",
+            "Terminate the emulator process cleanly. The reply arrives before the process \
+             exits; the bridge then closes its session. Use session_close to disconnect \
+             without stopping an emulator you did not launch.",
+            no_params(),
+            json!({}),
+        ),
+        // Execution control
+        resume_entry(
+            "continue",
+            format!(
+                "Resume execution and block until the machine stops (a breakpoint, watch, \
+                 catch, loadseg trap, or a bridge pause after `wait_ms`). {STOP_EVENT} A \
+                 continue with no breakpoint and no wait_ms never returns."
+            ),
+            vec![],
+            &[],
+            json!({"wait_ms": 1000}),
+        ),
+        resume_entry(
+            "step",
+            format!("Execute `n` CPU instructions (default 1, at most 1000000) and stop. {STOP_EVENT}"),
+            vec![("n", int("Instructions to execute", Some(1), Some(1_000_000)))],
+            &[],
+            json!({"n": 1}),
+        ),
+        resume_entry(
+            "step_over",
+            format!(
+                "Execute the instruction at PC treating a subroutine call (JSR/BSR) as one \
+                 step, bounded by a 5000000-instruction budget. {STOP_EVENT}"
+            ),
+            vec![],
+            &[],
+            json!({}),
+        ),
+        resume_entry(
+            "step_out",
+            format!(
+                "Run until the current subroutine returns, bounded by a \
+                 5000000-instruction budget. {STOP_EVENT}"
+            ),
+            vec![],
+            &[],
+            json!({}),
+        ),
+        resume_entry(
+            "step_copper",
+            format!("Run until the Copper executes its next instruction. {STOP_EVENT}"),
+            vec![],
+            &[],
+            json!({}),
+        ),
+        resume_entry(
+            "step_frame",
+            format!(
+                "Run `n` complete video frames (default 1, at most 1000000) and stop at \
+                 the frame boundary; a breakpoint hit inside the run stops early. \
+                 {STOP_EVENT}"
+            ),
+            vec![("n", int("Frames to run", Some(1), Some(1_000_000)))],
+            &[],
+            json!({"n": 1}),
+        ),
+        resume_entry(
+            "run_until",
+            format!(
+                "Run until exactly one target is reached: `pc` (an address), `vpos` \
+                 (optionally with `hpos`, the next time the beam reaches that line), \
+                 `frame` (absolute frame number), `cck` (absolute colour clock), \
+                 `seconds` (absolute emulated seconds), or `stable_frames` (the display \
+                 stops changing: that many consecutive identical frames, optionally only \
+                 within the region x/y/w/h, giving up after `max_frames`). A breakpoint \
+                 hit on the way stops early. {STOP_EVENT}"
+            ),
+            vec![
+                ("pc", addr("Stop when PC reaches this address")),
+                ("vpos", uint("Stop at this beam line (0-based)", Some(0), Some(65535))),
+                (
+                    "hpos",
+                    uint(
+                        "With vpos: stop at this horizontal position (colour clock) on the line",
+                        Some(0),
+                        Some(65535),
+                    ),
+                ),
+                ("frame", uint("Stop at this absolute frame number", Some(0), None)),
+                ("cck", uint("Stop at this absolute colour clock", Some(0), None)),
+                ("seconds", number("Stop at this absolute emulated time in seconds")),
+                (
+                    "stable_frames",
+                    int(
+                        "Stop once this many consecutive frames render identically (at least 2)",
+                        Some(2),
+                        None,
+                    ),
+                ),
+                (
+                    "max_frames",
+                    int(
+                        "With stable_frames: give up after this many frames (reason \"budget\")",
+                        Some(2),
+                        None,
+                    ),
+                ),
+                ("x", int("With stable_frames: region left edge (default 0)", Some(0), None)),
+                ("y", int("With stable_frames: region top edge (default 0)", Some(0), None)),
+                ("w", int("With stable_frames: region width", Some(1), None)),
+                ("h", int("With stable_frames: region height", Some(1), None)),
+            ],
+            &[],
+            json!({"seconds": 2.0}),
+        ),
+        entry(
+            "pause",
+            "Stop a running machine at the next quantum boundary and return its position as \
+             a stop event. Through this bridge the machine is only running inside a \
+             blocking resume call, so this normally reports the current paused position; \
+             use `wait_ms` on the resume verbs to bound a run instead.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "machine.reset",
+            "Reset the emulated machine: `warm` (default, like Ctrl-Amiga-Amiga) or \
+             `cold` (power cycle, memory cleared). Breakpoints stay installed.",
+            object(vec![("kind", enumeration("Reset kind (default warm)", &["warm", "cold"]))], &[]),
+            json!({"kind": "warm"}),
+        ),
+        // Speed
+        entry(
+            "warp.get",
+            "Report whether warp (unpaced emulation) is on, whether the machine is paced \
+             to real time, and who holds warp (`source`: none, manual, control, guest, \
+             launch, boot, capture, headless). A headless (--control) server is unpaced \
+             end to end and reports `headless: true`.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "warp.set",
+            "Engage or release warp on a windowed (--control-gui) session: `on: true` runs \
+             the machine unpaced with audio muted, `on: false` re-paces it and cancels a \
+             pending --run/--warp-boot phase. Accepted as a no-op with a note by a headless \
+             server. Released automatically when the session disconnects.",
+            object(vec![("on", boolean("true to engage warp, false to release it"))], &["on"]),
+            json!({"on": true}),
+        ),
+        // Reverse execution
+        entry(
+            "reverse_step",
+            "Step backward `n` instructions (default 1) through the recorded timeline. \
+             Needs time travel armed (`tt_armed` in status). Returns the new position or \
+             `history_exhausted`.",
+            object(vec![("n", int("Instructions to step back", Some(1), None))], &[]),
+            json!({"n": 1}),
+        ),
+        entry(
+            "reverse_frame",
+            "Step backward one video frame through the recorded timeline (time travel \
+             must be armed).",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "reverse_continue",
+            "Run backward until the most recent earlier breakpoint or watch hit, or the \
+             start of the recorded history.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "last_writer",
+            "Find the instruction that last wrote the given memory address by replaying \
+             the recorded history: returns the writer PC, position, and value. Time travel \
+             must be armed; the machine is left at the write.",
+            object(vec![("addr", addr("Memory address to trace"))], &["addr"]),
+            json!({"addr": "0x20000"}),
+        ),
+        // State inspection
+        entry(
+            "regs.get",
+            "Read the CPU registers: d0-d7, a0-a7, pc, sr, usp/ssp and the status flags.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "regs.set",
+            "Write one CPU register. `reg` is d0-d7, a0-a7, sp, fp (a6), sr or pc; \
+             `value` is a 32-bit value.",
+            object(
+                vec![
+                    ("reg", string("Register name: d0-d7, a0-a7, sp, fp, sr, pc")),
+                    ("value", addr("New value")),
+                ],
+                &["reg", "value"],
+            ),
+            json!({"reg": "d0", "value": "0x1234"}),
+        ),
+        entry(
+            "mem.read",
+            "Read `len` bytes (default 2, at most 1048576) at `addr` through the CPU's \
+             address map (chip, slow, fast RAM, ROM; custom registers read as the CPU \
+             sees them). Returns `data` as lowercase hex, or base64 with \
+             `encoding: \"base64\"`.",
+            object(
+                vec![
+                    ("addr", addr("Start address")),
+                    ("len", uint("Bytes to read (default 2)", Some(1), Some(1_048_576))),
+                    (
+                        "encoding",
+                        enumeration("Payload encoding (default hex)", &["hex", "base64"]),
+                    ),
+                ],
+                &["addr"],
+            ),
+            json!({"addr": "0x400", "len": 16}),
+        ),
+        entry(
+            "mem.write",
+            "Write bytes at `addr`: `data` is hex (default) or base64 (`encoding`), 1 to \
+             1048576 bytes. Lands at a deterministic timeline boundary and is journaled \
+             for reverse execution.",
+            object(
+                vec![
+                    ("addr", addr("Start address")),
+                    ("data", string("Bytes to write, hex (default) or base64")),
+                    (
+                        "encoding",
+                        enumeration("Payload encoding (default hex)", &["hex", "base64"]),
+                    ),
+                ],
+                &["addr", "data"],
+            ),
+            json!({"addr": "0x400", "data": "deadbeef"}),
+        ),
+        entry(
+            "disasm",
+            "Disassemble `count` 68k instructions (default 16, at most 256) starting at \
+             `addr` (default: the current PC). Each line carries the address, opcode words \
+             and mnemonic.",
+            object(
+                vec![
+                    ("addr", addr("Start address (default: PC)")),
+                    ("count", uint("Instructions to disassemble", Some(1), Some(256))),
+                ],
+                &[],
+            ),
+            json!({"count": 8}),
+        ),
+        entry(
+            "custom.dump",
+            "Dump the custom chip register file ($DFF000-$DFF1FE) as name/offset/value \
+             entries: DMACON, INTENA, BPLCON0, COPxLC, sprite and audio pointers, and the \
+             rest. Read-only.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "custom.read",
+            "Read one custom chip register by name (\"DMACON\", \"VPOSR\", \"COLOR00\") \
+             or by offset (\"0x096\"); write-only registers return the last value written.",
+            object(vec![("reg", addr("Register name or offset below 0x200"))], &["reg"]),
+            json!({"reg": "DMACON"}),
+        ),
+        entry(
+            "custom.writer",
+            "Report the PC and beam position (frame, vpos, hpos) of the last write to a \
+             custom register, from the last-writer table the chipset validator maintains; \
+             arm it with chipset.validate first.",
+            object(vec![("reg", addr("Register name or offset below 0x200"))], &["reg"]),
+            json!({"reg": "COLOR00"}),
+        ),
+        entry(
+            "palette.dump",
+            "Dump the live Denise palette: all 256 AGA entries with their high and low \
+             nibble-plane words (32 on OCS/ECS).",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "cia.get",
+            "Report one CIA (`a` or `b`): timers A/B with control bits, TOD counter and \
+             alarm, port data and direction registers, serial, and interrupt mask/flags.",
+            object(vec![("cia", enumeration("Which CIA", &["a", "b"]))], &["cia"]),
+            json!({"cia": "a"}),
+        ),
+        entry(
+            "beam.get",
+            "Report the raster beam position: `vpos`, `hpos` (colour clock), `frame`, \
+             the frame's line count, and whether the field is long.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "display.get",
+            "Report the active display: video standard, canvas size and pixel format, \
+             the display window and fetch registers as decoded, bitplane count, \
+             resolution mode (lores/hires/shres), HAM/dual-playfield, and interlace.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "rtc.get",
+            "Report the emulated battery-backed clock: fitted, frozen, unix seconds and \
+             the calendar time the guest reads.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "rtc.set",
+            "Move the emulated clock: an absolute time as `unix` seconds or `time` \
+             (\"YYYY-MM-DD HH:MM[:SS]\"), or a relative `advance` in seconds (negative \
+             allowed); `frozen` pins or releases it. Give at least one; absolute and \
+             advance are exclusive.",
+            object(
+                vec![
+                    ("unix", uint("Absolute time as Unix seconds (UTC)", Some(0), None)),
+                    ("time", string("Absolute time as \"YYYY-MM-DD HH:MM[:SS]\"")),
+                    ("advance", int("Seconds to add to the current clock", None, None)),
+                    ("frozen", boolean("true to stop the clock ticking, false to resume")),
+                ],
+                &[],
+            ),
+            json!({"time": "2005-03-18 01:58:29"}),
+        ),
+        entry(
+            "copper.list",
+            "Disassemble up to `max` Copper instructions (default 32, at most 256) from \
+             `addr` (default: the Copper's current program counter): MOVE, WAIT, SKIP, \
+             with register names and beam positions decoded.",
+            object(
+                vec![
+                    ("addr", addr("Copper list address (default: current Copper PC)")),
+                    ("max", uint("Instructions to list", Some(1), Some(256))),
+                ],
+                &[],
+            ),
+            json!({"max": 16}),
+        ),
+        entry(
+            "pc_history",
+            "Return the most recently executed instruction addresses (newest last), the \
+             trail that led to the current PC.",
+            no_params(),
+            json!({}),
+        ),
+        // Diagnostics
+        entry(
+            "chipset.validate",
+            "Arm (`enabled: true`) or disarm the custom register access validator, which \
+             records undefined bits, absent registers, byte accesses, stray pointers, \
+             read-only writes, impossible blits and disk DMA against empty drives, and \
+             maintains the last-writer table custom.writer reads. `clear` drops the \
+             findings so far.",
+            object(
+                vec![
+                    ("enabled", boolean("Arm or disarm the validator; absent leaves it as is")),
+                    ("clear", boolean("Clear the findings (default false)")),
+                ],
+                &[],
+            ),
+            json!({"enabled": true}),
+        ),
+        entry(
+            "chipset.report",
+            "Report the chipset validator's findings so far, each with kind, register, \
+             writer PC and beam position, and a hit count.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "smc.detect",
+            "Arm (`enabled: true`) or disarm the self-modifying-code detector, which \
+             records writes to memory that was later executed; `clear` drops the findings.",
+            object(
+                vec![
+                    ("enabled", boolean("Arm or disarm the detector; absent leaves it as is")),
+                    ("clear", boolean("Clear the findings (default false)")),
+                ],
+                &[],
+            ),
+            json!({"enabled": true}),
+        ),
+        entry(
+            "smc.report",
+            "Report the self-modifying-code detector's findings: written address, the \
+             writer PC, and the execution that followed.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "fault.inject",
+            "Arm a bus fault over `len` bytes (default 2) from `addr`: the next `count` \
+             matching accesses (default: every access) of the chosen kind (`on`: read, \
+             write, or both) raise a bus error in the guest. Returns the fault id.",
+            object(
+                vec![
+                    ("addr", addr("Window start")),
+                    ("len", uint("Window length in bytes (default 2)", Some(1), None)),
+                    (
+                        "on",
+                        enumeration("Which accesses fault (default both)", &["read", "write", "both"]),
+                    ),
+                    (
+                        "count",
+                        uint("Fire this many times then disarm (default: unlimited)", Some(1), None),
+                    ),
+                ],
+                &["addr"],
+            ),
+            json!({"addr": "0x400", "len": 2, "on": "write"}),
+        ),
+        entry(
+            "fault.list",
+            "List the armed bus faults with their windows, kinds and remaining counts.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "fault.clear",
+            "Disarm every bus fault.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "memory.heatmap",
+            "Enable (default) or disable address-space access tracking over the window \
+             `base`..`base+span` (default the whole 16 MB map). Enabling resets the counts.",
+            object(
+                vec![
+                    ("enabled", boolean("true (default) to arm, false to disarm")),
+                    ("base", addr("Window start (default 0)")),
+                    ("span", addr("Window length in bytes (default 0x1000000)")),
+                ],
+                &[],
+            ),
+            json!({"enabled": true, "base": 0, "span": "0x200000"}),
+        ),
+        entry(
+            "memory.heatmap.report",
+            "Report the memory heat map: per-bucket read/write/execute counts over the \
+             tracked window, optionally also written as a file to `path`.",
+            object(vec![("path", string("Host file to write the report to (optional)"))], &[]),
+            json!({}),
+        ),
+        entry(
+            "debug.resources",
+            "List the bitmaps, palettes and copper lists the guest registered through the \
+             WinUAE-compatible uaelib trap (debug_register_*): address, size, name, type, \
+             flags, geometry and the frame they were registered in. Not found when the \
+             guest registered nothing.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "debug.idle",
+            "Report the guest's uaelib idle markers (debug_start_idle/stop_idle): current \
+             state, whether ever used, and the last completed frame's idle_cck/frame_cck.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "trace.start",
+            "Start writing an instruction execution trace (one line per instruction) to \
+             `path` (default: a file in the working directory), stopping by itself after \
+             `max_lines` (default 1000000, at most 10000000).",
+            object(
+                vec![
+                    ("path", string("Host file for the trace (optional)")),
+                    ("max_lines", uint("Line cap", Some(1), Some(10_000_000))),
+                ],
+                &[],
+            ),
+            json!({"path": "/tmp/trace.txt", "max_lines": 10000}),
+        ),
+        entry(
+            "trace.stop",
+            "Stop the instruction trace and report the lines written.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "trace.status",
+            "Report whether an instruction trace is running, its path and line count.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "waveform.start",
+            "Arm a VCD chip-signal capture (for GTKWave): `trigger` is `now`, `pc=ADDR`, \
+             `beam=VPOS[:HPOS]`, `reg=OFF` (a custom register write) or `time=SECS`; \
+             `duration` is `Ncck`, `Nf`/`Nframes`, `Nms` or `Ns`; `signals` is a comma \
+             list of beam, bus, cpu, copper, blitter, regs, irq, audio, or `all`. The \
+             capture runs as the machine runs and finishes on its own.",
+            object(
+                vec![
+                    ("path", string("Host .vcd file (default: a file in the working directory)")),
+                    ("trigger", string("now | pc=ADDR | beam=VPOS[:HPOS] | reg=OFF | time=SECS")),
+                    ("duration", string("Ncck | Nf | Nframes | Nms | Ns")),
+                    ("signals", string("Comma-separated groups or all")),
+                ],
+                &[],
+            ),
+            json!({"path": "/tmp/out.vcd", "trigger": "now", "duration": "2frames"}),
+        ),
+        entry(
+            "waveform.stop",
+            "Stop the waveform capture early and finish the VCD file.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "waveform.status",
+            "Report the waveform capture state: armed, triggered, running, finished, and \
+             the path.",
+            no_params(),
+            json!({}),
+        ),
+        // Breakpoints
+        entry(
+            "break.add",
+            "Install a breakpoint and return its `id`. `kind` selects the trap: `pc` (an \
+             `addr`, optional `cond` {lhs, op, rhs} over registers, immediates or \
+             {\"mem\": addr} words with op eq/ne/lt/gt/le/ge/and, and `ignore` count), \
+             `watch` (any access to `addr`, optionally by `class` cpu|blitter|disk|copper| \
+             bpl1..bpl8|spr0..spr7|aud0..aud3 and, for cpu, a `pc`), `reg_watch` (a write \
+             to custom register `reg`), `beam` (`vpos`, optional `hpos`), `copper` (the \
+             Copper fetching `addr`), `catch` (exception `vector` number), `loadseg` (an \
+             AmigaDOS program load, optionally matching its `name`). Hits end a resume with \
+             the matching stop reason.",
+            object(
+                vec![
+                    (
+                        "kind",
+                        enumeration(
+                            "Breakpoint kind",
+                            &["pc", "watch", "reg_watch", "beam", "copper", "catch", "loadseg"],
+                        ),
+                    ),
+                    ("addr", addr("pc/watch/copper: the address")),
+                    (
+                        "cond",
+                        json!({
+                            "type": "object",
+                            "description": "pc: only stop when lhs op rhs holds",
+                            "properties": {
+                                "lhs": {"description": "register name, number, or {\"mem\": addr}"},
+                                "op": {"type": "string", "enum": ["eq", "ne", "lt", "gt", "le", "ge", "and"]},
+                                "rhs": {"description": "register name, number, or {\"mem\": addr}"}
+                            },
+                            "required": ["lhs", "op", "rhs"]
+                        }),
+                    ),
+                    ("ignore", uint("pc: skip this many hits first", Some(0), None)),
+                    ("class", string("watch: cpu | blitter | disk | copper | bpl1..bpl8 | spr0..spr7 | aud0..aud3")),
+                    ("pc", addr("watch (cpu class): only accesses by the instruction at this PC")),
+                    ("reg", addr("reg_watch: custom register name or offset")),
+                    ("vpos", uint("beam: the line", Some(0), Some(65535))),
+                    ("hpos", uint("beam: the colour clock on the line (optional)", Some(0), Some(65535))),
+                    ("vector", uint("catch: exception vector number", Some(0), Some(65535))),
+                    ("name", string("loadseg: program name to match, case-insensitive (optional)")),
+                ],
+                &["kind"],
+            ),
+            json!({"kind": "pc", "addr": "0xFC0100"}),
+        ),
+        entry(
+            "break.remove",
+            "Remove the breakpoint with this `id` (from break.add or break.list).",
+            object(vec![("id", uint("Breakpoint id", Some(0), None))], &["id"]),
+            json!({"id": 1}),
+        ),
+        entry(
+            "break.list",
+            "List the installed breakpoints, watches and traps with ids and hit counts; \
+             points set from the debugger window are listed without ids.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "break.clear",
+            "Remove every breakpoint this session installed.",
+            no_params(),
+            json!({}),
+        ),
+        // Input
+        entry(
+            "input.key",
+            "Inject a keyboard event by Amiga raw key code (`rawkey` 0-255, e.g. 0x45 \
+             Esc, 0x44 Return, 0x40 Space, 0x50-0x59 F1-F10; letters follow the Amiga \
+             matrix, not ASCII). `action` is tap (default: press, then release after \
+             `hold_ms`, default 80), press, or release. `at_seconds` schedules it in \
+             emulated time. Input is journaled, so a rewind replays it.",
+            object(
+                vec![
+                    ("rawkey", uint("Amiga raw key code", Some(0), Some(255))),
+                    ("action", enumeration("Key action (default tap)", &["press", "release", "tap"])),
+                    ("hold_ms", uint("tap: emulated milliseconds to hold (default 80)", Some(0), None)),
+                    ("at_seconds", at_seconds()),
+                ],
+                &["rawkey"],
+            ),
+            json!({"rawkey": "0x45"}),
+        ),
+        entry(
+            "input.mouse",
+            "Inject relative mouse motion (`dx`, `dy` in mouse counts) and/or button \
+             transitions (`left`, `right`, `middle`: true pressed, false released, absent \
+             unchanged) on `port` (default 1). For an absolute pointer position use \
+             input.mouse_to.",
+            object(
+                vec![
+                    ("dx", int("Horizontal motion, positive right", None, None)),
+                    ("dy", int("Vertical motion, positive down", None, None)),
+                    ("left", boolean("Left button state")),
+                    ("right", boolean("Right button state")),
+                    ("middle", boolean("Middle button state")),
+                    ("port", port("Controller port (default 1)")),
+                    ("at_seconds", at_seconds()),
+                ],
+                &[],
+            ),
+            json!({"dx": 10, "dy": -5}),
+        ),
+        entry(
+            "input.mouse_to",
+            "Steer the guest's pointer to the presented-pixel position (`x`, `y`) by \
+             servoing mouse deltas until sprite 0 lands within `tolerance` pixels \
+             (default 2), running the machine up to `max_frames` frames (default 60) to \
+             do it. Coordinates are those of capture.screenshot. Fails if the pointer \
+             does not converge (no mouse pointer sprite on screen, or a hit breakpoint).",
+            object(
+                vec![
+                    ("x", int("Target column", None, None)),
+                    ("y", int("Target row", None, None)),
+                    ("port", port("Controller port (default 1)")),
+                    ("tolerance", int("Arrival tolerance in pixels (0-64)", Some(0), Some(64))),
+                    ("max_frames", int("Frame budget (1-600)", Some(1), Some(600))),
+                ],
+                &["x", "y"],
+            ),
+            json!({"x": 160, "y": 100}),
+        ),
+        entry(
+            "input.joy",
+            "Set the joystick or CD32 pad state on `port` (default 2): each of `up`, \
+             `down`, `left`, `right`, `red` (fire), `blue`, `green`, `yellow`, `play`, \
+             `rwd`, `ffw` is true for held, absent or false for released. The state \
+             persists until the next input.joy, so send a second call with the buttons \
+             cleared to release them.",
+            object(
+                vec![
+                    ("up", boolean("Direction up held")),
+                    ("down", boolean("Direction down held")),
+                    ("left", boolean("Direction left held")),
+                    ("right", boolean("Direction right held")),
+                    ("red", boolean("Fire / CD32 red held")),
+                    ("blue", boolean("Second fire / CD32 blue held")),
+                    ("green", boolean("CD32 green held")),
+                    ("yellow", boolean("CD32 yellow held")),
+                    ("play", boolean("CD32 play/pause held")),
+                    ("rwd", boolean("CD32 reverse shoulder held")),
+                    ("ffw", boolean("CD32 forward shoulder held")),
+                    ("port", port("Controller port (default 2)")),
+                    ("at_seconds", at_seconds()),
+                ],
+                &[],
+            ),
+            json!({"red": true}),
+        ),
+        entry(
+            "input.analogue",
+            "Set the analogue stick or paddle position on `port` (default 2): `x` and \
+             `y` are 0-255 (128 centred).",
+            object(
+                vec![
+                    ("x", uint("Horizontal position 0-255", Some(0), Some(255))),
+                    ("y", uint("Vertical position 0-255", Some(0), Some(255))),
+                    ("port", port("Controller port (default 2)")),
+                    ("at_seconds", at_seconds()),
+                ],
+                &["x", "y"],
+            ),
+            json!({"x": 128, "y": 128}),
+        ),
+        entry(
+            "input.set_port",
+            "Hot-plug a controller device into `port` 1 or 2: mouse, gamepad-mouse (port \
+             1 only), joystick, cd32, analogue, or none. Releases every line the previous \
+             device drove.",
+            object(
+                vec![
+                    ("port", port("Controller port")),
+                    (
+                        "device",
+                        enumeration(
+                            "Device to fit",
+                            &["mouse", "gamepad-mouse", "joystick", "cd32", "analogue", "none"],
+                        ),
+                    ),
+                ],
+                &["port", "device"],
+            ),
+            json!({"port": 2, "device": "joystick"}),
+        ),
+        entry(
+            "input.get_ports",
+            "Report which device is fitted to each controller port.",
+            no_params(),
+            json!({}),
+        ),
+        // Media
+        entry(
+            "media.floppy.insert",
+            "Insert a disk image (ADF, ADZ, DMS, IPF, SCP...) into drive `drive` (0-3), \
+             optionally write-protected. The change is a live media event the guest sees \
+             as a disk change.",
+            object(
+                vec![
+                    ("drive", uint("Drive number 0-3 (df0..df3)", Some(0), Some(3))),
+                    ("path", string("Host path of the disk image")),
+                    ("write_protected", boolean("Insert write-protected (default false)")),
+                ],
+                &["drive", "path"],
+            ),
+            json!({"drive": 0, "path": "/path/to/game.adf"}),
+        ),
+        entry(
+            "media.floppy.eject",
+            "Eject the disk from drive `drive` (0-3).",
+            object(vec![("drive", uint("Drive number 0-3", Some(0), Some(3)))], &["drive"]),
+            json!({"drive": 0}),
+        ),
+        entry(
+            "media.floppy.query",
+            "Report the connected floppy drives, the image in each, write protection, and \
+             motor/track state.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "media.cd.insert",
+            "Swap the CD image (ISO, CUE/BIN, CHD) in the machine's CD drive (CDTV, CD32, \
+             or a SCSI CD-ROM).",
+            object(vec![("path", string("Host path of the CD image"))], &["path"]),
+            json!({"path": "/path/to/game.cue"}),
+        ),
+        entry(
+            "media.cd.eject",
+            "Eject the CD image from the machine's CD drive.",
+            no_params(),
+            json!({}),
+        ),
+        // Events
+        entry(
+            "events.subscribe",
+            "Subscribe this session to asynchronous notifications, queued by the bridge \
+             for events_next / events_drain: `frame` (every `frame_interval` frames, \
+             default 1, with an optional framebuffer digest), `serial` (Paula serial \
+             output), `interrupt` (INTREQ/INTENA transitions), `media` (disk and CD \
+             changes), `debug` (guest uaelib log lines and resource registrations). The \
+             queues are bounded; check the drop counts.",
+            object(
+                vec![
+                    (
+                        "events",
+                        json!({
+                            "type": "array",
+                            "description": "Event families to subscribe to",
+                            "items": {"type": "string", "enum": ["frame", "serial", "interrupt", "media", "debug"]},
+                            "minItems": 1
+                        }),
+                    ),
+                    ("frame_interval", uint("Emit one frame event per this many frames (default 1)", Some(1), Some(1_000_000))),
+                    ("frame_digest", boolean("Include an FNV-1a digest of each reported frame")),
+                ],
+                &["events"],
+            ),
+            json!({"events": ["frame"], "frame_interval": 50}),
+        ),
+        entry(
+            "events.unsubscribe",
+            "Unsubscribe from the listed event families, or from all of them when \
+             `events` is absent.",
+            object(
+                vec![(
+                    "events",
+                    json!({
+                        "type": "array",
+                        "description": "Event families to drop (absent: all)",
+                        "items": {"type": "string", "enum": ["frame", "serial", "interrupt", "media", "debug"]}
+                    }),
+                )],
+                &[],
+            ),
+            json!({"events": ["frame"]}),
+        ),
+        entry(
+            "events.list",
+            "List the active event subscriptions and their settings.",
+            no_params(),
+            json!({}),
+        ),
+        // State files
+        entry(
+            "state.save",
+            "Snapshot the whole machine to a save-state file at `path`; state.load or \
+             `--load-state` resumes it byte-identically.",
+            object(vec![("path", string("Host path for the .clstate file"))], &["path"]),
+            json!({"path": "/tmp/at120.clstate"}),
+        ),
+        entry(
+            "state.load",
+            "Restore the machine from the save-state file at `path`. The machine must be \
+             paused; scheduled input and the reverse-execution history are dropped.",
+            object(vec![("path", string("Host path of the .clstate file"))], &["path"]),
+            json!({"path": "/tmp/at120.clstate"}),
+        ),
+        // Capture
+        entry(
+            "capture.screenshot",
+            "Render the current frame as a PNG. Through this bridge the image is also \
+             returned as an image content block so you can look at the screen; with no \
+             `path` the file is temporary and deleted after it is read, with a `path` it \
+             is kept there. Returns the path, width and height.",
+            object(vec![("path", string("Host path for the PNG (optional)"))], &[]),
+            json!({}),
+        ),
+        entry(
+            "capture.digest",
+            "Return an FNV-1a hash of the current rendered frame, for cheap \"did the \
+             picture change\" comparisons across steps.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "capture.region_digest",
+            "Return an FNV-1a hash of the `w` x `h` rectangle at (`x`, `y`) of the \
+             rendered frame, in capture.screenshot's pixel coordinates; fails if the \
+             rectangle falls outside the frame.",
+            object(
+                vec![
+                    ("x", uint("Left edge (default 0)", Some(0), None)),
+                    ("y", uint("Top edge (default 0)", Some(0), None)),
+                    ("w", uint("Width in pixels", Some(1), None)),
+                    ("h", uint("Height in pixels", Some(1), None)),
+                ],
+                &["w", "h"],
+            ),
+            json!({"x": 0, "y": 0, "w": 64, "h": 32}),
+        ),
+    ];
+    entries
+        .into_iter()
+        .map(|e| ToolDef {
+            method: e.method,
+            name: tool_name(e.method),
+            description: e.description,
+            schema: e.schema,
+            example: e.example,
+            wait_ms: e.wait_ms,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::exec;
+    use crate::control::proto;
+
+    /// Method names the drivers answer before `parse_method` sees them.
+    const DRIVER_METHODS: &[&str] = &["shutdown"];
+
+    /// The method names `parse_method` dispatches on, read from its
+    /// source: the string-literal arms at the match's own indentation
+    /// (nested matches on parameter values sit deeper).
+    fn parser_methods() -> Vec<String> {
+        let src = include_str!("exec.rs");
+        let start = src
+            .find("pub fn parse_method(")
+            .expect("parse_method in exec.rs");
+        let body = &src[start..];
+        let end = body.find("\n}\n").expect("end of parse_method");
+        let mut names = Vec::new();
+        for line in body[..end].lines() {
+            let Some(rest) = line.strip_prefix("        \"") else {
+                continue;
+            };
+            if line.starts_with("         ") {
+                continue;
+            }
+            let Some(close) = rest.find('"') else {
+                continue;
+            };
+            if !rest[close..].starts_with("\" =>") {
+                continue;
+            }
+            names.push(rest[..close].to_string());
+        }
+        assert!(names.len() > 60, "found only {} arms", names.len());
+        names
+    }
+
+    fn valid_tool_name(name: &str) -> bool {
+        !name.is_empty()
+            && name.len() <= 64
+            && name
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+    }
+
+    #[test]
+    fn every_parser_arm_has_a_catalogue_entry() {
+        let missing: Vec<String> = parser_methods()
+            .into_iter()
+            .filter(|m| find_method(m).is_none())
+            .collect();
+        assert!(missing.is_empty(), "methods without a tool: {missing:?}");
+    }
+
+    #[test]
+    fn every_catalogue_entry_is_a_real_method() {
+        let known = parser_methods();
+        for def in catalogue() {
+            assert!(
+                known.iter().any(|m| m == def.method) || DRIVER_METHODS.contains(&def.method),
+                "{} is not a method the parser or a driver answers",
+                def.method
+            );
+        }
+    }
+
+    #[test]
+    fn every_example_parses() {
+        for def in catalogue() {
+            if DRIVER_METHODS.contains(&def.method) {
+                continue;
+            }
+            match exec::parse_method(def.method, &def.example) {
+                Ok(_) => {}
+                Err(e) if e.code == proto::METHOD_NOT_FOUND || e.code == proto::INVALID_PARAMS => {
+                    panic!(
+                        "{} example {} rejected: {}",
+                        def.method, def.example, e.message
+                    )
+                }
+                Err(e) => panic!("{} example failed: {}", def.method, e.message),
+            }
+        }
+    }
+
+    #[test]
+    fn names_are_valid_unique_and_round_trip() {
+        let mut seen = std::collections::HashSet::new();
+        for def in catalogue() {
+            assert!(valid_tool_name(&def.name), "bad tool name {}", def.name);
+            assert!(seen.insert(def.name.clone()), "duplicate tool {}", def.name);
+            assert_eq!(tool_name(def.method), def.name);
+            let back = find(&def.name).expect("tool name resolves");
+            assert_eq!(back.method, def.method, "round trip of {}", def.name);
+        }
+        assert_eq!(find("warp_get").map(|d| d.method), Some("warp.get"));
+        assert!(find("warp.get").is_none());
+    }
+
+    #[test]
+    fn schemas_are_objects_whose_required_keys_exist() {
+        for def in catalogue() {
+            assert_eq!(def.schema["type"], "object", "{} schema type", def.method);
+            let props = def.schema["properties"]
+                .as_object()
+                .unwrap_or_else(|| panic!("{} schema has properties", def.method));
+            if let Some(required) = def.schema.get("required") {
+                for key in required.as_array().expect("required is an array") {
+                    let key = key.as_str().expect("required names are strings");
+                    assert!(
+                        props.contains_key(key),
+                        "{} requires unknown {key}",
+                        def.method
+                    );
+                }
+            }
+            for prop in props.values() {
+                assert!(prop.is_object(), "{} property schema", def.method);
+            }
+            assert!(!def.description.is_empty());
+            assert!(
+                def.description.is_ascii(),
+                "{} description is not ASCII",
+                def.method
+            );
+        }
+    }
+
+    #[test]
+    fn examples_carry_only_schema_keys() {
+        for def in catalogue() {
+            let props = def.schema["properties"].as_object().unwrap();
+            for key in def.example.as_object().unwrap().keys() {
+                assert!(
+                    props.contains_key(key),
+                    "{} example key {key} not in schema",
+                    def.method
+                );
+            }
+            if let Some(required) = def.schema.get("required") {
+                for key in required.as_array().unwrap() {
+                    assert!(
+                        def.example.get(key.as_str().unwrap()).is_some(),
+                        "{} example lacks required {key}",
+                        def.method
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn only_resume_verbs_take_wait_ms() {
+        let waiting: Vec<&str> = catalogue()
+            .iter()
+            .filter(|d| d.wait_ms)
+            .map(|d| d.method)
+            .collect();
+        assert_eq!(
+            waiting,
+            [
+                "continue",
+                "step",
+                "step_over",
+                "step_out",
+                "step_copper",
+                "step_frame",
+                "run_until"
+            ]
+        );
+        for def in catalogue() {
+            assert_eq!(
+                def.schema["properties"].get("wait_ms").is_some(),
+                def.wait_ms,
+                "{} wait_ms schema",
+                def.method
+            );
+        }
+    }
+}

--- a/src/control/headless.rs
+++ b/src/control/headless.rs
@@ -936,13 +936,57 @@ fn headless_warp_value() -> Value {
     })
 }
 
+/// The token the in-process test sessions are served with.
+#[cfg(test)]
+pub(crate) const TEST_TOKEN: &str = "sesame";
+
+/// The control test machine with time travel and PC history armed the
+/// way `run()` arms them.
+#[cfg(test)]
+pub(crate) fn control_test_emulator() -> Emulator {
+    let mut emu = crate::control::test_emulator();
+    emu.enable_time_travel(64, 1);
+    emu.debug_ensure_time_travel_anchor().unwrap();
+    emu.machine.ui_set_pc_history_enabled(true);
+    emu
+}
+
+/// Serve one control connection on a background thread against a fresh
+/// test machine, for clients that live on the test thread (the MCP
+/// bridge tests): the bound address, the token, and the thread, which
+/// ends when the client disconnects or shuts the session down.
+#[cfg(test)]
+pub(crate) fn spawn_test_session() -> (
+    std::net::SocketAddr,
+    &'static str,
+    std::thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("binding a loopback listener");
+    let addr = listener
+        .local_addr()
+        .expect("resolving the listener address");
+    let handle = std::thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accepting the test client");
+        let config = Config::new(":0".into());
+        let mut session = Session::new(
+            control_test_emulator(),
+            stream,
+            TEST_TOKEN,
+            &config,
+            MachineInputState::default(),
+        );
+        session.serve().expect("session should not error");
+        session.teardown();
+    });
+    (addr, TEST_TOKEN, handle)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::control::test_emulator;
     use std::io::BufRead;
 
-    const TOKEN: &str = "sesame";
+    const TOKEN: &str = TEST_TOKEN;
 
     /// A minimal JSON-RPC line client for driving a [`Session`] over
     /// loopback, with out-of-order response matching by id.
@@ -1015,14 +1059,6 @@ mod tests {
             let hello = self.result("hello", json!({"token": TOKEN}));
             assert_eq!(hello["authed"], true);
         }
-    }
-
-    fn control_test_emulator() -> Emulator {
-        let mut emu = test_emulator();
-        emu.enable_time_travel(64, 1);
-        emu.debug_ensure_time_travel_anchor().unwrap();
-        emu.machine.ui_set_pc_history_enabled(true);
-        emu
     }
 
     fn stopped_control_test_emulator() -> Emulator {

--- a/src/control/mcp.rs
+++ b/src/control/mcp.rs
@@ -1,0 +1,1194 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! An MCP (Model Context Protocol) server over stdio that exposes the
+//! control protocol as tools, so an agent in Claude Code, Cursor, or any
+//! other MCP client can drive a live machine without a REPL:
+//! `copperline-ctl --mcp`.
+//!
+//! The server is a bridge. Every control-protocol method is a tool named
+//! after it with dots replaced by underscores (see `catalogue`), called
+//! over one authenticated connection (`bridge`); the session tools
+//! (`session_launch`, `session_attach`, `session_status`,
+//! `session_close`) manage that connection and the emulator process
+//! behind it, and `events_next` / `events_drain` read the notifications
+//! the bridge queues.
+//!
+//! Protocol subset: newline-delimited JSON-RPC 2.0 on stdin/stdout,
+//! `initialize`, `notifications/initialized`, `ping`, `tools/list` and
+//! `tools/call`, per MCP 2025-06-18 (earlier revisions are accepted on
+//! `initialize`, the wire subset is identical). Stdout carries protocol
+//! messages only; diagnostics go to stderr. MCP requests are handled one
+//! at a time, so a blocking resume verb blocks the loop, which is the
+//! documented behaviour: give it `wait_ms`.
+
+use super::bridge::{self, Bridge, LaunchSpec, Launched, Reply};
+use super::catalogue::{self, ToolDef};
+use super::proto::{self, INVALID_PARAMS, INVALID_REQUEST, METHOD_NOT_FOUND, PARSE_ERROR};
+use serde_json::{json, Map, Value};
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// The protocol revision this server speaks.
+pub const LATEST_PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// Revisions accepted on `initialize`; the subset served here is the
+/// same on each, so the client's choice is echoed.
+pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26", "2024-11-05"];
+
+/// After a `wait_ms` expiry the bridge sends `pause` and waits this long
+/// for the machine to land on a quantum boundary and reply.
+const PAUSE_GRACE: Duration = Duration::from_secs(30);
+
+/// Default `events_next` wait.
+const DEFAULT_EVENT_WAIT: Duration = Duration::from_secs(1);
+
+/// Longest `events_next` wait, so a typo cannot park the loop for hours.
+const MAX_EVENT_WAIT: Duration = Duration::from_secs(600);
+
+/// How long `session_close` and `shutdown` give the emulator to exit on
+/// its own before it is killed.
+const EXIT_GRACE: Duration = Duration::from_secs(3);
+
+/// The workflow summary handed to the client on `initialize`.
+pub const INSTRUCTIONS: &str =
+    "Copperline is a cycle-driven Amiga emulator; these tools drive one \
+live machine through its control protocol. Start with session_launch (spawns a headless emulator, \
+paused at power-on, with the arguments you give: a config file, --model, --run PROG, --whdload \
+PKG...) or session_attach (an emulator started with --control/--control-gui and --control-info). \
+Then: continue, run_until, step, step_frame and friends run the machine and return a stop event; \
+status, regs_get, mem_read, disasm, custom_dump, beam_get and display_get inspect it; break_add \
+installs breakpoints, watches and traps; input_key, input_mouse, input_mouse_to and input_joy \
+inject input; media_floppy_insert and media_cd_insert swap media; capture_screenshot returns the \
+screen as an image. Tool names are the control-protocol method names with dots replaced by \
+underscores (warp.get -> warp_get). Times are emulated seconds; addresses take integers or hex \
+strings (\"0xDFF096\", \"$C00000\"). A resume with no stop condition blocks until something stops \
+the machine, so give continue, run_until and step_frame a wait_ms: the bridge pauses the machine \
+for you when it expires. Subscribe to notifications with events_subscribe and read them with \
+events_next or events_drain. session_close disconnects and stops an emulator this server \
+launched.";
+
+/// The server: at most one attached session, plus the counters the
+/// session tools report.
+pub struct McpServer {
+    session: Option<Session>,
+    screenshot_seq: u64,
+}
+
+struct Session {
+    bridge: Bridge,
+    launched: Option<Launched>,
+}
+
+impl Default for McpServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A tool call's outcome, rendered as the MCP `tools/call` result.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolResult {
+    pub content: Vec<Value>,
+    pub is_error: bool,
+}
+
+impl ToolResult {
+    fn text_block(value: &Value) -> Value {
+        let text = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
+        json!({"type": "text", "text": text})
+    }
+
+    /// A successful result carrying one JSON document.
+    pub fn ok(value: Value) -> Self {
+        Self {
+            content: vec![Self::text_block(&value)],
+            is_error: false,
+        }
+    }
+
+    /// A bridge-side failure.
+    pub fn error(message: impl Into<String>) -> Self {
+        Self {
+            content: vec![Self::text_block(&json!({"error": message.into()}))],
+            is_error: true,
+        }
+    }
+
+    /// A control-protocol error reply, kept as a tool result so the
+    /// model sees the code and message rather than a transport failure.
+    pub fn ccp_error(code: i64, message: String) -> Self {
+        Self {
+            content: vec![Self::text_block(
+                &json!({"error": {"code": code, "message": message}}),
+            )],
+            is_error: true,
+        }
+    }
+
+    fn into_value(self) -> Value {
+        json!({"content": self.content, "isError": self.is_error})
+    }
+}
+
+type RpcResult = Result<Value, (i64, String)>;
+
+impl McpServer {
+    pub fn new() -> Self {
+        Self {
+            session: None,
+            screenshot_seq: 0,
+        }
+    }
+
+    /// Attach an already-connected bridge (the `--info` / `--connect`
+    /// command-line forms).
+    pub fn attach(&mut self, bridge: Bridge) {
+        self.session = Some(Session {
+            bridge,
+            launched: None,
+        });
+    }
+
+    pub fn attached(&self) -> bool {
+        self.session.is_some()
+    }
+
+    /// Serve newline-delimited JSON-RPC from `reader` to `writer` until
+    /// EOF. Diagnostics go to stderr; nothing else is written to
+    /// `writer`.
+    pub fn serve<R: BufRead, W: Write>(&mut self, mut reader: R, mut writer: W) -> io::Result<()> {
+        loop {
+            let line = match proto::read_msg_line(&mut reader)? {
+                Some(line) => line,
+                None => return Ok(()),
+            };
+            if let Some(reply) = self.handle_message(&line) {
+                proto::write_line(&mut writer, &reply)?;
+            }
+        }
+    }
+
+    /// Handle one client message; the reply line to send, if any
+    /// (notifications get none).
+    pub fn handle_message(&mut self, line: &str) -> Option<String> {
+        let msg: Value = match serde_json::from_str(line) {
+            Ok(msg) => msg,
+            Err(e) => {
+                return Some(error_line(
+                    &Value::Null,
+                    PARSE_ERROR,
+                    format!("parse error: {e}"),
+                ))
+            }
+        };
+        let Some(obj) = msg.as_object() else {
+            return Some(error_line(
+                &Value::Null,
+                INVALID_REQUEST,
+                "request must be a JSON object (batches are not supported)",
+            ));
+        };
+        let id = obj.get("id").cloned().filter(|id| !id.is_null());
+        let Some(method) = obj.get("method").and_then(Value::as_str) else {
+            // A reply to a server-initiated request (this server sends
+            // none) is ignored; a request without a method is malformed.
+            return id
+                .filter(|_| obj.get("result").is_none() && obj.get("error").is_none())
+                .map(|id| error_line(&id, INVALID_REQUEST, "request has no method"));
+        };
+        let params = obj.get("params").cloned().unwrap_or(Value::Null);
+        let Some(id) = id else {
+            self.handle_notification(method, &params);
+            return None;
+        };
+        Some(match self.handle_request(method, &params) {
+            Ok(result) => proto::ok_line(&id, result),
+            Err((code, message)) => error_line(&id, code, message),
+        })
+    }
+
+    fn handle_notification(&mut self, method: &str, _params: &Value) {
+        // notifications/initialized, notifications/cancelled, and
+        // anything a newer client adds: nothing to do for a server
+        // that answers each request before reading the next.
+        let _ = method;
+    }
+
+    fn handle_request(&mut self, method: &str, params: &Value) -> RpcResult {
+        match method {
+            "initialize" => Ok(initialize_result(params)),
+            "ping" => Ok(json!({})),
+            "tools/list" => Ok(json!({"tools": list_tools()})),
+            "tools/call" => {
+                let name = params
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| (INVALID_PARAMS, "tools/call needs a tool name".to_string()))?;
+                let arguments = match params.get("arguments") {
+                    None | Some(Value::Null) => Value::Object(Map::new()),
+                    Some(args @ Value::Object(_)) => args.clone(),
+                    Some(_) => {
+                        return Err((INVALID_PARAMS, "arguments must be an object".to_string()))
+                    }
+                };
+                Ok(self.call_tool(name, arguments).into_value())
+            }
+            other => Err((METHOD_NOT_FOUND, format!("unknown method: {other}"))),
+        }
+    }
+
+    /// Run one tool. Every failure is a tool result with `isError`, so
+    /// the model can read it and adapt; protocol errors are for
+    /// malformed requests only.
+    pub fn call_tool(&mut self, name: &str, args: Value) -> ToolResult {
+        match name {
+            "session_launch" => self.session_launch(&args),
+            "session_attach" => self.session_attach(&args),
+            "session_status" => self.session_status(),
+            "session_close" => self.session_close(),
+            "events_next" => self.events_next(&args),
+            "events_drain" => self.events_drain(),
+            _ => match catalogue::find(name) {
+                Some(def) => self.call_ccp(def, args),
+                None => ToolResult::error(format!("unknown tool: {name}")),
+            },
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Session tools
+
+    fn session_launch(&mut self, args: &Value) -> ToolResult {
+        if self.session.is_some() {
+            return ToolResult::error(
+                "a session is already attached; session_close it first (one session at a time)",
+            );
+        }
+        let mut spec = LaunchSpec {
+            binary: args
+                .get("binary")
+                .and_then(Value::as_str)
+                .map(PathBuf::from),
+            cwd: args.get("cwd").and_then(Value::as_str).map(PathBuf::from),
+            timeout: Duration::from_millis(
+                args.get("timeout_ms")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(bridge::DEFAULT_LAUNCH_TIMEOUT.as_millis() as u64),
+            ),
+            args: Vec::new(),
+        };
+        if args.get("factory").and_then(Value::as_bool) == Some(true) {
+            spec.args.push("--factory".into());
+        }
+        for (key, flag) in [
+            ("config", "--config"),
+            ("model", "--model"),
+            ("run", "--run"),
+            ("whdload", "--whdload"),
+        ] {
+            match args.get(key) {
+                None | Some(Value::Null) => {}
+                Some(Value::String(value)) => {
+                    spec.args.push(flag.into());
+                    spec.args.push(value.clone());
+                }
+                Some(_) => return ToolResult::error(format!("{key} must be a string")),
+            }
+        }
+        match args.get("args") {
+            None | Some(Value::Null) => {}
+            Some(Value::Array(extra)) => {
+                for item in extra {
+                    match item.as_str() {
+                        Some(s) => spec.args.push(s.to_string()),
+                        None => return ToolResult::error("args must be an array of strings"),
+                    }
+                }
+            }
+            Some(_) => return ToolResult::error("args must be an array of strings"),
+        }
+        let (bridge, launched) = match bridge::launch(&spec) {
+            Ok(pair) => pair,
+            Err(e) => return ToolResult::error(e),
+        };
+        eprintln!(
+            "copperline-mcp: launched pid {} on {} (log {})",
+            launched.pid(),
+            bridge.listen(),
+            launched.log_path.display()
+        );
+        let mut session = Session {
+            bridge,
+            launched: Some(launched),
+        };
+        let status = session.status_value();
+        let launched = session.launched.as_ref().expect("just set");
+        let result = json!({
+            "launched": true,
+            "pid": launched.pid(),
+            "listen": session.bridge.listen(),
+            "proto": session.bridge.hello()["proto"],
+            "emulator": session.bridge.hello()["emulator"],
+            "log": launched.log_path.display().to_string(),
+            "command": launched.command,
+            "status": status,
+        });
+        self.session = Some(session);
+        ToolResult::ok(result)
+    }
+
+    fn session_attach(&mut self, args: &Value) -> ToolResult {
+        if self.session.is_some() {
+            return ToolResult::error(
+                "a session is already attached; session_close it first (one session at a time)",
+            );
+        }
+        let bridge = if let Some(path) = args.get("info_file").and_then(Value::as_str) {
+            Bridge::connect_info_file(std::path::Path::new(path))
+        } else {
+            match (
+                args.get("listen").and_then(Value::as_str),
+                args.get("token").and_then(Value::as_str),
+            ) {
+                (Some(listen), Some(token)) => Bridge::connect(listen, token),
+                _ => {
+                    return ToolResult::error("session_attach needs info_file, or listen and token")
+                }
+            }
+        };
+        let bridge = match bridge {
+            Ok(bridge) => bridge,
+            Err(e) => return ToolResult::error(e),
+        };
+        eprintln!("copperline-mcp: attached to {}", bridge.listen());
+        let mut session = Session {
+            bridge,
+            launched: None,
+        };
+        let status = session.status_value();
+        let result = json!({
+            "attached": true,
+            "listen": session.bridge.listen(),
+            "proto": session.bridge.hello()["proto"],
+            "emulator": session.bridge.hello()["emulator"],
+            "status": status,
+        });
+        self.session = Some(session);
+        ToolResult::ok(result)
+    }
+
+    fn session_status(&mut self) -> ToolResult {
+        let Some(session) = &self.session else {
+            return ToolResult::ok(json!({"attached": false}));
+        };
+        let (queued, dropped) = session.bridge.event_counts();
+        let mut result = json!({
+            "attached": true,
+            "listen": session.bridge.listen(),
+            "proto": session.bridge.hello()["proto"],
+            "emulator": session.bridge.hello()["emulator"],
+            "connection": match session.bridge.closed() {
+                None => "open".to_string(),
+                Some(reason) => format!("lost: {reason}"),
+            },
+            "events_queued": queued,
+            "events_dropped": dropped,
+        });
+        if let Some(launched) = &session.launched {
+            result["launched_pid"] = json!(launched.pid());
+            result["log"] = json!(launched.log_path.display().to_string());
+        }
+        ToolResult::ok(result)
+    }
+
+    fn session_close(&mut self) -> ToolResult {
+        let Some(session) = self.session.take() else {
+            return ToolResult::ok(json!({"closed": false, "note": "no session was attached"}));
+        };
+        let report = close_session(session, true);
+        ToolResult::ok(report)
+    }
+
+    // -----------------------------------------------------------------
+    // Event tools
+
+    fn events_next(&mut self, args: &Value) -> ToolResult {
+        let Some(session) = &self.session else {
+            return ToolResult::error(NO_SESSION);
+        };
+        let timeout = match args.get("timeout_ms") {
+            None | Some(Value::Null) => DEFAULT_EVENT_WAIT,
+            Some(v) => match v.as_u64() {
+                Some(ms) => Duration::from_millis(ms).min(MAX_EVENT_WAIT),
+                None => return ToolResult::error("timeout_ms must be a non-negative integer"),
+            },
+        };
+        let event = session.bridge.next_event(timeout);
+        let (queued, dropped) = session.bridge.event_counts();
+        let mut result = json!({
+            "event": event.as_ref().map(event_value),
+            "timed_out": event.is_none(),
+            "queued": queued,
+            "dropped": dropped,
+        });
+        if let Some(reason) = session.bridge.closed() {
+            result["connection"] = json!(format!("lost: {reason}"));
+        }
+        ToolResult::ok(result)
+    }
+
+    fn events_drain(&mut self) -> ToolResult {
+        let Some(session) = &self.session else {
+            return ToolResult::error(NO_SESSION);
+        };
+        let events: Vec<Value> = session
+            .bridge
+            .drain_events()
+            .iter()
+            .map(event_value)
+            .collect();
+        let (_, dropped) = session.bridge.event_counts();
+        ToolResult::ok(json!({
+            "count": events.len(),
+            "events": events,
+            "dropped": dropped,
+        }))
+    }
+
+    // -----------------------------------------------------------------
+    // Control-protocol tools
+
+    fn call_ccp(&mut self, def: &ToolDef, mut args: Value) -> ToolResult {
+        let Some(session) = self.session.as_mut() else {
+            return ToolResult::error(NO_SESSION);
+        };
+        if let Some(reason) = session.bridge.closed() {
+            return ToolResult::error(format!(
+                "the session connection was lost ({reason}); session_close it and launch or \
+                 attach again"
+            ));
+        }
+        if def.method == "capture.screenshot" {
+            self.screenshot_seq += 1;
+            return screenshot(session, &args, self.screenshot_seq);
+        }
+        let wait = if def.wait_ms {
+            match args.as_object_mut().and_then(|o| o.remove("wait_ms")) {
+                None | Some(Value::Null) => None,
+                Some(v) => match v.as_u64() {
+                    Some(ms) if ms > 0 => Some(Duration::from_millis(ms)),
+                    _ => return ToolResult::error("wait_ms must be a positive integer"),
+                },
+            }
+        } else {
+            None
+        };
+        let reply = match wait {
+            None => session.bridge.call(def.method, args),
+            Some(wait) => resume_with_wait(&mut session.bridge, def.method, args, wait),
+        };
+        match reply {
+            Ok(Reply::Ok(mut value)) => {
+                if def.method == "shutdown" {
+                    // The emulator is on its way out; reap it and let the
+                    // model know the session is gone.
+                    let session = self.session.take().expect("checked above");
+                    value["session"] = close_session(session, false);
+                }
+                ToolResult::ok(value)
+            }
+            Ok(Reply::Err { code, message }) => ToolResult::ccp_error(code, message),
+            Ok(Reply::TimedOut) => ToolResult::error(format!(
+                "the machine did not stop within {} ms of the bridge's pause; the run is \
+                 still outstanding",
+                PAUSE_GRACE.as_millis()
+            )),
+            Err(e) => ToolResult::error(e),
+        }
+    }
+
+    /// Close the session, stopping an emulator this server launched.
+    /// Called on stdin EOF so no emulator outlives its agent.
+    pub fn shutdown(&mut self) {
+        if let Some(session) = self.session.take() {
+            close_session(session, true);
+        }
+    }
+}
+
+impl Drop for McpServer {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+impl Session {
+    /// The machine's `status`, or the error, for the attach reports.
+    fn status_value(&mut self) -> Value {
+        match self.bridge.call("status", Value::Null) {
+            Ok(Reply::Ok(status)) => status,
+            Ok(Reply::Err { code, message }) => {
+                json!({"error": {"code": code, "message": message}})
+            }
+            Ok(Reply::TimedOut) => Value::Null,
+            Err(e) => json!({"error": e}),
+        }
+    }
+}
+
+const NO_SESSION: &str = "no session attached; call session_launch or session_attach first";
+
+/// Send a resume verb and wait `wait` for its stop; on expiry, pause the
+/// machine and return the stop that produces.
+fn resume_with_wait(
+    bridge: &mut Bridge,
+    method: &str,
+    params: Value,
+    wait: Duration,
+) -> Result<Reply, String> {
+    let id = bridge.send(method, params)?;
+    match bridge.wait(id, Some(wait))? {
+        Reply::TimedOut => {
+            let pause_id = bridge.send("pause", Value::Null)?;
+            let reply = bridge.wait(id, Some(PAUSE_GRACE))?;
+            let _ = bridge.wait(pause_id, Some(Duration::from_millis(1)));
+            Ok(match reply {
+                Reply::Ok(mut stop) => {
+                    stop["bridge"] = json!({"paused_after_ms": wait.as_millis() as u64});
+                    Reply::Ok(stop)
+                }
+                other => other,
+            })
+        }
+        reply => Ok(reply),
+    }
+}
+
+/// `capture.screenshot` with the PNG attached as an image content block.
+fn screenshot(session: &mut Session, args: &Value, seq: u64) -> ToolResult {
+    let explicit = args.get("path").and_then(Value::as_str).map(PathBuf::from);
+    let temporary = explicit.is_none();
+    let path = explicit.unwrap_or_else(|| {
+        std::env::temp_dir().join(format!("copperline-mcp-{}-{seq}.png", std::process::id()))
+    });
+    let reply = session.bridge.call(
+        "capture.screenshot",
+        json!({"path": path.display().to_string()}),
+    );
+    let mut result = match reply {
+        Ok(Reply::Ok(result)) => result,
+        Ok(Reply::Err { code, message }) => return ToolResult::ccp_error(code, message),
+        Ok(Reply::TimedOut) => unreachable!("waited without a timeout"),
+        Err(e) => return ToolResult::error(e),
+    };
+    let png = std::fs::read(&path);
+    if temporary {
+        let _ = std::fs::remove_file(&path);
+        result["path"] = Value::Null;
+        result["note"] = json!("temporary file deleted after reading; the image is attached");
+    }
+    let mut content = vec![ToolResult::text_block(&result)];
+    match png {
+        Ok(bytes) => content.push(json!({
+            "type": "image",
+            "data": proto::encode_base64(&bytes),
+            "mimeType": "image/png",
+        })),
+        Err(e) => content.push(ToolResult::text_block(&json!({
+            "note": format!("the PNG could not be read back from {}: {e}", path.display())
+        }))),
+    }
+    ToolResult {
+        content,
+        is_error: false,
+    }
+}
+
+/// Disconnect, and stop an emulator the server launched: `shutdown` is
+/// offered first when `ask` (the connection is still usable), then the
+/// process gets `EXIT_GRACE` to exit before it is killed.
+fn close_session(session: Session, ask: bool) -> Value {
+    let Session {
+        mut bridge,
+        launched,
+    } = session;
+    let mut report = json!({"closed": true, "listen": bridge.listen()});
+    match launched {
+        None => {
+            bridge.close();
+        }
+        Some(mut launched) => {
+            if ask && bridge.closed().is_none() {
+                let _ = bridge.call("shutdown", Value::Null);
+            }
+            bridge.close();
+            let killed = launched.finish(EXIT_GRACE);
+            eprintln!(
+                "copperline-mcp: pid {} {}",
+                launched.pid(),
+                if killed { "killed" } else { "exited" }
+            );
+            report["terminated_pid"] = json!(launched.pid());
+            report["killed"] = json!(killed);
+            report["log"] = json!(launched.log_path.display().to_string());
+        }
+    }
+    report
+}
+
+/// A queued notification as the model sees it: method and params.
+fn event_value(msg: &Value) -> Value {
+    json!({
+        "method": msg.get("method").cloned().unwrap_or(Value::Null),
+        "params": msg.get("params").cloned().unwrap_or(Value::Null),
+    })
+}
+
+fn error_line(id: &Value, code: i64, message: impl Into<String>) -> String {
+    proto::err_line(id, &proto::CtlError::new(code, message))
+}
+
+fn initialize_result(params: &Value) -> Value {
+    let requested = params.get("protocolVersion").and_then(Value::as_str);
+    let version = match requested {
+        Some(v) if SUPPORTED_PROTOCOL_VERSIONS.contains(&v) => v,
+        _ => LATEST_PROTOCOL_VERSION,
+    };
+    json!({
+        "protocolVersion": version,
+        "capabilities": {"tools": {"listChanged": false}},
+        "serverInfo": {"name": "copperline", "version": env!("CARGO_PKG_VERSION")},
+        "instructions": INSTRUCTIONS,
+    })
+}
+
+/// The bridge-owned tools, listed ahead of the protocol catalogue.
+pub fn bridge_tools() -> Vec<Value> {
+    let object = |props: Value, required: Vec<&str>| {
+        let mut schema = json!({"type": "object", "properties": props});
+        if !required.is_empty() {
+            schema["required"] = json!(required);
+        }
+        schema
+    };
+    vec![
+        json!({
+            "name": "session_launch",
+            "description": "Start a headless Copperline emulator (paused at power-on, no audio, \
+                            unpaced) with a control server on an ephemeral loopback port, \
+                            connect to it, and make it the current session. Pass a `config` \
+                            TOML path, a `model` (A500, A600, A1200, A4000, CD32, CDTV...), a \
+                            `run` executable or `whdload` package, `factory: true` to ignore any \
+                            saved default configuration, and any other copperline command-line \
+                            flags verbatim in `args` (\"--chipset\", \"AGA\", \"--fast\", \"8M\", \
+                            \"--insert-disk-after\", \"0\", \"df0\", \"game.adf\"...). The binary \
+                            is `binary`, else $COPPERLINE_BIN, else the copperline next to \
+                            copperline-ctl. Returns the pid, the listen address, the log file \
+                            the emulator's output goes to, and the initial status. One session \
+                            at a time: session_close first to launch another.",
+            "inputSchema": object(json!({
+                "config": {"type": "string", "description": "Configuration TOML path (--config)"},
+                "model": {"type": "string", "description": "Machine model (--model)"},
+                "run": {"type": "string", "description": "Amiga executable to boot straight into (--run)"},
+                "whdload": {"type": "string", "description": "WHDLoad package or slave directory (--whdload)"},
+                "factory": {"type": "boolean", "description": "Ignore the saved default configuration (--factory)"},
+                "args": {"type": "array", "items": {"type": "string"}, "description": "Further copperline flags, verbatim"},
+                "binary": {"type": "string", "description": "Path of the copperline binary (optional)"},
+                "cwd": {"type": "string", "description": "Working directory for the emulator (optional)"},
+                "timeout_ms": {"type": "integer", "minimum": 1, "description": "How long to wait for the control endpoint (default 30000)"}
+            }), vec![]),
+        }),
+        json!({
+            "name": "session_attach",
+            "description": "Attach to a running emulator's control server: either `info_file` \
+                            (the JSON file `--control-info` wrote) or `listen` and `token` (as \
+                            printed on the emulator's stderr). Works with both a headless \
+                            `--control` server and a windowed `--control-gui` session. Returns \
+                            the protocol version, emulator version and initial status.",
+            "inputSchema": object(json!({
+                "info_file": {"type": "string", "description": "Path of the --control-info file"},
+                "listen": {"type": "string", "description": "Control server address, host:port"},
+                "token": {"type": "string", "description": "Session token"}
+            }), vec![]),
+        }),
+        json!({
+            "name": "session_status",
+            "description": "Report the bridge's own state: whether a session is attached, its \
+                            address, the pid and log of an emulator this server launched, \
+                            whether the connection is still open, and the event queue's \
+                            depth and drop count. Does not touch the machine; use status for \
+                            the machine's state.",
+            "inputSchema": object(json!({}), vec![]),
+        }),
+        json!({
+            "name": "session_close",
+            "description": "Disconnect from the current session (the server drops this \
+                            session's breakpoints and subscriptions) and, if session_launch \
+                            started the emulator, shut it down (killed after 3 s if it does \
+                            not exit). Safe with no session attached.",
+            "inputSchema": object(json!({}), vec![]),
+        }),
+        json!({
+            "name": "events_next",
+            "description": "Wait up to `timeout_ms` (default 1000, at most 600000) for the \
+                            next queued notification from an events_subscribe subscription \
+                            (or the unsolicited event.warp) and return it as {method, params}, \
+                            or `timed_out: true`. Also reports the queue depth and how many \
+                            events the bounded queue (1024) has dropped.",
+            "inputSchema": object(json!({
+                "timeout_ms": {"type": "integer", "minimum": 0, "maximum": 600000, "description": "Milliseconds to wait for an event (default 1000)"}
+            }), vec![]),
+        }),
+        json!({
+            "name": "events_drain",
+            "description": "Return every queued notification, oldest first, and empty the \
+                            queue; `dropped` counts events the bounded queue lost since the \
+                            session started.",
+            "inputSchema": object(json!({}), vec![]),
+        }),
+    ]
+}
+
+/// The `tools/list` payload: the session and event tools, then every
+/// control-protocol method.
+pub fn list_tools() -> Vec<Value> {
+    let mut tools = bridge_tools();
+    tools.extend(catalogue::catalogue().iter().map(|def| {
+        json!({
+            "name": def.name,
+            "description": def.description,
+            "inputSchema": def.schema,
+        })
+    }));
+    tools
+}
+
+/// Serve stdin/stdout until EOF, then close the session (stopping an
+/// emulator this server launched).
+pub fn run_stdio(attach: Option<Bridge>) -> io::Result<()> {
+    let mut server = McpServer::new();
+    if let Some(bridge) = attach {
+        server.attach(bridge);
+    }
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let result = server.serve(stdin.lock(), stdout.lock());
+    server.shutdown();
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::headless::spawn_test_session;
+    use std::thread::JoinHandle;
+
+    fn request(id: u64, method: &str, params: Value) -> String {
+        json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params}).to_string()
+    }
+
+    fn call(server: &mut McpServer, id: u64, tool: &str, args: Value) -> Value {
+        let line = request(id, "tools/call", json!({"name": tool, "arguments": args}));
+        let reply = server.handle_message(&line).expect("requests get replies");
+        let reply: Value = serde_json::from_str(&reply).unwrap();
+        assert_eq!(reply["id"], id);
+        assert!(reply.get("error").is_none(), "protocol error: {reply}");
+        reply["result"].clone()
+    }
+
+    /// The JSON document in a tool result's first text block.
+    fn text_json(result: &Value) -> Value {
+        let text = result["content"][0]["text"].as_str().expect("text block");
+        serde_json::from_str(text).expect("text block is JSON")
+    }
+
+    /// A server attached to a fresh headless session on a background
+    /// thread; the handle joins once the session is closed.
+    fn attached() -> (McpServer, JoinHandle<()>) {
+        let (addr, token, handle) = spawn_test_session();
+        let mut server = McpServer::new();
+        let result = call(
+            &mut server,
+            1,
+            "session_attach",
+            json!({"listen": addr.to_string(), "token": token}),
+        );
+        assert_eq!(result["isError"], false, "{result}");
+        let doc = text_json(&result);
+        assert_eq!(doc["attached"], true);
+        assert_eq!(doc["status"]["state"], "paused");
+        (server, handle)
+    }
+
+    fn close(mut server: McpServer, handle: JoinHandle<()>) {
+        let result = call(&mut server, 999, "session_close", json!({}));
+        assert_eq!(text_json(&result)["closed"], true);
+        assert!(!server.attached());
+        handle.join().expect("session thread");
+    }
+
+    #[test]
+    fn initialize_echoes_a_supported_version_and_describes_the_server() {
+        let mut server = McpServer::new();
+        let reply = server
+            .handle_message(&request(
+                1,
+                "initialize",
+                json!({"protocolVersion": "2025-03-26", "capabilities": {}, "clientInfo": {"name": "t", "version": "0"}}),
+            ))
+            .unwrap();
+        let reply: Value = serde_json::from_str(&reply).unwrap();
+        assert_eq!(reply["id"], 1);
+        let result = &reply["result"];
+        assert_eq!(result["protocolVersion"], "2025-03-26");
+        assert_eq!(result["capabilities"]["tools"]["listChanged"], false);
+        assert_eq!(result["serverInfo"]["name"], "copperline");
+        assert_eq!(result["serverInfo"]["version"], env!("CARGO_PKG_VERSION"));
+        assert!(result["instructions"]
+            .as_str()
+            .unwrap()
+            .contains("session_launch"));
+
+        // An unknown revision gets the latest one this server speaks.
+        let reply = server
+            .handle_message(&request(
+                2,
+                "initialize",
+                json!({"protocolVersion": "1999-01-01"}),
+            ))
+            .unwrap();
+        let reply: Value = serde_json::from_str(&reply).unwrap();
+        assert_eq!(reply["result"]["protocolVersion"], LATEST_PROTOCOL_VERSION);
+
+        // The initialized notification and ping.
+        assert!(server
+            .handle_message(
+                &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}).to_string()
+            )
+            .is_none());
+        let reply = server
+            .handle_message(&request(3, "ping", Value::Null))
+            .unwrap();
+        let reply: Value = serde_json::from_str(&reply).unwrap();
+        assert_eq!(reply["result"], json!({}));
+    }
+
+    #[test]
+    fn malformed_and_unknown_requests_get_json_rpc_errors() {
+        let mut server = McpServer::new();
+        let reply: Value =
+            serde_json::from_str(&server.handle_message("{not json").unwrap()).unwrap();
+        assert_eq!(reply["error"]["code"], PARSE_ERROR);
+        assert_eq!(reply["id"], Value::Null);
+
+        let reply: Value = serde_json::from_str(&server.handle_message("[1,2]").unwrap()).unwrap();
+        assert_eq!(reply["error"]["code"], INVALID_REQUEST);
+
+        let reply: Value = serde_json::from_str(
+            &server
+                .handle_message("{\"id\": 4, \"jsonrpc\": \"2.0\"}")
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(reply["error"]["code"], INVALID_REQUEST);
+        assert_eq!(reply["id"], 4);
+
+        let reply: Value = serde_json::from_str(
+            &server
+                .handle_message(&request(5, "resources/list", Value::Null))
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(reply["error"]["code"], METHOD_NOT_FOUND);
+
+        let reply: Value = serde_json::from_str(
+            &server
+                .handle_message(&request(6, "tools/call", json!({"arguments": {}})))
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(reply["error"]["code"], INVALID_PARAMS);
+
+        // A stray response is ignored, an unknown notification too.
+        assert!(server
+            .handle_message("{\"jsonrpc\": \"2.0\", \"id\": 9, \"result\": {}}")
+            .is_none());
+        assert!(server
+            .handle_message("{\"jsonrpc\": \"2.0\", \"method\": \"notifications/cancelled\"}")
+            .is_none());
+    }
+
+    #[test]
+    fn tools_list_carries_session_tools_and_the_catalogue() {
+        let mut server = McpServer::new();
+        let reply: Value = serde_json::from_str(
+            &server
+                .handle_message(&request(1, "tools/list", json!({})))
+                .unwrap(),
+        )
+        .unwrap();
+        let tools = reply["result"]["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"status"));
+        assert!(names.contains(&"session_launch"));
+        assert!(names.contains(&"events_next"));
+        assert!(names.contains(&"capture_screenshot"));
+        assert!(names.contains(&"warp_get"));
+        assert_eq!(
+            tools.len(),
+            bridge_tools().len() + catalogue::catalogue().len()
+        );
+        let mut seen = std::collections::HashSet::new();
+        for tool in tools {
+            let name = tool["name"].as_str().unwrap();
+            assert!(seen.insert(name), "duplicate {name}");
+            assert!(
+                name.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+                    && name.len() <= 64,
+                "bad name {name}"
+            );
+            assert_eq!(tool["inputSchema"]["type"], "object", "{name}");
+            assert!(tool["description"].as_str().unwrap().is_ascii(), "{name}");
+        }
+    }
+
+    #[test]
+    fn tools_need_a_session_first() {
+        let mut server = McpServer::new();
+        let result = call(&mut server, 1, "status", json!({}));
+        assert_eq!(result["isError"], true);
+        assert!(text_json(&result)["error"]
+            .as_str()
+            .unwrap()
+            .contains("session_launch"));
+        let result = call(&mut server, 2, "events_next", json!({"timeout_ms": 10}));
+        assert_eq!(result["isError"], true);
+        let result = call(&mut server, 3, "session_status", json!({}));
+        assert_eq!(text_json(&result)["attached"], false);
+        let result = call(&mut server, 4, "session_close", json!({}));
+        assert_eq!(text_json(&result)["closed"], false);
+        let result = call(&mut server, 5, "session_attach", json!({}));
+        assert_eq!(result["isError"], true);
+    }
+
+    #[test]
+    fn status_through_the_bridge_reports_the_machine() {
+        let (mut server, handle) = attached();
+        let result = call(&mut server, 2, "status", json!({}));
+        assert_eq!(result["isError"], false);
+        assert_eq!(result["content"][0]["type"], "text");
+        let status = text_json(&result);
+        assert_eq!(status["frame"], 0);
+        assert_eq!(status["pc"], 0xF80010);
+        assert_eq!(status["state"], "paused");
+
+        let result = call(&mut server, 3, "session_status", json!({}));
+        let doc = text_json(&result);
+        assert_eq!(doc["attached"], true);
+        assert_eq!(doc["connection"], "open");
+        assert!(doc.get("launched_pid").is_none());
+        close(server, handle);
+    }
+
+    #[test]
+    fn unknown_tools_and_protocol_errors_are_tool_results() {
+        let (mut server, handle) = attached();
+        let result = call(&mut server, 2, "no_such_tool", json!({}));
+        assert_eq!(result["isError"], true);
+        assert!(text_json(&result)["error"]
+            .as_str()
+            .unwrap()
+            .contains("no_such_tool"));
+
+        // mem.read without addr: the parser's invalid-params error.
+        let result = call(&mut server, 3, "mem_read", json!({}));
+        assert_eq!(result["isError"], true);
+        let doc = text_json(&result);
+        assert_eq!(doc["error"]["code"], INVALID_PARAMS);
+        assert_eq!(doc["error"]["message"], "missing addr");
+
+        // The dotted name is not a tool name.
+        let result = call(&mut server, 4, "mem.read", json!({"addr": 0}));
+        assert_eq!(result["isError"], true);
+        close(server, handle);
+    }
+
+    #[test]
+    fn mem_and_step_round_trip_with_hex_addresses() {
+        let (mut server, handle) = attached();
+        let result = call(
+            &mut server,
+            2,
+            "mem_write",
+            json!({"addr": "0x1000", "data": "cafe"}),
+        );
+        assert_eq!(result["isError"], false, "{result}");
+        let result = call(
+            &mut server,
+            3,
+            "mem_read",
+            json!({"addr": "$1000", "len": 2}),
+        );
+        assert_eq!(text_json(&result)["data"], "cafe");
+        let result = call(&mut server, 4, "step", json!({"n": 1}));
+        let stop = text_json(&result);
+        assert_eq!(stop["reason"], "step");
+        assert_eq!(stop["pc"], 0xF80012);
+        close(server, handle);
+    }
+
+    #[test]
+    fn continue_with_wait_ms_pauses_a_free_running_machine() {
+        let (mut server, handle) = attached();
+        let result = call(&mut server, 2, "continue", json!({"wait_ms": 100}));
+        assert_eq!(result["isError"], false, "{result}");
+        let stop = text_json(&result);
+        assert_eq!(stop["reason"], "pause");
+        assert_eq!(stop["bridge"]["paused_after_ms"], 100);
+        assert!(stop["retired_instructions"].as_u64().unwrap() > 0);
+        // The machine is paused again and answers.
+        let status = text_json(&call(&mut server, 3, "status", json!({})));
+        assert_eq!(status["state"], "paused");
+        // wait_ms is stripped before forwarding: a breakpoint stop still
+        // arrives as itself, without the bridge marker.
+        call(
+            &mut server,
+            4,
+            "break_add",
+            json!({"kind": "pc", "addr": "$F8001A"}),
+        );
+        let stop = text_json(&call(&mut server, 5, "continue", json!({"wait_ms": 5000})));
+        assert_eq!(stop["reason"], "breakpoint");
+        assert!(stop.get("bridge").is_none());
+        let result = call(&mut server, 6, "continue", json!({"wait_ms": 0}));
+        assert_eq!(result["isError"], true);
+        close(server, handle);
+    }
+
+    #[test]
+    fn events_flow_through_the_queue() {
+        let (mut server, handle) = attached();
+        let result = call(&mut server, 2, "events_next", json!({"timeout_ms": 20}));
+        let doc = text_json(&result);
+        assert_eq!(doc["timed_out"], true);
+        assert_eq!(doc["event"], Value::Null);
+
+        call(
+            &mut server,
+            3,
+            "events_subscribe",
+            json!({"events": ["frame"], "frame_interval": 1}),
+        );
+        let stop = text_json(&call(&mut server, 4, "step_frame", json!({"n": 3})));
+        assert_eq!(stop["reason"], "step");
+        let next = text_json(&call(
+            &mut server,
+            5,
+            "events_next",
+            json!({"timeout_ms": 2000}),
+        ));
+        assert_eq!(next["timed_out"], false);
+        assert_eq!(next["event"]["method"], "event.frame");
+        let drained = text_json(&call(&mut server, 6, "events_drain", json!({})));
+        assert!(drained["count"].as_u64().unwrap() >= 1, "{drained}");
+        assert_eq!(drained["dropped"], 0);
+        let again = text_json(&call(&mut server, 7, "events_drain", json!({})));
+        assert_eq!(again["count"], 0);
+        close(server, handle);
+    }
+
+    #[test]
+    fn screenshots_come_back_as_images() {
+        let (mut server, handle) = attached();
+        let result = call(&mut server, 2, "capture_screenshot", json!({}));
+        assert_eq!(result["isError"], false, "{result}");
+        let content = result["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        let doc = text_json(&result);
+        assert!(doc["width"].as_u64().unwrap() > 0);
+        assert_eq!(doc["path"], Value::Null);
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[1]["mimeType"], "image/png");
+        let png = proto::decode_base64(content[1]["data"].as_str().unwrap()).unwrap();
+        assert_eq!(&png[..8], b"\x89PNG\r\n\x1a\n");
+
+        // An explicit path is kept.
+        let dir = std::env::temp_dir().join(format!("ccp-mcp-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("shot.png");
+        let result = call(
+            &mut server,
+            3,
+            "capture_screenshot",
+            json!({"path": path.display().to_string()}),
+        );
+        assert_eq!(text_json(&result)["path"], path.display().to_string());
+        assert!(path.is_file());
+        std::fs::remove_dir_all(&dir).ok();
+        close(server, handle);
+    }
+
+    #[test]
+    fn one_session_at_a_time_and_a_lost_connection_is_reported() {
+        let (mut server, handle) = attached();
+        let result = call(
+            &mut server,
+            2,
+            "session_attach",
+            json!({"listen": "127.0.0.1:1", "token": "x"}),
+        );
+        assert_eq!(result["isError"], true);
+        assert!(text_json(&result)["error"]
+            .as_str()
+            .unwrap()
+            .contains("already attached"));
+
+        // shutdown ends the server thread; the bridge notices.
+        let result = call(&mut server, 3, "shutdown", json!({}));
+        assert_eq!(result["isError"], false, "{result}");
+        assert_eq!(text_json(&result)["session"]["closed"], true);
+        assert!(!server.attached());
+        handle.join().unwrap();
+        let result = call(&mut server, 4, "status", json!({}));
+        assert_eq!(result["isError"], true);
+    }
+
+    #[test]
+    fn serve_runs_a_script_to_eof_and_writes_only_replies() {
+        let (addr, token, handle) = spawn_test_session();
+        let script = [
+            request(1, "initialize", json!({"protocolVersion": LATEST_PROTOCOL_VERSION})),
+            json!({"jsonrpc": "2.0", "method": "notifications/initialized"}).to_string(),
+            request(
+                2,
+                "tools/call",
+                json!({"name": "session_attach", "arguments": {"listen": addr.to_string(), "token": token}}),
+            ),
+            request(3, "tools/call", json!({"name": "beam_get"})),
+            request(4, "tools/call", json!({"name": "session_close"})),
+        ]
+        .join("\n");
+        let mut out = Vec::new();
+        let mut server = McpServer::new();
+        server
+            .serve(std::io::Cursor::new(script), &mut out)
+            .unwrap();
+        handle.join().unwrap();
+        let lines: Vec<Value> = String::from_utf8(out)
+            .unwrap()
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        assert_eq!(lines.len(), 4);
+        assert_eq!(lines[0]["id"], 1);
+        assert_eq!(lines[1]["id"], 2);
+        assert_eq!(lines[2]["result"]["isError"], false);
+        let beam: Value =
+            serde_json::from_str(lines[2]["result"]["content"][0]["text"].as_str().unwrap())
+                .unwrap();
+        assert!(beam.get("vpos").is_some(), "{beam}");
+        assert_eq!(lines[3]["id"], 4);
+    }
+}

--- a/src/control/mcp.rs
+++ b/src/control/mcp.rs
@@ -194,13 +194,50 @@ impl McpServer {
                 "request must be a JSON object (batches are not supported)",
             ));
         };
-        let id = obj.get("id").cloned().filter(|id| !id.is_null());
-        let Some(method) = obj.get("method").and_then(Value::as_str) else {
+        if obj.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
+            return Some(error_line(
+                &Value::Null,
+                INVALID_REQUEST,
+                "jsonrpc must be \"2.0\"",
+            ));
+        }
+        // MCP narrows JSON-RPC's id to a string or an integer: no null,
+        // and nothing else. A reply to a malformed id carries null.
+        let id = match obj.get("id") {
+            None => None,
+            Some(Value::String(s)) => Some(Value::String(s.clone())),
+            Some(Value::Number(n)) if n.is_i64() || n.is_u64() => Some(Value::Number(n.clone())),
+            Some(_) => {
+                return Some(error_line(
+                    &Value::Null,
+                    INVALID_REQUEST,
+                    "id must be a string or an integer",
+                ))
+            }
+        };
+        let method = match obj.get("method") {
+            None => None,
+            Some(Value::String(method)) => Some(method.as_str()),
+            Some(_) => {
+                return Some(error_line(
+                    &id.unwrap_or(Value::Null),
+                    INVALID_REQUEST,
+                    "method must be a string",
+                ))
+            }
+        };
+        let Some(method) = method else {
             // A reply to a server-initiated request (this server sends
-            // none) is ignored; a request without a method is malformed.
-            return id
-                .filter(|_| obj.get("result").is_none() && obj.get("error").is_none())
-                .map(|id| error_line(&id, INVALID_REQUEST, "request has no method"));
+            // none) is ignored; anything else without a method is
+            // malformed, id or no id.
+            if obj.contains_key("result") || obj.contains_key("error") {
+                return None;
+            }
+            return Some(error_line(
+                &id.unwrap_or(Value::Null),
+                INVALID_REQUEST,
+                "request has no method",
+            ));
         };
         let params = obj.get("params").cloned().unwrap_or(Value::Null);
         let Some(id) = id else {
@@ -589,42 +626,71 @@ fn resume_with_wait(
 }
 
 /// `capture.screenshot` with the PNG attached as an image content block.
+///
+/// The path the emulator gets is absolute: the emulator writes relative
+/// to its own working directory and this process reads relative to ours,
+/// which differ for an attached session or a `session_launch` with a
+/// `cwd`, so a relative `path` is resolved here first. A `path` that is
+/// not a string goes through as it is, so the method's own invalid-params
+/// error comes back like any other tool's.
 fn screenshot(session: &mut Session, args: &Value, seq: u64) -> ToolResult {
-    let explicit = args.get("path").and_then(Value::as_str).map(PathBuf::from);
-    let temporary = explicit.is_none();
-    let path = explicit.unwrap_or_else(|| {
-        std::env::temp_dir().join(format!("copperline-mcp-{}-{seq}.png", std::process::id()))
-    });
-    let reply = session.bridge.call(
-        "capture.screenshot",
-        json!({"path": path.display().to_string()}),
-    );
+    let (param, path) = match args.get("path") {
+        None | Some(Value::Null) => {
+            let path = std::env::temp_dir()
+                .join(format!("copperline-mcp-{}-{seq}.png", std::process::id()));
+            (json!(path.display().to_string()), Some((path, true)))
+        }
+        Some(Value::String(given)) => {
+            let path = std::path::absolute(given).unwrap_or_else(|_| PathBuf::from(given));
+            (json!(path.display().to_string()), Some((path, false)))
+        }
+        Some(other) => (other.clone(), None),
+    };
+    let reply = session
+        .bridge
+        .call("capture.screenshot", json!({"path": param}));
     let mut result = match reply {
         Ok(Reply::Ok(result)) => result,
         Ok(Reply::Err { code, message }) => return ToolResult::ccp_error(code, message),
         Ok(Reply::TimedOut) => unreachable!("waited without a timeout"),
         Err(e) => return ToolResult::error(e),
     };
+    let Some((path, temporary)) = path else {
+        return ToolResult::ok(result);
+    };
     let png = std::fs::read(&path);
     if temporary {
         let _ = std::fs::remove_file(&path);
-        result["path"] = Value::Null;
-        result["note"] = json!("temporary file deleted after reading; the image is attached");
     }
-    let mut content = vec![ToolResult::text_block(&result)];
     match png {
-        Ok(bytes) => content.push(json!({
-            "type": "image",
-            "data": proto::encode_base64(&bytes),
-            "mimeType": "image/png",
-        })),
-        Err(e) => content.push(ToolResult::text_block(&json!({
-            "note": format!("the PNG could not be read back from {}: {e}", path.display())
-        }))),
-    }
-    ToolResult {
-        content,
-        is_error: false,
+        Ok(bytes) => {
+            if temporary {
+                result["path"] = Value::Null;
+                result["note"] =
+                    json!("temporary file deleted after reading; the image is attached");
+            }
+            ToolResult {
+                content: vec![
+                    ToolResult::text_block(&result),
+                    json!({
+                        "type": "image",
+                        "data": proto::encode_base64(&bytes),
+                        "mimeType": "image/png",
+                    }),
+                ],
+                is_error: false,
+            }
+        }
+        Err(e) => ToolResult {
+            content: vec![ToolResult::text_block(&json!({
+                "error": format!(
+                    "the screenshot was written but could not be read back from {}: {e}",
+                    path.display()
+                ),
+                "result": result,
+            }))],
+            is_error: true,
+        },
     }
 }
 
@@ -946,6 +1012,80 @@ mod tests {
     }
 
     #[test]
+    fn envelopes_must_be_json_rpc_2_with_a_string_or_integer_id() {
+        let mut server = McpServer::new();
+        let invalid = |server: &mut McpServer, line: &str| -> Value {
+            let reply: Value = serde_json::from_str(
+                &server
+                    .handle_message(line)
+                    .unwrap_or_else(|| panic!("{line} must be answered")),
+            )
+            .unwrap();
+            assert_eq!(reply["error"]["code"], INVALID_REQUEST, "{line}: {reply}");
+            reply
+        };
+        // The version is required, and must be 2.0.
+        let reply = invalid(&mut server, "{\"id\": 1, \"method\": \"ping\"}");
+        assert_eq!(reply["id"], Value::Null);
+        invalid(
+            &mut server,
+            "{\"jsonrpc\": \"1.0\", \"id\": 1, \"method\": \"ping\"}",
+        );
+        invalid(
+            &mut server,
+            "{\"jsonrpc\": 2, \"id\": 1, \"method\": \"ping\"}",
+        );
+        // Ids: null, booleans, floats, objects and arrays are not ids,
+        // and the error reply for one carries null.
+        for id in ["null", "true", "1.5", "{}", "[1]"] {
+            let reply = invalid(
+                &mut server,
+                &format!("{{\"jsonrpc\": \"2.0\", \"id\": {id}, \"method\": \"ping\"}}"),
+            );
+            assert_eq!(reply["id"], Value::Null, "id {id}");
+        }
+        // No method and no id is malformed, not a notification.
+        let reply = invalid(&mut server, "{\"jsonrpc\": \"2.0\"}");
+        assert_eq!(reply["id"], Value::Null);
+        let reply = invalid(&mut server, "{\"jsonrpc\": \"2.0\", \"params\": {}}");
+        assert_eq!(reply["id"], Value::Null);
+        // A method that is not a string is malformed too, with the id.
+        let reply = invalid(
+            &mut server,
+            "{\"jsonrpc\": \"2.0\", \"id\": 7, \"method\": 3}",
+        );
+        assert_eq!(reply["id"], 7);
+
+        // String and integer ids are answered as themselves.
+        for (id, expect) in [
+            ("\"abc\"", json!("abc")),
+            ("0", json!(0)),
+            ("-3", json!(-3)),
+        ] {
+            let reply: Value = serde_json::from_str(
+                &server
+                    .handle_message(&format!(
+                        "{{\"jsonrpc\": \"2.0\", \"id\": {id}, \"method\": \"ping\"}}"
+                    ))
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(reply["id"], expect);
+            assert_eq!(reply["result"], json!({}));
+        }
+        // A valid notification with an unknown method is still ignored,
+        // and so is a stray response, whatever its id.
+        assert!(server
+            .handle_message(
+                "{\"jsonrpc\": \"2.0\", \"method\": \"notifications/progress\", \"params\": {}}"
+            )
+            .is_none());
+        assert!(server
+            .handle_message("{\"jsonrpc\": \"2.0\", \"id\": \"x\", \"error\": {\"code\": 1, \"message\": \"m\"}}")
+            .is_none());
+    }
+
+    #[test]
     fn tools_list_carries_session_tools_and_the_catalogue() {
         let mut server = McpServer::new();
         let reply: Value = serde_json::from_str(
@@ -1217,6 +1357,34 @@ mod tests {
         assert_eq!(text_json(&result)["path"], path.display().to_string());
         assert!(path.is_file());
         std::fs::remove_dir_all(&dir).ok();
+
+        // A relative path is resolved against this process's working
+        // directory and forwarded absolute, so an emulator with another
+        // cwd writes the file where it is read back from.
+        let rel_dir = format!("ccp-mcp-rel-{}", std::process::id());
+        std::fs::create_dir_all(&rel_dir).unwrap();
+        let result = call(
+            &mut server,
+            4,
+            "capture_screenshot",
+            json!({"path": format!("{rel_dir}/shot.png")}),
+        );
+        assert_eq!(result["isError"], false, "{result}");
+        let expected = std::env::current_dir()
+            .unwrap()
+            .join(&rel_dir)
+            .join("shot.png");
+        assert_eq!(text_json(&result)["path"], expected.display().to_string());
+        assert!(expected.is_file());
+        assert_eq!(result["content"][1]["type"], "image");
+        std::fs::remove_dir_all(&rel_dir).ok();
+
+        // A path that is not a string is the method's own invalid-params
+        // error, not a temporary screenshot.
+        let result = call(&mut server, 5, "capture_screenshot", json!({"path": 7}));
+        assert_eq!(result["isError"], true, "{result}");
+        assert_eq!(text_json(&result)["error"]["code"], INVALID_PARAMS);
+        assert_eq!(result["content"].as_array().unwrap().len(), 1);
         close(server, handle);
     }
 

--- a/src/control/mcp.rs
+++ b/src/control/mcp.rs
@@ -40,6 +40,11 @@ pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26", "
 /// for the machine to land on a quantum boundary and reply.
 const PAUSE_GRACE: Duration = Duration::from_secs(30);
 
+/// Once the stop has landed, how long the bridge waits for the pause's
+/// own reply (the server writes it right behind the stop) before
+/// forgetting the id, so a later arrival is dropped rather than kept.
+const PAUSE_REPLY_GRACE: Duration = Duration::from_millis(50);
+
 /// Default `events_next` wait.
 const DEFAULT_EVENT_WAIT: Duration = Duration::from_secs(1);
 
@@ -541,6 +546,13 @@ const NO_SESSION: &str = "no session attached; call session_launch or session_at
 
 /// Send a resume verb and wait `wait` for its stop; on expiry, pause the
 /// machine and return the stop that produces.
+///
+/// Every id this opens is answered or forgotten before it returns: the
+/// server answers the pause with the same stop position right behind the
+/// stop, so the bridge takes that reply when it is prompt and forgets the
+/// id otherwise (the reader then drops a late arrival), and a resume
+/// still unanswered after `PAUSE_GRACE` is forgotten the same way. The
+/// pending map therefore cannot grow across timed resumes.
 fn resume_with_wait(
     bridge: &mut Bridge,
     method: &str,
@@ -550,9 +562,20 @@ fn resume_with_wait(
     let id = bridge.send(method, params)?;
     match bridge.wait(id, Some(wait))? {
         Reply::TimedOut => {
-            let pause_id = bridge.send("pause", Value::Null)?;
-            let reply = bridge.wait(id, Some(PAUSE_GRACE))?;
-            let _ = bridge.wait(pause_id, Some(Duration::from_millis(1)));
+            let pause_id = match bridge.send("pause", Value::Null) {
+                Ok(pause_id) => pause_id,
+                Err(e) => {
+                    bridge.forget(id);
+                    return Err(e);
+                }
+            };
+            let reply = bridge.wait(id, Some(PAUSE_GRACE));
+            let _ = bridge.wait(pause_id, Some(PAUSE_REPLY_GRACE));
+            bridge.forget(pause_id);
+            let reply = reply?;
+            if reply == Reply::TimedOut {
+                bridge.forget(id);
+            }
             Ok(match reply {
                 Reply::Ok(mut stop) => {
                     stop["bridge"] = json!({"paused_after_ms": wait.as_millis() as u64});
@@ -781,7 +804,10 @@ pub fn run_stdio(attach: Option<Bridge>) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::control::bridge::test_support::{hello_reply, scripted_server};
     use crate::control::headless::spawn_test_session;
+    use std::net::TcpListener;
+    use std::sync::Mutex;
     use std::thread::JoinHandle;
 
     fn request(id: u64, method: &str, params: Value) -> String {
@@ -1065,6 +1091,70 @@ mod tests {
         let result = call(&mut server, 6, "continue", json!({"wait_ms": 0}));
         assert_eq!(result["isError"], true);
         close(server, handle);
+    }
+
+    #[test]
+    fn a_late_pause_reply_leaves_nothing_pending() {
+        // A scripted server that never stops on its own: `continue` gets
+        // no reply until `pause` arrives, which is answered with the stop
+        // for the resume only; the pause's own reply is held back until
+        // the next request, well past the bridge's grace for it.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let ids = Mutex::new((None::<Value>, None::<Value>));
+        let server = scripted_server(listener, move |req| {
+            if let Some(hello) = hello_reply(req) {
+                return vec![hello];
+            }
+            let mut ids = ids.lock().unwrap();
+            let stop = json!({"reason": "pause", "frame": 7});
+            match req["method"].as_str() {
+                Some("continue") => {
+                    ids.0 = Some(req["id"].clone());
+                    vec![]
+                }
+                Some("pause") => {
+                    ids.1 = Some(req["id"].clone());
+                    vec![proto::ok_line(
+                        ids.0.as_ref().expect("continue first"),
+                        stop,
+                    )]
+                }
+                Some("status") => {
+                    let mut lines = Vec::new();
+                    if let Some(pause_id) = ids.1.take() {
+                        lines.push(proto::ok_line(&pause_id, stop));
+                    }
+                    lines.push(proto::ok_line(&req["id"], json!({"frame": 7})));
+                    lines
+                }
+                _ => vec![],
+            }
+        });
+        let mut bridge = Bridge::connect(&addr.to_string(), "ok").unwrap();
+        for round in 0..3 {
+            let reply = resume_with_wait(
+                &mut bridge,
+                "continue",
+                Value::Null,
+                Duration::from_millis(20),
+            )
+            .unwrap();
+            let Reply::Ok(stop) = reply else {
+                panic!("round {round}: {reply:?}");
+            };
+            assert_eq!(stop["reason"], "pause");
+            assert_eq!(stop["bridge"]["paused_after_ms"], 20);
+            assert_eq!(bridge.outstanding(), 0, "round {round}");
+            // The pause reply lands now, late, and is dropped unread.
+            assert_eq!(
+                bridge.call("status", Value::Null).unwrap(),
+                Reply::Ok(json!({"frame": 7}))
+            );
+            assert_eq!(bridge.outstanding(), 0, "round {round}");
+        }
+        bridge.close();
+        server.join().unwrap();
     }
 
     #[test]

--- a/tests/mcp_stdio.rs
+++ b/tests/mcp_stdio.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! End-to-end smoke test of `copperline-ctl --mcp`: the built ctl binary
+//! is driven over its stdio like an MCP client would, and it in turn
+//! launches the built emulator with the bundled AROS ROM, so no local
+//! assets are needed. Ignored like the rest of this directory because it
+//! spawns two processes and runs the emulator; run it with
+//!
+//! ```sh
+//! cargo test --release --test mcp_stdio -- --ignored
+//! ```
+
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+fn request(id: u64, method: &str, params: Value) -> String {
+    json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params}).to_string()
+}
+
+/// The JSON document in a tool result's first text block.
+fn text_json(reply: &Value) -> Value {
+    let text = reply["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no text block in {reply}"));
+    serde_json::from_str(text).expect("text block is JSON")
+}
+
+#[test]
+#[ignore]
+fn mcp_over_stdio_launches_runs_and_closes_an_emulator() {
+    let ctl = env!("CARGO_BIN_EXE_copperline-ctl");
+    let emulator = env!("CARGO_BIN_EXE_copperline");
+    let mut child = Command::new(ctl)
+        .arg("--mcp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("starting copperline-ctl --mcp");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    let mut exchange = |line: String| -> Value {
+        stdin.write_all(line.as_bytes()).unwrap();
+        stdin.write_all(b"\n").unwrap();
+        stdin.flush().unwrap();
+        let mut reply = String::new();
+        assert!(
+            stdout.read_line(&mut reply).unwrap() > 0,
+            "server closed stdout"
+        );
+        serde_json::from_str(reply.trim()).expect("reply is JSON")
+    };
+
+    let init = exchange(request(
+        1,
+        "initialize",
+        json!({"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "test", "version": "0"}}),
+    ));
+    assert_eq!(init["result"]["serverInfo"]["name"], "copperline");
+    assert_eq!(init["result"]["protocolVersion"], "2025-06-18");
+
+    let list = exchange(request(2, "tools/list", json!({})));
+    let names: Vec<&str> = list["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"session_launch"));
+    assert!(names.contains(&"run_until"));
+    assert!(names.contains(&"capture_screenshot"));
+
+    let launch = exchange(request(
+        3,
+        "tools/call",
+        json!({"name": "session_launch", "arguments": {"factory": true, "binary": emulator, "model": "A500", "timeout_ms": 60000}}),
+    ));
+    assert_eq!(launch["result"]["isError"], false, "{launch}");
+    let doc = text_json(&launch);
+    assert_eq!(doc["launched"], true);
+    let pid = doc["pid"].as_u64().expect("pid");
+    assert_eq!(doc["status"]["state"], "paused");
+
+    let stop = exchange(request(
+        4,
+        "tools/call",
+        json!({"name": "run_until", "arguments": {"frame": 5, "wait_ms": 60000}}),
+    ));
+    assert_eq!(stop["result"]["isError"], false, "{stop}");
+    let stop = text_json(&stop);
+    assert_eq!(stop["reason"], "target");
+    assert_eq!(stop["frame"], 5);
+
+    let shot = exchange(request(
+        5,
+        "tools/call",
+        json!({"name": "capture_screenshot"}),
+    ));
+    let blocks = shot["result"]["content"].as_array().unwrap();
+    assert_eq!(blocks.len(), 2, "{shot}");
+    assert_eq!(blocks[1]["type"], "image");
+    assert_eq!(blocks[1]["mimeType"], "image/png");
+
+    let closed = exchange(request(6, "tools/call", json!({"name": "session_close"})));
+    let doc = text_json(&closed);
+    assert_eq!(doc["closed"], true);
+    assert_eq!(doc["terminated_pid"], pid);
+
+    drop(stdin);
+    let status = child.wait().expect("ctl exits on EOF");
+    assert!(status.success(), "ctl exit status {status}");
+    // The launched emulator is gone with it.
+    #[cfg(unix)]
+    {
+        std::thread::sleep(Duration::from_millis(200));
+        let alive = Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(!alive, "emulator pid {pid} outlived the session");
+    }
+}


### PR DESCRIPTION
An MCP server mode for `copperline-ctl`, so an agent in Claude Code, Cursor, or any other MCP client drives a live machine through the control protocol as tools instead of a REPL.

## What changes

- **`copperline-ctl --mcp [--info FILE | --connect ADDR --token TOKEN]`** (`src/control/mcp.rs`): an MCP server over stdio. Every control-protocol method is a tool named after it with dots replaced by underscores (`warp.get` -> `warp_get`); with connection arguments it attaches at startup, without them the agent launches or attaches a session through the session tools. Claude Code: `claude mcp add copperline -- copperline-ctl --mcp`, or an `.mcp.json` entry.
- **Tool catalogue** (`src/control/catalogue.rs`): one entry per method with a one-paragraph description, a JSON Schema for its params (required fields, enums, integer-or-hex-string addresses, bounds from the parser) and an example. Tests pin it to `exec::parse_method` both ways: every string-literal arm of the parser has an entry, every entry is a method the parser or a driver answers, every example parses. `hello`/`auth` stay the bridge's own handshake.
- **Bridge** (`src/control/bridge.rs`): one authenticated connection; a reader thread owns the receive side, routes replies by id and queues `event.*` notifications (bounded to 1024, drops counted) so subscriptions keep collecting while a resume verb's reply is outstanding. It also launches a headless emulator for `session_launch` (`copperline --control :0 --control-info TMP --noaudio` plus the caller's flags; binary from the argument, `$COPPERLINE_BIN`, the sibling of `copperline-ctl`, or the PATH), waits for the endpoint and sends the process's output to a log file named in the result.
- **Session tools**: `session_launch {config, model, run, whdload, factory, args, binary, cwd, timeout_ms}`, `session_attach {info_file} | {listen, token}`, `session_status`, `session_close`. One session at a time; an emulator this server launched is shut down on close and on stdin EOF, killed after 3 s if it does not exit.
- **Event tools**: `events_next {timeout_ms}` (blocks for the next queued notification or the timeout) and `events_drain`.
- **`wait_ms`** on the resume verbs (`continue`, `run_until`, `step`, `step_over`, `step_out`, `step_copper`, `step_frame`): both servers reply to a resume with the eventual stop event and MCP handles one request at a time, so a `continue` with no breakpoint would block the server for good. On expiry the bridge sends `pause` and returns the stop that produces, marked `bridge.paused_after_ms`; a stop that arrives in time is returned as it is.
- **`capture_screenshot`** returns the PNG as an MCP image content block alongside the text result, so the model can look at the screen; with no `path` the file is temporary and deleted after reading.
- `ctl-bin` now depends on the `control` feature (the bin links the library's `mcp` module); the bin itself stays a thin shim on std + serde_json, no rmcp/tokio.
- Docs: an "MCP server" section in `docs/debugger/control.md` (command line, Claude Code setup, name mapping, session tools, `wait_ms`, events, screenshots, protocol subset); a paragraph in AGENTS.md's Live control section; README's debugging bullet; `docs/index.md`.

## Design

- **Protocol subset, hand-rolled.** Newline-delimited JSON-RPC 2.0 on stdin/stdout: `initialize` (protocolVersion echoed when it is 2025-06-18, 2025-03-26 or 2024-11-05, else the latest; capabilities `tools.listChanged: false`; serverInfo `copperline` / CARGO_PKG_VERSION; an `instructions` workflow summary), `notifications/initialized` and other notifications ignored, `ping`, `tools/list`, `tools/call`. Unknown methods get -32601, malformed messages -32600/-32700; a tool failure, including a control-protocol error reply, is a `tools/call` result with `isError` and the code and message in the text, never a JSON-RPC error, so the model can read it and adapt. Stdout carries protocol messages only; diagnostics go to stderr, and the launched emulator's stdout/stderr go to its log file rather than inheriting ours.
- **No lock across a blocking wait.** The request thread does the control-protocol round trip itself and waits on a condition variable for its id; the reader thread only takes the state mutex to store a reply or push an event. A closed connection fails every waiter with the reason and is reported by `session_status`.
- **Name mapping is a table lookup**, not a string edit: `run_until` and `step_over` carry underscores of their own, so the reverse map goes through the catalogue.
- The `wait_ms` handling lives in the bridge, not the servers: the headless and windowed servers already service `pause` mid-run at a quantum boundary and answer both ids with the stop position, so no server change was needed.
- `headless.rs` gains a `#[cfg(test)]` helper that serves one session on a background thread, so the MCP tests run against a real headless session (the bundled test ROM) from the test thread.

## Verification

- `cargo test`: 3175 lib tests passed (new: catalogue coverage/round-trip/example tests; bridge routing, timeout, bounded queue, lost connection, launch failure reports; MCP initialize handshake, malformed/unknown requests, tools/list contents, `status` through the bridge, unknown tool and invalid-params as `isError` results, hex address round trip, `continue` with `wait_ms` pausing a free-running machine and a breakpoint stop arriving unmarked, event queue flow, screenshot image blocks, one-session-at-a-time, `shutdown` closing the session, `serve` over in-memory reader/writer). `cargo clippy --all-targets` and `cargo fmt --check` clean.
- `cargo test --release --test mcp_stdio -- --ignored`: passes (1.05 s): the built `copperline-ctl --mcp` driven over its stdio launches the built emulator on the bundled AROS ROM, runs to frame 5 with `wait_ms`, returns a screenshot image block, closes the session, exits on EOF, and the emulator pid is gone afterwards.
- By hand, against the release binaries:

  ```sh
  ./target/release/copperline --factory --noaudio --control :0 --control-info /tmp/x.json &
  printf '%s\n' \
    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"shell","version":"0"}}}' \
    '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
    '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
    '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"status"}}' \
    '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"run_until","arguments":{"seconds":2,"wait_ms":20000}}}' \
    '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"capture_screenshot"}}' \
    '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"session_status"}}' \
    | ./target/release/copperline-ctl --mcp --info /tmp/x.json
  ```

  `initialize` answers with the capabilities and instructions, `tools/list` lists 80 tools (6 bridge tools + 74 methods), `status` returns the JSON text block with `frame: 0`, `run_until` returns `{"reason": "target", "frame": 99, "seconds": 2.0000008, ...}`, `capture_screenshot` returns a text block plus an `image/png` block, nothing but protocol lines reaches stdout, and the emulator log shows the clean detach.

  ```sh
  printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"shutdown"}}' \
    | ./target/release/copperline-ctl --mcp --info /tmp/x.json
  ```

  ends that emulator (`session.closed: true`, the process exits).

  ```sh
  printf '%s\n' \
    '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"session_launch","arguments":{"factory":true,"model":"A500","args":["/path/to/KICK13.ROM"]}}}' \
    '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"run_until","arguments":{"seconds":8,"wait_ms":60000}}}' \
    '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"capture_screenshot","arguments":{"path":"/tmp/kick13.png"}}}' \
    '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"session_close"}}' \
    | ./target/release/copperline-ctl --mcp
  ```

  launches the sibling `copperline` (the result carries the pid, address, log path and full command line), runs to 8 s, writes the Kickstart 1.3 insert-disk screen (also attached as the image block, checked by eye), and `session_close` reports `killed: false`: the emulator exited on `shutdown` by itself. The same without a ROM boots the bundled AROS.
- Not run: the windowed `--control-gui` attach (it would open a window on the dev host); the bridge speaks the same wire format to both servers and the windowed drain already answers `pause` mid-run.

## Judgment calls

- `wait_ms` is offered on every resume verb, not only `continue`/`run_until`/`step_frame`: `step_out` and `step_over` run to the instruction budget when the routine never returns, and a uniform rule is easier to explain than an exception.
- The whole catalogue is exposed, 80 tools: the brief asked for the full protocol, and a client that wants fewer can filter by name. `tools/list` descriptions say what each returns and whether it blocks, so the model does not need the reference.
- `shutdown` is a tool (it is a documented method); after it succeeds the bridge closes the session and reports so in the result, since the emulator is on its way out either way.
- The end-to-end stdio test is `#[ignore]` like the rest of `tests/`: it spawns two processes and runs the emulator, even though it needs no local assets.
