### PR TITLE
debugger: let --gdb-gui and --control-gui share one window

### DIFF
--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -204,12 +204,14 @@ events.unsubscribe {"events":["serial"]}
   reports it). `dropped_events` counts items the bounded queue lost before
   this batch.
 - **`event.warp`:** Sent without a subscription, in both modes, whenever warp
-  changes for a reason other than the client's own `warp.set`:
-  `{"on", "paced", "source", "holders", "position"}` with `source` one of
-  `manual`, `guest`, `gdb`, `launch`, `boot`, `power_off`, and `holders`
-  listing every programmatic hold still in force (`control`, `gdb`,
-  `guest`). The headless server reports the guest's `warpmode()` request
-  with `paced` always false.
+  or its holder set changes for a reason other than the client's own
+  `warp.set`: `{"on", "paced", "source", "position"}` with `source` one of
+  `manual`, `guest`, `gdb`, `launch`, `boot`, `power_off`. A windowed session
+  adds `holders`, every programmatic hold still in force (`control`, `gdb`,
+  `guest`), and also sends the event when a holder joins or leaves without
+  pacing changing, so the list never goes stale. The headless server has no
+  holds (it is unpaced end to end), omits `holders`, and reports the guest's
+  `warpmode()` request with `paced` always false.
 
 ## Command reference summary
 
@@ -231,7 +233,7 @@ events.unsubscribe {"events":["serial"]}
 - `machine.reset {"kind": "warm"|"cold"}`: Reset the emulated machine (default: warm).
 
 ### Speed
-- `warp.get`: Report whether warp (unpaced emulation) is active, whether the machine is paced, and the source holding warp (`none`, `manual`, `control`, `gdb`, `guest`, `launch`, `boot`, `capture`, or `headless`); `holders` lists every programmatic hold in force (`control`, `gdb`, `guest`), `source` being the first.
+- `warp.get`: Report whether warp (unpaced emulation) is active, whether the machine is paced, and the source holding warp (`none`, `manual`, `control`, `gdb`, `guest`, `launch`, `boot`, `capture`, or `headless`); in a windowed session `holders` lists every programmatic hold in force (`control`, `gdb`, `guest`), `source` being the first (the headless server has no holds and omits the field).
 - `warp.set {"on": true|false}`: Engage or release the client's own warp hold (unthrottled execution with audio muted). Holds are independent: releasing yours re-paces the machine only when no other holder (a GDB client, the guest) remains, and the reply's `note` says who still holds it. Disabling warp also cancels active `--run` or `--warp-boot` phases.
 
 ### Reverse execution

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -16,6 +16,13 @@ execution, inject input events, change media, and capture framebuffers.
 ./target/release/copperline --config kick13.example.toml --control-gui :7710
 ```
 
+`--control-gui` can share the window with `--gdb-gui` (see [GDB](gdb.md)):
+a machine stop answers whichever resumes are pending on both clients, a stop
+the control client did not request arrives as `event.stopped`, and
+`reverse_*`, `memory.last_writer`, `mouse.to`, and `state.load` are refused
+while the GDB client's `continue` is outstanding (`pause` first). Either
+client's pause ends the other's run with reason `pause`.
+
 When `--control-info FILE` is specified, connection details are written to a
 JSON file:
 
@@ -198,9 +205,11 @@ events.unsubscribe {"events":["serial"]}
   this batch.
 - **`event.warp`:** Sent without a subscription, in both modes, whenever warp
   changes for a reason other than the client's own `warp.set`:
-  `{"on", "paced", "source", "position"}` with `source` one of `manual`,
-  `guest`, `launch`, `boot`, `power_off`. The headless server reports the
-  guest's `warpmode()` request with `paced` always false.
+  `{"on", "paced", "source", "holders", "position"}` with `source` one of
+  `manual`, `guest`, `gdb`, `launch`, `boot`, `power_off`, and `holders`
+  listing every programmatic hold still in force (`control`, `gdb`,
+  `guest`). The headless server reports the guest's `warpmode()` request
+  with `paced` always false.
 
 ## Command reference summary
 
@@ -222,8 +231,8 @@ events.unsubscribe {"events":["serial"]}
 - `machine.reset {"kind": "warm"|"cold"}`: Reset the emulated machine (default: warm).
 
 ### Speed
-- `warp.get`: Report whether warp (unpaced emulation) is active, whether the machine is paced, and the source holding warp (`none`, `manual`, `control`, `guest`, `launch`, `boot`, `capture`, or `headless`).
-- `warp.set {"on": true|false}`: Engage or release warp speed (unthrottled execution with audio muted). Disabling warp also cancels active `--run` or `--warp-boot` phases.
+- `warp.get`: Report whether warp (unpaced emulation) is active, whether the machine is paced, and the source holding warp (`none`, `manual`, `control`, `gdb`, `guest`, `launch`, `boot`, `capture`, or `headless`); `holders` lists every programmatic hold in force (`control`, `gdb`, `guest`), `source` being the first.
+- `warp.set {"on": true|false}`: Engage or release the client's own warp hold (unthrottled execution with audio muted). Holds are independent: releasing yours re-paces the machine only when no other holder (a GDB client, the guest) remains, and the reply's `note` says who still holds it. Disabling warp also cancels active `--run` or `--warp-boot` phases.
 
 ### Reverse execution
 - `reverse_step {"n": 1}`: Step backward by instruction.

--- a/docs/debugger/gdb.md
+++ b/docs/debugger/gdb.md
@@ -44,8 +44,11 @@ session:
   naming the reason. Local debugger breakpoints open the internal debugger
   window only when neither client had a resume pending; a plain pause from
   the window just pauses (and completes any outstanding resume).
-- Reverse execution (`reverse-step`, `reverse-continue`) is refused while a
-  control-protocol resume is outstanding: pause first.
+- Anything that repositions the machine -- reverse execution
+  (`reverse-step`, `reverse-continue`), resuming or stepping at an address
+  (`continue ADDR`, `jump`), a write to `pc` -- is refused while a
+  control-protocol resume is outstanding: pause first. Plain `continue`,
+  `stepi`, memory and other register writes stay allowed.
 - `--run` break-at-entry functions identically to headless `--gdb`.
 - `--gdb-gui` cannot be combined with `--gdb`, `--control`, or
   `--benchmark-until`. It can share the window with `--control-gui`: a GDB

--- a/docs/debugger/gdb.md
+++ b/docs/debugger/gdb.md
@@ -24,8 +24,11 @@ session:
 
 - The emulated machine remains interactive in the window and runs at real-time
   speed. Execution advances in real time on `continue` unless unthrottled via
-  `monitor warp on` (`monitor warp off` restores pacing; disconnecting
-  automatically releases warp holds).
+  `monitor warp on`, which engages a warp hold for the GDB client. `monitor
+  warp off` releases that hold only: the machine re-paces once no other holder
+  (a control client's `warp.set`, the guest's `warpmode()`) remains, and the
+  console line names who still holds it. Disconnecting releases the GDB hold
+  the same way; the window's warp shortcut ends every hold at once.
 - Attaching a debugger pauses the machine. Detaching (`detach`, connection loss,
   or GDB `kill`) leaves the window open and listening for new connections
   (`kill` detaches rather than terminating the process so that VS Code "Stop
@@ -34,11 +37,21 @@ session:
   during the windowed frame loop. Breakpoints set within the UI remain independent,
   and detaching GDB removes only points set by the remote client.
 - When execution halts during an active GDB `continue`, the stop event is sent
-  to the client. Manual UI pauses or local debugger breakpoints open the
-  internal debugger window normally.
+  to the client. With `--control-gui` attached to the same window, a
+  control-protocol resume outstanding at the same time gets its stop reply
+  too, and a stop the control client causes (its `pause`, a `run_until`
+  target) completes the GDB `continue` with a plain `T05` and a console line
+  naming the reason. Local debugger breakpoints open the internal debugger
+  window only when neither client had a resume pending; a plain pause from
+  the window just pauses (and completes any outstanding resume).
+- Reverse execution (`reverse-step`, `reverse-continue`) is refused while a
+  control-protocol resume is outstanding: pause first.
 - `--run` break-at-entry functions identically to headless `--gdb`.
-- `--gdb-gui` cannot be combined with `--gdb`, `--control`, `--control-gui`, or
-  `--benchmark-until`.
+- `--gdb-gui` cannot be combined with `--gdb`, `--control`, or
+  `--benchmark-until`. It can share the window with `--control-gui`: a GDB
+  frontend for source-level debugging and a control-protocol client for
+  observation and control attach to one session (see
+  [Control Protocol](control.md)).
 
 Standard GDB frontends work with both modes: VS Code cppdbg configurations
 (`"MIMode": "gdb"`, `"miDebuggerServerAddress": "localhost:2345"`,
@@ -83,8 +96,10 @@ Copper disassembly, and Exec structures:
 (gdb) monitor memlist          # List Exec memory allocations
 ```
 
