### PR TITLE
debugger: pin headless observation as timeline-transparent, drop the crash alarm from save states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,11 @@ debuggers.
   environment variables: breakpoints, watchpoints, instruction traces,
   Copper-list dumps, per-hit screenshots (`docs/debugger/headless.md`).
   All `COPPERLINE_*` variables are snapshotted at startup and cannot change
-  at runtime.
+  at runtime. Arming them is timeline-transparent: the debugged run
+  retires the same instructions at the same colour clocks as the plain
+  run, so instruments can be added one at a time to the same run (the one
+  exception is `[cpu] jit`, which falls back to precise timing while any
+  hook is armed and says so in the log).
 - `--waveform out.vcd` with `--wave-trigger`/`--wave-duration` exports a VCD
   chip-signal trace for GTKWave (`docs/debugger/waveform.md`).
 - `--benchmark-until SECS` measures host-CPU cost of the deterministic

--- a/docs/debugger/headless.md
+++ b/docs/debugger/headless.md
@@ -18,6 +18,34 @@ COPPERLINE_DBG_SHOT=/tmp/hit \
 
 Addresses are specified in hexadecimal (with or without `0x` or `$` prefixes).
 
+## Timeline transparency
+
+The headless debugger is a pure observer. Its hooks read machine state
+through side-effect-free peeks, never bill chip-bus or CPU time, and write
+only to the host log, so arming any combination of the variables below
+leaves the emulated timeline byte-identical to an undebugged run: the same
+instructions retire at the same colour clocks, chip RAM holds the same
+bytes, and every frame renders the same. An investigation can therefore
+start from a plain `--screenshot-after` run and add breakpoints, watches,
+catches, traces, and dumps one at a time, knowing that each new
+instrument sees the same run the previous one did. The guarantee is held
+by `tests/debugger_transparency.rs`, which boots the bundled ROM twice,
+once with every hook armed, and compares the two machines after every
+frame.
+
+Two things do move a timeline, and both are documented behaviour rather
+than instrumentation cost:
+
+- A `[cpu] jit` machine (`--jit`) runs the batch/trace core, which bills
+  time in coarse batches instead of per instruction. Any armed debug or
+  diagnostic hook needs the per-instruction loop, so the machine drops back
+  to it for the whole run and logs a warning at start-up: the debugged run
+  is then the precise-timing run, not the JIT run. Compare debugged and
+  undebugged runs with JIT off.
+- Model knobs are not observation: `COPPERLINE_IRQ_LATENCY_CCK`,
+  `COPPERLINE_DBG_EXTCCK`, the CPU model, and any input script change the
+  machine and so change the timeline by design.
+
 ## Breakpoint and watchpoint variables
 
 `COPPERLINE_DBG_BREAK=PC[,PC...]`

--- a/docs/debugger/headless.md
+++ b/docs/debugger/headless.md
@@ -30,18 +30,25 @@ start from a plain `--screenshot-after` run and add breakpoints, watches,
 catches, traces, and dumps one at a time, knowing that each new
 instrument sees the same run the previous one did. The guarantee is held
 by `tests/debugger_transparency.rs`, which boots the bundled ROM twice,
-once with every hook armed, and compares the two machines after every
-frame.
+once with every hook that has a programmatic switch armed (the whole
+breakpoint/watchpoint/catch/trace debugger plus the CPU-level `MEMW`,
+`FC`, `SPREN`, `IRQ`, `DIAG_IPL`, `DIAG_PCHIST` and `DIAG_CRASH`
+observers), and compares the two machines after every frame. The
+bus-level log-only knobs (`DBG_CIA`, `DBG_DSKLEN`, `DBG_BLIT`,
+`DBG_FRAMESTATE`) read the environment at their log sites; they were
+verified by hand the same way (save-state and screenshot hashes at 25 s on
+three workloads, identical with each knob armed).
 
 Two things do move a timeline, and both are documented behaviour rather
 than instrumentation cost:
 
 - A `[cpu] jit` machine (`--jit`) runs the batch/trace core, which bills
   time in coarse batches instead of per instruction. Any armed debug or
-  diagnostic hook needs the per-instruction loop, so the machine drops back
-  to it for the whole run and logs a warning at start-up: the debugged run
-  is then the precise-timing run, not the JIT run. Compare debugged and
-  undebugged runs with JIT off.
+  diagnostic hook (every variable in this chapter's first two sections,
+  `DBG_MEMW` included) needs the per-instruction loop, so the machine
+  drops back to it for the whole run and logs a warning at start-up: the
+  debugged run is then the precise-timing run, not the JIT run. Compare
+  debugged and undebugged runs with JIT off.
 - Model knobs are not observation: `COPPERLINE_IRQ_LATENCY_CCK`,
   `COPPERLINE_DBG_EXTCCK`, the CPU model, and any input script change the
   machine and so change the timeline by design.

