### PR TITLE
gdb: attach the stub to the interactive window with --gdb-gui

### DIFF
--- a/docs/debugger/gdb.md
+++ b/docs/debugger/gdb.md
@@ -36,11 +36,12 @@ window instead, the way `--control-gui` attaches the control server:
   windowed frame loop. Points the window's own debugger set are never
   touched, and a detach removes exactly what the client installed.
 - A stop while the client's `continue` is outstanding answers the
-  client; any other stop (a GUI breakpoint, the pause hotkey) opens the
-  local debugger window as usual.
+  client; any other debug stop (a GUI breakpoint, a watchpoint) opens
+  the local debugger window as usual, and a plain pause from the window
+  just pauses.
 - `--run` break-at-entry works exactly as with `--gdb` (below).
-- `--gdb-gui` cannot be combined with `--gdb`, `--control`, or
-  `--control-gui`.
+- `--gdb-gui` cannot be combined with `--gdb`, `--control`,
+  `--control-gui`, or `--benchmark-until`.
 
 Stock GDB frontends debug either mode: VS Code's cppdbg configuration
 (`"MIMode": "gdb"`, `"miDebuggerServerAddress": "localhost:2345"`,

--- a/docs/debugger/gdb.md
+++ b/docs/debugger/gdb.md
@@ -9,6 +9,45 @@ Copperline includes a built-in GDB remote debugging stub:
 Port-only syntax (`2345` or `:2345`) binds to `127.0.0.1`. To bind to all
 interfaces on a trusted local network, specify `0.0.0.0:2345`.
 
+## Headless and windowed modes
+
+`--gdb` runs headless: the stub owns the machine, starts it halted at
+reset, advances it unpaced, and cannot be combined with a window or the
+scheduled capture flags.
+
+`--gdb-gui ADDR` attaches the same stub to the normal interactive
+window instead, the way `--control-gui` attaches the control server:
+
+```sh
+./target/release/copperline --config copperline.example.toml --gdb-gui :2345
+```
+
+- The machine stays visible and paced to real time; `continue` runs at
+  Amiga speed unless the client turns pacing off with `monitor warp on`
+  (`monitor warp off` re-paces, and a disconnect releases the client's
+  warp hold automatically).
+- Attaching pauses the machine. Detaching (`detach`, a dropped
+  connection, or GDB's `kill`) leaves the window running and the stub
+  listening for the next client -- `kill` deliberately detaches instead
+  of ending the session, because the window belongs to the user and
+  VS Code sends `kill` on Stop Debugging.
+- Breakpoints, watchpoints, and register watches install into the same
+  machine break stores the debugger window uses, so they hit inside the
+  windowed frame loop. Points the window's own debugger set are never
+  touched, and a detach removes exactly what the client installed.
+- A stop while the client's `continue` is outstanding answers the
+  client; any other stop (a GUI breakpoint, the pause hotkey) opens the
+  local debugger window as usual.
+- `--run` break-at-entry works exactly as with `--gdb` (below).
+- `--gdb-gui` cannot be combined with `--gdb`, `--control`, or
+  `--control-gui`.
+
+Stock GDB frontends debug either mode: VS Code's cppdbg configuration
+(`"MIMode": "gdb"`, `"miDebuggerServerAddress": "localhost:2345"`,
+`"miDebuggerPath"` pointing at `m68k-amigaos-gdb`) or Native Debug's
+`target remote` setup, with `--gdb-gui` keeping the Amiga screen
+interactive beside the editor.
+
 ## Connecting from GDB
 
 Start a 68k-aware GDB (such as `m68k-amigaos-gdb` or multiarch `gdb`) and connect:
@@ -46,6 +85,11 @@ Copper disassembly, and Exec structures:
 (gdb) monitor tasks            # List Exec ready, waiting, and active tasks
 (gdb) monitor memlist          # List Exec memory allocations
 ```
+
+A windowed session (`--gdb-gui`) additionally answers
+`monitor warp on|off|status`, toggling the App's warp hold: the machine
+runs unpaced (audio muted) until the client turns it back off or
+disconnects.
 
 ## Source-level debugging and program loading
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,10 @@ pub struct CliArgs {
     /// not the `gdb` feature is compiled in; rejected at validation when
     /// it is not, like the control flags.
     pub gdb: Option<String>,
+    /// `--gdb-gui ADDR`: attach a GDB remote-protocol server to the
+    /// normal windowed session instead of owning the machine, the way
+    /// `--control-gui` attaches the control server.
+    pub gdb_gui: Option<String>,
     /// `--control ADDR`: run the headless Copperline Control Protocol
     /// server (JSON-RPC over loopback TCP), pausing at reset until a
     /// client resumes. `--control-token`/`--control-info` refine it.
@@ -340,6 +344,7 @@ where
     let mut load_state: Option<PathBuf> = None;
     let mut benchmark_until: Option<f32> = None;
     let mut gdb: Option<String> = None;
+    let mut gdb_gui: Option<String> = None;
     let mut control_listen: Option<String> = None;
     let mut control_gui_listen: Option<String> = None;
     let mut control_token: Option<String> = None;
@@ -997,6 +1002,12 @@ where
                     .ok_or_else(|| anyhow!("--gdb requires ADDR, :PORT, or PORT"))?;
                 gdb = Some(listen);
             }
+            "--gdb-gui" => {
+                let listen = args
+                    .next()
+                    .ok_or_else(|| anyhow!("--gdb-gui requires ADDR, :PORT, or PORT"))?;
+                gdb_gui = Some(listen);
+            }
             "--control" => {
                 let listen = args
                     .next()
@@ -1248,6 +1259,7 @@ where
         load_state,
         benchmark_until,
         gdb,
+        gdb_gui,
         control: control_listen,
         control_gui: control_gui_listen,
         control_token,
@@ -1401,6 +1413,7 @@ fn print_help() {
          \x20                            time SECS, report counters, then exit\n  \
          --gdb ADDR                     run a headless GDB remote server on ADDR,\n  \
          \x20                            :PORT, or PORT; port-only forms bind 127.0.0.1\n  \
+         --gdb-gui ADDR                 attach the GDB remote server to the normal window\n  \
          --control ADDR                 run the headless JSON-RPC control server on ADDR\n  \
          \x20                            (port 0 picks a free port; see docs/debugger/control.md)\n  \
          --control-gui ADDR             attach the control server to the normal window\n  \

--- a/src/gdbstub/core.rs
+++ b/src/gdbstub/core.rs
@@ -42,8 +42,8 @@ pub(crate) const TARGET_XML: &str = r#"<?xml version="1.0"?>
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Watchpoint {
-    addr: u32,
-    len: usize,
+    pub(crate) addr: u32,
+    pub(crate) len: usize,
     last: Vec<u8>,
 }
 

--- a/src/gdbstub/mod.rs
+++ b/src/gdbstub/mod.rs
@@ -5,6 +5,9 @@
 //! - [`headless`] owns the Emulator and drives it directly from the
 //!   connection (`--gdb`), one blocking session at a time -- the shape
 //!   the headless control server copies.
+//! - [`windowed`] is the socket plumbing for `--gdb-gui`: packets cross
+//!   to the winit frame loop, which owns the machine and drives the same
+//!   core from its frame-boundary drain (`src/video/window/gdb.rs`).
 //!
 //! The packet semantics shared by any driver live in [`core`]: a
 //! transport-free [`core::GdbCore`] each driver runs against the machine
@@ -14,5 +17,7 @@ pub(crate) mod core;
 mod headless;
 #[cfg(test)]
 pub(crate) mod testkit;
+#[cfg(feature = "frontend")]
+pub mod windowed;
 
 pub use headless::{run, Config};

--- a/src/gdbstub/testkit.rs
+++ b/src/gdbstub/testkit.rs
@@ -153,4 +153,19 @@ impl GdbClient {
     pub(crate) fn request(&mut self, payload: &str) -> String {
         self.request_collect(payload).1
     }
+
+    /// Write raw bytes to the stream (interrupts, deliberately bad
+    /// frames).
+    pub(crate) fn raw(&mut self, bytes: &[u8]) {
+        self.stream.write_all(bytes).unwrap();
+        self.stream.flush().unwrap();
+    }
+
+    /// Read exactly `n` bytes, for asserting the precise wire encoding
+    /// (framing, ack bytes) rather than just the payload.
+    pub(crate) fn read_bytes(&mut self, n: usize) -> Vec<u8> {
+        let mut buf = vec![0u8; n];
+        self.stream.read_exact(&mut buf).unwrap();
+        buf
+    }
 }

--- a/src/gdbstub/windowed.rs
+++ b/src/gdbstub/windowed.rs
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Socket plumbing for the windowed GDB stub (`--gdb-gui`): an accept
+//! thread plus, per connection, a reader thread (RSP framing, checksum
+//! verification, ack handling) and a writer thread. Framed packets cross
+//! to the winit frame loop over an mpsc channel and are drained at the
+//! top of `about_to_wait`, the same deterministic boundary the windowed
+//! control server uses; replies travel back over a per-connection
+//! channel of pre-framed strings, so the two socket threads never
+//! interleave on the stream. This module holds no winit types -- the
+//! frame loop passes a wake callback so a packet arriving while the
+//! machine is paused (`ControlFlow::Wait`) still gets serviced promptly.
+//!
+//! One client at a time, like the headless stub: the accept thread
+//! reads each connection to completion before accepting the next, so an
+//! extra client waits in the listener backlog until the current one
+//! detaches.
+
+use super::core::{checksum, hex_encode, parse_hex_byte, MAX_PACKET_PAYLOAD_BYTES};
+use anyhow::{Context, Result};
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, Sender, SyncSender, TrySendError};
+use std::sync::{Arc, Mutex};
+
+/// A message from the socket threads to the frame loop.
+pub enum GdbMsg {
+    /// A client connected; the frame loop pauses the machine and builds
+    /// a fresh [`super::core::GdbCore`].
+    Connected,
+    /// The client went away (EOF or error); the frame loop removes the
+    /// session's machine-installed debug state and keeps serving.
+    Disconnected,
+    /// A framed, checksum-verified packet payload.
+    Packet(String),
+    /// The RSP interrupt byte (0x03) arrived between packets.
+    Interrupt,
+}
+
+/// Outbound queue depth (pre-framed packets). Far more than a stopped
+/// protocol exchange ever queues; a client this far behind is gone.
+const OUTBOUND_PACKET_CAPACITY: usize = 256;
+
+/// The frame loop's handle on the windowed GDB server.
+pub struct GdbHandle {
+    listener: Option<TcpListener>,
+    cmd_tx: Sender<GdbMsg>,
+    cmd_rx: Receiver<GdbMsg>,
+    connection: Arc<Mutex<Option<Arc<OutboundConnection>>>>,
+    connected: Arc<AtomicBool>,
+}
+
+struct OutboundConnection {
+    frame_tx: SyncSender<String>,
+    disconnect_stream: Option<TcpStream>,
+}
+
+impl GdbHandle {
+    /// Bind the listener and announce the endpoint. Called from `main`
+    /// before the window exists so a debugger can attach as soon as it
+    /// opens; threads are spawned later by [`GdbHandle::start`].
+    pub fn bind(config: &super::Config) -> Result<Self> {
+        let bind = crate::debugger::normalize_listen_addr(&config.listen)?;
+        let listener =
+            TcpListener::bind(&bind).with_context(|| format!("binding GDB stub {bind}"))?;
+        let local = listener
+            .local_addr()
+            .context("resolving GDB stub address")?;
+        eprintln!("gdb: listening on {local}");
+        log::info!("gdb: listening on {local}");
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
+        Ok(Self {
+            listener: Some(listener),
+            cmd_tx,
+            cmd_rx,
+            connection: Arc::new(Mutex::new(None)),
+            connected: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    /// A loopback handle with no sockets, for driving the frame-loop
+    /// drain directly in tests: messages are pushed through the returned
+    /// sender, framed replies arrive on the returned receiver.
+    pub fn test_pair() -> (Self, Sender<GdbMsg>, Receiver<String>) {
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
+        let (frame_tx, frame_rx) = std::sync::mpsc::sync_channel(OUTBOUND_PACKET_CAPACITY);
+        let connection = OutboundConnection {
+            frame_tx,
+            disconnect_stream: None,
+        };
+        let handle = Self {
+            listener: None,
+            cmd_tx: cmd_tx.clone(),
+            cmd_rx,
+            connection: Arc::new(Mutex::new(Some(Arc::new(connection)))),
+            connected: Arc::new(AtomicBool::new(true)),
+        };
+        (handle, cmd_tx, frame_rx)
+    }
+
+    /// Spawn the accept thread. `wake` is invoked after every enqueued
+    /// message so the event loop leaves `ControlFlow::Wait`.
+    pub fn start(&mut self, wake: Box<dyn Fn() + Send + Sync>) {
+        let Some(listener) = self.listener.take() else {
+            return; // test handle, or started twice
+        };
+        let cmd_tx = self.cmd_tx.clone();
+        let connection_slot = Arc::clone(&self.connection);
+        let connected = Arc::clone(&self.connected);
+        let wake: Arc<dyn Fn() + Send + Sync> = Arc::from(wake);
+        std::thread::Builder::new()
+            .name("gdb-accept".into())
+            .spawn(move || {
+                accept_loop(listener, cmd_tx, connection_slot, connected, wake);
+            })
+            .expect("spawning gdb accept thread");
+    }
+
+    /// Whether a client is currently attached (status-bar indicator).
+    pub fn connected(&self) -> bool {
+        self.connected.load(Ordering::Relaxed)
+    }
+
+    /// Drain one queued message, non-blocking.
+    pub(crate) fn try_recv(&self) -> Option<GdbMsg> {
+        self.cmd_rx.try_recv().ok()
+    }
+
+    /// Frame `payload` as an RSP packet and enqueue it without blocking
+    /// the emulator frame loop. A full queue disconnects the client:
+    /// silently dropping a reply would leave the debugger hung.
+    pub(crate) fn send_packet(&self, payload: &str) {
+        let sum = checksum(payload.as_bytes());
+        self.send_frame(format!("${payload}#{sum:02x}"));
+    }
+
+    /// Deliver console text as `O` packets (200-byte chunks), the RSP
+    /// side channel gdb prints verbatim.
+    pub(crate) fn send_console(&self, output: &str) {
+        for chunk in output.as_bytes().chunks(200) {
+            self.send_packet(&format!("O{}", hex_encode(chunk)));
+        }
+    }
+
+    fn send_frame(&self, frame: String) {
+        let Some(connection) = self.connection.lock().expect("connection lock").clone() else {
+            return;
+        };
+        match connection.frame_tx.try_send(frame) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                self.disconnect_current(&connection, "outbound packet queue is full");
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                self.disconnect_current(&connection, "gdb writer stopped");
+            }
+        }
+    }
+
+    /// Tear down the socket side of the current connection (the `k`
+    /// packet's detach). The reader sees EOF and the accept thread emits
+    /// the normal [`GdbMsg::Disconnected`] cleanup.
+    pub(crate) fn disconnect(&self, reason: &str) {
+        let connection = self.connection.lock().expect("connection lock").clone();
+        if let Some(connection) = connection {
+            self.disconnect_current(&connection, reason);
+        }
+    }
+
+    fn disconnect_current(&self, connection: &Arc<OutboundConnection>, reason: &str) {
+        let removed = {
+            let mut active = self.connection.lock().expect("connection lock");
+            if active
+                .as_ref()
+                .is_some_and(|current| Arc::ptr_eq(current, connection))
+            {
+                active.take();
+                true
+            } else {
+                false
+            }
+        };
+        if !removed {
+            return;
+        }
+        log::warn!("gdb: {reason}; detaching client");
+        self.connected.store(false, Ordering::Relaxed);
+        if let Some(stream) = &connection.disconnect_stream {
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+    }
+}
+
+fn accept_loop(
+    listener: TcpListener,
+    cmd_tx: Sender<GdbMsg>,
+    connection_slot: Arc<Mutex<Option<Arc<OutboundConnection>>>>,
+    connected: Arc<AtomicBool>,
+    wake: Arc<dyn Fn() + Send + Sync>,
+) {
+    loop {
+        let (stream, peer) = match listener.accept() {
+            Ok(conn) => conn,
+            Err(e) => {
+                log::warn!("gdb: accept failed: {e}");
+                return;
+            }
+        };
+        log::info!("gdb: connection from {peer}");
+        stream.set_nodelay(true).ok();
+
+        // Writer thread: owns the write half, drains the frame channel.
+        let (frame_tx, frame_rx) =
+            std::sync::mpsc::sync_channel::<String>(OUTBOUND_PACKET_CAPACITY);
+        let disconnect_stream = match stream.try_clone() {
+            Ok(clone) => clone,
+            Err(e) => {
+                log::warn!("gdb: cloning disconnect stream failed: {e}");
+                continue;
+            }
+        };
+        let write_stream = match stream.try_clone() {
+            Ok(clone) => clone,
+            Err(e) => {
+                log::warn!("gdb: cloning stream failed: {e}");
+                continue;
+            }
+        };
+        write_stream
+            .set_write_timeout(Some(std::time::Duration::from_millis(250)))
+            .ok();
+        let writer = std::thread::Builder::new()
+            .name("gdb-write".into())
+            .spawn(move || {
+                let mut stream = write_stream;
+                for frame in frame_rx {
+                    if stream.write_all(frame.as_bytes()).is_err() {
+                        break;
+                    }
+                    stream.flush().ok();
+                }
+            })
+            .expect("spawning gdb writer thread");
+
+        let connection = Arc::new(OutboundConnection {
+            frame_tx,
+            disconnect_stream: Some(disconnect_stream),
+        });
+        *connection_slot.lock().expect("connection lock") = Some(Arc::clone(&connection));
+        connected.store(true, Ordering::Relaxed);
+        let _ = cmd_tx.send(GdbMsg::Connected);
+        wake();
+
+        // Read this connection to completion on the accept thread; the
+        // next client is only accepted afterwards (one at a time).
+        read_connection(stream, &cmd_tx, &connection.frame_tx, &wake);
+
+        let mut active = connection_slot.lock().expect("connection lock");
+        if active
+            .as_ref()
+            .is_some_and(|current| Arc::ptr_eq(current, &connection))
+        {
+            active.take();
+        }
+        drop(active);
+        connected.store(false, Ordering::Relaxed);
+        let _ = cmd_tx.send(GdbMsg::Disconnected);
+        wake();
+        drop(connection); // writer thread drains and exits
+        let _ = writer.join();
+        log::info!("gdb: client detached; listening again");
+    }
+}
+
+/// Read one connection until EOF: RSP framing, checksum verification,
+/// and acks happen here, so the frame loop only ever sees whole valid
+/// packets. Acks go through the writer channel (never written directly)
+/// so the two threads cannot interleave bytes on the stream.
+fn read_connection(
+    mut stream: TcpStream,
+    cmd_tx: &Sender<GdbMsg>,
+    frame_tx: &SyncSender<String>,
+    wake: &Arc<dyn Fn() + Send + Sync>,
+) {
+    // The client's own NoAckMode view: flipped as soon as the request is
+    // read, since the drain always answers it with OK.
+    let mut no_ack = false;
+    let mut byte = [0u8; 1];
+    'connection: loop {
+        // Hunt for a packet start, surfacing interrupts along the way.
+        loop {
+            match stream.read(&mut byte) {
+                Ok(0) => return,
+                Ok(_) => {}
+                Err(_) => return,
+            }
+            match byte[0] {
+                b'$' => break,
+                0x03 => {
+                    let _ = cmd_tx.send(GdbMsg::Interrupt);
+                    wake();
+                }
+                _ => {} // '+', '-', line noise
+            }
+        }
+        let mut payload = Vec::new();
+        loop {
+            match stream.read(&mut byte) {
+                Ok(0) => return,
+                Ok(_) => {}
+                Err(_) => return,
+            }
+            if byte[0] == b'#' {
+                break;
+            }
+            payload.push(byte[0]);
+            if payload.len() > MAX_PACKET_PAYLOAD_BYTES {
+                log::warn!("gdb: packet exceeds payload limit; disconnecting");
+                let _ = stream.shutdown(Shutdown::Both);
+                return;
+            }
+        }
+        let mut sum_bytes = [0u8; 2];
+        if stream.read_exact(&mut sum_bytes).is_err() {
+            return;
+        }
+        let Ok(expected) = parse_hex_byte(sum_bytes[0], sum_bytes[1]) else {
+            continue 'connection;
+        };
+        if expected != checksum(&payload) {
+            if !no_ack {
+                let _ = frame_tx.try_send("-".to_string());
+            }
+            continue;
+        }
+        if !no_ack {
+            let _ = frame_tx.try_send("+".to_string());
+        }
+        let Ok(text) = String::from_utf8(payload) else {
+            continue;
+        };
+        if text == "QStartNoAckMode" {
+            no_ack = true;
+        }
+        let _ = cmd_tx.send(GdbMsg::Packet(text));
+        wake();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gdbstub::testkit::GdbClient;
+
+    fn started_handle() -> (GdbHandle, std::net::SocketAddr) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
+        let mut handle = GdbHandle {
+            listener: Some(listener),
+            cmd_tx,
+            cmd_rx,
+            connection: Arc::new(Mutex::new(None)),
+            connected: Arc::new(AtomicBool::new(false)),
+        };
+        handle.start(Box::new(|| {}));
+        (handle, addr)
+    }
+
+    fn recv(handle: &GdbHandle) -> GdbMsg {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if let Some(msg) = handle.try_recv() {
+                return msg;
+            }
+            assert!(std::time::Instant::now() < deadline, "no gdb message");
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    fn reader_frames_packets_acks_and_surfaces_interrupts() {
+        let (handle, addr) = started_handle();
+        let mut client = GdbClient::connect(addr);
+        assert!(matches!(recv(&handle), GdbMsg::Connected));
+        assert!(handle.connected());
+
+        // A framed packet arrives whole, and the reader acks it.
+        client.send("qC");
+        assert!(matches!(recv(&handle), GdbMsg::Packet(p) if p == "qC"));
+        // Answer through the handle; the client reads the framed reply
+        // (read_reply also consumes the "+" ack transparently).
+        handle.send_packet("QC1");
+        // An interrupt byte between packets surfaces as its own message.
+        client.raw(&[0x03]);
+        assert!(matches!(recv(&handle), GdbMsg::Interrupt));
+        // A bad checksum is dropped (nacked), not forwarded.
+        client.raw(b"$qC#00");
+        client.send("qAttached");
+        assert!(matches!(recv(&handle), GdbMsg::Packet(p) if p == "qAttached"));
+        assert_eq!(client.read_reply(), "QC1");
+        drop(client);
+        assert!(matches!(recv(&handle), GdbMsg::Disconnected));
+        assert!(!handle.connected());
+    }
+
+    #[test]
+    fn no_ack_mode_stops_acks_and_the_packet_still_reaches_the_drain() {
+        let (handle, addr) = started_handle();
+        let mut client = GdbClient::connect(addr);
+        assert!(matches!(recv(&handle), GdbMsg::Connected));
+        client.send("QStartNoAckMode");
+        assert!(matches!(recv(&handle), GdbMsg::Packet(p) if p == "QStartNoAckMode"));
+        handle.send_packet("OK");
+        // From here the reader must not ack; the next reply the client
+        // sees is the framed OK followed directly by the next packet's
+        // reply, with no '+' in between.
+        client.send("qC");
+        assert!(matches!(recv(&handle), GdbMsg::Packet(p) if p == "qC"));
+        handle.send_packet("QC1");
+        // Exact wire bytes: the ack for QStartNoAckMode itself (sent in
+        // the old mode), then the two framed replies with no ack bytes
+        // in between.
+        let expected = b"+$OK#9a$QC1#c5";
+        assert_eq!(client.read_bytes(expected.len()), expected);
+        drop(client);
+        assert!(matches!(recv(&handle), GdbMsg::Disconnected));
+    }
+
+    #[test]
+    fn a_dropped_client_frees_the_listener_for_the_next() {
+        let (handle, addr) = started_handle();
+        let first = GdbClient::connect(addr);
+        assert!(matches!(recv(&handle), GdbMsg::Connected));
+        drop(first);
+        assert!(matches!(recv(&handle), GdbMsg::Disconnected));
+        assert!(!handle.connected());
+        // Reconnecting gets a fresh session on the same endpoint.
+        let _second = GdbClient::connect(addr);
+        assert!(matches!(recv(&handle), GdbMsg::Connected));
+        assert!(handle.connected());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,10 +139,18 @@ fn validate_run_args(cli: &CliArgs) -> Result<()> {
 
 fn validate_gdb_args(cli: &CliArgs) -> Result<()> {
     #[cfg(not(feature = "gdb"))]
-    if cli.gdb.is_some() {
+    if cli.gdb.is_some() || cli.gdb_gui.is_some() {
         return Err(anyhow!(
             "this build was compiled without the gdb feature; \
-             rebuild with --features gdb for --gdb"
+             rebuild with --features gdb for --gdb/--gdb-gui"
+        ));
+    }
+    if cli.gdb.is_some() && cli.gdb_gui.is_some() {
+        return Err(anyhow!("--gdb and --gdb-gui cannot be combined"));
+    }
+    if cli.gdb_gui.is_some() && cli.benchmark_until.is_some() {
+        return Err(anyhow!(
+            "--gdb-gui cannot be combined with --benchmark-until"
         ));
     }
     if cli.gdb.is_none() {
@@ -197,9 +205,9 @@ fn validate_control_args(cli: &CliArgs) -> Result<()> {
         ));
     }
     if cli.control.is_some() || cli.control_gui.is_some() {
-        if cli.gdb.is_some() {
+        if cli.gdb.is_some() || cli.gdb_gui.is_some() {
             return Err(anyhow!(
-                "--control/--control-gui cannot be combined with --gdb"
+                "--control/--control-gui cannot be combined with --gdb/--gdb-gui"
             ));
         }
         if cli.benchmark_until.is_some() {
@@ -1040,8 +1048,9 @@ fn main() -> Result<()> {
     // window-server access), and a capture run must work anywhere.
     // --control-gui keeps the windowed path: it explicitly asks for an
     // interactive session.
-    let windowless_capture =
-        (!cli.screenshot_after.is_empty() || cli.frame_dump.is_some()) && cli.control_gui.is_none();
+    let windowless_capture = (!cli.screenshot_after.is_empty() || cli.frame_dump.is_some())
+        && cli.control_gui.is_none()
+        && cli.gdb_gui.is_none();
     // The warp-launch gate belongs to interactive sessions only: a capture
     // run is already unpaced end to end and must never be re-paced when the
     // program loads.
@@ -1113,6 +1122,17 @@ fn main() -> Result<()> {
         config.info_file = cli.control_info;
         let handle = copperline::control::windowed::ControlHandle::bind(&config)?;
         app.attach_control(handle, &config);
+    }
+    #[cfg(feature = "gdb")]
+    if let Some(listen) = cli.gdb_gui {
+        // Same shape for the windowed GDB stub: bind before the window
+        // opens, socket threads start inside App::run.
+        let mut config = gdbstub::Config::new(listen);
+        // --run + --gdb-gui: stop at the program's first instruction,
+        // the moment the guest OS loads it.
+        config.stop_on_load = run_prog_name.clone();
+        let handle = copperline::gdbstub::windowed::GdbHandle::bind(&config)?;
+        app.attach_gdb(handle, &config);
     }
 
     // Elevate the thread that is about to run the event loop and the pacer.
@@ -1269,6 +1289,7 @@ fn launcher_requested(cli: &CliArgs) -> bool {
         && cli.frame_dump.is_none()
         && cli.benchmark_until.is_none()
         && cli.gdb.is_none()
+        && cli.gdb_gui.is_none()
         && cli.control.is_none()
         && cli.control_gui.is_none()
         && cli.load_state.is_none()
@@ -1939,6 +1960,30 @@ mod tests {
         assert_eq!(args.gdb.as_deref(), Some(":2345"));
         assert!(!args.audio_live);
         validate_gdb_args(&args)?;
+        Ok(())
+    }
+
+    #[test]
+    fn gdb_gui_parses_and_excludes_the_contending_modes() -> Result<()> {
+        // The windowed stub keeps live audio: the machine stays paced
+        // and audible like any interactive session.
+        let args = parse(&["--gdb-gui", ":2345"])?;
+        assert_eq!(args.gdb_gui.as_deref(), Some(":2345"));
+        assert!(args.audio_live);
+        validate_gdb_args(&args)?;
+        validate_control_args(&args)?;
+
+        let args = parse(&["--gdb-gui", ":2345", "--gdb", ":2346"])?;
+        let err = validate_gdb_args(&args).unwrap_err();
+        assert!(err.to_string().contains("cannot be combined"), "{err:#}");
+
+        let args = parse(&["--gdb-gui", ":2345", "--benchmark-until", "5"])?;
+        let err = validate_gdb_args(&args).unwrap_err();
+        assert!(err.to_string().contains("--benchmark-until"), "{err:#}");
+
+        let args = parse(&["--gdb-gui", ":2345", "--control-gui", ":7710"])?;
+        let err = validate_control_args(&args).unwrap_err();
+        assert!(err.to_string().contains("--gdb-gui"), "{err:#}");
         Ok(())
     }
 

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1045,6 +1045,9 @@ pub struct App {
     /// drained at the top of `about_to_wait` (see window/control.rs).
     #[cfg(feature = "control")]
     control: Option<control::ControlState>,
+    /// The windowed GDB stub (`--gdb-gui`), when attached.
+    #[cfg(feature = "gdb")]
+    gdb: Option<gdb::GdbGuiState>,
     /// Scheduled relative port-1 mouse motions from --mouse-after,
     /// one-shot per entry; (at_emulated_secs, dx, dy).
     auto_mouse: Vec<(f64, i32, i32, u8)>,
@@ -2060,6 +2063,8 @@ impl App {
             auto_joy_engaged: [false; 2],
             #[cfg(feature = "control")]
             control: None,
+            #[cfg(feature = "gdb")]
+            gdb: None,
             auto_mouse: Vec::new(),
             pending_auto_mouse: mouse_after,
             auto_mouse_to: Vec::new(),
@@ -2899,6 +2904,14 @@ impl App {
         if let Some(ctl) = app.control.as_mut() {
             let proxy = event_loop.create_proxy();
             ctl.handle.start(Box::new(move || {
+                let _ = proxy.send_event(());
+            }));
+        }
+        // Same for the windowed GDB stub's socket threads.
+        #[cfg(feature = "gdb")]
+        if let Some(gdb) = app.gdb.as_mut() {
+            let proxy = event_loop.create_proxy();
+            gdb.handle.start(Box::new(move || {
                 let _ = proxy.send_event(());
             }));
         }
@@ -4197,14 +4210,17 @@ impl ApplicationHandler for App {
                     .cursor_pos
                     .and_then(|pos| control_at(pos, &bar_layout(&media)));
                 let control_connected = {
+                    #[allow(unused_mut)]
+                    let mut connected = false;
                     #[cfg(feature = "control")]
                     {
-                        self.control.as_ref().is_some_and(|c| c.handle.connected())
+                        connected |= self.control.as_ref().is_some_and(|c| c.handle.connected());
                     }
-                    #[cfg(not(feature = "control"))]
+                    #[cfg(feature = "gdb")]
                     {
-                        false
+                        connected |= self.gdb.as_ref().is_some_and(|g| g.handle.connected());
                     }
+                    connected
                 };
                 let view = StatusBarView {
                     status,
@@ -4692,6 +4708,8 @@ impl ApplicationHandler for App {
                 return;
             }
         }
+        #[cfg(feature = "gdb")]
+        self.drain_gdb();
         // Frames retired outside the burst (a control step, a debugger
         // step) may have carried a guest warp request.
         self.service_uaelib();
@@ -5403,14 +5421,17 @@ impl App {
             status.fdd_track = self.last_fdd_track;
         }
         let control_connected = {
+            #[allow(unused_mut)]
+            let mut connected = false;
             #[cfg(feature = "control")]
             {
-                self.control.as_ref().is_some_and(|c| c.handle.connected())
+                connected |= self.control.as_ref().is_some_and(|c| c.handle.connected());
             }
-            #[cfg(not(feature = "control"))]
+            #[cfg(feature = "gdb")]
             {
-                false
+                connected |= self.gdb.as_ref().is_some_and(|g| g.handle.connected());
             }
+            connected
         };
         #[cfg(feature = "mt32")]
         let mt32_face = if crate::video::mt32_panel_shown() {
@@ -6413,6 +6434,8 @@ mod control;
 mod crt_shader;
 #[cfg(feature = "coppersynth")]
 mod csynthpanel;
+#[cfg(feature = "gdb")]
+mod gdb;
 mod host_input;
 mod kbdpanel;
 #[cfg(feature = "mt32")]

--- a/src/video/window/app_debugger.rs
+++ b/src/video/window/app_debugger.rs
@@ -907,6 +907,8 @@ impl App {
                 if !self.control_complete_pending("double_fault", &message) {
                     self.control_notify_stopped("double_fault", &message);
                 }
+                #[cfg(feature = "gdb")]
+                self.gdb_complete_pending_stop(&message);
                 self.show_osd(message);
                 self.request_redraw();
                 return true;
@@ -923,6 +925,17 @@ impl App {
         // pauses without commandeering the local debugger window.
         #[cfg(feature = "control")]
         if self.control_completes_stop(&stop) {
+            self.paused = true;
+            self.sync_live_audio_suspension();
+            self.last_debug_stop = Some(message.clone());
+            self.show_osd(message);
+            self.request_redraw();
+            return true;
+        }
+        // Same rule for a pending GDB continue: the stop answers the
+        // client and pauses without opening the local debugger window.
+        #[cfg(feature = "gdb")]
+        if self.gdb_completes_stop(&stop) {
             self.paused = true;
             self.sync_live_audio_suspension();
             self.last_debug_stop = Some(message.clone());

--- a/src/video/window/app_session.rs
+++ b/src/video/window/app_session.rs
@@ -10,6 +10,7 @@ use super::*;
 pub(super) enum WarpSource {
     Manual,
     Control,
+    Gdb,
     Guest,
 }
 
@@ -19,6 +20,7 @@ impl WarpSource {
         match self {
             Self::Manual => "manual",
             Self::Control => "control",
+            Self::Gdb => "gdb",
             Self::Guest => "guest",
         }
     }
@@ -27,6 +29,7 @@ impl WarpSource {
         match self {
             Self::Manual => "manual",
             Self::Control => "control client",
+            Self::Gdb => "gdb client",
             Self::Guest => "guest request",
         }
     }
@@ -1245,6 +1248,8 @@ impl App {
             // the client learns where the machine stopped.
             #[cfg(feature = "control")]
             self.control_complete_pending("user_pause", "paused from the window");
+            #[cfg(feature = "gdb")]
+            self.gdb_complete_pending_stop("paused from the window");
         } else {
             info!("pause button: emulation resumed");
         }
@@ -1303,6 +1308,8 @@ impl App {
         info!("power button: machine powered off (cold boot state)");
         #[cfg(feature = "control")]
         self.control_complete_pending("pause", "power state changed");
+        #[cfg(feature = "gdb")]
+        self.gdb_complete_pending_stop("power state changed");
         if let Err(e) = self.emu.power_on_reset() {
             error!("cold power-on reset failed: {e:#}");
             self.cpu_halted = true;

--- a/src/video/window/gdb.rs
+++ b/src/video/window/gdb.rs
@@ -74,7 +74,11 @@ impl GdbBreaks {
         let desired: Vec<u32> = core.breakpoints.iter().map(|&a| a & mask).collect();
         self.pc.retain(|&addr| {
             if desired.contains(&addr) {
-                return true;
+                // The GUI may have toggled our point off meanwhile;
+                // dropping the stale ownership entry lets the insertion
+                // pass restore it. The client's acknowledged break state
+                // is authoritative for its own points.
+                return emu.machine.ui_breaks().is_breakpoint(addr);
             }
             if emu.machine.ui_breaks().is_breakpoint(addr) {
                 emu.machine.ui_set_breakpoint(addr, None, 0);
@@ -127,7 +131,9 @@ impl GdbBreaks {
         };
         self.watch_words.retain(|&addr| {
             if desired_words.contains(&addr) {
-                return true;
+                // Same rule as PC breakpoints: a GUI-removed word comes
+                // back through the insertion pass.
+                return word_watched(emu, addr);
             }
             if word_watched(emu, addr) {
                 emu.machine.ui_toggle_watch(addr);
@@ -149,7 +155,8 @@ impl GdbBreaks {
             |emu: &Emulator, off: u16| emu.machine.ui_breaks().reg_watches.contains(&off);
         self.reg_watches.retain(|&off| {
             if core.reg_watches.contains(&off) {
-                return true;
+                // Same rule: a GUI-removed watch comes back below.
+                return reg_watched(emu, off);
             }
             if reg_watched(emu, off) {
                 emu.machine.ui_toggle_reg_watch(off);
@@ -187,6 +194,12 @@ impl GdbBreaks {
                 self.loadseg = None;
             }
             (Some(_), false, false) => self.loadseg = None, // GUI beat us to it
+            (Some(_), true, false) => {
+                // The GUI removed our catch while the client still wants
+                // it; restore it, like the other break kinds.
+                emu.machine.ui_toggle_loadseg_catch(filter.clone());
+                self.loadseg = Some(filter);
+            }
             (None, true, false) => {
                 emu.machine.ui_toggle_loadseg_catch(filter.clone());
                 self.loadseg = Some(filter);
@@ -365,6 +378,13 @@ impl App {
                 self.gdb_send_packet("E01");
             }
             Ok(CoreReply::Packet(reply)) => {
+                if packet.starts_with('M') {
+                    // The core refreshed its own watch snapshots; the
+                    // machine-installed word watches need the same, or
+                    // the write itself fires them on the next step
+                    // (CCP's memory.write does likewise).
+                    self.emu.machine.ui_rebaseline_watches();
+                }
                 self.gdb_sync_machine_debug_state();
                 self.gdb_flush_console();
                 self.gdb_send_packet(&reply);

--- a/src/video/window/gdb.rs
+++ b/src/video/window/gdb.rs
@@ -1,0 +1,624 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The windowed GDB drain (`--gdb-gui`): packets enqueued by the socket
+//! threads (`gdbstub::windowed`) are executed here, on the winit thread,
+//! at the top of `about_to_wait` -- the same frame boundary the windowed
+//! control server drains at. The packet semantics are the shared
+//! transport-free [`GdbCore`]; this module owns what differs in a
+//! windowed session:
+//!
+//! - The machine runs paced and visible, so an open-ended continue
+//!   cannot spin a per-instruction socket-polling loop the way the
+//!   headless driver does. Instead, `c`/`vCont;c` defers the stop reply
+//!   (`pending`) and lets the ordinary frame loop run; stops surface
+//!   through `surface_debug_stop` and answer the client via
+//!   [`App::gdb_completes_stop`].
+//! - The core's session breakpoint list is polled per instruction by the
+//!   headless continue loop and never seen by the CPU hot loop, so here
+//!   every core-held break translates into machine-installed debug state
+//!   ([`GdbBreaks`]), with the control session's ownership rule: never
+//!   touch a point the local GUI owns, remove only our own on detach.
+//! - `monitor warp` engages the App's warp hold (`WarpSource::Gdb`), and
+//!   the register-watch monitors go through the machine's toggle API so
+//!   they compose with GUI-set watches instead of clobbering them.
+//! - `k` detaches instead of killing the session: the window is the
+//!   user's, and VS Code sends `k` on Stop Debugging.
+
+use super::app_session::WarpSource;
+use super::*;
+use crate::debugger::DebugStop;
+use crate::gdbstub::core::{hex_decode, CoreReply, GdbCore, ResumeRequest};
+use crate::gdbstub::windowed::{GdbHandle, GdbMsg};
+
+/// Machine word watches installed per GDB watchpoint request. Every
+/// covered word is a per-instruction comparison on the stop path, so a
+/// huge Z2 range must not turn into thousands of them.
+const GDB_WATCH_WORD_CAP: usize = 8;
+
+/// Per-connection GDB state owned by the `App`.
+pub(super) struct GdbGuiState {
+    pub(super) handle: GdbHandle,
+    core: GdbCore,
+    breaks: GdbBreaks,
+    /// A continue whose stop reply is deferred until the machine stops.
+    pending: bool,
+    /// `--run` + `--gdb-gui`: re-armed per connection, so a reconnecting
+    /// client gets the same break-at-entry.
+    stop_on_load: Option<String>,
+    reverse_budget_mb: usize,
+    reverse_interval_frames: u64,
+}
+
+/// The machine-installed debug state this GDB session owns. Everything
+/// here went in through the same toggle APIs the GUI debugger uses, so
+/// the rule from the control session applies: a point that already
+/// existed is never touched (or removed), and detach removes exactly
+/// what this session installed and no more.
+#[derive(Default)]
+struct GdbBreaks {
+    pc: Vec<u32>,
+    watch_words: Vec<u32>,
+    reg_watches: Vec<u16>,
+    /// `Some(filter)` when this session armed the machine loadseg catch.
+    loadseg: Option<Option<String>>,
+}
+
+impl GdbBreaks {
+    /// Reconcile the machine's debug stores with what the core now
+    /// holds, returning console notes (a truncated watchpoint, say).
+    fn sync(&mut self, emu: &mut Emulator, core: &GdbCore) -> Vec<String> {
+        let mut notes = Vec::new();
+        let mask = emu.machine.ui_addr_mask();
+
+        // PC breakpoints: the core list is the desired set.
+        let desired: Vec<u32> = core.breakpoints.iter().map(|&a| a & mask).collect();
+        self.pc.retain(|&addr| {
+            if desired.contains(&addr) {
+                return true;
+            }
+            if emu.machine.ui_breaks().is_breakpoint(addr) {
+                emu.machine.ui_set_breakpoint(addr, None, 0);
+            }
+            false
+        });
+        for &addr in &desired {
+            if self.pc.contains(&addr) || emu.machine.ui_breaks().is_breakpoint(addr) {
+                continue; // ours already, or the GUI owns it
+            }
+            emu.machine.ui_set_breakpoint(addr, None, 0);
+            self.pc.push(addr);
+        }
+
+        // Watchpoints: every covered word becomes a machine word watch,
+        // bounded by the cap.
+        let mut desired_words: Vec<u32> = Vec::new();
+        let mut truncated = false;
+        'expand: for watch in &core.watchpoints {
+            let len = watch.len.max(1) as u32;
+            let start = watch.addr & mask & !1;
+            let last = watch.addr.wrapping_add(len - 1) & mask & !1;
+            let mut addr = start;
+            loop {
+                if !desired_words.contains(&addr) {
+                    if desired_words.len() == GDB_WATCH_WORD_CAP {
+                        truncated = true;
+                        break 'expand;
+                    }
+                    desired_words.push(addr);
+                }
+                if addr == last {
+                    break;
+                }
+                addr = addr.wrapping_add(2) & mask;
+            }
+        }
+        if truncated {
+            notes.push(format!(
+                "watchpoints cover more than {GDB_WATCH_WORD_CAP} words; \
+                 watching the first {GDB_WATCH_WORD_CAP}\n"
+            ));
+        }
+        let word_watched = |emu: &Emulator, addr: u32| {
+            emu.machine
+                .ui_breaks()
+                .watches
+                .iter()
+                .any(|w| w.addr == addr)
+        };
+        self.watch_words.retain(|&addr| {
+            if desired_words.contains(&addr) {
+                return true;
+            }
+            if word_watched(emu, addr) {
+                emu.machine.ui_toggle_watch(addr);
+            }
+            false
+        });
+        for &addr in &desired_words {
+            if self.watch_words.contains(&addr) || word_watched(emu, addr) {
+                continue;
+            }
+            emu.machine.ui_toggle_watch(addr);
+            self.watch_words.push(addr);
+        }
+
+        // Chipset register watches (fed by the intercepted monitor
+        // commands below), through the per-register toggle so GUI-set
+        // watches survive.
+        let reg_watched =
+            |emu: &Emulator, off: u16| emu.machine.ui_breaks().reg_watches.contains(&off);
+        self.reg_watches.retain(|&off| {
+            if core.reg_watches.contains(&off) {
+                return true;
+            }
+            if reg_watched(emu, off) {
+                emu.machine.ui_toggle_reg_watch(off);
+            }
+            false
+        });
+        for &off in &core.reg_watches {
+            if self.reg_watches.contains(&off) || reg_watched(emu, off) {
+                continue;
+            }
+            emu.machine.ui_toggle_reg_watch(off);
+            self.reg_watches.push(off);
+        }
+
+        // The machine-level loadseg catch stands in for the headless
+        // driver's per-instruction tracker poll: armed while the client
+        // wants library events, a loadseg break, or the one-shot --run
+        // stop; the name filter narrows to the --run target when that is
+        // the only consumer.
+        let want = core.lib_events_armed || core.loadseg_break || core.run_stop.is_some();
+        let filter = if core.lib_events_armed || core.loadseg_break {
+            None
+        } else {
+            core.run_stop.clone()
+        };
+        let have = emu.machine.ui_breaks().loadseg_catch.is_some();
+        match (&self.loadseg, want, have) {
+            (Some(installed), true, true) if *installed != filter => {
+                emu.machine.ui_toggle_loadseg_catch(None); // off (ours)
+                emu.machine.ui_toggle_loadseg_catch(filter.clone());
+                self.loadseg = Some(filter);
+            }
+            (Some(_), false, true) => {
+                emu.machine.ui_toggle_loadseg_catch(None);
+                self.loadseg = None;
+            }
+            (Some(_), false, false) => self.loadseg = None, // GUI beat us to it
+            (None, true, false) => {
+                emu.machine.ui_toggle_loadseg_catch(filter.clone());
+                self.loadseg = Some(filter);
+            }
+            // GUI owns the catch, or the state already matches.
+            _ => {}
+        }
+        notes
+    }
+
+    /// Remove everything this session installed (detach). GUI-set points
+    /// are left alone; a point the GUI already removed counts as done.
+    fn remove_all(&mut self, emu: &mut Emulator) {
+        for addr in self.pc.drain(..) {
+            if emu.machine.ui_breaks().is_breakpoint(addr) {
+                emu.machine.ui_set_breakpoint(addr, None, 0);
+            }
+        }
+        for addr in self.watch_words.drain(..) {
+            if emu
+                .machine
+                .ui_breaks()
+                .watches
+                .iter()
+                .any(|w| w.addr == addr)
+            {
+                emu.machine.ui_toggle_watch(addr);
+            }
+        }
+        for off in self.reg_watches.drain(..) {
+            if emu.machine.ui_breaks().reg_watches.contains(&off) {
+                emu.machine.ui_toggle_reg_watch(off);
+            }
+        }
+        if self.loadseg.take().is_some() && emu.machine.ui_breaks().loadseg_catch.is_some() {
+            emu.machine.ui_toggle_loadseg_catch(None);
+        }
+    }
+}
+
+/// The decoded text of a qRcmd (monitor) packet, when it is one.
+fn decode_qrcmd(packet: &str) -> Option<String> {
+    let hex = packet.strip_prefix("qRcmd,")?;
+    let bytes = hex_decode(hex).ok()?;
+    String::from_utf8(bytes).ok().map(|s| s.trim().to_string())
+}
+
+impl App {
+    /// Adopt a bound GDB server; called from `main` between `App::new`
+    /// and `run()`.
+    pub fn attach_gdb(&mut self, handle: GdbHandle, config: &crate::gdbstub::Config) {
+        let core = GdbCore::new(&self.emu, config.stop_on_load.clone());
+        self.gdb = Some(GdbGuiState {
+            handle,
+            core,
+            breaks: GdbBreaks::default(),
+            pending: false,
+            stop_on_load: config.stop_on_load.clone(),
+            reverse_budget_mb: config.reverse_budget_mb,
+            reverse_interval_frames: config.reverse_interval_frames,
+        });
+    }
+
+    /// Drain queued GDB messages. Runs at the top of `about_to_wait`,
+    /// before the machine steps, so packets land at a frame boundary;
+    /// also callable directly from tests (no sockets or event loop).
+    pub(super) fn drain_gdb(&mut self) {
+        if self.gdb.is_none() {
+            return;
+        }
+        while let Some(msg) = self.gdb.as_ref().and_then(|g| g.handle.try_recv()) {
+            match msg {
+                GdbMsg::Connected => self.gdb_on_connected(),
+                GdbMsg::Disconnected => self.gdb_detach_cleanup("GDB client detached"),
+                GdbMsg::Interrupt => self.gdb_on_interrupt(),
+                GdbMsg::Packet(packet) => self.gdb_on_packet(&packet),
+            }
+        }
+    }
+
+    fn gdb_on_connected(&mut self) {
+        // Stale installs from a client that vanished without detaching
+        // come off before the fresh session starts.
+        if let Some(g) = self.gdb.as_mut() {
+            g.breaks.remove_all(&mut self.emu);
+            g.pending = false;
+            // A fresh core re-arms the stop-on-load target; its tracker
+            // absorbs an already-running program so nothing fires
+            // spuriously (same as the headless per-connection session).
+            g.core = GdbCore::new(&self.emu, g.stop_on_load.clone());
+        }
+        let (budget, interval) = match self.gdb.as_ref() {
+            Some(g) => (g.reverse_budget_mb, g.reverse_interval_frames),
+            None => return,
+        };
+        // Arm the reverse-debug ring for this client, like the headless
+        // driver does. No pc history: the headless stub leaves it off,
+        // and enabling it would change JIT/run-ahead behaviour.
+        self.emu.enable_time_travel(budget, interval);
+        if let Err(e) = self.emu.debug_ensure_time_travel_anchor() {
+            warn!("gdb: arming time travel failed: {e:#}");
+        }
+        // Attaching stops the target: gdb's first packets read registers
+        // and memory expecting a stopped inferior.
+        if !self.paused {
+            self.paused = true;
+            self.sync_live_audio_suspension();
+        }
+        self.show_osd("GDB client attached");
+        self.request_redraw();
+    }
+
+    /// Tear down session-installed state. Used for a socket disconnect,
+    /// a `D` detach, and the `k` packet; safe to run more than once.
+    fn gdb_detach_cleanup(&mut self, why: &str) {
+        let Some(g) = self.gdb.as_mut() else {
+            return;
+        };
+        g.pending = false;
+        g.breaks.remove_all(&mut self.emu);
+        // A warp the client engaged has no client left to release it.
+        if self.warp_hold == Some(WarpSource::Gdb) {
+            self.set_warp(false, WarpSource::Gdb);
+        }
+        self.show_osd(why.to_string());
+        self.request_redraw();
+    }
+
+    fn gdb_on_interrupt(&mut self) {
+        if let Some(g) = self.gdb.as_mut() {
+            g.pending = false;
+        }
+        if !self.paused {
+            self.paused = true;
+            self.sync_live_audio_suspension();
+        }
+        // Ctrl-C always gets a stop reply, pending continue or not (the
+        // headless driver answers the raw 0x03 the same way).
+        self.gdb_send_packet("T05thread:1;");
+        self.last_debug_stop = Some("interrupted by gdb".to_string());
+        self.show_osd("GDB: interrupted");
+        self.finish_render_for_current_frame();
+        self.request_redraw();
+    }
+
+    fn gdb_on_packet(&mut self, packet: &str) {
+        if packet == "QStartNoAckMode" {
+            // The reader thread already flipped its ack mode.
+            self.gdb_send_packet("OK");
+            return;
+        }
+        // Monitor commands that must run against the App rather than the
+        // core: warp (the App owns pacing) and the register-watch set
+        // (the core's own handlers write the whole bus list, which would
+        // clobber GUI-set watches; the machine toggle API composes).
+        if let Some(command) = decode_qrcmd(packet) {
+            if let Some(output) = self.gdb_monitor_intercept(&command) {
+                if let Some(g) = self.gdb.as_mut() {
+                    g.core.console.push(output);
+                }
+                self.gdb_sync_machine_debug_state();
+                self.gdb_flush_console();
+                self.gdb_send_packet("OK");
+                return;
+            }
+        }
+        let Some(mut g) = self.gdb.take() else {
+            return;
+        };
+        let result = g.core.handle_packet(&mut self.emu, packet);
+        self.gdb = Some(g);
+        match result {
+            Err(e) => {
+                warn!("gdb: packet {packet:?} failed: {e:#}");
+                self.gdb_flush_console();
+                self.gdb_send_packet("E01");
+            }
+            Ok(CoreReply::Packet(reply)) => {
+                self.gdb_sync_machine_debug_state();
+                self.gdb_flush_console();
+                self.gdb_send_packet(&reply);
+                if packet == "bs" || packet == "bc" {
+                    // Reverse execution moved the timeline; refresh the
+                    // presentation like the debugger's own transports.
+                    self.finish_render_for_current_frame();
+                    self.request_redraw();
+                }
+            }
+            Ok(CoreReply::Resume(request)) => {
+                // A resume against a machine that cannot run would leave
+                // the client waiting on a stop that never comes.
+                if !self.powered_on || self.emu.machine.cpu_double_faulted() {
+                    if let Some(g) = self.gdb.as_mut() {
+                        g.core.console.push(if self.powered_on {
+                            "CPU is double-faulted; reset the machine\n".to_string()
+                        } else {
+                            "machine is powered off\n".to_string()
+                        });
+                    }
+                    self.gdb_flush_console();
+                    self.gdb_send_packet("E01");
+                    return;
+                }
+                match request {
+                    ResumeRequest::Step => self.gdb_sync_step(),
+                    ResumeRequest::Continue => {
+                        self.gdb_sync_machine_debug_state();
+                        if let Some(g) = self.gdb.as_mut() {
+                            g.pending = true;
+                        }
+                        if self.paused {
+                            self.paused = false;
+                            self.sync_live_audio_suspension();
+                        }
+                        self.request_redraw();
+                    }
+                }
+            }
+            Ok(CoreReply::Disconnect) => {
+                self.gdb_flush_console();
+                self.gdb_send_packet("OK");
+                // The socket stays with the reader; its EOF follows and
+                // repeats this cleanup harmlessly.
+                self.gdb_detach_cleanup("GDB client detached");
+            }
+            Ok(CoreReply::Kill) => {
+                // A windowed session outlives its debugger: `k` detaches
+                // (VS Code sends it on Stop Debugging; killing the
+                // user's window would be hostile). Documented divergence
+                // from the headless driver.
+                self.gdb_detach_cleanup("GDB kill request: detached (window stays open)");
+                if let Some(g) = self.gdb.as_ref() {
+                    g.handle.disconnect("kill request");
+                }
+            }
+        }
+    }
+
+    /// `s` / `vCont;s`: one instruction, synchronously at the drain,
+    /// like the debugger window's own step button.
+    fn gdb_sync_step(&mut self) {
+        if !self.paused {
+            // A step against a free-running machine would race the burst
+            // loop; gdb only ever steps a stopped target anyway.
+            self.paused = true;
+            self.sync_live_audio_suspension();
+        }
+        let reply = match self.emu.debug_step_realtime() {
+            Err(e) => {
+                error!("gdb: step halted the machine: {e:?}");
+                self.cpu_halted = true;
+                self.sync_live_audio_suspension();
+                "T05thread:1;".to_string()
+            }
+            Ok(()) => match self.emu.machine.take_ui_debug_stop() {
+                Some(stop) => self.gdb_map_stop(&stop),
+                None => "T05thread:1;".to_string(),
+            },
+        };
+        self.gdb_sync_machine_debug_state();
+        self.gdb_flush_console();
+        self.gdb_send_packet(&reply);
+        self.finish_render_for_current_frame();
+        self.request_redraw();
+    }
+
+    /// Monitor commands the windowed driver answers itself. Returns the
+    /// console output, or None to let the core handle the command.
+    fn gdb_monitor_intercept(&mut self, command: &str) -> Option<String> {
+        let mut parts = command.split_whitespace();
+        let cmd = parts.next()?;
+        match cmd {
+            "warp" => Some(match parts.next() {
+                Some("on") => {
+                    let outcome = self.set_warp(true, WarpSource::Gdb);
+                    match outcome.note {
+                        Some(note) => format!("warp request refused: {note}\n"),
+                        None => "warp on (emulation unpaced)\n".to_string(),
+                    }
+                }
+                Some("off") => {
+                    self.set_warp(false, WarpSource::Gdb);
+                    "warp off (real-time pacing)\n".to_string()
+                }
+                Some("status") | None => format!(
+                    "warp {}\n",
+                    if self.emu.paced() {
+                        "off (paced)"
+                    } else {
+                        "on (unpaced)"
+                    }
+                ),
+                Some(_) => "usage: monitor warp on|off|status\n".to_string(),
+            }),
+            "watch-reg" | "unwatch-reg" => {
+                let usage = format!("usage: monitor {cmd} NAME|OFFSET\n");
+                let Some(name) = parts.next() else {
+                    return Some(usage);
+                };
+                let Some(off) = crate::debugger::parse_custom_reg(name) else {
+                    return Some(format!("unknown custom register {name}\n"));
+                };
+                let g = self.gdb.as_mut()?;
+                if cmd == "watch-reg" {
+                    if !g.core.reg_watches.contains(&off) {
+                        g.core.reg_watches.push(off);
+                    }
+                    Some(format!(
+                        "watching {} ${off:03X}\n",
+                        crate::debugger::custom_reg_name(off)
+                    ))
+                } else {
+                    g.core.reg_watches.retain(|&candidate| candidate != off);
+                    Some(format!(
+                        "not watching {} ${off:03X}\n",
+                        crate::debugger::custom_reg_name(off)
+                    ))
+                }
+            }
+            "clear-reg-watches" => {
+                let g = self.gdb.as_mut()?;
+                g.core.reg_watches.clear();
+                Some("cleared custom-register watches\n".to_string())
+            }
+            _ => None,
+        }
+    }
+
+    /// Map a machine stop to its RSP stop reply, consuming the one-shot
+    /// `--run` target and queueing the loadseg console notices the
+    /// headless check_stop prints.
+    fn gdb_map_stop(&mut self, stop: &DebugStop) -> String {
+        match stop {
+            DebugStop::Breakpoint { .. } => "T05hwbreak:;thread:1;".to_string(),
+            DebugStop::Watch { addr, .. } => format!("T05watch:{addr:x};thread:1;"),
+            DebugStop::LoadSeg { name, addr } => {
+                let Some(g) = self.gdb.as_mut() else {
+                    return "T05thread:1;".to_string();
+                };
+                let hint = format!(
+                    "first hunk ${addr:06X} (monitor segments / add-symbol-file FILE 0x{addr:X})\n"
+                );
+                if g.core
+                    .run_stop
+                    .as_deref()
+                    .is_some_and(|target| name.eq_ignore_ascii_case(target))
+                {
+                    // One-shot: the target rerunning later is ordinary
+                    // execution, not a fresh launch.
+                    g.core.run_stop = None;
+                    g.core
+                        .console
+                        .push(format!("run target loaded: {name} {hint}"));
+                    "T05thread:1;".to_string()
+                } else if g.core.loadseg_break {
+                    g.core.console.push(format!("loadseg: {name} {hint}"));
+                    "T05thread:1;".to_string()
+                } else if g.core.lib_events_armed {
+                    "T05library:;thread:1;".to_string()
+                } else {
+                    "T05thread:1;".to_string()
+                }
+            }
+            _ => "T05thread:1;".to_string(),
+        }
+    }
+
+    /// Hook for `surface_debug_stop`: when a GDB continue is pending,
+    /// the stop answers the client instead of commandeering the local
+    /// debugger window. Returns whether the stop was consumed remotely.
+    pub(super) fn gdb_completes_stop(&mut self, stop: &DebugStop) -> bool {
+        if !self.gdb.as_ref().is_some_and(|g| g.pending) {
+            return false;
+        }
+        if let Some(g) = self.gdb.as_mut() {
+            g.pending = false;
+        }
+        let reply = self.gdb_map_stop(stop);
+        // The one-shot --run target may have been consumed; the machine
+        // loadseg catch narrows or disarms with it.
+        self.gdb_sync_machine_debug_state();
+        self.gdb_flush_console();
+        self.gdb_send_packet(&reply);
+        true
+    }
+
+    /// A host-side stop with no DebugStop payload (user pause, power
+    /// off, double fault) completes a pending continue with a plain stop
+    /// reply so the client is not left hanging. Returns whether one was
+    /// completed.
+    pub(super) fn gdb_complete_pending_stop(&mut self, detail: &str) -> bool {
+        if !self.gdb.as_ref().is_some_and(|g| g.pending) {
+            return false;
+        }
+        if let Some(g) = self.gdb.as_mut() {
+            g.pending = false;
+        }
+        if let Some(g) = self.gdb.as_ref() {
+            g.handle.send_console(&format!("{detail}\n"));
+        }
+        self.gdb_send_packet("T05thread:1;");
+        true
+    }
+
+    fn gdb_send_packet(&self, payload: &str) {
+        if let Some(g) = &self.gdb {
+            g.handle.send_packet(payload);
+        }
+    }
+
+    /// Deliver the core's queued console lines as `O` packets, in order,
+    /// before whatever reply follows (the headless wire order).
+    fn gdb_flush_console(&mut self) {
+        let lines = match self.gdb.as_mut() {
+            Some(g) => g.core.take_console(),
+            None => return,
+        };
+        if let Some(g) = self.gdb.as_ref() {
+            for chunk in lines {
+                g.handle.send_console(&chunk);
+            }
+        }
+    }
+
+    /// Translate the core's session state into machine-installed debug
+    /// state after any packet that may have changed it.
+    fn gdb_sync_machine_debug_state(&mut self) {
+        let Some(mut g) = self.gdb.take() else {
+            return;
+        };
+        let notes = g.breaks.sync(&mut self.emu, &g.core);
+        g.core.console.extend(notes);
+        self.gdb = Some(g);
+    }
+}

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -10036,6 +10036,63 @@ mod gdb_drain {
     }
 
     #[test]
+    fn a_gui_removed_gdb_breakpoint_is_restored_on_the_next_sync() {
+        let (mut app, cmd_tx, frame_rx) = attached_app();
+        app.drain_gdb();
+        let target = app.emu.machine.pc().wrapping_add(8) & 0x00FF_FFFF;
+        packet(&cmd_tx, &format!("Z0,{target:x},2"));
+        app.drain_gdb();
+        assert!(app.emu.machine.ui_breaks().is_breakpoint(target));
+        // The GUI toggles the client's point off; the client's
+        // acknowledged break state is authoritative for its own points,
+        // so the next packet's sync restores it.
+        app.emu.machine.ui_set_breakpoint(target, None, 0);
+        assert!(!app.emu.machine.ui_breaks().is_breakpoint(target));
+        packet(&cmd_tx, "qC");
+        app.drain_gdb();
+        assert!(
+            app.emu.machine.ui_breaks().is_breakpoint(target),
+            "an acknowledged Z0 point must not silently stay gone"
+        );
+        // And a z0 removal still takes it out for good.
+        packet(&cmd_tx, &format!("z0,{target:x},2"));
+        app.drain_gdb();
+        assert!(!app.emu.machine.ui_breaks().is_breakpoint(target));
+        let _ = frames(&frame_rx);
+    }
+
+    #[test]
+    fn a_memory_write_packet_does_not_fire_the_machine_word_watch() {
+        let (mut app, cmd_tx, frame_rx) = attached_app();
+        app.drain_gdb();
+        // The fixture boots with the reset ROM overlay on, which shadows
+        // low chip RAM; drop it so the write lands.
+        app.emu.bus_mut().mem.overlay = false;
+        let addr = 0x0005_0000u32;
+        packet(&cmd_tx, &format!("Z2,{addr:x},2"));
+        app.drain_gdb();
+        assert!(app
+            .emu
+            .machine
+            .ui_breaks()
+            .watches
+            .iter()
+            .any(|w| w.addr == addr));
+        let _ = frames(&frame_rx);
+        // Writing the watched word through the stub must not fire the
+        // watch on the next step: the machine baselines are refreshed
+        // like CCP's memory.write does.
+        packet(&cmd_tx, &format!("M{addr:x},2:beef"));
+        packet(&cmd_tx, "s");
+        app.drain_gdb();
+        assert_eq!(
+            frames(&frame_rx),
+            vec![frame("OK"), frame("T05thread:1;")],
+            "the stub's own write must not report a watchpoint hit"
+        );
+    }
+
+    #[test]
     fn qxfer_libraries_read_arms_the_machine_loadseg_catch() {
         let (mut app, cmd_tx, frame_rx) = attached_app();
         app.drain_gdb();

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -9861,3 +9861,198 @@ mod warp_control {
         assert_eq!(debug[0]["text"], "hello from the guest");
     }
 }
+
+#[cfg(feature = "gdb")]
+mod gdb_drain {
+    use super::test_app;
+    use crate::gdbstub::core::{checksum, hex_encode};
+    use crate::gdbstub::windowed::{GdbHandle, GdbMsg};
+    use std::sync::mpsc::{Receiver, Sender};
+
+    fn attached_app() -> (super::super::App, Sender<GdbMsg>, Receiver<String>) {
+        let mut app = test_app();
+        let (handle, cmd_tx, frame_rx) = GdbHandle::test_pair();
+        app.attach_gdb(handle, &crate::gdbstub::Config::new(":0".into()));
+        cmd_tx.send(GdbMsg::Connected).unwrap();
+        (app, cmd_tx, frame_rx)
+    }
+
+    fn packet(cmd_tx: &Sender<GdbMsg>, payload: &str) {
+        cmd_tx.send(GdbMsg::Packet(payload.to_string())).unwrap();
+    }
+
+    fn monitor(cmd_tx: &Sender<GdbMsg>, command: &str) {
+        packet(cmd_tx, &format!("qRcmd,{}", hex_encode(command.as_bytes())));
+    }
+
+    /// The wire framing `GdbHandle::send_packet` produces for `payload`.
+    fn frame(payload: &str) -> String {
+        format!("${payload}#{:02x}", checksum(payload.as_bytes()))
+    }
+
+    fn frames(frame_rx: &Receiver<String>) -> Vec<String> {
+        let mut out = Vec::new();
+        while let Ok(f) = frame_rx.try_recv() {
+            out.push(f);
+        }
+        out
+    }
+
+    #[test]
+    fn attach_pauses_and_a_breakpoint_completes_a_deferred_continue() {
+        let (mut app, cmd_tx, frame_rx) = attached_app();
+        app.drain_gdb();
+        assert!(app.paused, "attaching stops the target");
+
+        // A Z0 breakpoint installs into the machine's break store (the
+        // burst loop steps whole frames; the core's polled list alone
+        // would never fire here).
+        let target = app.emu.machine.pc().wrapping_add(8) & 0x00FF_FFFF;
+        packet(&cmd_tx, &format!("Z0,{target:x},2"));
+        app.drain_gdb();
+        assert_eq!(frames(&frame_rx), vec![frame("OK")]);
+        assert!(app.emu.machine.ui_breaks().is_breakpoint(target));
+
+        // Continue defers its reply and lets the frame loop run.
+        packet(&cmd_tx, "c");
+        app.drain_gdb();
+        assert!(!app.paused, "continue resumes the machine");
+        assert!(frames(&frame_rx).is_empty(), "the stop reply is deferred");
+
+        // The hit surfaces mid-frame, answers the client, and leaves the
+        // local debugger window closed.
+        app.emu.step_frame().expect("frame");
+        assert!(app.surface_debug_stop());
+        assert!(app.paused);
+        assert_eq!(app.emu.machine.pc() & 0x00FF_FFFF, target);
+        assert_eq!(frames(&frame_rx), vec![frame("T05hwbreak:;thread:1;")]);
+        assert!(
+            app.debugger_panel.is_none(),
+            "a remote stop must not commandeer the local debugger"
+        );
+    }
+
+    #[test]
+    fn an_interrupt_pauses_and_always_gets_a_stop_reply() {
+        let (mut app, cmd_tx, frame_rx) = attached_app();
+        app.drain_gdb();
+        packet(&cmd_tx, "c");
+        app.drain_gdb();
+        assert!(!app.paused);
+        cmd_tx.send(GdbMsg::Interrupt).unwrap();
+        app.drain_gdb();
+        assert!(app.paused, "0x03 pauses the machine");
+        assert_eq!(frames(&frame_rx), vec![frame("T05thread:1;")]);
+    }
+
+    #[test]
+    fn a_step_replies_synchronously_and_stays_paused() {
+        let (mut app, cmd_tx, frame_rx) = attached_app();
+        app.drain_gdb();
+        let before = app.emu.retired_instructions();
+        packet(&cmd_tx, "s");
+        app.drain_gdb();
+        assert!(app.paused);
+        assert!(app.emu.retired_instructions() > before);
+        assert_eq!(frames(&frame_rx), vec![frame("T05thread:1;")]);
+    }
+
+    #[test]
+    fn detach_removes_only_gdb_installed_break_state() {
+        let (mut app, cmd_tx, frame_rx) = attached_app();
+        app.drain_gdb();
+        // The GUI owns a breakpoint of its own.
+        let gui_break = app.emu.machine.pc().wrapping_add(0x20) & 0x00FF_FFFF;
+        app.emu.machine.ui_set_breakpoint(gui_break, None, 0);
+        // The client sets one at the same spot (never touched: the GUI
+        // owns it) and one of its own, plus a register watch through the
+        // intercepted monitor command.
+        let own_break = app.emu.machine.pc().wrapping_add(0x40) & 0x00FF_FFFF;
+        packet(&cmd_tx, &format!("Z0,{gui_break:x},2"));
+        packet(&cmd_tx, &format!("Z0,{own_break:x},2"));
+        monitor(&cmd_tx, "watch-reg DMACON");
+        app.drain_gdb();
+        assert!(app.emu.machine.ui_breaks().is_breakpoint(own_break));
+        assert!(app.emu.machine.ui_breaks().reg_watches.contains(&0x096));
+        let sent = frames(&frame_rx);
+        assert_eq!(sent.last(), Some(&frame("OK")));
+        assert!(
+            sent.iter()
+                .any(|f| f.contains(&hex_encode(b"watching DMACON"))),
+            "monitor output arrives as O packets: {sent:?}"
+        );
+
+        cmd_tx.send(GdbMsg::Disconnected).unwrap();
+        app.drain_gdb();
+        assert!(
+            app.emu.machine.ui_breaks().is_breakpoint(gui_break),
+            "detach must leave GUI-owned points alone"
+        );
+        assert!(!app.emu.machine.ui_breaks().is_breakpoint(own_break));
+        assert!(!app.emu.machine.ui_breaks().reg_watches.contains(&0x096));
+    }
+
+    #[test]
+    fn monitor_warp_holds_until_disconnect_releases_it() {
+        let (mut app, cmd_tx, _frame_rx) = attached_app();
+        // The fixture starts unpaced; warp semantics are defined against
+        // a paced interactive session.
+        app.emu.set_paced(true);
+        app.drain_gdb();
+        monitor(&cmd_tx, "warp on");
+        app.drain_gdb();
+        assert!(!app.emu.paced(), "monitor warp on unpaces the machine");
+        assert_eq!(
+            app.warp_hold,
+            Some(super::super::app_session::WarpSource::Gdb)
+        );
+        cmd_tx.send(GdbMsg::Disconnected).unwrap();
+        app.drain_gdb();
+        assert!(
+            app.emu.paced(),
+            "a disconnect releases the client's warp hold"
+        );
+        assert!(app.warp_hold.is_none());
+    }
+
+    #[test]
+    fn kill_detaches_and_the_window_survives() {
+        let (mut app, cmd_tx, frame_rx) = attached_app();
+        app.drain_gdb();
+        let own_break = app.emu.machine.pc().wrapping_add(8) & 0x00FF_FFFF;
+        packet(&cmd_tx, &format!("Z0,{own_break:x},2"));
+        packet(&cmd_tx, "k");
+        app.drain_gdb();
+        assert!(!app.emu.machine.ui_breaks().is_breakpoint(own_break));
+        assert!(
+            app.gdb.is_some(),
+            "the server keeps serving for the next client"
+        );
+        assert!(
+            !app.gdb.as_ref().unwrap().handle.connected(),
+            "kill closes the connection instead of exiting the window"
+        );
+        let _ = frames(&frame_rx);
+    }
+
+    #[test]
+    fn qxfer_libraries_read_arms_the_machine_loadseg_catch() {
+        let (mut app, cmd_tx, frame_rx) = attached_app();
+        app.drain_gdb();
+        assert!(app.emu.machine.ui_breaks().loadseg_catch.is_none());
+        packet(&cmd_tx, "qXfer:libraries:read::0,1000");
+        app.drain_gdb();
+        assert_eq!(
+            frames(&frame_rx),
+            vec![frame("l<library-list version=\"1.0\"/>")]
+        );
+        assert!(
+            app.emu.machine.ui_breaks().loadseg_catch.is_some(),
+            "library events arm the machine-level loadseg catch"
+        );
+        // Detach disarms it again (it was ours).
+        cmd_tx.send(GdbMsg::Disconnected).unwrap();
+        app.drain_gdb();
+        assert!(app.emu.machine.ui_breaks().loadseg_catch.is_none());
+    }
+}


### PR DESCRIPTION
Stacked on #622 (`feat/gdb-core-split`); merges after it.

## What changes

`--gdb` serves a headless machine; a GDB session with the screen visible had no RSP endpoint at all -- and the VS Code integrators this serves want stock GDB frontends (cppdbg, Native Debug with `m68k-amigaos-gdb`) against a visible, audible Amiga. `--gdb-gui ADDR` attaches the stub to the normal windowed session the way `--control-gui` attaches the control server:

- `src/gdbstub/windowed.rs`: an accept thread plus per-connection reader/writer threads. The reader owns RSP framing, checksums and acks (acks are routed through the writer channel so the two threads never interleave bytes on the stream), flips NoAckMode locally, and surfaces `0x03` as an interrupt message.
- `src/video/window/gdb.rs`: the winit frame loop drains packets at the top of `about_to_wait` -- the same boundary the control drain uses -- and runs the shared transport-free `GdbCore` against the machine it owns.
- `docs/debugger/gdb.md` gains the two-mode section and the `monitor warp` note.

## Design

What differs in a window, and why:

- **Deferred continue.** The machine stays paced and visible, so `c`/`vCont;c` cannot spin the headless per-instruction socket-polling loop. The stop reply is deferred; a stop that surfaces through `surface_debug_stop` while the client's continue is outstanding answers the client instead of opening the local debugger panel (the control server's precedent). User pause, power-off, and a double fault complete a pending continue too, so the client is never left hanging.
- **Machine-installed break state.** The core's session breakpoint list is polled per instruction by the headless continue loop and never seen by the CPU hot loop -- useless when the windowed loop steps whole frames. Every core-held break translates into machine-installed debug state (`GdbBreaks`), under the control session's ownership rule: never touch a point the local GUI owns, remove exactly ours on detach. Watchpoints become per-word machine watches (capped at 8 words, with a console note when truncated); the register-watch monitors are intercepted onto the per-register toggle API, because the core's own handlers write the whole bus list and would clobber GUI-set watches; the machine-level loadseg catch stands in for the headless per-instruction tracker poll, narrowing to the `--run` target's name when that is the only consumer.
- **`monitor warp on|off|status`** flips the App's warp hold (`WarpSource::Gdb`), released automatically on disconnect. Continue otherwise runs at real Amiga speed.
- **`k` detaches instead of ending the session.** The window belongs to the user, and VS Code sends `k` on Stop Debugging; killing the window would be hostile. Documented divergence from the headless driver.
- A resume against a powered-off or double-faulted machine replies `E01` with a console note instead of deferring a stop that can never come.
- Exclusions: `--gdb-gui` cannot combine with `--gdb`, `--control`/`--control-gui` (both contend for the pause state and the deferred-stop hook), or `--benchmark-until`. It keeps live audio and the windowed capture path, suppresses the launcher like the other serving flags, and `--run` break-at-entry re-arms per connection exactly as with `--gdb`.

## Verification

- Real-socket reader tests: framing and acks, NoAckMode byte-exact (no ack bytes after the flip), interrupts, bad-checksum nack, reconnect after disconnect.
- Socket-free drain suite (`GdbHandle::test_pair`): attach pauses; a breakpoint hit mid-frame completes a deferred continue with `T05hwbreak:;` and leaves the debugger panel closed; synchronous step; interrupt; detach removes only GDB-installed break state while GUI-owned points survive; `monitor warp` + disconnect releases the hold; `k` detaches and the server keeps serving; a qXfer libraries read arms the machine loadseg catch and detach disarms it.
- `--gdb-gui` CLI validation tests (exclusions, live-audio default). Full suite (3160 lib + bins), clippy, fmt clean, copperline-player checks.
- Not yet run: a live session with real `m68k-amigaos-gdb` against a visible window (it opens a window); the drain tests cover the same paths socket-free.

## Judgment calls

- Accept is serial, as in the headless stub: the reader runs on the accept thread, so an extra client waits in the listener backlog until the current one detaches, rather than being refused.
- A stop with no continue outstanding stays local (the GUI panel opens); GDB has no unsolicited stop channel in vanilla RSP, and commandeering the panel for a detached-feeling client would be worse.