-In windowed mode (`--gdb-gui`), `monitor warp on|off|status` controls warp
-mode, running unthrottled with audio muted until disabled or disconnected.
+In windowed mode (`--gdb-gui`), `monitor warp on|off|status` controls the GDB
+client's warp hold, running unthrottled with audio muted until that hold is
+released or the client disconnects (another holder keeps the machine
+warping; `status` names every holder).
 
 ## Source-level debugging and program loading
 

--- a/docs/guide/run.md
+++ b/docs/guide/run.md
@@ -48,14 +48,16 @@ Additional operational notes:
 - **File naming:** Target filenames must use printable ASCII characters without quotes (`"`),
   colons (`:`), or slashes (`/`). Spaces in executable names are supported and quoted automatically.
 - **Manual override:** Pressing the warp toggle shortcut (`Cmd+W` / `Alt+W`) cancels
-  the automatic warp phase and any programmatic warp, returning to real-time
-  execution.
-- **Programmatic warp:** A control-protocol client can engage warp at any time
-  with `warp.set {"on": true}` (see [Control Protocol](../debugger/control.md)),
-  and the guest program itself can call `warpmode(1)` / `warpmode(0)` through
-  the [uaelib trap](#uaelib-trap) below (e.g. during heavy computation or asset loading).
-  Both mute live audio while engaged; `warp.set {"on": false}`, `warpmode(0)`, or the
-  shortcut return to real time.
+  the automatic warp phase and every programmatic warp hold at once, returning
+  to real-time execution.
+- **Programmatic warp:** A control-protocol client (`warp.set {"on": true}`, see
+  [Control Protocol](../debugger/control.md)), a GDB client (`monitor warp on`,
+  see [GDB](../debugger/gdb.md)), and the guest program itself (`warpmode(1)` /
+  `warpmode(0)` through the [uaelib trap](#uaelib-trap) below, e.g. during heavy
+  computation or asset loading) each hold warp independently. All mute live
+  audio while engaged; `warp.set {"on": false}`, `monitor warp off`, or
+  `warpmode(0)` release only that holder, real time returns when the last hold
+  goes, and the shortcut returns to real time regardless.
 - **Physical floppy drives:** If a physical floppy drive (FluxBridge) is attached, warp
   mode is disabled to match the physical drive rate.
 - **Headless mode:** Headless capture runs (`--screenshot-after`, `--dump-frames`) run
@@ -109,7 +111,7 @@ if (*(UWORD *)UaeConf == 0x4eb9 || *(UWORD *)UaeConf == 0xa00e) {
 - Enabled by default; set `[emulation] uaelib = false` to leave `$F0FF60` unmapped.
 - A CDTV extended ROM occupies `$F00000` and covers this address space.
 - Without the trap, `KPrintF` falls back to Exec `RawPutChar` and emits over the serial port.
-- Guest-initiated warp mutes live audio; press `Cmd+W` / `Alt+W` to cancel.
+- Guest-initiated warp mutes live audio; `warpmode(0)` releases the guest's hold, and `Cmd+W` / `Alt+W` ends every hold.
 - The return latch is shared: uaelib calls from interrupt handlers between a main-thread doorbell write and result read may overwrite D0.
 
 ## Kickstart compatibility

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -33,7 +33,7 @@ The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
 | `Cmd+F` | `Alt+F` | Toggle fullscreen on / off |
 | `Cmd+Shift+F` | `Alt+Shift+F` | Show / hide the status bar |
 | `Cmd+P` | `Alt+P` | Toggle the [performance overlay](#performance-overlay) (`[display] perf_overlay` sets the start-up value) |
-| `Cmd+W` | `Alt+W` | Toggle Warp Speed (turbo) on / off; one press also ends a warp a control client, the guest, or a boot phase engaged |
+| `Cmd+W` | `Alt+W` | Toggle Warp Speed (turbo) on / off; one press also ends every warp a control client, a GDB client, the guest, or a boot phase engaged |
 | `Cmd+Shift+W` | `Alt+Shift+W` | Cycle the Warp Speed limit: 2x, 4x, 8x, 16x, Max |
 | `Cmd+Z` | `Alt+Z` | Rewind the machine one step (needs `[emulation] rewind` or *Emulation Settings > Rewind*) |
 | `Esc` | `Esc` | Close an open menu or overlay panel (in a tool window, that window); otherwise passed through to the Amiga |
@@ -510,10 +510,11 @@ Shown only when something is on the port.
 
 - **Warp Speed** (also `Cmd+W` / `Alt+W`): runs the emulator unpaced for
   fast-forward. Toggling back re-anchors real-time pacing cleanly. A
-  control-protocol client (`warp.set`) or the guest program (`warpmode()`
-  through the uaelib trap, see [Direct launching](run.md)) can engage warp
-  too; such a warp mutes live audio, the OSD names who asked, and one press
-  of the shortcut ends it.
+  control-protocol client (`warp.set`), a GDB client (`monitor warp`), or the
+  guest program (`warpmode()` through the uaelib trap, see
+  [Direct launching](run.md)) can engage warp too; each holds it
+  independently and releases only its own, such a warp mutes live audio, the
+  OSD names who asked, and one press of the shortcut ends them all.
 - **Warp Limit** (also `Cmd+Shift+W` / `Alt+Shift+W`): how fast warp runs.
   Because the window presents with vsync, emulating one frame per presented
   frame would cap warp at the host monitor's refresh rate (about 1.2x for

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,17 +206,19 @@ fn validate_control_args(cli: &CliArgs) -> Result<()> {
              rebuild with --features control for --control/--control-gui"
         ));
     }
-    if cli.control.is_some() || cli.control_gui.is_some() {
-        if cli.gdb.is_some() || cli.gdb_gui.is_some() {
-            return Err(anyhow!(
-                "--control/--control-gui cannot be combined with --gdb/--gdb-gui"
-            ));
-        }
-        if cli.benchmark_until.is_some() {
-            return Err(anyhow!(
-                "--control/--control-gui cannot be combined with --benchmark-until"
-            ));
-        }
+    if (cli.control.is_some() || cli.control_gui.is_some()) && cli.benchmark_until.is_some() {
+        return Err(anyhow!(
+            "--control/--control-gui cannot be combined with --benchmark-until"
+        ));
+    }
+    // The headless servers each own the machine's run loop, so --control
+    // and --gdb exclude everything else. The two windowed forms share one
+    // interactive session: --control-gui with --gdb-gui is allowed.
+    if cli.control.is_some() && (cli.gdb.is_some() || cli.gdb_gui.is_some()) {
+        return Err(anyhow!("--control cannot be combined with --gdb/--gdb-gui"));
+    }
+    if cli.control_gui.is_some() && cli.gdb.is_some() {
+        return Err(anyhow!("--control-gui cannot be combined with --gdb"));
     }
     if cli.control.is_none() {
         return Ok(());
@@ -1988,9 +1990,17 @@ mod tests {
         let err = validate_gdb_args(&args).unwrap_err();
         assert!(err.to_string().contains("--benchmark-until"), "{err:#}");
 
+        // The two windowed forms share one interactive session; the
+        // headless forms each own the machine and still exclude the other.
         let args = parse(&["--gdb-gui", ":2345", "--control-gui", ":7710"])?;
+        validate_gdb_args(&args)?;
+        validate_control_args(&args)?;
+        let args = parse(&["--gdb-gui", ":2345", "--control", ":7710"])?;
         let err = validate_control_args(&args).unwrap_err();
-        assert!(err.to_string().contains("--gdb-gui"), "{err:#}");
+        assert!(err.to_string().contains("--control cannot"), "{err:#}");
+        let args = parse(&["--control-gui", ":7710", "--gdb", ":2345"])?;
+        let err = validate_control_args(&args).unwrap_err();
+        assert!(err.to_string().contains("--gdb"), "{err:#}");
         Ok(())
     }
 

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1108,11 +1108,12 @@ pub struct App {
     /// real-time pacing (src/warpboot.rs). One-shot; None once finished
     /// or cancelled. Host-side only, never serialized.
     warp_boot: Option<crate::warpboot::WarpBootGate>,
-    /// A warp a control client or the guest engaged (`App::set_warp`):
-    /// mutes live audio like the boot gates, outlives a gate that ends
-    /// under it, and is released by any warp-off, the manual toggle, or
-    /// power off. Never `Manual`. Host-side only, never serialized.
-    warp_hold: Option<app_session::WarpSource>,
+    /// The warps a control client, a GDB client, or the guest engaged
+    /// (`App::set_warp`): each mutes live audio like the boot gates,
+    /// outlives a gate that ends under it, and is released per holder
+    /// (its own warp-off or disconnect), all at once by the manual toggle
+    /// or power off. Host-side only, never serialized.
+    warp_holds: app_session::WarpHolds,
     /// Live-input recorder: logs every input event that reaches the
     /// emulated machine and writes a --script-replayable file on stop.
     /// None while not recording.
@@ -2111,7 +2112,7 @@ impl App {
             warp_launch: run_warp_target,
             warp_launch_tracker: crate::amigaos::LibraryTracker::default(),
             warp_boot: warp_boot_gate,
-            warp_hold: None,
+            warp_holds: app_session::WarpHolds::default(),
             input_recorder: record_input
                 .is_some()
                 .then(|| crate::inputrec::InputRecorder::new(0.0)),

--- a/src/video/window/app_debugger.rs
+++ b/src/video/window/app_debugger.rs
@@ -1113,12 +1113,11 @@ impl App {
                 }
                 self.paused = true;
                 self.sync_live_audio_suspension();
+                // Notify first (it self-suppresses while a resume is
+                // pending), then answer every pending resume.
                 #[cfg(feature = "control")]
-                if !self.control_complete_pending("double_fault", &message) {
-                    self.control_notify_stopped("double_fault", &message);
-                }
-                #[cfg(feature = "gdb")]
-                self.gdb_complete_pending_stop(&message);
+                self.control_notify_stopped("double_fault", &message);
+                self.complete_remote_resumes("double_fault", &message);
                 self.show_osd(message);
                 self.request_redraw();
                 return true;
@@ -1131,32 +1130,28 @@ impl App {
         };
         let message = stop.describe();
         info!("debugger stop: {message}");
-        // A stop while a remote resume is pending answers the client and
-        // pauses without commandeering the local debugger window.
+        // A stop while a remote resume is pending answers every client
+        // that has one -- a control-protocol continue and a GDB continue
+        // can both be outstanding when both share the window -- and pauses
+        // without commandeering the local debugger window; a control
+        // client with nothing pending still hears of it as event.stopped.
+        // Only a stop no client consumed opens the panel.
+        #[allow(unused_mut)]
+        let mut consumed = false;
         #[cfg(feature = "control")]
-        if self.control_completes_stop(&stop) {
-            self.paused = true;
-            self.sync_live_audio_suspension();
-            self.last_debug_stop = Some(message.clone());
-            self.show_osd(message);
-            self.request_redraw();
-            return true;
+        {
+            consumed |= self.control_completes_stop(&stop);
         }
-        // Same rule for a pending GDB continue: the stop answers the
-        // client and pauses without opening the local debugger window.
         #[cfg(feature = "gdb")]
-        if self.gdb_completes_stop(&stop) {
-            self.paused = true;
-            self.sync_live_audio_suspension();
-            self.last_debug_stop = Some(message.clone());
-            self.show_osd(message);
-            self.request_redraw();
-            return true;
+        {
+            consumed |= self.gdb_completes_stop(&stop);
         }
         self.paused = true;
-        self.paused_before_debugger = true;
         self.sync_live_audio_suspension();
-        self.open_debugger();
+        if !consumed {
+            self.paused_before_debugger = true;
+            self.open_debugger();
+        }
         self.last_debug_stop = Some(message.clone());
         self.show_osd(message);
         self.request_redraw();

--- a/src/video/window/app_session.rs
+++ b/src/video/window/app_session.rs
@@ -384,6 +384,7 @@ impl App {
             };
         }
         let was_paced = self.emu.paced();
+        let holds_before = self.warp_holds;
         let mut cancelled = false;
         // The holds still in force after a release that could not re-pace
         // the machine because another holder remains.
@@ -457,10 +458,16 @@ impl App {
                 _ => {}
             }
         }
+        // A control client hears of any change it did not make itself:
+        // pacing flipping, or the holder set changing under an unchanged
+        // pacing (a second holder joining, one of two releasing), so its
+        // view of `holders` never goes stale.
         #[cfg(feature = "control")]
-        if changed && source != WarpSource::Control {
+        if (changed || self.warp_holds != holds_before) && source != WarpSource::Control {
             self.control_notify_warp(source.label());
         }
+        #[cfg(not(feature = "control"))]
+        let _ = holds_before;
         self.request_redraw();
         WarpOutcome { changed, note }
     }

--- a/src/video/window/app_session.rs
+++ b/src/video/window/app_session.rs
@@ -35,11 +35,84 @@ impl WarpSource {
     }
 }
 
+/// The programmatic warp holds in force, one slot per source that can
+/// hold one (`Manual` never does). Each holder releases only its own; the
+/// machine re-paces when the last one goes, and the manual toggle or power
+/// off clears them all. A control client and a GDB client sharing the
+/// window therefore cannot take each other's warp away.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct WarpHolds(u8);
+
+impl WarpHolds {
+    /// Report order: the wire `source` is the first holder in it.
+    const ORDER: [WarpSource; 3] = [WarpSource::Control, WarpSource::Gdb, WarpSource::Guest];
+
+    fn bit(source: WarpSource) -> u8 {
+        match source {
+            WarpSource::Manual => 0,
+            WarpSource::Control => 1,
+            WarpSource::Gdb => 2,
+            WarpSource::Guest => 4,
+        }
+    }
+
+    pub(super) fn insert(&mut self, source: WarpSource) {
+        self.0 |= Self::bit(source);
+    }
+
+    pub(super) fn remove(&mut self, source: WarpSource) {
+        self.0 &= !Self::bit(source);
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.0 = 0;
+    }
+
+    pub(super) fn contains(self, source: WarpSource) -> bool {
+        let bit = Self::bit(source);
+        bit != 0 && self.0 & bit != 0
+    }
+
+    pub(super) fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    pub(super) fn iter(self) -> impl Iterator<Item = WarpSource> {
+        Self::ORDER.into_iter().filter(move |s| self.contains(*s))
+    }
+
+    /// The wire `source`: the first holder in report order.
+    #[cfg(feature = "control")]
+    pub(super) fn first(self) -> Option<WarpSource> {
+        self.iter().next()
+    }
+
+    /// The wire names of every holder, in report order.
+    #[cfg(feature = "control")]
+    pub(super) fn labels(self) -> Vec<&'static str> {
+        self.iter().map(WarpSource::label).collect()
+    }
+
+    /// "control client and gdb client", for logs, notes and the OSD.
+    pub(super) fn describe(self) -> String {
+        let parts: Vec<&str> = self.iter().map(WarpSource::describe).collect();
+        match parts.len() {
+            0 => "nobody".to_string(),
+            1 => parts[0].to_string(),
+            n => format!("{} and {}", parts[..n - 1].join(", "), parts[n - 1]),
+        }
+    }
+}
+
 /// What `App::set_warp` did: whether pacing actually changed, and why not
-/// when a request could not be honoured.
+/// when a request could not be honoured (or a release left the machine
+/// warping for another holder).
 pub(super) struct WarpOutcome {
     pub changed: bool,
-    pub note: Option<&'static str>,
+    /// Read by the remote drivers' replies; the guest path only needs
+    /// `changed`.
+    #[cfg_attr(not(any(feature = "control", feature = "gdb")), allow(dead_code))]
+    pub note: Option<String>,
 }
 
 pub(super) const WARP_NOTE_BRIDGED: &str =
@@ -167,9 +240,13 @@ impl App {
     /// hold keeps the machine warping, and tell an attached control client.
     fn end_gate_warp(&mut self, what: &str, source: &'static str) {
         let was_paced = self.emu.paced();
-        match self.warp_hold {
-            Some(hold) => info!("{what}: done; warp stays on for the {}", hold.describe()),
-            None => self.emu.set_paced(true),
+        if self.warp_holds.is_empty() {
+            self.emu.set_paced(true);
+        } else {
+            info!(
+                "{what}: done; warp stays on for the {}",
+                self.warp_holds.describe()
+            );
         }
         self.sync_live_audio_suspension();
         #[cfg(feature = "control")]
@@ -303,28 +380,43 @@ impl App {
             );
             return WarpOutcome {
                 changed: false,
-                note: Some(WARP_NOTE_CAPTURE),
+                note: Some(WARP_NOTE_CAPTURE.to_string()),
             };
         }
         let was_paced = self.emu.paced();
         let mut cancelled = false;
+        // The holds still in force after a release that could not re-pace
+        // the machine because another holder remains.
+        let mut remaining: Option<WarpHolds> = None;
         if on {
             self.emu.set_paced(false);
             let unpaced = !self.emu.paced();
-            self.warp_hold = match source {
-                WarpSource::Manual => None,
-                programmatic if unpaced => Some(programmatic),
-                _ => None,
-            };
+            match source {
+                WarpSource::Manual => self.warp_holds.clear(),
+                programmatic if unpaced => self.warp_holds.insert(programmatic),
+                // A refused request (bridged drive) leaves other holds alone.
+                _ => {}
+            }
         } else {
             cancelled = self.cancel_warp_gates(source.describe());
-            self.warp_hold = None;
-            self.emu.set_paced(true);
+            match source {
+                WarpSource::Manual => self.warp_holds.clear(),
+                programmatic => self.warp_holds.remove(programmatic),
+            }
+            if self.warp_holds.is_empty() {
+                self.emu.set_paced(true);
+            } else {
+                remaining = Some(self.warp_holds);
+            }
         }
         self.sync_live_audio_suspension();
         let paced = self.emu.paced();
         let changed = paced != was_paced;
-        let note = (on && paced).then_some(WARP_NOTE_BRIDGED);
+        let note = if on && paced {
+            Some(WARP_NOTE_BRIDGED.to_string())
+        } else {
+            remaining.map(|holds| format!("warp stays on: held by {}", holds.describe()))
+        };
         if on && paced {
             info!(
                 "warp: {} request refused: {WARP_NOTE_BRIDGED}",
@@ -349,6 +441,14 @@ impl App {
                 (_, true) if changed => {
                     info!("warp on ({})", source.describe());
                     self.show_osd(format!("Warp on ({})", source.describe()));
+                }
+                (_, false) if remaining.is_some() => {
+                    let holders = remaining.map(|h| h.describe()).unwrap_or_default();
+                    info!(
+                        "warp off ({}) requested; warp stays on for the {holders}",
+                        source.describe()
+                    );
+                    self.show_osd(format!("Warp stays on ({holders})"));
                 }
                 (_, false) if changed || cancelled => {
                     info!("warp off ({})", source.describe());
@@ -1045,7 +1145,7 @@ impl App {
         // way; the manual toggle is not.
         let warp_muted = self.warp_launch.as_ref().is_some_and(|l| l.engaged)
             || self.warp_boot.as_ref().is_some_and(|g| g.engaged)
-            || self.warp_hold.is_some();
+            || !self.warp_holds.is_empty();
         let suspended = !self.powered_on || self.cpu_halted || self.paused || warp_muted;
         self.emu.set_live_audio_suspended(suspended);
     }
@@ -1281,16 +1381,59 @@ impl App {
         self.sync_live_audio_suspension();
         if self.paused {
             info!("pause button: emulation paused");
-            // A user pause completes a remote client's pending resume;
-            // the client learns where the machine stopped.
-            #[cfg(feature = "control")]
-            self.control_complete_pending("user_pause", "paused from the window");
-            #[cfg(feature = "gdb")]
-            self.gdb_complete_pending_stop("paused from the window");
+            // A user pause completes every remote client's pending
+            // resume; the clients learn where the machine stopped.
+            self.complete_remote_resumes("user_pause", "paused from the window");
         } else {
             info!("pause button: emulation resumed");
         }
         self.request_redraw();
+    }
+
+    /// The machine came to a stop for a host-side reason: a user or client
+    /// pause, a GDB interrupt or attach, a run_until target, power off, a
+    /// double fault. Every remote resume still outstanding is answered here
+    /// -- a control-protocol continue/run_until and a GDB continue can both
+    /// be pending when both clients share the window -- so neither client
+    /// waits on a stop the other one caused. `reason` is the control
+    /// protocol's stop reason; `detail` reaches both clients (the control
+    /// reply's `detail`, a GDB `O` console line before `T05thread:1;`).
+    /// Returns whether any pending resume was completed.
+    pub(super) fn complete_remote_resumes(&mut self, reason: &str, detail: &str) -> bool {
+        #[allow(unused_mut)]
+        let mut completed = false;
+        #[cfg(feature = "control")]
+        {
+            completed |= self.control_complete_pending(reason, detail);
+        }
+        #[cfg(feature = "gdb")]
+        {
+            completed |= self.gdb_complete_pending_stop(detail);
+        }
+        // Only the control reply carries the reason; a build without it
+        // (or without either driver) still takes both for one call shape.
+        #[cfg(not(feature = "control"))]
+        let _ = reason;
+        #[cfg(not(any(feature = "control", feature = "gdb")))]
+        let _ = detail;
+        completed
+    }
+
+    /// Whether any remote client's resume is outstanding: the machine is
+    /// running on a client's behalf, so nothing may reposition it.
+    #[cfg(any(feature = "control", feature = "gdb"))]
+    pub(super) fn remote_resume_pending(&self) -> bool {
+        #[allow(unused_mut)]
+        let mut pending = false;
+        #[cfg(feature = "control")]
+        {
+            pending |= self.control_resume_pending();
+        }
+        #[cfg(feature = "gdb")]
+        {
+            pending |= self.gdb_resume_pending();
+        }
+        pending
     }
 
     /// Power off: drop into a cold-boot state (RAM cleared) and park the
@@ -1316,8 +1459,12 @@ impl App {
         }
         // A warp a control client or the guest holds goes with the machine
         // too: the guest is gone, and a client's warp.set was for it.
-        if let Some(hold) = self.warp_hold.take() {
-            info!("warp: {} hold released by power off", hold.describe());
+        if !self.warp_holds.is_empty() {
+            info!(
+                "warp: {} hold released by power off",
+                self.warp_holds.describe()
+            );
+            self.warp_holds.clear();
             self.emu.set_paced(true);
             #[cfg(feature = "control")]
             self.control_notify_warp("power_off");
@@ -1343,10 +1490,7 @@ impl App {
             info!("power button: {released} host disk(s) off with the machine, still held for it");
         }
         info!("power button: machine powered off (cold boot state)");
-        #[cfg(feature = "control")]
-        self.control_complete_pending("pause", "power state changed");
-        #[cfg(feature = "gdb")]
-        self.gdb_complete_pending_stop("power state changed");
+        self.complete_remote_resumes("pause", "power state changed");
         if let Err(e) = self.emu.power_on_reset() {
             error!("cold power-on reset failed: {e:#}");
             self.cpu_halted = true;

--- a/src/video/window/control.rs
+++ b/src/video/window/control.rs
@@ -84,6 +84,12 @@ impl App {
         });
     }
 
+    /// Whether this client's own resume (continue / run_until) is
+    /// outstanding.
+    pub(super) fn control_resume_pending(&self) -> bool {
+        self.control.as_ref().is_some_and(|c| c.pending.is_some())
+    }
+
     pub(super) fn control_exit_requested(&self) -> bool {
         self.control.as_ref().is_some_and(|c| c.exit_requested)
     }
@@ -178,8 +184,9 @@ impl App {
         }
         self.emu.bus_mut().ui_disarm_beam_trap_once();
         ctx.remove_all_breaks(&mut self.emu);
-        // A warp the client engaged has no client left to release it.
-        if self.warp_hold == Some(WarpSource::Control) {
+        // A warp the client engaged has no client left to release it;
+        // another holder's warp (a GDB client, the guest) stays.
+        if self.warp_holds.contains(WarpSource::Control) {
             self.set_warp(false, WarpSource::Control);
         }
         self.show_osd("Control client detached");
@@ -189,7 +196,11 @@ impl App {
     fn control_dispatch(&mut self, id: Value, req: Request) {
         match req {
             Request::Core(op) => {
-                let pending = self.control.as_ref().is_some_and(|c| c.pending.is_some());
+                let own_pending = self.control_resume_pending();
+                // Any client's outstanding resume (a GDB continue too, when
+                // both share the window) means the machine is running on
+                // its behalf and must not be repositioned under it.
+                let pending = self.remote_resume_pending();
                 if pending && !op.allowed_while_running() {
                     self.control_send(proto::err_line(
                         &id,
@@ -206,7 +217,7 @@ impl App {
                         .as_mut()
                         .expect("dispatch without control state");
                     ctl.ctx.running = powered_on && !halted && !paused;
-                    ctl.ctx.pending = pending;
+                    ctl.ctx.pending = own_pending;
                     ctl.ctx.powered_on = powered_on;
                     exec::exec_core(&mut self.emu, &mut ctl.ctx, &op)
                 };
@@ -247,7 +258,10 @@ impl App {
     fn control_dispatch_host(&mut self, id: Value, op: HostOp) {
         match op {
             HostOp::Pause => {
-                let had_pending = self.control_complete_pending("pause", "paused by client");
+                let had_pending = self.control_resume_pending();
+                // A GDB continue outstanding on the same window ends here
+                // too, with the same detail.
+                self.complete_remote_resumes("pause", "paused by client");
                 let was_paused = self.paused;
                 if !was_paused {
                     self.paused = true;
@@ -299,7 +313,7 @@ impl App {
                 // itself, so it would step frames out from under a
                 // pending run_until -- past a pc target, or through
                 // frames a stable_frames watcher never got to sample.
-                if self.control.as_ref().is_some_and(|c| c.pending.is_some()) {
+                if self.remote_resume_pending() {
                     self.control_send(proto::err_line(
                         &id,
                         &CtlError::invalid_state("pause before servoing the pointer"),
@@ -376,7 +390,7 @@ impl App {
                 ));
             }
             HostOp::StateLoad { path } => {
-                if self.control.as_ref().is_some_and(|c| c.pending.is_some()) {
+                if self.remote_resume_pending() {
                     self.control_send(proto::err_line(
                         &id,
                         &CtlError::invalid_state("pause before loading a state"),
@@ -416,7 +430,7 @@ impl App {
                 // not reposition the machine, and flipping warp mid-continue
                 // is the point.
                 let outcome = self.set_warp(on, WarpSource::Control);
-                let value = self.warp_report_value(outcome.note);
+                let value = self.warp_report_value(outcome.note.as_deref());
                 self.control_send(proto::ok_line(&id, value));
             }
             HostOp::Reset { warm } => {
@@ -673,7 +687,7 @@ impl App {
             // --control-gui combined with --screenshot-after/--dump-frames:
             // unpaced end to end with no hold or gate, not a manual toggle.
             "capture"
-        } else if let Some(hold) = self.warp_hold {
+        } else if let Some(hold) = self.warp_holds.first() {
             hold.label()
         } else if self.warp_launch.as_ref().is_some_and(|l| l.engaged) {
             "launch"
@@ -686,6 +700,8 @@ impl App {
             "on": !paced,
             "paced": paced,
             "source": source,
+            // Every programmatic hold in force; `source` is the first.
+            "holders": self.warp_holds.labels(),
             "headless": false,
         });
         if let Some(note) = note {
@@ -703,6 +719,7 @@ impl App {
     pub(super) fn control_notify_warp(&mut self, source: &'static str) {
         let paced = self.emu.paced();
         let position = crate::control::observe::position(&self.emu);
+        let holders = self.warp_holds.labels();
         let Some(ctl) = self.control.as_mut() else {
             return;
         };
@@ -715,6 +732,7 @@ impl App {
                 "on": !paced,
                 "paced": paced,
                 "source": source,
+                "holders": holders,
                 "position": position,
             }),
         );
@@ -759,7 +777,7 @@ impl App {
             };
             self.paused = true;
             self.sync_live_audio_suspension();
-            self.control_complete_pending(reason, &detail);
+            self.complete_remote_resumes(reason, &detail);
             self.request_redraw();
             return true;
         }
@@ -767,7 +785,7 @@ impl App {
             if self.emu.bus().emulated_frames() >= frame {
                 self.paused = true;
                 self.sync_live_audio_suspension();
-                self.control_complete_pending(reason, &format!("frame {frame}"));
+                self.complete_remote_resumes(reason, &format!("frame {frame}"));
                 self.request_redraw();
                 return true;
             }
@@ -791,7 +809,7 @@ impl App {
                 }
                 self.paused = true;
                 self.sync_live_audio_suspension();
-                self.control_complete_pending(reason, &format!("cck {cck}"));
+                self.complete_remote_resumes(reason, &format!("cck {cck}"));
                 self.request_redraw();
                 return true;
             }

--- a/src/video/window/gdb.rs
+++ b/src/video/window/gdb.rs
@@ -240,6 +240,19 @@ impl GdbBreaks {
     }
 }
 
+/// Whether `packet` moves the machine's position rather than reading or
+/// resuming it in place: reverse step/continue, `sADDR` / `cADDR` (the
+/// core writes the PC before returning the resume), and a write to the
+/// PC register (regnum 17, `P11=`). Bare `s`/`c`, memory writes and other
+/// register writes are in-place, like the control protocol's own
+/// `allowed_while_running` set.
+fn repositions_machine(packet: &str) -> bool {
+    packet == "bs"
+        || packet == "bc"
+        || (packet.len() > 1 && (packet.starts_with('s') || packet.starts_with('c')))
+        || packet.starts_with("P11=")
+}
+
 /// The decoded text of a qRcmd (monitor) packet, when it is one.
 fn decode_qrcmd(packet: &str) -> Option<String> {
     let hex = packet.strip_prefix("qRcmd,")?;
@@ -379,10 +392,11 @@ impl App {
                 return;
             }
         }
-        // Reverse execution repositions the timeline; refused while a
-        // control client's resume is outstanding, as the control protocol
-        // refuses its own reverse verbs while a GDB continue runs.
-        if (packet == "bs" || packet == "bc") && self.remote_resume_pending() {
+        // Packets that reposition the machine -- reverse execution, a
+        // resume at an address, a PC write -- are refused while a control
+        // client's resume is outstanding, as the control protocol refuses
+        // its own repositioning verbs while a GDB continue runs.
+        if repositions_machine(packet) && self.remote_resume_pending() {
             if let Some(g) = self.gdb.as_mut() {
                 g.core.console.push(
                     "machine is running (a control client resume is pending); pause first\n"

--- a/src/video/window/gdb.rs
+++ b/src/video/window/gdb.rs
@@ -263,6 +263,11 @@ impl App {
         });
     }
 
+    /// Whether this client's continue is outstanding.
+    pub(super) fn gdb_resume_pending(&self) -> bool {
+        self.gdb.as_ref().is_some_and(|g| g.pending)
+    }
+
     /// Drain queued GDB messages. Runs at the top of `about_to_wait`,
     /// before the machine steps, so packets land at a frame boundary;
     /// also callable directly from tests (no sockets or event loop).
@@ -303,11 +308,14 @@ impl App {
             warn!("gdb: arming time travel failed: {e:#}");
         }
         // Attaching stops the target: gdb's first packets read registers
-        // and memory expecting a stopped inferior.
+        // and memory expecting a stopped inferior. A control client's
+        // resume outstanding on the same window ends here (this client's
+        // own pending was cleared above, so no stale stop reply is sent).
         if !self.paused {
             self.paused = true;
             self.sync_live_audio_suspension();
         }
+        self.complete_remote_resumes("pause", "paused: gdb client attached");
         self.show_osd("GDB client attached");
         self.request_redraw();
     }
@@ -320,8 +328,9 @@ impl App {
         };
         g.pending = false;
         g.breaks.remove_all(&mut self.emu);
-        // A warp the client engaged has no client left to release it.
-        if self.warp_hold == Some(WarpSource::Gdb) {
+        // A warp the client engaged has no client left to release it;
+        // another holder's warp (a control client, the guest) stays.
+        if self.warp_holds.contains(WarpSource::Gdb) {
             self.set_warp(false, WarpSource::Gdb);
         }
         self.show_osd(why.to_string());
@@ -336,6 +345,10 @@ impl App {
             self.paused = true;
             self.sync_live_audio_suspension();
         }
+        // A control client's resume outstanding on the same window ends
+        // with the interrupt (this client's own pending is already
+        // cleared, so exactly one stop reply follows).
+        self.complete_remote_resumes("pause", "interrupted by gdb");
         // Ctrl-C always gets a stop reply, pending continue or not (the
         // headless driver answers the raw 0x03 the same way).
         self.gdb_send_packet("T05thread:1;");
@@ -365,6 +378,20 @@ impl App {
                 self.gdb_send_packet("OK");
                 return;
             }
+        }
+        // Reverse execution repositions the timeline; refused while a
+        // control client's resume is outstanding, as the control protocol
+        // refuses its own reverse verbs while a GDB continue runs.
+        if (packet == "bs" || packet == "bc") && self.remote_resume_pending() {
+            if let Some(g) = self.gdb.as_mut() {
+                g.core.console.push(
+                    "machine is running (a control client resume is pending); pause first\n"
+                        .to_string(),
+                );
+            }
+            self.gdb_flush_console();
+            self.gdb_send_packet("E01");
+            return;
         }
         let Some(mut g) = self.gdb.take() else {
             return;
@@ -450,9 +477,11 @@ impl App {
     fn gdb_sync_step(&mut self) {
         if !self.paused {
             // A step against a free-running machine would race the burst
-            // loop; gdb only ever steps a stopped target anyway.
+            // loop; gdb only ever steps a stopped target anyway. A control
+            // client's resume that was running the machine ends here.
             self.paused = true;
             self.sync_live_audio_suspension();
+            self.complete_remote_resumes("pause", "paused for a gdb step");
         }
         let reply = match self.emu.debug_step_realtime() {
             Err(e) => {
@@ -488,17 +517,28 @@ impl App {
                     }
                 }
                 Some("off") => {
-                    self.set_warp(false, WarpSource::Gdb);
-                    "warp off (real-time pacing)\n".to_string()
-                }
-                Some("status") | None => format!(
-                    "warp {}\n",
-                    if self.emu.paced() {
-                        "off (paced)"
-                    } else {
-                        "on (unpaced)"
+                    let outcome = self.set_warp(false, WarpSource::Gdb);
+                    match outcome.note {
+                        // Another holder keeps the machine warping.
+                        Some(note) => format!("warp off for gdb; {note}\n"),
+                        None => "warp off (real-time pacing)\n".to_string(),
                     }
-                ),
+                }
+                Some("status") | None => {
+                    let held = if self.warp_holds.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" (held by {})", self.warp_holds.describe())
+                    };
+                    format!(
+                        "warp {}{held}\n",
+                        if self.emu.paced() {
+                            "off (paced)"
+                        } else {
+                            "on (unpaced)"
+                        }
+                    )
+                }
                 Some(_) => "usage: monitor warp on|off|status\n".to_string(),
             }),
             "watch-reg" | "unwatch-reg" => {

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -11110,6 +11110,7 @@ mod gdb_and_control {
         let far = d.app.emu.bus().emulated_frames() + 1000;
         push(&d.ctl_tx, 3, "run_until", json!({"frame": far}));
         d.app.drain_control();
+        let _ = lines(&d.ctl_rx);
         packet(&d.gdb_tx, "bs");
         d.app.drain_gdb();
         let sent = frames(&d.gdb_rx);
@@ -11118,6 +11119,33 @@ mod gdb_and_control {
             sent.iter().any(|f| f.contains(&hex_encode(b"pause first"))),
             "{sent:?}"
         );
+        // So are a resume at an address (the core writes the PC before
+        // handing back the resume) and a PC register write ...
+        let pc = d.app.emu.machine.pc();
+        packet(&d.gdb_tx, &format!("s{pc:x}"));
+        packet(&d.gdb_tx, &format!("c{pc:x}"));
+        packet(&d.gdb_tx, "P11=00001000");
+        d.app.drain_gdb();
+        assert_eq!(
+            frames(&d.gdb_rx)
+                .iter()
+                .filter(|f| *f == &frame("E01"))
+                .count(),
+            3,
+            "sADDR, cADDR and a PC write are all refused"
+        );
+        assert!(!d.app.paused, "the control run is still going");
+        assert_eq!(d.app.emu.machine.pc(), pc, "nothing moved the PC");
+        // ... while a bare step pauses the machine, ending the control
+        // run, and then steps in place.
+        packet(&d.gdb_tx, "s");
+        d.app.drain_gdb();
+        assert!(d.app.paused);
+        let ctl = lines(&d.ctl_rx);
+        assert_eq!(ctl.len(), 1, "{ctl:?}");
+        assert_eq!(ctl[0]["id"], 3);
+        assert_eq!(ctl[0]["result"]["reason"], "pause");
+        assert_eq!(frames(&d.gdb_rx).last(), Some(&frame("T05thread:1;")));
     }
 
     #[test]
@@ -11145,6 +11173,32 @@ mod gdb_and_control {
         let msg = reply(&d.ctl_rx);
         assert_eq!(msg["result"]["source"], "control");
         assert_eq!(msg["result"]["holders"], json!(["control", "gdb"]));
+
+        // A holder joining or leaving without pacing changing still
+        // reaches the control client as event.warp, so its holder list
+        // never goes stale.
+        d.app
+            .set_warp(true, super::super::app_session::WarpSource::Guest);
+        let evs = lines(&d.ctl_rx);
+        let joined = evs
+            .iter()
+            .find(|l| l["method"] == "event.warp")
+            .expect("event.warp for a joining holder");
+        assert_eq!(joined["params"]["on"], true);
+        assert_eq!(joined["params"]["source"], "guest");
+        assert_eq!(
+            joined["params"]["holders"],
+            json!(["control", "gdb", "guest"])
+        );
+        d.app
+            .set_warp(false, super::super::app_session::WarpSource::Guest);
+        let evs = lines(&d.ctl_rx);
+        let left = evs
+            .iter()
+            .find(|l| l["method"] == "event.warp")
+            .expect("event.warp for a leaving holder");
+        assert_eq!(left["params"]["on"], true, "still warping");
+        assert_eq!(left["params"]["holders"], json!(["control", "gdb"]));
 
         // Releasing the control hold leaves the gdb hold in force.
         push(&d.ctl_tx, 2, "warp.set", json!({"on": false}));

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -7496,12 +7496,12 @@ mod control_drain {
         (app, cmd_tx, reply_rx)
     }
 
-    fn push(cmd_tx: &Sender<CtlMsg>, id: u64, method: &str, params: Value) {
+    pub(super) fn push(cmd_tx: &Sender<CtlMsg>, id: u64, method: &str, params: Value) {
         let req = parse_method(method, &params).expect("request should parse");
         cmd_tx.send(CtlMsg::Request { id: json!(id), req }).unwrap();
     }
 
-    fn reply(reply_rx: &Receiver<String>) -> Value {
+    pub(super) fn reply(reply_rx: &Receiver<String>) -> Value {
         serde_json::from_str(&reply_rx.try_recv().expect("a reply should be queued"))
             .expect("replies are JSON")
     }
@@ -9774,30 +9774,42 @@ fn programmatic_warp_mutes_audio_but_manual_warp_does_not() {
     assert!(outcome.changed);
     assert!(outcome.note.is_none());
     assert!(!app.emu.paced());
-    assert_eq!(app.warp_hold, Some(WarpSource::Guest));
+    assert!(app.warp_holds.contains(WarpSource::Guest));
     assert_eq!(states.borrow().last(), Some(&true), "guest warp is silent");
 
     // One press of the hotkey ends it: paced and audible again.
     app.toggle_warp();
     assert!(app.emu.paced());
-    assert_eq!(app.warp_hold, None);
+    assert!(app.warp_holds.is_empty());
     assert_eq!(states.borrow().last(), Some(&false));
 
     // The manual toggle warps without a hold and without muting.
     app.toggle_warp();
     assert!(!app.emu.paced());
-    assert_eq!(app.warp_hold, None);
+    assert!(app.warp_holds.is_empty());
     assert_eq!(states.borrow().last(), Some(&false));
     app.toggle_warp();
     assert!(app.emu.paced());
 
-    // Warp off is a complete action whoever asks: a control client's
-    // request releases a guest hold too.
+    // Holds are independent: a control client's warp-off releases only
+    // its own hold, so a guest hold keeps the machine warping (the
+    // outcome says who) until the guest releases it.
     app.set_warp(true, WarpSource::Guest);
     let outcome = app.set_warp(false, WarpSource::Control);
+    assert!(!outcome.changed);
+    assert!(
+        outcome.note.as_deref().is_some_and(|n| n.contains("guest")),
+        "{:?}",
+        outcome.note
+    );
+    assert!(!app.emu.paced());
+    assert!(app.warp_holds.contains(WarpSource::Guest));
+    assert_eq!(states.borrow().last(), Some(&true), "still silent");
+    let outcome = app.set_warp(false, WarpSource::Guest);
     assert!(outcome.changed);
     assert!(app.emu.paced());
-    assert_eq!(app.warp_hold, None);
+    assert!(app.warp_holds.is_empty());
+    assert_eq!(states.borrow().last(), Some(&false));
 }
 
 #[test]
@@ -9813,7 +9825,7 @@ fn power_off_releases_a_programmatic_hold() {
     assert!(!app.emu.paced());
     app.power_off();
     assert!(app.emu.paced(), "the hold goes with the machine");
-    assert_eq!(app.warp_hold, None);
+    assert!(app.warp_holds.is_empty());
 }
 
 /// Control-protocol warp control through the windowed drain.
@@ -9956,7 +9968,7 @@ mod warp_control {
         assert_eq!(reply["headless"], false);
         assert!(reply["note"].is_null());
         assert!(!app.emu.paced());
-        assert_eq!(app.warp_hold, Some(WarpSource::Control));
+        assert!(app.warp_holds.contains(WarpSource::Control));
         assert_eq!(
             states.borrow().last(),
             Some(&true),
@@ -9973,7 +9985,7 @@ mod warp_control {
         assert_eq!(reply["on"], false);
         assert_eq!(reply["source"], "none");
         assert!(app.emu.paced());
-        assert_eq!(app.warp_hold, None);
+        assert!(app.warp_holds.is_empty());
         assert_eq!(states.borrow().last(), Some(&false));
 
         let reply = call(&mut app, &tx, &rx, 3, "warp.get", json!({}));
@@ -10024,7 +10036,7 @@ mod warp_control {
         assert!(ended, "the gate should end within a dozen frames");
         assert!(app.warp_boot.is_none());
         assert!(!app.emu.paced());
-        assert_eq!(app.warp_hold, Some(WarpSource::Control));
+        assert!(app.warp_holds.contains(WarpSource::Control));
         assert_eq!(states.borrow().last(), Some(&true));
         assert!(
             events(&rx, "event.warp").is_empty(),
@@ -10034,7 +10046,7 @@ mod warp_control {
         // The hotkey ends it, and the client hears about it.
         app.toggle_warp();
         assert!(app.emu.paced());
-        assert_eq!(app.warp_hold, None);
+        assert!(app.warp_holds.is_empty());
         assert_eq!(states.borrow().last(), Some(&false));
         let warp = events(&rx, "event.warp");
         assert_eq!(warp.len(), 1);
@@ -10058,7 +10070,7 @@ mod warp_control {
             .request_warp(true);
         assert!(app.service_uaelib(), "pacing changed: the burst breaks");
         assert!(!app.emu.paced());
-        assert_eq!(app.warp_hold, Some(WarpSource::Guest));
+        assert!(app.warp_holds.contains(WarpSource::Guest));
         assert_eq!(states.borrow().last(), Some(&true));
         let warp = events(&rx, "event.warp");
         assert_eq!(warp.len(), 1);
@@ -10075,7 +10087,7 @@ mod warp_control {
             .request_warp(false);
         assert!(app.service_uaelib());
         assert!(app.emu.paced());
-        assert_eq!(app.warp_hold, None);
+        assert!(app.warp_holds.is_empty());
         assert_eq!(states.borrow().last(), Some(&false));
         let warp = events(&rx, "event.warp");
         assert_eq!(warp.len(), 1);
@@ -10088,14 +10100,14 @@ mod warp_control {
         let (mut app, states) = audio_app();
         let (tx, rx) = attach(&mut app);
         call(&mut app, &tx, &rx, 1, "warp.set", json!({"on": true}));
-        assert_eq!(app.warp_hold, Some(WarpSource::Control));
+        assert!(app.warp_holds.contains(WarpSource::Control));
         tx.send(CtlMsg::Disconnected).unwrap();
         app.drain_control();
         assert!(
             app.emu.paced(),
             "a warp the client engaged has no client left to release it"
         );
-        assert_eq!(app.warp_hold, None);
+        assert!(app.warp_holds.is_empty());
         assert_eq!(states.borrow().last(), Some(&false));
     }
 
@@ -10116,7 +10128,7 @@ mod warp_control {
         );
         let reply = call(&mut app, &tx, &rx, 2, "warp.set", json!({"on": true}));
         assert!(reply["note"].is_string());
-        assert_eq!(app.warp_hold, None);
+        assert!(app.warp_holds.is_empty());
         let reply = call(&mut app, &tx, &rx, 3, "warp.get", json!({}));
         assert_eq!(reply["on"], true);
         assert_eq!(reply["source"], "capture");
@@ -10166,20 +10178,20 @@ mod gdb_drain {
         (app, cmd_tx, frame_rx)
     }
 
-    fn packet(cmd_tx: &Sender<GdbMsg>, payload: &str) {
+    pub(super) fn packet(cmd_tx: &Sender<GdbMsg>, payload: &str) {
         cmd_tx.send(GdbMsg::Packet(payload.to_string())).unwrap();
     }
 
-    fn monitor(cmd_tx: &Sender<GdbMsg>, command: &str) {
+    pub(super) fn monitor(cmd_tx: &Sender<GdbMsg>, command: &str) {
         packet(cmd_tx, &format!("qRcmd,{}", hex_encode(command.as_bytes())));
     }
 
     /// The wire framing `GdbHandle::send_packet` produces for `payload`.
-    fn frame(payload: &str) -> String {
+    pub(super) fn frame(payload: &str) -> String {
         format!("${payload}#{:02x}", checksum(payload.as_bytes()))
     }
 
-    fn frames(frame_rx: &Receiver<String>) -> Vec<String> {
+    pub(super) fn frames(frame_rx: &Receiver<String>) -> Vec<String> {
         let mut out = Vec::new();
         while let Ok(f) = frame_rx.try_recv() {
             out.push(f);
@@ -10291,17 +10303,16 @@ mod gdb_drain {
         monitor(&cmd_tx, "warp on");
         app.drain_gdb();
         assert!(!app.emu.paced(), "monitor warp on unpaces the machine");
-        assert_eq!(
-            app.warp_hold,
-            Some(super::super::app_session::WarpSource::Gdb)
-        );
+        assert!(app
+            .warp_holds
+            .contains(super::super::app_session::WarpSource::Gdb));
         cmd_tx.send(GdbMsg::Disconnected).unwrap();
         app.drain_gdb();
         assert!(
             app.emu.paced(),
             "a disconnect releases the client's warp hold"
         );
-        assert!(app.warp_hold.is_none());
+        assert!(app.warp_holds.is_empty());
     }
 
     #[test]
@@ -10871,5 +10882,296 @@ mod uaelib_insights {
             lines,
             vec!["no resources registered (uaelib debug_register_*)".to_string()]
         );
+    }
+}
+
+/// GDB and the control protocol sharing one window (`--gdb-gui` with
+/// `--control-gui`): a stop answers every outstanding resume, either
+/// client's pause ends the other's run, repositioning is refused while
+/// either runs the machine, and warp holds are per client.
+#[cfg(all(feature = "control", feature = "gdb"))]
+mod gdb_and_control {
+    use super::control_drain::{push, reply};
+    use super::gdb_drain::{frame, frames, monitor, packet};
+    use super::test_app;
+    use crate::control::windowed::{ControlHandle, CtlMsg};
+    use crate::gdbstub::core::hex_encode;
+    use crate::gdbstub::windowed::{GdbHandle, GdbMsg};
+    use serde_json::{json, Value};
+    use std::sync::mpsc::{Receiver, Sender};
+
+    type App = super::super::App;
+
+    struct Duo {
+        app: App,
+        ctl_tx: Sender<CtlMsg>,
+        ctl_rx: Receiver<String>,
+        gdb_tx: Sender<GdbMsg>,
+        gdb_rx: Receiver<String>,
+    }
+
+    /// Both clients attached to one window; with `connect_gdb` the GDB
+    /// client has connected, which pauses the machine.
+    fn attached(connect_gdb: bool) -> Duo {
+        let mut app = test_app();
+        let (ctl_handle, ctl_tx, ctl_rx) = ControlHandle::test_pair();
+        app.attach_control(ctl_handle, &crate::control::Config::new(":0".into()));
+        let (gdb_handle, gdb_tx, gdb_rx) = GdbHandle::test_pair();
+        app.attach_gdb(gdb_handle, &crate::gdbstub::Config::new(":0".into()));
+        if connect_gdb {
+            gdb_tx.send(GdbMsg::Connected).unwrap();
+            app.drain_gdb();
+        }
+        Duo {
+            app,
+            ctl_tx,
+            ctl_rx,
+            gdb_tx,
+            gdb_rx,
+        }
+    }
+
+    fn drain(app: &mut App) {
+        app.drain_control();
+        app.drain_gdb();
+    }
+
+    /// Every line the control client received so far (replies and
+    /// notifications).
+    fn lines(rx: &Receiver<String>) -> Vec<Value> {
+        let mut out = Vec::new();
+        while let Ok(line) = rx.try_recv() {
+            out.push(serde_json::from_str(&line).expect("json line"));
+        }
+        out
+    }
+
+    /// The framed `O` packet carrying a console line.
+    fn console(text: &str) -> String {
+        frame(&format!("O{}", hex_encode(text.as_bytes())))
+    }
+
+    /// The window's burst loop per frame, up to `n` frames: step, surface
+    /// stops, check control targets. True when a stop or target ended it.
+    fn run_frames(app: &mut App, n: usize) -> bool {
+        for _ in 0..n {
+            app.emu.step_frame().expect("frame");
+            if app.surface_debug_stop() {
+                return true;
+            }
+            if app.control_run_target_reached() {
+                return true;
+            }
+        }
+        false
+    }
+
+    #[test]
+    fn a_breakpoint_answers_both_pending_clients_and_keeps_the_panel_closed() {
+        let mut d = attached(true);
+        assert!(d.app.paused, "attaching gdb stops the target");
+        let target = d.app.emu.machine.pc().wrapping_add(8) & 0x00FF_FFFF;
+        packet(&d.gdb_tx, &format!("Z0,{target:x},2"));
+        push(&d.ctl_tx, 1, "continue", json!({}));
+        packet(&d.gdb_tx, "c");
+        drain(&mut d.app);
+        assert!(!d.app.paused);
+        assert_eq!(
+            frames(&d.gdb_rx),
+            vec![frame("OK")],
+            "Z0 answered, c deferred"
+        );
+        assert!(lines(&d.ctl_rx).is_empty(), "continue deferred");
+
+        assert!(run_frames(&mut d.app, 4), "the breakpoint hits");
+        assert!(d.app.paused);
+        assert_eq!(d.app.emu.machine.pc() & 0x00FF_FFFF, target);
+        let ctl = lines(&d.ctl_rx);
+        assert_eq!(ctl.len(), 1, "{ctl:?}");
+        assert_eq!(ctl[0]["id"], 1);
+        assert_eq!(ctl[0]["result"]["reason"], "breakpoint");
+        assert_eq!(frames(&d.gdb_rx), vec![frame("T05hwbreak:;thread:1;")]);
+        assert!(
+            d.app.debugger_panel.is_none(),
+            "a stop both clients consumed must not open the local panel"
+        );
+    }
+
+    #[test]
+    fn a_control_pause_completes_a_pending_gdb_continue() {
+        let mut d = attached(true);
+        packet(&d.gdb_tx, "c");
+        drain(&mut d.app);
+        assert!(!d.app.paused);
+        assert!(frames(&d.gdb_rx).is_empty());
+        push(&d.ctl_tx, 1, "pause", json!({}));
+        d.app.drain_control();
+        assert!(d.app.paused);
+        let msg = reply(&d.ctl_rx);
+        assert_eq!(msg["id"], 1);
+        assert_eq!(msg["result"]["reason"], "pause");
+        assert_eq!(
+            frames(&d.gdb_rx),
+            vec![console("paused by client\n"), frame("T05thread:1;")],
+            "the gdb continue ends with the client's pause"
+        );
+    }
+
+    #[test]
+    fn a_gdb_interrupt_completes_a_pending_control_run_until() {
+        let mut d = attached(true);
+        let far = d.app.emu.bus().emulated_frames() + 1000;
+        push(&d.ctl_tx, 1, "run_until", json!({"frame": far}));
+        d.app.drain_control();
+        assert!(!d.app.paused);
+        d.gdb_tx.send(GdbMsg::Interrupt).unwrap();
+        d.app.drain_gdb();
+        assert!(d.app.paused);
+        let ctl = lines(&d.ctl_rx);
+        assert_eq!(ctl.len(), 1, "{ctl:?}");
+        assert_eq!(ctl[0]["result"]["reason"], "pause");
+        assert!(
+            ctl[0]["result"]["detail"]
+                .as_str()
+                .is_some_and(|d| d.contains("gdb")),
+            "{ctl:?}"
+        );
+        assert_eq!(
+            frames(&d.gdb_rx),
+            vec![frame("T05thread:1;")],
+            "exactly one stop reply for the interrupt"
+        );
+    }
+
+    #[test]
+    fn a_control_frame_target_completes_a_pending_gdb_continue() {
+        let mut d = attached(true);
+        let target = d.app.emu.bus().emulated_frames() + 2;
+        push(&d.ctl_tx, 1, "run_until", json!({"frame": target}));
+        packet(&d.gdb_tx, "c");
+        drain(&mut d.app);
+        assert!(!d.app.paused);
+        assert!(run_frames(&mut d.app, 6), "the frame target lands");
+        assert!(d.app.paused);
+        let msg = reply(&d.ctl_rx);
+        assert_eq!(msg["result"]["reason"], "target");
+        assert_eq!(
+            frames(&d.gdb_rx),
+            vec![console(&format!("frame {target}\n")), frame("T05thread:1;")]
+        );
+    }
+
+    #[test]
+    fn a_gdb_attach_mid_run_completes_the_control_pending() {
+        let mut d = attached(false);
+        push(&d.ctl_tx, 1, "continue", json!({}));
+        d.app.drain_control();
+        assert!(!d.app.paused);
+        d.gdb_tx.send(GdbMsg::Connected).unwrap();
+        d.app.drain_gdb();
+        assert!(d.app.paused, "attaching stops the target");
+        let msg = reply(&d.ctl_rx);
+        assert_eq!(msg["result"]["reason"], "pause");
+        assert!(
+            msg["result"]["detail"]
+                .as_str()
+                .is_some_and(|d| d.contains("attached")),
+            "{msg}"
+        );
+        assert!(
+            frames(&d.gdb_rx).is_empty(),
+            "the new client must not get a stale stop reply"
+        );
+    }
+
+    #[test]
+    fn repositioning_is_refused_while_the_other_client_runs_the_machine() {
+        let mut d = attached(true);
+        packet(&d.gdb_tx, "c");
+        drain(&mut d.app);
+        // A control reverse step under the gdb continue is refused; reads
+        // are still fine.
+        push(&d.ctl_tx, 1, "reverse_step", json!({"n": 1}));
+        push(&d.ctl_tx, 2, "regs.get", Value::Null);
+        d.app.drain_control();
+        let ctl = lines(&d.ctl_rx);
+        assert_eq!(ctl.len(), 2, "{ctl:?}");
+        assert!(
+            ctl[0]["error"]["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("pause before repositioning")),
+            "{ctl:?}"
+        );
+        assert_eq!(ctl[1]["result"]["pc"], d.app.emu.machine.pc());
+        // And gdb's reverse step under a control run_until likewise.
+        d.gdb_tx.send(GdbMsg::Interrupt).unwrap();
+        d.app.drain_gdb();
+        let _ = frames(&d.gdb_rx);
+        let far = d.app.emu.bus().emulated_frames() + 1000;
+        push(&d.ctl_tx, 3, "run_until", json!({"frame": far}));
+        d.app.drain_control();
+        packet(&d.gdb_tx, "bs");
+        d.app.drain_gdb();
+        let sent = frames(&d.gdb_rx);
+        assert_eq!(sent.last(), Some(&frame("E01")), "{sent:?}");
+        assert!(
+            sent.iter().any(|f| f.contains(&hex_encode(b"pause first"))),
+            "{sent:?}"
+        );
+    }
+
+    #[test]
+    fn warp_holds_are_per_client_and_release_independently() {
+        let mut d = attached(true);
+        d.app.emu.set_paced(true);
+        monitor(&d.gdb_tx, "warp on");
+        d.app.drain_gdb();
+        assert!(!d.app.emu.paced());
+        assert!(d
+            .app
+            .warp_holds
+            .contains(super::super::app_session::WarpSource::Gdb));
+        // The control client hears about the gdb hold.
+        let evs = lines(&d.ctl_rx);
+        let warp_on = evs
+            .iter()
+            .find(|l| l["method"] == "event.warp")
+            .expect("event.warp");
+        assert_eq!(warp_on["params"]["source"], "gdb");
+        assert_eq!(warp_on["params"]["holders"], json!(["gdb"]));
+
+        push(&d.ctl_tx, 1, "warp.set", json!({"on": true}));
+        d.app.drain_control();
+        let msg = reply(&d.ctl_rx);
+        assert_eq!(msg["result"]["source"], "control");
+        assert_eq!(msg["result"]["holders"], json!(["control", "gdb"]));
+
+        // Releasing the control hold leaves the gdb hold in force.
+        push(&d.ctl_tx, 2, "warp.set", json!({"on": false}));
+        d.app.drain_control();
+        let msg = reply(&d.ctl_rx);
+        assert_eq!(msg["result"]["on"], true);
+        assert_eq!(msg["result"]["holders"], json!(["gdb"]));
+        assert!(
+            msg["result"]["note"]
+                .as_str()
+                .is_some_and(|n| n.contains("gdb")),
+            "{msg}"
+        );
+        assert!(!d.app.emu.paced());
+
+        // The gdb client going away releases the last hold.
+        d.gdb_tx.send(GdbMsg::Disconnected).unwrap();
+        d.app.drain_gdb();
+        assert!(d.app.emu.paced());
+        assert!(d.app.warp_holds.is_empty());
+        let evs = lines(&d.ctl_rx);
+        let warp_off = evs
+            .iter()
+            .find(|l| l["method"] == "event.warp")
+            .expect("event.warp on release");
+        assert_eq!(warp_off["params"]["source"], "gdb");
+        assert_eq!(warp_off["params"]["on"], false);
+        assert_eq!(warp_off["params"]["holders"], json!([]));
     }
 }


### PR DESCRIPTION
## What changes

`--gdb-gui` and `--control-gui` can now be attached to the same windowed session: a stock GDB frontend for source-level debugging and a control-protocol client for emulator control and observation, side by side -- the split the VS Code integration is built around. Until now `main.rs` rejected the pair; the headless forms (`--gdb`, `--control`) still exclude everything, since each owns the machine's run loop.

## Design

Both windowed drivers were already frame-boundary drains on one session with disjoint `App` state; the exclusion stood in for two contentions, resolved here instead of avoided:

- **A stop answers every outstanding resume.** `surface_debug_stop` lets both the control hook and the GDB hook consume a `DebugStop` (a control client with nothing pending still hears of it as `event.stopped`) and opens the local debugger panel only when neither did. Every host-side stop -- user or client pause, `run_until` target, GDB attach / `^C` / step, power off, double fault -- goes through one App primitive, `complete_remote_resumes(reason, detail)`, so a control `run_until` ends with reason `pause` when GDB interrupts, and a GDB `continue` ends with `T05` plus a console line naming the reason when the control client pauses or its target lands. No client is ever left waiting on a stop the other caused.
- **Repositioning is refused under the other client's run.** The control `allowed_while_running` guard, the pointer servo and `state.load` now consult either client's outstanding resume; GDB's `bs`/`bc` are refused (with a console line) while a control resume is pending.
- **Per-client warp holds.** The single `warp_hold` slot becomes `WarpHolds`, one bit per programmatic source: the control client, the GDB client and the guest each hold warp independently and release only their own; the machine re-paces when the last hold goes, the reply / console line names any remaining holder, and the manual toggle or power off clears them all. `warp.get` and `event.warp` gain a `holders` array, and `event.warp` can now report `source: "gdb"`.

## Verification

- New `mod gdb_and_control` drain suite (both handles on one `test_app`, socket-free): one breakpoint answers both pending clients and keeps the panel closed; a control `pause` and a control frame target each end a pending GDB `continue` (`O` line + `T05`); a GDB interrupt and a GDB attach each end a pending control run with reason `pause`; `reverse_step` refused under the GDB continue and `bs` refused under the control run; warp holds compose and release per client, with `event.warp` on the release.
- The independent-holds semantics replace the "any warp-off ends warp" assertion in the existing warp test; CLI tests cover the accepted pair and the remaining headless exclusions.
- Full suite green (3268 lib + bins), clippy and fmt clean, single-feature builds (`frontend,control`, `frontend,gdb`, `frontend`) and copperline-player check, strict HTML + PDF docs builds.
- Not yet run live with real `m68k-amigaos-gdb` and `copperline-ctl` on one window (opens a window); the drain suite exercises the same paths.

## Judgment calls

- Warp-off no longer releases another source's hold (agreed with the maintainer); the window's warp shortcut remains the "make it all stop" escape hatch.
- A GDB attach pauses a control-driven run and answers the control client with `reason: "pause"` -- a stop it did not request, the same shape as a user pause today.
- GDB believes the target is stopped while a control `continue` runs it; reads still happen at frame boundaries and only reverse execution is refused. Same situation as the user unpausing the window under GDB; documented rather than enforced.
- Local pause paths (`debugger_toggle_run`, console `PAUSE`, panel opens) still complete nobody's pending -- pre-existing for each client alone, cheap follow-up.
- Shared state left alone: `last_debug_stop` (OSD), time-travel ring sizing (last attach wins), control's PC-history arming now applying while GDB is attached.