--- a/docs/internals/savestate.md
+++ b/docs/internals/savestate.md
@@ -56,8 +56,12 @@ Deliberately excluded, with the mechanism in parentheses:
   restored Paula stream; this is host presentation state, not serialized
   audio hardware.
 - **Memo caches and transient diagnostics**: the bitplane slot-plan `Cell`
-  cache and the pending debugger-window register hit (skipped; rebuilt or
-  irrelevant).
+  cache, the pending debugger-window register hit, and the low-memory
+  blit crash-context alarm (`diag_lowmem_blit`, consumed only by
+  `COPPERLINE_DIAG_CRASH`) are skipped; rebuilt or irrelevant. Keeping
+  host diagnostics out of the layout is what lets a resumed run and the
+  uninterrupted run it came from write byte-identical states
+  (`tests/savestate_roundtrip.rs` compares the files).
 
 The ROM bytes are embedded in the state, not loaded from a path: a state
 is self-contained with respect to everything that was in memory, so

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -828,6 +828,12 @@ pub struct Bus {
     /// Diagnostic crash context: set when a blit is started whose D
     /// destination lands in the exception-vector / low-memory region, so
     /// the CPU wrapper can dump its instruction history at that moment.
+    /// Host diagnostics, not machine state: only `COPPERLINE_DIAG_CRASH`
+    /// ever consumes it, so on an undiagnosed run it stays latched from the
+    /// first such blit on. Excluded from the serialized layout so a save
+    /// state written after that blit is byte-identical whether the run was
+    /// resumed (which launders the alarm) or not.
+    #[serde(skip)]
     pub diag_lowmem_blit: bool,
 
     /// Latched agnus-frame-crossing that has not yet been ORed into

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -9567,6 +9567,18 @@ fn lowmem_blit_diagnostic_uses_mode_specific_write_gate() {
         !bus.diag_lowmem_blit,
         "a restored save state must not replay stale diagnostic alarms"
     );
+
+    // The alarm is host diagnostics, not machine state: it never enters
+    // the serialized layout, so a state written while it is latched is
+    // byte-identical to one written while it is clear.
+    bus.diag_lowmem_blit = true;
+    let latched = bincode::serialize(&bus).expect("serialize bus with the alarm latched");
+    bus.diag_lowmem_blit = false;
+    let clear = bincode::serialize(&bus).expect("serialize bus with the alarm clear");
+    assert_eq!(
+        latched, clear,
+        "diag_lowmem_blit must be excluded from the save-state layout"
+    );
 }
 
 #[test]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1971,6 +1971,36 @@ impl M68kMachine {
         self.dbg.is_some()
     }
 
+    /// Arm (or, with `None`, disarm) the environment-style headless debugger
+    /// programmatically. The debugger is a pure observer: its per-instruction
+    /// hooks read machine state through side-effect-free peeks and never
+    /// bill bus time, so arming it must not move the emulated timeline
+    /// (tests/debugger_transparency.rs holds that guarantee). The one
+    /// documented exception is a `[cpu] jit` machine, which drops back to
+    /// the precise per-instruction loop while any hook is armed.
+    pub fn arm_headless_debugger(&mut self, dbg: Option<crate::debugger::Debugger>) {
+        self.dbg = dbg;
+        self.note_jit_debug_fallback();
+    }
+
+    /// Log once when a JIT-enabled machine has been pushed onto the precise
+    /// loop by a debug or diagnostic hook: the batch model bills time
+    /// differently, so the run's timeline is no longer the undebugged JIT
+    /// run's. Silent otherwise.
+    fn note_jit_debug_fallback(&self) {
+        if self.jit_enabled
+            && !matches!(self.cpu.cpu_type, CpuType::M68000 | CpuType::M68010)
+            && !self.jit_fast_path_ok()
+        {
+            log::warn!(
+                "cpu jit: a debug or diagnostic hook is armed, so this run uses the \
+                 precise per-instruction loop instead of the batch path; its \
+                 timeline differs from an undebugged [cpu] jit run (drop jit to \
+                 keep runs comparable)"
+            );
+        }
+    }
+
     /// Why interactive or environment-driven debugger state cannot observe
     /// speculative frames. Unlike CPU and chipset state, these counters,
     /// files, and rolling views intentionally survive a machine restore.
@@ -2181,6 +2211,7 @@ impl M68kMachine {
         }
         self.jit_enabled = on;
         self.bus.jit_enabled = on;
