### PR TITLE
deps: bump m68k to 0.12.1 for the 68030/68040 timing models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2090,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.11.6"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaedc7710ba71202eb3f539c1be37f171083c17253c26a9eba5f96d24137095"
+checksum = "d1e596886511cf8e15e844b7a2448874f91d288eb22370c5f200b8f5e9bdfa3c"
 dependencies = [
  "cranelift-codegen 0.132.3",
  "cranelift-frontend 0.132.3",
@@ -3748,7 +3748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ gdb = []
 fluxbridge = ["dep:fluxbridge"]
 
 [dependencies]
-m68k = { version = "0.11", features = ["serde"] }
+m68k = { version = "0.12", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.

--- a/crates/copperline-player/Cargo.lock
+++ b/crates/copperline-player/Cargo.lock
@@ -1546,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.11.6"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaedc7710ba71202eb3f539c1be37f171083c17253c26a9eba5f96d24137095"
+checksum = "d1e596886511cf8e15e844b7a2448874f91d288eb22370c5f200b8f5e9bdfa3c"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/crates/copperline-web/Cargo.lock
+++ b/crates/copperline-web/Cargo.lock
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.11.6"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaedc7710ba71202eb3f539c1be37f171083c17253c26a9eba5f96d24137095"
+checksum = "d1e596886511cf8e15e844b7a2448874f91d288eb22370c5f200b8f5e9bdfa3c"
 dependencies = [
  "serde",
 ]

--- a/crates/cputest-runner/Cargo.lock
+++ b/crates/cputest-runner/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "m68k"
-version = "0.11.6"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaedc7710ba71202eb3f539c1be37f171083c17253c26a9eba5f96d24137095"
+checksum = "d1e596886511cf8e15e844b7a2448874f91d288eb22370c5f200b8f5e9bdfa3c"
 
 [[package]]
 name = "shlex"

--- a/crates/cputest-runner/Cargo.toml
+++ b/crates/cputest-runner/Cargo.toml
@@ -15,7 +15,7 @@ name = "cputest-runner"
 path = "src/main.rs"
 
 [dependencies]
-m68k = "0.11"
+m68k = "0.12"
 
 [build-dependencies]
 cc = "1"

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -3,7 +3,7 @@
 ## The wrapper and the bus adapter
 
 `M68kMachine` (`src/cpu.rs`) wraps the published pure-Rust
-[`m68k` 0.11 core](https://docs.rs/crate/m68k/0.11.0). The core sees
+[`m68k` 0.12 core](https://docs.rs/crate/m68k/0.12.1). The core sees
 the machine through an adapter implementing its `AddressBus` trait, so
 every CPU-visible access -- RAM, ROM, custom registers, CIA, RTC,
 autoconfig, Gayle, Akiko -- routes into the shared `Bus` and is billed in
@@ -35,7 +35,7 @@ fits a 68881/68882 to any 020/030 (and is on by default for the 68040,
 whose FPU is on-die): the `m68k` core executes the 6888x instruction
 set in true 80-bit extended precision via a pure-Rust software floating-
 point engine
-([`softfloat.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/fpu/softfloat.rs)).
+([`softfloat.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/fpu/softfloat.rs)).
 Arithmetic (add, sub,
 mul, div, sqrt, and the single-accuracy FSGLMUL/FSGLDIV, which round the
 mantissa to 24 bits but keep the extended exponent range -- gcc -m68040
@@ -53,13 +53,13 @@ whose saved FPU frame carries a foreign size) are all modelled. The transcendent
 FASIN/FACOS/FATAN, the hyperbolics, FETOX/FETOXM1/FTWOTOX/FTENTOX,
 FLOGN/FLOGNP1/FLOG2/FLOG10) and FSINCOS run in extended precision too: a
 double-`FloatX80` ("double-double", ~128-bit) layer
-([`dd.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/fpu/dd.rs))
+([`dd.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/fpu/dd.rs))
 evaluates Taylor/atanh series over reduced
 ranges and rounds the result to extended under the FPCR mode, setting INEX
 and the domain flags (OPERR/DZ). Accuracy is validated against an
 arbitrary-precision oracle (the pure-Rust `astro-float`, a dev-only
 dependency;
-[`fpu_accuracy.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/tests/fpu_accuracy.rs)):
+[`fpu_accuracy.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/tests/fpu_accuracy.rs)):
 every function is within
 1 ULP across a wide sweep and all four rounding modes, and round-to-nearest
 is correctly rounded in practice. They are not chip-bit-exact -- the real
@@ -69,7 +69,7 @@ quotient byte. This covers Kickstart's
 detection and per-task FPU context switching. The
 68000's per-instruction cycle counts in the `m68k` core have been
 corrected to exact totals across the SingleStepTests 68000 cycle corpus
-([validation details](https://github.com/benletchford/m68k-rs/tree/m68k-v0.11.0#validation--testing)),
+([validation details](https://github.com/benletchford/m68k-rs/tree/m68k-v0.12.1#validation--testing)),
 which is what makes
 cycle-budgeted pacing trustworthy.
 
@@ -139,7 +139,7 @@ precise.
 
 The 68000's two-word instruction prefetch queue (IRD/IRC) is modelled in
 the `m68k` core
-([`prefetch_queue`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/core/cpu.rs)):
+([`prefetch_queue`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/core/cpu.rs)):
 the
 next opcode is fetched before the current instruction finishes, so
 self-modifying code that overwrites the *next* instruction executes the
@@ -201,13 +201,13 @@ DBcc loop mode: a DBcc that branches -4 back to a loopable one-word
 instruction holds the body/DBcc pair in the prefetch queue and re-executes
 it with no instruction fetches until the condition turns true, the counter
 expires, or an exception intervenes (`loop_mode` in
-[`core/cpu.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/core/cpu.rs);
+[`core/cpu.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/core/cpu.rs);
 the loopable set and the DBcc entry/exit arms live in
-[`core/decode.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/core/decode.rs)).
+[`core/decode.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/core/decode.rs)).
 A looping DBcc iteration costs 6 internal
 clocks and touches the bus only for the body's operands, which is what
 makes tight copy/clear loops measurably faster on a real 68010.
-[`loop_mode_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/tests/loop_mode_timing_tests.rs)
+[`loop_mode_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/tests/loop_mode_timing_tests.rs)
 pins engagement, the
 68000's non-engagement, and the no-fetch iteration cost.
 
@@ -231,7 +231,7 @@ the STOP itself, so the handler's RTE re-executes it; a pending trace
 (T set in the SR the instruction started with) has priority and recovers
 from the stop, while a T bit loaded *by* STOP does not fire while
 stopped.
-[`stop_and_68010_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/tests/stop_and_68010_timing_tests.rs)
+[`stop_and_68010_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/tests/stop_and_68010_timing_tests.rs)
 pins all of these.
 
 ## Caches
@@ -315,7 +315,7 @@ shares the 040's three-level walker and TC[15] enable; PTEST is gone
 faulting with the format $4 frame.
 
 **Timing.**
-[`timing_060.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/core/timing_060.rs)
+[`timing_060.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/core/timing_060.rs)
 replaces the 020+
 scaling formula for the 060: every opcode word classifies (a build-once
 64K table over a pure function) into the MC68060UM Chapter 10 dispatch
@@ -357,7 +357,7 @@ instruction cache, a three-stage pipeline, execution overlap, dynamic bus
 sizing, and alignment-dependent transfers, so an opcode does not have one
 context-free cycle count.
 
-[`timing_020.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.11.0/src/core/timing_020.rs)
+[`timing_020.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/core/timing_020.rs)
 transcribes the integer timing tables
 from section 8.2 of the
 [MC68020 User's Manual](https://www.nxp.com/docs/en/data-sheet/MC68020UM.pdf).
@@ -369,22 +369,61 @@ immediate fetches hit the instruction cache; any instruction-stream miss
 selects Worst Case. This covers the standard effective-address tables, the
 complete MOVE matrix, arithmetic and logical instructions, multiply/divide,
 shifts, bit/bitfield operations, branches, control flow, and save/restore
-paths. The 68000 and 68010 timing paths are unchanged, and the 68030/040
-retain the earlier scaled approximation rather than incorrectly inheriting
-68020 silicon timings.
+paths. The 68000 and 68010 timing paths are unchanged.
 
-Real-hardware measurements in `timing-test/accelprobe.asm` document timing on
-an A4000 with a 25 MHz 68030 board, a 25 MHz A3640 (68040), and a 50 MHz
-BFG9060 (68060). Key findings:
+The 68030 runs the same MC68020UM tables (m68k 0.12): its integer core is
+the 020's, and the real-hardware columns in `timing-test/accelprobe.asm`
+(a 25 MHz 68030 CPU-slot board in an A4000) measure the same anchor
+figures the real A1200's 020 did -- taken `dbra` 6 clocks, `mulu.w` ~29.
+Re-running the probe on `tt-a4000-030.toml` after the switch lands the
+`move.w`, `mulu.w`, and fast-stack `trap` rows within 1% of the board
+(the scaled-68000 approximation had the `move.w` loop 1.26x over and the
+fast-stack `trap` 1.13x under; `mulu.w` was already exact) and pulls the
+bare taken `dbra` from 1.35x to 1.18x over. The call, `movem`, and chip-stack
+`trap` rows are bus-bound and unchanged at 1.2-1.7x over.
 
-- The scaled approximation over-penalizes basic 68040 instruction execution
-  by ~2-2.5x (a taken `dbra` measures ~4 clocks on hardware vs ~8 in the model;
-  `mulu.w` is ~10 vs ~27).
-- Real 68030 instruction execution matches measured 68020 timings (taken
-  `dbra` is 6 clocks; `mulu.w` is ~29 clocks), indicating 68030 timing aligns
-  with MC68020UM tables while 68040 requires dedicated pipeline modeling.
+## 68040 timing
+
+[`timing_040.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/core/timing_040.rs)
+(m68k 0.12) gives the 68040 a single-issue pipeline model in place of the
+scaled approximation, which the same accelprobe columns (a 25 MHz A3640,
+two byte-identical serial captures) measured as ~2-2.5x pessimistic on
+plain execution: a taken-`dbra` loop runs 4.06 clocks per iteration where
+the approximation billed ~8, a `move.w`+`dbra` loop 4.08 (the one-clock
+body hides entirely in the branch resolution), and `mulu.w #imm`+`dbra`
+14.0 against ~35. The model reuses the 68060 opcode classifier: most
+ALU/move instructions cost their one-clock occupancy, data-dependent and
+unclassified costs derive from the corrected 68000 reference count as
+`(raw/4).max(1)`, an indexed EA adds a clock, and branches pay small static
+costs (taken Bcc/BRA 3, not-taken 2, DBcc 3 either way, computed flow
+changes a 4-clock refill floor) -- the 040 has no branch cache, so there is
+nothing to predict or fold. CINV/CPUSH cost a dozen clocks even on a clean
+line (the A3640 measures ~12 per `CPUSHL DC,(An)`, accelprobe row 15).
+Memory latency stays billed by the host bus per access, as on the 020 and
+060 paths, and exception entries keep the legacy scaled costs so the
+exception timing calibration is unchanged.
+
+DBcc-taken at 3 clocks lands the ubiquitous one-clock-body loop on the
+measured 4 per iteration; the empty `dbra` loop then reads 3 against the
+measured 4.06, the deliberate compromise of a model with no
+overlap/absorption stage. Residuals are not uniformly conservative: there
+is no execute-stage overlap (pessimistic), shifts and bit operations take
+the 060 class costs (optimistic where real 040 silicon runs those forms a
+clock or two slower), and the write-back stage and store buffer are not
+modelled (writes bill at bus rate).
+
+Re-running the probe on `tt-a4000-040.toml` against the A3640 captures:
+the `move.w`+`dbra` row is tick-exact, `mulu.w` and `cpushl` are within
+7%, and the bare `dbra` reads the documented 3.0 against 4.06 clocks. The
+`trap` rows stay 1.4-1.7x under (exception entries keep the legacy scaled
+costs) and `movem` 1.4x over; everything else that still differs is the
+bridge and fast-RAM region billing below, not the core.
+
+What no CPU table covers, the same accelprobe columns quantify and remain
+open on the Copperline side:
+
 - The A3640/BFG9060 CPU-slot bridge increases chip-RAM `move.l` read latency
-  to 2.5-3.4 us (the 68030 chip path matches emulated timing directly).
+  to 2.5-3.4 us (the 68030 board's chip path matches emulated timing directly).
 - Fast RAM regions exhibit distinct access speeds on hardware (CPU-card ~66 ns,
   motherboard ~320 ns, Zorro III ~530 ns per sequential longword read) whereas
   the current emulator bills all fast RAM at native CPU clock rates.
@@ -524,7 +563,7 @@ The same column appeared to show 020 result forwarding -- the RAW-dependent
 MOVE pair of `timing-test` row 29 runs one clock per iteration faster than
 the independent pair of row 28 -- and m68k modelled it as such up to and
 including 0.5.0. **That model was wrong; it was removed upstream in m68k
-0.5.1, and remains absent from this tree's 0.11.0 dependency.** A second probe disk
+0.5.1, and remains absent from this tree's 0.12.1 dependency.** A second probe disk
 (`timing-test/fwdprobe.asm`) ran the same two
 loops at the opposite alignments on the same machine and reversed the
 ordering, which closes the 2x2: with the register dependency and the branch

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -692,7 +692,7 @@ debits a per-frame instruction budget one of two ways, selected by
   tails, chip-bus grants and contention waits -- so the slice's elapsed bus
   CCK is the true hardware cost (`real_slice_accounting` in
   `src/emulator.rs`). Because the m68k core's 68000 cycle totals are exact
-  across its [SingleStepTests validation corpus](https://github.com/benletchford/m68k-rs/tree/m68k-v0.11.0#validation--testing),
+  across its [SingleStepTests validation corpus](https://github.com/benletchford/m68k-rs/tree/m68k-v0.12.1#validation--testing),
   this matches a stock PAL 68000.
 - `instructions`: a flat cycles-per-instruction quota
   (`COPPERLINE_REAL_CPU_CPI`, default 4.0), debited by retired

--- a/timing-test/README.md
+++ b/timing-test/README.md
@@ -61,9 +61,13 @@ memory bank.
 The probe header compares predicted timings for A4000 models
 (`tt-a4000-060/-040/-030.toml`) with real-hardware measurements from an A4000
 (equipped with BFG9060 68060/50, A3640 68040/25, and a 25 MHz 68030 board).
-Key findings show that basic 68040 execution is currently over-penalized
-~2-2.5x, CPU-slot bridge reads to chip RAM introduce 2.5-3.4 us latency, and
-fast RAM exhibits distinct speed classes on real hardware. The probe detects
+Key findings: basic 68040 execution was over-penalized ~2-2.5x by the old
+scaled-68000 approximation and the 68030 rows land on the 68020 tables (both
+addressed upstream in m68k 0.12: the 030 now runs the MC68020UM tables and
+the 040 its own single-issue pipeline model, see `docs/internals/cpu.md`),
+CPU-slot bridge reads to chip RAM introduce 2.5-3.4 us latency, and fast RAM
+exhibits distinct speed classes on real hardware (both still open on the
+Copperline side). The probe detects
 the CPU model automatically and initializes cache state; on a standard 68000
 it displays only its header signature. Boot the probe from cold and power-cycle
 afterwards, as write benchmarking overwrites memory in each enumerated region.

--- a/timing-test/accelprobe.asm
+++ b/timing-test/accelprobe.asm
@@ -72,12 +72,15 @@
 ;   row 30 bare page step tst.l + 4K adda   x512
 ;   row 31 E-clock ticks per video frame (PAL ~28375)
 ;
-; Copperline PREDICTED columns (v2 binary $ACCE1B02, A4000 profile, PAL,
-; tt-a4000-060/-040/-030.toml: 2M motherboard RAM mirroring the real
-; machine -- Copperline bases it top-down at $07E00020 exactly like real
-; Ramsey -- plus 128M Z3; 060 also 64M CPU-card RAM). The v2 composite
-; walks the LARGEST fast region (Z3 here); Copperline's numbers match v1's
-; region-1 walk because it bills every fast class identically.
+; Copperline PREDICTED columns, m68k 0.11 -- HISTORICAL: the model every
+; VERDICTS block below was written against, kept so those verdicts stay
+; readable; the m68k 0.12 columns follow this table. (v2 binary
+; $ACCE1B02, A4000 profile, PAL, tt-a4000-060/-040/-030.toml: 2M
+; motherboard RAM mirroring the real machine -- Copperline bases it
+; top-down at $07E00020 exactly like real Ramsey -- plus 128M Z3; 060 also
+; 64M CPU-card RAM). The v2 composite walks the LARGEST fast region (Z3
+; here); Copperline's numbers match v1's region-1 walk because it bills
+; every fast class identically.
 ;   row    060@50MHz  040@25MHz  030@25MHz   row    060       040       030
 ;   06 reg 00000040   00000498   00000498    16 crd 000009B4  00000CDF  00000CDF
 ;   07 dbr 0000003E   000003AC   000003AC    17 cwr 00000671  00000671  00000673
@@ -94,6 +97,36 @@
 ;   Fast regions: 060 f1=accel $08000020, f2=mb $07E00020, f3=Z3 $40000020;
 ;   040/030 (no CPU-card RAM) f1=mb $07E00020, f2=Z3, f3 absent.
 ;
+; Copperline PREDICTED columns, m68k 0.12 (same binary and configs; the
+; 030 now runs the MC68020UM tables and the 040 its single-issue pipeline
+; model, both calibrated on the real columns below -- docs/internals/cpu.md
+; "68020 timing" / "68040 timing"; the 060 model is unchanged):
+;   row    060@50MHz  040@25MHz  030@25MHz   row    060       040       030
+;   06 reg 00000040   000001DA   000003AE    16 crd 000009B4  000009B4  00000CE1
+;   07 dbr 0000003E   00000163   00000337    17 cwr 00000671  00000671  00000671
+;   08 mul 000000B4   000005F5   00001078    19 f1r 00000078  0000050A  000007CA
+;   09 trC 0000101C   000010E9   000011BC    20 f1w 00000078  0000050A  0000083D
+;   10 trF 0000033A   0000059D   0000073A    22 f2r 00000078  0000050A  000007CA
+;   11 jsr 00000CE0   00000CE0   00001029    23 f2w 00000078  0000050A  0000083D
+;   12 jsv 0000168A   0000168A   000019BA    25 f3r 00000078  0 absent  0 absent
+;   13 jsf 00000CE0   00000CDF   00001028    26 f3w 00000078  0 absent  0 absent
+;   14 mvm 0000099D   0000138F   000013E7    27 cfu 0000073D  00000E71  0 skip
+;   15 cpl 0000007A   00000754   0 skip      28 cnt 00000613  00000BA2  0 skip
+;   30 stp 00000013   000000A5   000000FD    29 cnc 0000073C  00000DA5  00000EDC
+;   31 frame length: 00003780/1 on all three, as before.
+;   vs the real columns below: 040 row 6 is tick-exact ($1DA), rows 8 and
+;   15 within 7%, row 7 3.0 vs 4.06 clk (the model's documented compromise:
+;   no overlap stage, so the empty dbra loop under-reads while the
+;   one-clock-body loop is exact); the 040 trap rows stay 1.4-1.7x under
+;   (exception entries keep the legacy scaled costs) and movem 1.4x over.
+;   030 rows 6/8/10 within 1%, row 7 1.18x over (was 1.35x); its call,
+;   movem and chip-stack trap rows are bus-bound and unchanged, its chip
+;   rows stay tick-exact. The memory rows (16-26) and the composite walk
+;   move only by the cheaper loop overhead: the region/bridge billing
+;   itself is unchanged, so on the 040 the chip-over-bridge read under-bill
+;   widens from 3x to 4x and the Z3 read from 2.6x to 4.8x, while the
+;   030's motherboard read goes from 1.12x over to 5% under.
+;
 ; REAL A4000 + BFG9060 (68060 rev 5 @ 50 MHz, PCR $04300502 with DFP set at
 ; entry, AttnFlags $000F, VBR 0), CPU-card RAM f1=$08000020, 2M motherboard
 ; RAM f2=$07E00020 (top-down: only 2M fitted), ZZ9000 Z3 RAM f3=$50000020.
@@ -108,7 +141,8 @@
 ; Internal consistency: rows 11 and 13 identical (cached call target's
 ; region is irrelevant); rows 27-28 = 617 ticks/512 pages = 1.70us/trap =
 ; row 10 exactly; rows 27-29 = 185/512 = 0.51us/cpushl ~ row 15's 0.44us.
-; VERDICTS vs the Copperline predicted column (060@50):
+; VERDICTS vs the m68k 0.11 Copperline predicted column (060@50; the 060
+; model is unchanged in 0.12, so these still stand):
 ;   - Fast RAM is NOT one class on real silicon: line-read cost CPU-card
 ;     263ns / motherboard 1.22us / ZZ9000 Z3 2.04us per 16 bytes, where
 ;     Copperline bills all three 41ns (6x / 30x / 50x under-billed).
@@ -163,8 +197,9 @@
 ; real silicon. Combined with the ~2x plain-execution over-bill, the
 ; emulated AmigaVision 040 boot is slow for the WRONG reasons: the CPU
 ; share should shrink ~2x and the walk share should grow ~1.6x.
-; VERDICTS vs the Copperline predicted 040@25 column -- the direction
-; INVERTS on the CPU core:
+; VERDICTS vs the m68k 0.11 Copperline predicted 040@25 column
+; (HISTORICAL: the 0.12 pipeline model closes the CPU-core items, see the
+; 0.12 table above) -- the direction INVERTS on the CPU core:
 ;   - Plain execution is OVER-billed ~2-2.5x: reg+dbra real 4.1 clk/iter
 ;     vs CL 10.1; bare taken dbra real ~4 clk vs CL ~8; mulu.w real ~14
 ;     clk (databook figure) vs CL ~35. Copperline's 040 runs plain code
@@ -195,8 +230,9 @@
 ;   07 dbr 000002BB   11 jsr 00000992   16 crd 00000CDE   22 f2r 00000AA9
 ;   08 mul 0000105A   12 jsv 00001028   17 cwr 00000671   23 f2w 00000573
 ;   09 trC 00000E88   13 jsf 00000991   19 f1r 0000082E   31 frm 0000377C
-; VERDICTS vs the Copperline predicted 030@25 column -- the closest model
-; of the three:
+; VERDICTS vs the m68k 0.11 Copperline predicted 030@25 column
+; (HISTORICAL: 0.12 moves the 030 onto the MC68020UM tables, see the 0.12
+; table above) -- the closest model of the three:
 ;   - Chip RAM is TICK-EXACT: read real $CDE vs CL $CDF, write $671/$671.
 ;     The 3x chip gap on the 040/060 cards is their CPU-slot bridge, not
 ;     the motherboard path.
@@ -214,11 +250,12 @@
 ;     under (real 2.56us = 64 clk vs 85 on real 040/060).
 ;   - Composite rows 0 on this machine (v1 guard + <040 cpushl skips);
 ;     row 29 (no-cpushl walk) needs a v2 re-run to land.
-; Notable predictions to test against real silicon: Copperline bills the
-; 030 and 040 identically on most CPU rows, bills all three fast-RAM
-; classes identically (real Z3 over a Zorro III bus is far slower than
-; CPU-card RAM), and its CPUSHL is nearly free (the cache-op is modelled
-; as an invalidate). The trap rows and the composite walk are the direct
+; Notable m68k 0.11 predictions the real columns tested: Copperline billed
+; the 030 and 040 identically on most CPU rows (no longer so in 0.12),
+; bills all three fast-RAM classes identically (real Z3 over a Zorro III
+; bus is far slower than CPU-card RAM; still open), and its 060 CPUSHL is
+; nearly free (the cache-op is modelled as an invalidate; the 040 model
+; bills ~12 clocks). The trap rows and the composite walk are the direct
 ; check on the boot-time MMU page-walk cost that scales with fitted RAM.
 ;
 ; Scratch chip addresses (all below the 2M A4000 chip ceiling):


### PR DESCRIPTION
## Summary

Bumps the `m68k` crate from 0.11.6 to 0.12.1 everywhere it is used.

- 0.12.0 is the accelprobe-calibrated CPU timing work driven from Copperline ([m68k-rs #160](https://github.com/benletchford/m68k-rs/pull/160)): the 68030 now runs the MC68020UM section-8 tables (its integer core is the 020's, and the real 25 MHz 68030 board measures the same anchor figures the real A1200's 020 did), and the 68040 gets a single-issue pipeline model (`timing_040.rs`) in place of the scaled-68000 approximation that real A3640 captures showed ~2-2.5x pessimistic on plain execution.
- 0.12.1 adds decoded fast paths for immediate bit ops, LINK/UNLK and MOVEM.L, plus trace-JIT scheduling improvements.
- The public API change is additive (new module and `CYC_040_*` constants), so no wrapper changes are needed.

## Changes

- `Cargo.toml` and `crates/cputest-runner/Cargo.toml`: `m68k = "0.12"`.
- All four lockfiles that carry m68k move together: root, `crates/cputest-runner`, `crates/copperline-player`, `crates/copperline-web`. The root lock also re-picks tempfile's getrandom between two already-locked versions (tempfile accepts `>=0.3, <0.5`).
- `docs/internals/cpu.md`: links follow the `m68k-v0.12.1` tag, the stale "030/040 keep the scaled approximation" paragraph is replaced, a new "68040 timing" section describes the pipeline model and its residuals, and the post-bump probe figures are recorded. `docs/internals/timing.md` and `timing-test/README.md` follow the version.

## Verification

- `cargo build --release`, `cargo test` (3268 passed, 0 failed), `cargo clippy`, `cargo fmt --check`: clean.
- `cargo tree --locked` passes in all five workspaces the lockfile-sync workflow checks; `crates/cputest-runner` builds `--locked`.
- `timing-test/accelprobe.adf` re-run on `tt-a4000-040.toml` and `tt-a4000-030.toml` against the real-hardware columns in the probe header (E-clock ticks, emulated vs real):

| Row | 040 emu | 040 real | 030 emu | 030 real |
|---|---|---|---|---|
| 6 `move.w`+`dbra` | $1DA | $1DA | $3AE | $3A5 |
| 7 bare `dbra` | $163 | $1D8 | $337 | $2BB |
| 8 `mulu.w` | $5F5 | $65E | $1078 | $105A |
| 15 `cpushl` | $754 | $6D9 | n/a | n/a |

The 040 anchor row is tick-exact and the bare `dbra` sits at the compromise upstream documents (3.0 vs 4.06 clocks). The 030 anchors land within 1%, with the bare `dbra` moving from 1.35x to 1.18x over. The trap, call and `movem` rows, the CPU-slot bridge chip latency and the per-region fast-RAM billing are unchanged and remain the Copperline-side backlog.
