### PR TITLE
toccata: silence the mixer fallback once the codec stops

### DIFF
--- a/src/toccata/ad1848.rs
+++ b/src/toccata/ad1848.rs
@@ -280,7 +280,19 @@ impl Ad1848 {
     /// codec's own causally-paced cadence (`Toccata::advance_codec`) has
     /// produced yet, so a resampler's internal lookahead/priming can
     /// never pull `produce_one_sample`'s side effects out of order.
+    ///
+    /// Only valid while the codec is actively playing: once stopped,
+    /// `advance_codec` no longer runs at all, so without this guard the
+    /// resampler would keep pulling this same fallback and hold the final
+    /// decoded sample as a constant DC offset for the rest of the capture
+    /// -- forever, not just across one underrun. A real codec's DAC line
+    /// may hold that voltage too, but nothing downstream of it (the mixer,
+    /// the master mix, a stem capture) should still be observing a stopped
+    /// channel's last note.
     pub fn peek_last_sample(&self) -> (f32, f32) {
+        if !self.play_active() {
+            return (0.0, 0.0);
+        }
         let (l, r) = self.last_sample;
         (l * self.left_volume, r * self.right_volume)
     }
@@ -678,6 +690,31 @@ mod tests {
         assert!(first.0 > 0.9);
         let repeated = chip.produce_one_sample(); // FIFO now empty: underrun
         assert_eq!(repeated, first);
+    }
+
+    #[test]
+    fn peek_last_sample_falls_silent_once_the_codec_stops() {
+        let mut chip = Ad1848::new();
+        enable_play(&mut chip);
+        chip.write_index(8);
+        chip.write_data(0x00); // mono 8-bit
+        chip.write_index(6);
+        chip.write_data(0x00);
+        chip.write_index(7);
+        chip.write_data(0x00);
+        latch_format(&mut chip); // reg 9 rising edge -> codec_start(), play_active() true
+        chip.write_fifo_byte(0xff); // one full sample: (255-128)/128 ~= 0.992
+        let last = chip.produce_one_sample();
+        assert!(last.0 > 0.9);
+        assert!(chip.play_active());
+        assert_eq!(chip.peek_last_sample(), last);
+        // Stopping playback (reg 9 bit 0 cleared) must not leave the
+        // resampler's fallback holding this sample as a permanent DC
+        // offset.
+        chip.write_index(9);
+        chip.write_data(0x10); // stop: SDC bit only, play/record enable cleared
+        assert!(!chip.play_active());
+        assert_eq!(chip.peek_last_sample(), (0.0, 0.0));
     }
 
     #[test]

--- a/src/toccata/ad1848.rs
+++ b/src/toccata/ad1848.rs
@@ -243,9 +243,13 @@ impl Ad1848 {
         }
         if v & 0x01 != 0 {
             self.active |= STATUS_FIFO_PLAY;
+        } else {
+            self.active &= !STATUS_FIFO_PLAY;
         }
         if v & 0x02 != 0 {
             self.active |= STATUS_FIFO_RECORD;
+        } else {
+            self.active &= !STATUS_FIFO_RECORD;
         }
         self.regs[9] = v;
     }
@@ -715,6 +719,24 @@ mod tests {
         chip.write_data(0x10); // stop: SDC bit only, play/record enable cleared
         assert!(!chip.play_active());
         assert_eq!(chip.peek_last_sample(), (0.0, 0.0));
+    }
+
+    #[test]
+    fn play_active_clears_when_only_play_enable_drops_with_capture_still_set() {
+        // Regression for a latched-active bug: `write_reg9` used to only
+        // clear `active` (and so `play_active()`) when both PEN and CEN
+        // dropped to zero together, via the full `codec_stop()` path. A
+        // driver that disables playback (PEN) while leaving capture (CEN)
+        // enabled -- 0x03 -> 0x02 -- never took that path, so
+        // `play_active()` stayed stuck true and the mixer fallback kept
+        // emitting the final sample forever, exactly like the bug this
+        // whole fix addresses.
+        let mut chip = Ad1848::new();
+        chip.write_index(9);
+        chip.write_data(0x03); // PEN + CEN both enabled
+        assert!(chip.play_active());
+        chip.write_data(0x02); // PEN cleared, CEN still set
+        assert!(!chip.play_active());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `Ad1848::peek_last_sample()` is the resampler's fallback in `Toccata::advance_mixer` for whenever the mixer's cadence outruns the codec's own causally-paced sample production.
- `advance_codec` stops running entirely once `play_active()` is false, so after `codec_stop()` the mixer took this fallback on *every* tick, and `peek_last_sample()` kept returning the last decoded DAC value forever — a permanent DC offset in the stem/mix instead of silence.
- Fix: gate the fallback on `play_active()` so it still holds the last sample across a genuine underrun during active playback, but returns silence once the codec is stopped.

## Test plan
- [x] `cargo test --lib toccata` — all 35 Toccata tests pass, including new regression test `peek_last_sample_falls_silent_once_the_codec_stops`
- [x] `cargo fmt --check` / `cargo clippy --lib` clean
- [x] Re-run the narrator.wyoming end-to-end AHI/Toccata stem capture to confirm the DC plateau is gone in a full guest-driven run

🤖 Generated with [Claude Code](https://claude.com/claude-code)