+        self.note_jit_debug_fallback();
     }
 
     pub fn jit_enabled(&self) -> bool {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -238,6 +238,26 @@ fn deserialize_component<R: std::io::Read, T: serde::de::DeserializeOwned>(
     crate::savestate::deserialize_from_state(r).map_err(|e| anyhow!("reading {what}: {e}"))
 }
 
+/// The CPU-level diagnostic observers `M68kMachine::arm_diagnostic_hooks`
+/// switches on, one field per environment knob. All default to off.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct DiagnosticHooks {
+    /// `COPPERLINE_DBG_MEMW`: CPU-write watch on one word.
+    pub memw_addr: Option<u32>,
+    /// `COPPERLINE_DBG_FC`: log every change of the word at this address.
+    pub frame_counter_addr: Option<u32>,
+    /// `COPPERLINE_DBG_SPREN`: report DMACON sprite-enable clears.
+    pub spren_clear: bool,
+    /// `COPPERLINE_DBG_IRQ` with its `(after, until)` window in seconds.
+    pub irq_window: Option<(f64, f64)>,
+    /// `COPPERLINE_DIAG_IPL`: per-frame handler/main cycle split.
+    pub ipl_split: bool,
+    /// `COPPERLINE_DIAG_PCHIST`: PC histogram over its window.
+    pub pc_histogram: bool,
+    /// `COPPERLINE_DIAG_CRASH`: recent-PC ring for crash context.
+    pub crash_ring: bool,
+}
+
 /// Machine-level runtime state outside `CpuCore` and `Bus` that a save
 /// state must carry: cache-sync memo, timing carries, and clock scaling.
 /// The `dbg_*` fields are host instrumentation and stay live across a load.
@@ -1983,6 +2003,25 @@ impl M68kMachine {
         self.note_jit_debug_fallback();
     }
 
+    /// Arm the CPU-level diagnostic observers the environment normally arms
+    /// (`COPPERLINE_DBG_MEMW`, `DBG_FC`, `DBG_SPREN`, `DBG_IRQ`,
+    /// `DIAG_IPL`, `DIAG_PCHIST`, `DIAG_CRASH`), programmatically. Like the
+    /// headless debugger they are pure observers -- peeks and host-side
+    /// counters only -- and tests/debugger_transparency.rs holds them to
+    /// that. The bus-level log-only knobs (`DBG_CIA`, `DBG_DSKLEN`,
+    /// `DBG_BLIT`, `DBG_FRAMESTATE`) read the environment at their log
+    /// sites and have no programmatic switch.
+    pub fn arm_diagnostic_hooks(&mut self, hooks: DiagnosticHooks) {
+        self.bus.dbg_memw_addr = hooks.memw_addr;
+        self.dbg_fc_addr = hooks.frame_counter_addr;
+        self.dbg_spren_on = hooks.spren_clear;
+        self.bus.dbg_irq_window = hooks.irq_window;
+        self.dbg_ipl_on = hooks.ipl_split;
+        self.dbg_pc_on = hooks.pc_histogram;
+        self.dbg_crash_on = hooks.crash_ring;
+        self.note_jit_debug_fallback();
+    }
+
     /// Log once when a JIT-enabled machine has been pushed onto the precise
     /// loop by a debug or diagnostic hook: the batch model bills time
     /// differently, so the run's timeline is no longer the undebugged JIT
@@ -1990,7 +2029,7 @@ impl M68kMachine {
     fn note_jit_debug_fallback(&self) {
         if self.jit_enabled
             && !matches!(self.cpu.cpu_type, CpuType::M68000 | CpuType::M68010)
-            && !self.jit_fast_path_ok()
+            && self.debug_hooks_armed()
         {
             log::warn!(
                 "cpu jit: a debug or diagnostic hook is armed, so this run uses the \
@@ -2238,19 +2277,31 @@ impl M68kMachine {
         if matches!(self.cpu.cpu_type, CpuType::M68000 | CpuType::M68010) {
             return false;
         }
-        !(self.dbg.is_some()
+        !(self.debug_hooks_armed() || (!self.fpu_enabled && self.cpu.cpu_type == CpuType::M68040))
+    }
+
+    /// Whether any per-instruction debug or diagnostic hook is armed: the
+    /// headless debugger, the CPU-level `COPPERLINE_DBG_*`/`DIAG_*`
+    /// observers, the interactive debugger's stops and traces, the
+    /// waveform PC trigger and the self-modifying-code tracker. Each of
+    /// these is serviced only by the precise loop, so together they are
+    /// what pushes a JIT machine off the batch path (`jit_fast_path_ok`)
+    /// and what `note_jit_debug_fallback` reports; the FPU-absence shim is
+    /// a model property, not a hook, and is kept out of this predicate.
+    fn debug_hooks_armed(&self) -> bool {
+        self.dbg.is_some()
             || self.dbg_pc_on
             || self.dbg_crash_on
             || self.dbg_sched_on
             || self.dbg_fc_addr.is_some()
             || self.dbg_ipl_on
             || self.dbg_spren_on
+            || self.bus.dbg_memw_addr.is_some()
             || self.ui_breaks.armed()
             || self.ui_pc_history_enabled
             || self.ui_trace.is_some()
             || self.bus.bus.wave_pc_trigger
             || self.bus.bus.smc.is_some()
-            || (!self.fpu_enabled && self.cpu.cpu_type == CpuType::M68040))
     }
 
     /// Select the diagnostic-capable precise loop once per slice instead of
@@ -6234,6 +6285,52 @@ mod tests {
         machine.bus_mut().paula.intreq = INT_VERTB;
         machine.step_slice(64)?;
         assert_eq!(machine.d(0), 42, "handler must have run");
+        Ok(())
+    }
+
+    /// Every CPU-level diagnostic observer is serviced only by the precise
+    /// loop, the single-word CPU write watch included: arming one on a JIT
+    /// machine must take it off the batch path, and it must count as an
+    /// armed hook for the fallback warning.
+    #[test]
+    fn jit_memw_hook_forces_the_precise_loop() -> Result<()> {
+        let pc = FAST_RAM_BASE as u32 + 0x100;
+        let mut bus = test_bus_with_pc(pc);
+        write_program(&mut bus, pc, &[0x60FE]); // bra.s *
+        let mut machine = M68kMachine::new(bus, CpuModel::M68020, true)?;
+        machine.set_jit_enabled(true);
+        assert!(!machine.debug_hooks_armed());
+        assert!(machine.jit_fast_path_ok());
+        machine.arm_diagnostic_hooks(DiagnosticHooks {
+            memw_addr: Some(0x0000_0400),
+            ..DiagnosticHooks::default()
+        });
+        assert!(machine.debug_hooks_armed());
+        assert!(!machine.jit_fast_path_ok());
+        machine.arm_diagnostic_hooks(DiagnosticHooks::default());
+        assert!(
+            machine.jit_fast_path_ok(),
+            "disarming restores the batch path"
+        );
+        Ok(())
+    }
+
+    /// An FPU-less 68040 always runs the precise loop (the host shim covers
+    /// its missing FPU), which is a model property and not an armed hook:
+    /// the JIT fallback warning must not claim a debugger changed the
+    /// timeline of an undebugged run.
+    #[test]
+    fn fpu_less_68040_shim_is_not_a_debug_hook() -> Result<()> {
+        let pc = FAST_RAM_BASE as u32 + 0x100;
+        let mut bus = test_bus_with_pc(pc);
+        write_program(&mut bus, pc, &[0x60FE]); // bra.s *
+        let mut machine = M68kMachine::new(bus, CpuModel::M68040, false)?;
+        machine.set_jit_enabled(true);
+        assert!(
+            !machine.jit_fast_path_ok(),
+            "the FPU shim keeps the precise loop"
+        );
+        assert!(!machine.debug_hooks_armed());
         Ok(())
     }
 

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -1156,6 +1156,40 @@ pub struct Debugger {
 }
 
 impl Debugger {
+    /// An armed debugger with nothing configured: no breakpoints, watches,
+    /// catches, or trace, an open time window, and the default hit budget.
+    /// Hosts that arm the headless debugger programmatically (tests, the
+    /// transparency check) fill in the public fields; `from_env` is the
+    /// environment-driven equivalent.
+    pub fn new(addr_mask: u32) -> Self {
+        Self {
+            addr_mask,
+            breakpoints: Vec::new(),
+            watches: Vec::new(),
+            dumps: Vec::new(),
+            trace: false,
+            trace_full: false,
+            trace_lo: 0,
+            trace_hi: u32::MAX,
+            catches: Vec::new(),
+            catch_alert: false,
+            alert_break: None,
+            after_secs: 0.0,
+            until_secs: f64::INFINITY,
+            max_hits: 200,
+            hits: 0,
+            shot_prefix: None,
+            shot_seq: 0,
+            trace_lines: 0,
+            copper_dump: None,
+            copper_dumped: false,
+            ram_dump: None,
+            ram_dumped: false,
+            listcheck: Vec::new(),
+            listcheck_reported: false,
+        }
+    }
+
     /// Build a debugger from the `COPPERLINE_DBG_*` environment, or `None` when no
     /// breakpoint, watchpoint, or trace is configured.
     pub fn from_env(addr_mask: u32) -> Option<Self> {

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -352,7 +352,12 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      event queue, the resource registry and the idle accounting travel
 //      with the state, so run-ahead and rewind restore them together with
 //      the guest state that produced them.
-pub const STATE_VERSION: u32 = 73;
+//  74: the bus dropped the `diag_lowmem_blit` crash-context alarm from the
+//      layout. It is host diagnostics (consumed only by
+//      COPPERLINE_DIAG_CRASH) and the loader already cleared it, so a run
+//      resumed from a state and the uninterrupted run it was taken from now
+//      write byte-identical states again.
+pub const STATE_VERSION: u32 = 74;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/tests/debugger_transparency.rs
+++ b/tests/debugger_transparency.rs
@@ -1,0 +1,195 @@
+//! Headless debugger transparency: arming `COPPERLINE_DBG_*`-style
+//! observation must not move the emulated timeline
+//! (docs/debugger/headless.md, "Timeline transparency").
+//!
+//! The headless debugger is a pure observer. Its per-instruction hooks read
+//! machine state through side-effect-free peeks, never bill bus time, and
+//! only write to the host log. A run with breakpoints, watchpoints, exception
+//! catches, and an instruction trace armed must therefore retire the same
+//! instructions at the same colour clocks as an undebugged run, write the
+//! same chip RAM, and render the same frames -- so an investigation can add
+//! instrumentation without changing what it is investigating.
+//!
+//! Two machines boot the bundled AROS ROM side by side from the same
+//! configuration. One is armed with every hook the environment could arm
+//! (chosen so they all fire during the boot), the other is left alone. Both
+//! are stepped frame by frame and fingerprinted after every frame; the first
+//! mismatch names the frame.
+//!
+//! Asset-free: the bundled AROS ROM boots with an empty DF0. The guest clock
+//! is pinned with a fixed RTC seed so the two builds agree.
+//!
+//! Release-only, like tests/savestate_roundtrip.rs: a debug-build emulator is
+//! far too slow for a multi-second emulated boot.
+//!
+//! ```sh
+//! cargo test --release --test debugger_transparency -- --nocapture
+//! ```
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use copperline::audio::NullSink;
+use copperline::config::Config;
+use copperline::debugger::{Debugger, Watch};
+use copperline::emulator::{build_machine, Emulator};
+use copperline::video::{bitplane, FB_WIDTH, MAX_CANVAS_PIXELS};
+
+/// Emulated seconds to run both machines. Long enough to cover the AROS
+/// bootstrap handing control up and the guest screen coming live.
+const RUN_SECS: f64 = 12.0;
+
+/// Fixed power-on RTC seed (Unix seconds).
+const RTC_SEED: u64 = 1_111_111_109;
+
+/// Level-3 autovector (VERTB): vector 24 + 3. Caught so the exception hook
+/// fires on every frame.
+const VERTB_VECTOR: u16 = 27;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn pin_bundled_aros() {
+    std::env::set_var("COPPERLINE_AROS_DIR", repo_root().join("assets/aros"));
+}
+
+fn make_config() -> anyhow::Result<Config> {
+    let mut cfg = Config {
+        rtc_seed_unix: Some(RTC_SEED),
+        ..Config::default()
+    };
+    copperline::config::resolve_bundled_rom(&mut cfg)?;
+    Ok(cfg)
+}
+
+fn build() -> anyhow::Result<Emulator> {
+    build_machine(&make_config()?, Box::new(NullSink), false, false)
+}
+
+/// Every environment-armable hook at once, tuned so each one fires during
+/// the boot: a watch over the low chip-RAM vector/ExecBase area the guest
+/// rewrites constantly, a PC breakpoint on the reset vector's first
+/// instruction, the VERTB exception catch (every frame), the exec Alert()
+/// trap arming, a memory dump on every hit, and an instruction trace over a
+/// short window. The hit budget is unbounded so the hooks never retire.
+fn armed_debugger(emu: &Emulator) -> Debugger {
+    let mut dbg = Debugger::new(emu.machine.ui_addr_mask());
+    dbg.watches.push(Watch {
+        addr: 0x0000_0000,
+        len: 0x200,
+    });
+    dbg.breakpoints
+        .push(emu.machine.pc() & emu.machine.ui_addr_mask());
+    dbg.catches.push(VERTB_VECTOR);
+    dbg.catch_alert = true;
+    dbg.dumps.push((0x0000_0004, 4));
+    dbg.trace = true;
+    dbg.after_secs = 0.0;
+    dbg.until_secs = f64::INFINITY;
+    dbg.max_hits = u64::MAX;
+    dbg
+}
+
+fn fnv1a64_from(mut hash: u64, bytes: &[u8]) -> u64 {
+    for &b in bytes {
+        hash ^= u64::from(b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// Everything two runs must agree on at one emulated instant: the timeline
+/// position, the CPU's place in the program, the rendered frame, and the
+/// whole of chip RAM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Fingerprint {
+    cck: u64,
+    frames: u64,
+    pc: u32,
+    fb_hash: u64,
+    chip_hash: u64,
+}
+
+impl Fingerprint {
+    /// Capture via the side-effect-free display path, exactly as the control
+    /// protocol's `capture.digest` does.
+    fn capture(emu: &Emulator) -> Self {
+        let input = bitplane::RenderInput::from_bus(emu.bus());
+        let mut fb = vec![0u32; MAX_CANVAS_PIXELS];
+        bitplane::render_from_input(&input, &mut fb);
+        let lines = emu.bus().frame_geometry().visible_lines;
+        let width = FB_WIDTH * emu.bus().frame_canvas_scale();
+        let mut fb_hash = 0xcbf2_9ce4_8422_2325;
+        for px in &fb[..width * lines] {
+            fb_hash = fnv1a64_from(fb_hash, &px.to_le_bytes());
+        }
+        let chip_hash = fnv1a64_from(0xcbf2_9ce4_8422_2325, emu.bus().mem.chip_ram.as_slice());
+        Fingerprint {
+            cck: emu.bus().emulated_cck(),
+            frames: emu.bus().emulated_frames(),
+            pc: emu.machine.pc(),
+            fb_hash,
+            chip_hash,
+        }
+    }
+}
+
+/// Step both machines one frame at a time to `RUN_SECS`, holding the armed
+/// machine to the plain machine's fingerprint after every frame.
+fn run_side_by_side(plain: &mut Emulator, armed: &mut Emulator) -> anyhow::Result<u64> {
+    let mut frames = 0u64;
+    let mut progressed = false;
+    let mut last_chip = Fingerprint::capture(plain).chip_hash;
+    while plain.bus().emulated_seconds() < RUN_SECS {
+        plain.step_frame()?;
+        armed.step_frame()?;
+        frames += 1;
+        let want = Fingerprint::capture(plain);
+        let got = Fingerprint::capture(armed);
+        assert_eq!(
+            want, got,
+            "the armed headless debugger moved the timeline {frames} frame(s) in:\n  \
+             plain = {want:?}\n  armed = {got:?}"
+        );
+        if want.chip_hash != last_chip {
+            progressed = true;
+            last_chip = want.chip_hash;
+        }
+    }
+    assert!(
+        progressed,
+        "chip RAM never changed across the run; the comparison would be vacuous"
+    );
+    Ok(frames)
+}
+
+/// Arming breakpoints, watchpoints, exception catches, Alert() catching,
+/// memory dumps and an instruction trace leaves every frame of the boot
+/// byte-identical to an undebugged run.
+#[test]
+fn armed_headless_debugger_leaves_the_timeline_unchanged() {
+    if cfg!(debug_assertions) {
+        eprintln!(
+            "skipping debugger transparency; run with --release \
+             (a debug emulator is too slow for the emulated boot)"
+        );
+        return;
+    }
+    pin_bundled_aros();
+
+    let started = Instant::now();
+    let mut plain = build().expect("plain machine");
+    let mut armed = build().expect("armed machine");
+    let dbg = armed_debugger(&armed);
+    armed.machine.arm_headless_debugger(Some(dbg));
+    assert!(armed.machine.headless_debugger_armed());
+    assert!(!plain.machine.headless_debugger_armed());
+
+    let frames = run_side_by_side(&mut plain, &mut armed).expect("side-by-side run");
+    println!(
+        "  {frames} frames ({RUN_SECS}s emulated) byte-identical with the debugger armed, \
+         {:.1}s wall",
+        started.elapsed().as_secs_f64()
+    );
+}

--- a/tests/debugger_transparency.rs
+++ b/tests/debugger_transparency.rs
@@ -11,10 +11,15 @@
 //! instrumentation without changing what it is investigating.
 //!
 //! Two machines boot the bundled AROS ROM side by side from the same
-//! configuration. One is armed with every hook the environment could arm
-//! (chosen so they all fire during the boot), the other is left alone. Both
-//! are stepped frame by frame and fingerprinted after every frame; the first
-//! mismatch names the frame.
+//! configuration. One is armed with every hook that has a programmatic
+//! switch: the whole `Debugger` (watch, breakpoint, exception catch, Alert()
+//! catch, dumps, trace) and the CPU-level diagnostic observers
+//! (`DiagnosticHooks`: MEMW, FC, SPREN, IRQ, IPL split, PC histogram, crash
+//! ring), chosen so they all fire during the boot; the other is left alone.
+//! Both are stepped frame by frame and fingerprinted after every frame; the
+//! first mismatch names the frame. The bus-level log-only knobs (CIA,
+//! DSKLEN, BLIT, FRAMESTATE) read the environment at their log sites and
+//! are covered by the CLI probe recorded in PR #617 instead.
 //!
 //! Asset-free: the bundled AROS ROM boots with an empty DF0. The guest clock
 //! is pinned with a fixed RTC seed so the two builds agree.
@@ -31,6 +36,7 @@ use std::time::Instant;
 
 use copperline::audio::NullSink;
 use copperline::config::Config;
+use copperline::cpu::DiagnosticHooks;
 use copperline::debugger::{Debugger, Watch};
 use copperline::emulator::{build_machine, Emulator};
 use copperline::video::{bitplane, FB_WIDTH, MAX_CANVAS_PIXELS};
@@ -89,6 +95,24 @@ fn armed_debugger(emu: &Emulator) -> Debugger {
     dbg.until_secs = f64::INFINITY;
     dbg.max_hits = u64::MAX;
     dbg
+}
+
+/// The CPU-level diagnostic observers, all on: the single-word CPU write
+/// watch and the frame-counter change log on a low chip-RAM word the boot
+/// rewrites, sprite-enable clear reports, the interrupt log over an open
+/// window, the per-frame IPL cycle split, the PC histogram and the crash
+/// ring. The bus-level log-only knobs (CIA, DSKLEN, BLIT, FRAMESTATE) have
+/// no programmatic switch; the CLI probe on record in PR #617 covers them.
+fn armed_diagnostic_hooks() -> DiagnosticHooks {
+    DiagnosticHooks {
+        memw_addr: Some(0x0000_0400),
+        frame_counter_addr: Some(0x0000_0400),
+        spren_clear: true,
+        irq_window: Some((0.0, f64::INFINITY)),
+        ipl_split: true,
+        pc_histogram: true,
+        crash_ring: true,
+    }
 }
 
 fn fnv1a64_from(mut hash: u64, bytes: &[u8]) -> u64 {
@@ -165,8 +189,9 @@ fn run_side_by_side(plain: &mut Emulator, armed: &mut Emulator) -> anyhow::Resul
 }
 
 /// Arming breakpoints, watchpoints, exception catches, Alert() catching,
-/// memory dumps and an instruction trace leaves every frame of the boot
-/// byte-identical to an undebugged run.
+/// memory dumps, an instruction trace and every CPU-level diagnostic
+/// observer leaves every frame of the boot byte-identical to an undebugged
+/// run.
 #[test]
 fn armed_headless_debugger_leaves_the_timeline_unchanged() {
     if cfg!(debug_assertions) {
@@ -183,6 +208,7 @@ fn armed_headless_debugger_leaves_the_timeline_unchanged() {
     let mut armed = build().expect("armed machine");
     let dbg = armed_debugger(&armed);
     armed.machine.arm_headless_debugger(Some(dbg));
+    armed.machine.arm_diagnostic_hooks(armed_diagnostic_hooks());
     assert!(armed.machine.headless_debugger_armed());
     assert!(!plain.machine.headless_debugger_armed());
 

--- a/tests/savestate_roundtrip.rs
+++ b/tests/savestate_roundtrip.rs
@@ -195,8 +195,10 @@ fn assert_checkpoints_match(label: &str, expected: &[Fingerprint], actual: &[Fin
 }
 
 /// The uninterrupted history: boot, step straight through the split point and
-/// every checkpoint, fingerprinting on the way past.
-fn uninterrupted_run() -> anyhow::Result<(Fingerprint, Vec<Fingerprint>)> {
+/// every checkpoint, fingerprinting on the way past. The state written at the
+/// last checkpoint (`final_state`) is the byte-for-byte record a resumed run
+/// must reproduce.
+fn uninterrupted_run(final_state: &Path) -> anyhow::Result<(Fingerprint, Vec<Fingerprint>)> {
     let started = Instant::now();
     let (mut emu, split_frame) = boot_to_split()?;
     let at_split = Fingerprint::capture(&emu);
@@ -216,7 +218,33 @@ fn uninterrupted_run() -> anyhow::Result<(Fingerprint, Vec<Fingerprint>)> {
         last.fb_hash,
         last.chip_hash,
     );
+    emu.save_state(final_state)?;
     Ok((at_split, checkpoints))
+}
+
+/// A resumed run's state file at the last checkpoint must be byte-identical
+/// to the uninterrupted run's: the fingerprints prove the timeline agrees,
+/// this proves nothing host-side leaked into (or was laundered out of) the
+/// serialized machine along the way. A single differing byte is a field
+/// that belongs out of the layout (host diagnostics) or a field the loader
+/// fails to carry across.
+fn assert_final_states_identical(label: &str, expected: &Path, actual: &Path) {
+    let want = std::fs::read(expected).expect("read the uninterrupted run's final state");
+    let got = std::fs::read(actual).expect("read the resumed run's final state");
+    if want == got {
+        return;
+    }
+    let first = want
+        .iter()
+        .zip(got.iter())
+        .position(|(a, b)| a != b)
+        .unwrap_or(want.len().min(got.len()));
+    panic!(
+        "{label}: the final state file differs from the uninterrupted run's \
+         (sizes {} vs {}, first difference at byte {first})",
+        want.len(),
+        got.len()
+    );
 }
 
 /// The resumed history: a second machine boots independently to the split
@@ -227,6 +255,7 @@ fn resumed_run(
     state_path: &Path,
     at_split: &Fingerprint,
     expected: &[Fingerprint],
+    final_state: &Path,
 ) -> anyhow::Result<()> {
     let started = Instant::now();
     let (emu, split_frame) = boot_to_split()?;
@@ -265,6 +294,10 @@ fn resumed_run(
         t1.elapsed().as_secs_f64()
     );
     assert_checkpoints_match("resumed", expected, &actual);
+    let resumed_final = scratch_path("final-resumed.clstate");
+    resumed.save_state(&resumed_final)?;
+    assert_final_states_identical("resumed", final_state, &resumed_final);
+    let _ = std::fs::remove_file(&resumed_final);
     Ok(())
 }
 
@@ -318,7 +351,8 @@ fn resume_matches_uninterrupted_run() {
     pin_bundled_aros();
 
     println!("run A: uninterrupted");
-    let (at_split, checkpoints) = uninterrupted_run().expect("uninterrupted run");
+    let final_state = scratch_path("final.clstate");
+    let (at_split, checkpoints) = uninterrupted_run(&final_state).expect("uninterrupted run");
 
     // Sanity: the machine actually advanced across the checkpoint span. All
     // equal would make the comparison vacuous.
@@ -331,12 +365,13 @@ fn resume_matches_uninterrupted_run() {
 
     println!("run B: save at T, resume in a fresh machine");
     let state_path = scratch_path("split.clstate");
-    resumed_run(&state_path, &at_split, &checkpoints).expect("resumed run");
+    resumed_run(&state_path, &at_split, &checkpoints, &final_state).expect("resumed run");
 
     println!("run C: same state into a differently constructed machine");
     resumed_run_alternate_construction(&state_path, &checkpoints).expect("alternate run");
 
     let _ = std::fs::remove_file(&state_path);
+    let _ = std::fs::remove_file(&final_state);
 }
 
 /// Two independent builds stepped to the same emulated instant must already


### PR DESCRIPTION
The headless debugger (`COPPERLINE_DBG_*`) is pinned as timeline-transparent, the one way a debugged run silently diverged from a plain one is now announced, and the one byte by which a resumed AGA save state differed from the uninterrupted run's is gone.

## What changes

A note from an August investigation claimed that arming `COPPERLINE_DBG_*` knobs shifted the emulated timeline before their window even opened, so nothing could be instrumented without changing what was being measured. Re-measured knob by knob on three workloads (KS1.3 A500 with a disk-loading game, KS3.1 A1200/68020 with an AGA loader, the bundled AROS ROM): save-state and screenshot hashes at 25 s are byte-identical with WATCH, BREAK (139 hits), CATCH, CATCHALERT, TRACE (7169 lines), DUMP, SHOT (three mid-frame renders), IRQ, MEMW, FC, SPREN, DSKLEN, BLIT, FRAMESTATE, COPPER, RR and RWATCH armed. The August divergence was the control-protocol quantum bug fixed in d70d0b16. Two real findings remained:

- **`[cpu] jit` runs drop to the precise loop when any hook is armed** (`jit_fast_path_ok`), so the debugged run is the precise-timing run and not the JIT run, and nothing said so. `M68kMachine::note_jit_debug_fallback` now logs a warning when JIT is enabled on a machine whose hooks force the fallback, at `set_jit_enabled` and at `arm_headless_debugger`.
- **Resumed AGA states differed from the uninterrupted run's by one byte.** `Bus::diag_lowmem_blit`, the `COPPERLINE_DIAG_CRASH`-only alarm latched by a blit whose D destination lands in low memory (Kickstart 3.1 AGA game loaders do this), was serialized but cleared by the loader; on an undiagnosed run it stays latched for good, so `RWATCH` (which snapshots and restores around its backward query) and `--load-state` produced state files one byte off. It is host diagnostics, so it is `#[serde(skip)]` now (state version 74). The timeline was never affected: the blob diff was that single byte.

Also: `Debugger::new(addr_mask)` and `M68kMachine::arm_headless_debugger` arm the environment-style debugger programmatically, which is what lets a test hold the guarantee without the `envcfg` snapshot.

## Verification

- New `tests/debugger_transparency.rs` (release-only, asset-free): two machines boot the bundled ROM side by side, one armed with a watch over the vector/ExecBase area, a breakpoint on the reset vector, the VERTB exception catch, Alert() catching, a memory dump on every hit and an unbounded instruction trace; fingerprints (colour clock, frame, PC, rendered frame, chip RAM) are compared after every one of 756 frames. Passes in 8.6 s.
- `tests/savestate_roundtrip.rs` now also compares the resumed run's state file at the last checkpoint byte for byte with the uninterrupted run's. Passes.
- The bundled-ROM boot does not trip the alarm, so the CLI check that found it was re-run against this build: an A1200 KS3.1 workload with `--rtc-time` pinned, `--save-state-after 15` then `--load-state` plus `--save-state-after 25`, against a plain `--save-state-after 25`. One byte apart before the change; identical after (both `d4d872c6...`). The same workload under `COPPERLINE_DBG_RWATCH=0x400` matches two baseline runs on both the state hash and the screenshot hash.
- `src/bus/tests.rs`: serializing a bus with the alarm latched and clear gives identical bytes.
- `cargo test --lib` (3149 passed), `cargo clippy --all-targets --all-features --locked -- -D warnings`, `cargo fmt --check`, `git diff --check` all clean.
- Probe recipe, for the record: `--save-state-after 25 --screenshot-after 25` under each knob with `--rtc-time` pinned, hashes compared against two baseline runs; the differing field was found by tree-diffing `serde_json::to_value` of both buses.

## Docs

`docs/debugger/headless.md` gains a "Timeline transparency" section stating the guarantee, the JIT exception and the model knobs that do move a timeline by design; `docs/internals/savestate.md` lists the alarm among the skipped host diagnostics; AGENTS.md says the knobs are safe to layer onto one run.

## Judgment calls

- The alarm is skipped rather than made to survive a load: it is consumed only under `COPPERLINE_DIAG_CRASH`, and a resumed run should not dump a crash ring for a blit that happened before the state was taken.
- State version bump: removing a field changes the layout, so this branch moves `STATE_VERSION` to 74. The HRTmon cartridge branch (`feat/hrtmon-cartridge`) also moves it to 74; whichever of the two merges second must move to 75.
