### PR TITLE
Add blitter and Copper visualizers

### DIFF
--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -72,7 +72,7 @@ Commands are case-insensitive. Addresses and data values use hexadecimal notatio
 | `DIS [ADDR] [N]` (or `D`) | Disassemble `N` instructions starting at `ADDR` (default: PC) |
 | `COPPER [PC\|ADDR] [N]` | Disassemble Copper list |
 | `CUSTOM` | Display custom chipset register summary |
-| `BLITS` | List all blits started in the traced frame (with control words, size, pointers, and start/end beam positions; requires Frame Analyzer) |
+| `BLITS` | List all blits referenced by the traced frame, including stable ID, cross-frame beam span, direction/fill/line mode, channels, pointers/modulos, shifts/masks/minterm, and clocks used versus stalled (requires Frame Analyzer) |
 | `CPUWAIT` | Summarise the traced frame's CPU chip-bus waits: waited clocks by denier (bitplane, Copper, blitter with BLTPRI clear or set, ...) and by access kind, and the instructions that waited longest (requires Frame Analyzer; see [the CPU wait view](window.md#frame-analyzer-pane)) |
 | `FIND HEXBYTES [START]` | Search CPU-visible memory (RAM and ROM) for byte sequence |
 | `WRITER ADDR` | Query last instruction that modified memory at `ADDR` |

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -294,8 +294,13 @@ events.unsubscribe {"events":["serial"]}
   Reconstruct a recorded blit channel from the exact DMA word stream and write
   it as PNG. The reply includes the selected plane count and whether it came
   from a registered bitmap containing BLTDPT or the frame's BPLCON0, plus the
-  simplified Boolean minterm formula. Disabled A/B/C channels use their
-  latched BLTxDAT value. The path is optional.
+  safely decoded `render_planes`, interleaving status, and simplified Boolean
+  minterm formula. Non-interleaved resources and the BPLCON0 fallback render
+  one plane rather than guessing that consecutive blit rows are planes of one
+  image. Disabled A/B/C channels use their effective constant input (including
+  BLTBDAT's write-time-shifted hold latch). `result` uses captured D writes and
+  returns an error when no destination stream exists rather than approximating
+  the hardware shift/mask/fill pipeline. The path is optional.
 - `display.get`: Query active display parameters, viewport size, and pixel format.
 - `rtc.get` / `rtc.set {"unix": ..., "time": "...", "advance": ..., "frozen": ...}`: Inspect or move real-time clock.
 - `cartridge.get`: Query freezer cartridge state (`model`, memory `base`/`size`, monitor `version`, `entered` status, `nmi_pending`, and freeze count).

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -290,11 +290,21 @@ events.unsubscribe {"events":["serial"]}
   rows return errors. `instantaneous_records` contains any ordered zero-time
   floppy-turbo transfers at positions on the requested row; replay these after
   the ordinary record at the matching HPOS.
+- `blit.render {"index": N, "channel": "A"|"B"|"C"|"D"|"result", "path": "..."}`:
+  Reconstruct a recorded blit channel from the exact DMA word stream and write
+  it as PNG. The reply includes the selected plane count and whether it came
+  from a registered bitmap containing BLTDPT or the frame's BPLCON0, plus the
+  simplified Boolean minterm formula. Disabled A/B/C channels use their
+  latched BLTxDAT value. The path is optional.
 - `display.get`: Query active display parameters, viewport size, and pixel format.
 - `rtc.get` / `rtc.set {"unix": ..., "time": "...", "advance": ..., "frozen": ...}`: Inspect or move real-time clock.
 - `cartridge.get`: Query freezer cartridge state (`model`, memory `base`/`size`, monitor `version`, `entered` status, `nmi_pending`, and freeze count).
 - `cartridge.freeze`: Trigger the freezer cartridge NMI (level 7), transferring execution to the monitor.
-- `copper.list {"addr": ..., "resource": ..., "max": ...}`: Disassemble Copper instructions starting at `addr` or a registered `resource` (default: current Copper PC).
+- `copper.list {"addr": ..., "resource": ..., "max": ..., "trace": true}`:
+  Disassemble Copper instructions starting at `addr` or a registered
+  `resource` (default: current Copper PC). With `trace`, each instruction that
+  ran in the last full Frame Analyzer trace carries its exact frame, VPOS and
+  HPOS execution slot.
 - `pc_history`: Return recently executed instruction addresses.
 - `segments.list`: The hunk segments (`current`: `{start, size}` per hunk, first hunk first) of the program the scheduled process is running, and every program an armed `loadseg` catch has seen loaded (`modules`). At a `loadseg` stop, `current` is the just-loaded program: the addresses to relocate its symbols and debug information by.
 
@@ -341,7 +351,13 @@ events.unsubscribe {"events":["serial"]}
 - `state.load {"path": "..."}`: Restore machine state from file.
 
 ### Framebuffer capture
-- `capture.screenshot {"path": "..."}`: Write PNG screenshot of framebuffer.
+- `capture.screenshot {"path": "...", "overlays": ["blits", "overdraw", "sources"]}`:
+  Write a PNG from the side-effect-free display renderer. Optional overlays
+  outline recorded blitter destinations, heat pixels by repeated D-channel
+  and other chip-memory writes from a full Phase 2 trace (falling back to the
+  captured D stream without one), and colour final Denise/Lisa output by playfield 1, playfield 2,
+  sprite number, background, or outside-DIW provenance. They work in headless
+  sessions and the MCP bridge returns the resulting PNG as its image block.
 - `capture.digest`: Return FNV-1a hash digest of current frame.
 - `capture.region_digest {"x": ..., "y": ..., "w": ..., "h": ...}`: Return hash of screen region.
 

--- a/docs/debugger/profiling.md
+++ b/docs/debugger/profiling.md
@@ -125,6 +125,15 @@ The same fields are available live from `frame.slots {"row": V}` and in the
 Frame Analyzer's selected/hovered-slot readout. On that JSON surface, `data`
 is a fixed-width hexadecimal string so all 64 bits remain exact.
 
+Each frame's `blits` array also carries a stable blit ID, start/end frame and
+beam positions, direction, fill/line mode, enabled channels, all four
+pointers/modulos, A/B shifts, A masks, minterm and formula, latched A/B/C data,
+captured-word counts, and clocks used versus stalled. An in-flight blit is
+referenced from both adjacent frame records and finalised in both when it
+ends. The full DMA words remain in the live trace for `blit.render`; the
+profile keeps their bounded counts while the slot sidecar is the lossless
+offline transfer stream.
+
 Floppy turbo DMA deliberately consumes no emulated time, so several transfers
 can occur at one beam position and cannot occupy the single raster record for
 that colour clock. Those transfers remain zero-time while tracing and are

--- a/docs/debugger/profiling.md
+++ b/docs/debugger/profiling.md
@@ -127,7 +127,8 @@ is a fixed-width hexadecimal string so all 64 bits remain exact.
 
 Each frame's `blits` array also carries a stable blit ID, start/end frame and
 beam positions, direction, fill/line mode, enabled channels, all four
-pointers/modulos, A/B shifts, A masks, minterm and formula, latched A/B/C data,
+pointers/modulos, A/B shifts, A masks, minterm and formula, effective A/B/C
+constant inputs (including BLTBDAT's write-time-shifted hold latch),
 captured-word counts, and clocks used versus stalled. An in-flight blit is
 referenced from both adjacent frame records and finalised in both when it
 ends. The full DMA words remain in the live trace for `blit.render`; the

--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -143,6 +143,11 @@ that colour clock cycle (CPU, Copper, Blitter, Bitplane, Sprite, Audio, Disk, Re
 Pointing at a cell shows its full slot record below the raster; clicking pins
 the same readout. It includes the custom register, address, transfer data and
 width, owner subtype, CPU-visible IPL, and decoded hardware events.
+Copper MOVE execution slots are cross-shaped markers coloured by destination
+register class (blitter, audio, display/bitplane, sprite, palette, or control).
+Their readout includes the Copper instruction address; the reciprocal
+`copper.list {"trace": true}` entry links that instruction back to this beam
+slot.
 
 - **Picture underlay (`U`):** Overlays the rendered video frame beneath the bus heatmap.
 - **Beam scrub (`B`):** Progressively displays the frame up to the selected raster position.
@@ -184,6 +189,21 @@ and a [profile capture](profiling) exports it per frame.
 Profile captures over the control protocol ([](profiling)) share bus tracing
 with the Frame Analyzer: closing the pane does not interrupt an active capture,
 and stopping a capture keeps an open pane recording.
+
+### Blits tab
+
+The Blits tab lists every recorded blit with its start/end frame and beam
+position, ascending/descending, fill or line mode, enabled channels, transfer
+geometry, BLTDPT, and colour clocks used versus stalled. A blit that crosses a
+frame boundary retains one stable identity and is finalised in both frame
+records.
+
+Selecting a row shows the first active source channel and the computed
+result/D channel side by side. These previews use the exact captured DMA words,
+including shifts, first/last-word masks, modulos, and latched BLTxDAT inputs;
+the detail line shows the simplified minterm expression and whether plane
+count came from the registered destination bitmap or BPLCON0. Cursor Up/Down
+changes the selected blit. The same renderer is available as `blit.render`.
 
 (frame-analyzer-memory-tab)=
 ### Memory heatmap tab

--- a/src/blitviz.rs
+++ b/src/blitviz.rs
@@ -154,49 +154,59 @@ pub fn minterm_formula(minterm: u8) -> String {
         .join(" | ")
 }
 
-fn minterm_word(minterm: u8, a: u16, b: u16, c: u16) -> u16 {
-    let mut out = 0u16;
-    for abc in 0..8 {
-        if minterm & (1 << abc) == 0 {
-            continue;
-        }
-        let av = if abc & 4 != 0 { a } else { !a };
-        let bv = if abc & 2 != 0 { b } else { !b };
-        let cv = if abc & 1 != 0 { c } else { !c };
-        out |= av & bv & cv;
-    }
-    out
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BlitPlaneLayout {
+    /// Plane count advertised by the matching resource or BPLCON0.
+    pub planes: usize,
+    /// Planes that can safely be combined in the preview. A non-interleaved
+    /// resource (or the BPLCON0 fallback) does not establish that successive
+    /// blit rows belong to successive planes, so it is decoded as one plane.
+    pub render_planes: usize,
+    pub source: &'static str,
+    pub interleaved: bool,
 }
 
-/// Plane count used by the visualiser: a registered bitmap containing the
-/// destination wins, otherwise the frame-start Denise BPU decode does.
-pub fn plane_count_for_blit(
+/// Plane layout used by the visualiser: a registered bitmap containing the
+/// destination wins, otherwise the frame-start Denise BPU decode supplies
+/// the reported count without guessing that the blit itself is interleaved.
+pub fn plane_layout_for_blit(
     blit: &FrameBlitRecord,
     resources: &[DebugResource],
     base: RenderRegisterSnapshot,
-) -> (usize, &'static str) {
-    if let Some(planes) = resources.iter().find_map(|resource| {
+) -> BlitPlaneLayout {
+    if let Some((planes, interleaved)) = resources.iter().find_map(|resource| {
         let end = resource.address.saturating_add(resource.size);
         if !(resource.address..end).contains(&blit.dpt) {
             return None;
         }
         match resource.kind {
-            ResourceKind::Bitmap { planes, .. } => Some(usize::from(planes).clamp(1, 8)),
+            ResourceKind::Bitmap { planes, .. } => Some((
+                usize::from(planes).clamp(1, 8),
+                resource.flags & RESOURCE_FLAG_INTERLEAVED != 0,
+            )),
             _ => None,
         }
     }) {
-        return (planes, "resource");
+        return BlitPlaneLayout {
+            planes,
+            render_planes: if interleaved { planes } else { 1 },
+            source: "resource",
+            interleaved,
+        };
     }
     let aga = matches!(
         base.agnus_revision,
         crate::chipset::agnus::AgnusRevision::AgaAlice
     );
-    (
-        BitplaneMode::from_bplcon0(base.bplcon0, aga)
-            .display_planes()
-            .max(1),
-        "BPLCON0",
-    )
+    let planes = BitplaneMode::from_bplcon0(base.bplcon0, aga)
+        .display_planes()
+        .max(1);
+    BlitPlaneLayout {
+        planes,
+        render_planes: 1,
+        source: "BPLCON0",
+        interleaved: false,
+    }
 }
 
 fn channel_words(blit: &FrameBlitRecord, channel: BlitChannel, count: usize) -> Vec<u16> {
@@ -209,26 +219,7 @@ fn channel_words(blit: &FrameBlitRecord, channel: BlitChannel, count: usize) -> 
         }
         return Vec::new();
     }
-    if !blit.channel_words[3].is_empty() {
-        return blit.channel_words[3].clone();
-    }
-    let inputs: [Vec<u16>; 3] = std::array::from_fn(|index| {
-        if blit.channels[index] {
-            blit.channel_words[index].clone()
-        } else {
-            vec![blit.data[index]; count]
-        }
-    });
-    (0..count)
-        .map(|index| {
-            minterm_word(
-                blit.minterm,
-                inputs[0].get(index).copied().unwrap_or(blit.data[0]),
-                inputs[1].get(index).copied().unwrap_or(blit.data[1]),
-                inputs[2].get(index).copied().unwrap_or(blit.data[2]),
-            )
-        })
-        .collect()
+    blit.channel_words[3].clone()
 }
 
 fn indexed_colour(index: usize, planes: usize) -> u32 {
@@ -253,6 +244,12 @@ pub fn render_blit(
     channel: BlitChannel,
     planes: usize,
 ) -> Result<BitmapPreview, String> {
+    if matches!(channel, BlitChannel::Result) && blit.channel_words[3].is_empty() {
+        return Err(
+            "result rendering requires captured D writes; reconstructing the hardware shifts, masks, fill state, or line pipeline from raw source words would be inaccurate"
+                .to_string(),
+        );
+    }
     if blit.line_mode
         && !matches!(
             channel,
@@ -449,6 +446,19 @@ mod tests {
     }
 
     #[test]
+    fn result_without_destination_writes_is_rejected_instead_of_guessed() {
+        let mut blit = recorded_blit();
+        blit.channels[3] = false;
+        blit.channel_words[3].clear();
+        blit.channel_addrs[3].clear();
+        let err = match render_blit(&blit, BlitChannel::Result, 1) {
+            Ok(_) => panic!("missing destination stream must not be guessed"),
+            Err(err) => err,
+        };
+        assert!(err.contains("captured D writes"), "{err}");
+    }
+
+    #[test]
     fn destination_addresses_map_through_registered_bitmap_layout() {
         let resource = DebugResource {
             address: 0x1000,
@@ -462,7 +472,28 @@ mod tests {
             name: "bitmap".to_string(),
             registered_frame: 0,
         };
-        let (pixel, width, height) = destination_word_pixel(0x1006, &[resource]).unwrap();
+        let (pixel, width, height) =
+            destination_word_pixel(0x1006, std::slice::from_ref(&resource)).unwrap();
         assert_eq!((pixel.x, pixel.y, width, height), (16, 1, 32, 10));
+
+        let plain = plane_layout_for_blit(
+            &recorded_blit(),
+            std::slice::from_ref(&resource),
+            RenderRegisterSnapshot::default(),
+        );
+        assert_eq!((plain.planes, plain.render_planes), (2, 1));
+        assert!(!plain.interleaved);
+
+        let interleaved_resource = DebugResource {
+            flags: RESOURCE_FLAG_INTERLEAVED,
+            ..resource
+        };
+        let interleaved = plane_layout_for_blit(
+            &recorded_blit(),
+            &[interleaved_resource],
+            RenderRegisterSnapshot::default(),
+        );
+        assert_eq!((interleaved.planes, interleaved.render_planes), (2, 2));
+        assert!(interleaved.interleaved);
     }
 }

--- a/src/blitviz.rs
+++ b/src/blitviz.rs
@@ -1,0 +1,468 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Pure helpers for the Frame Analyzer's blitter visualisations.
+//!
+//! The inputs are the exact per-blit DMA words recorded by the bus. Nothing
+//! here reads or mutates the emulated machine, so CCP image export, the tool
+//! window, and headless screenshot overlays all share one deterministic path.
+
+use crate::bus::{FrameBlitRecord, RenderRegisterSnapshot};
+use crate::chipset::denise::{rgb24_to_rgba8, BitplaneMode};
+use crate::uaelib::{DebugResource, ResourceKind, RESOURCE_FLAG_INTERLEAVED};
+use crate::video::resource_preview::{BitmapPreview, PREVIEW_MAX_PIXELS, PREVIEW_MAX_WIDTH};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlitChannel {
+    A,
+    B,
+    C,
+    D,
+    Result,
+}
+
+impl BlitChannel {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.to_ascii_uppercase().as_str() {
+            "A" => Some(Self::A),
+            "B" => Some(Self::B),
+            "C" => Some(Self::C),
+            "D" => Some(Self::D),
+            "RESULT" => Some(Self::Result),
+            _ => None,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::A => "A",
+            Self::B => "B",
+            Self::C => "C",
+            Self::D => "D",
+            Self::Result => "result",
+        }
+    }
+
+    fn index(self) -> Option<usize> {
+        match self {
+            Self::A => Some(0),
+            Self::B => Some(1),
+            Self::C => Some(2),
+            Self::D => Some(3),
+            Self::Result => None,
+        }
+    }
+}
+
+/// Smallest sum-of-products formula for the blitter's three-input truth
+/// table. With only eight minterms an exhaustive implicant cover is smaller
+/// and easier to audit than a general-purpose Quine-McCluskey implementation,
+/// while producing the same minimum term/literal ordering.
+pub fn minterm_formula(minterm: u8) -> String {
+    if minterm == 0 {
+        return "0".to_string();
+    }
+    if minterm == u8::MAX {
+        return "1".to_string();
+    }
+
+    #[derive(Clone, Copy)]
+    struct Implicant {
+        value: u8,
+        mask: u8,
+        covers: u8,
+        literals: u8,
+    }
+
+    let mut implicants = Vec::new();
+    // mask bit set = that variable is significant. Enumerating all ternary
+    // cubes (0/1/don't-care) is exactly the prime-implicant search for three
+    // variables; cubes touching a false minterm are rejected.
+    for mask in 0u8..8 {
+        for value in 0u8..8 {
+            if value & !mask != 0 {
+                continue;
+            }
+            let mut covers = 0u8;
+            for abc in 0u8..8 {
+                if abc & mask == value {
+                    covers |= 1 << abc;
+                }
+            }
+            if covers != 0 && covers & !minterm == 0 {
+                implicants.push(Implicant {
+                    value,
+                    mask,
+                    covers,
+                    literals: mask.count_ones() as u8,
+                });
+            }
+        }
+    }
+    // Remove cubes wholly covered by a less-specific cube.
+    let all_implicants = implicants.clone();
+    implicants.retain(|candidate| {
+        !all_implicants.iter().any(|other| {
+            other.covers != candidate.covers
+                && other.covers | candidate.covers == other.covers
+                && other.literals <= candidate.literals
+        })
+    });
+
+    let mut best: Option<(u32, u32, u64)> = None;
+    let count = implicants.len();
+    for subset in 1u64..(1u64 << count) {
+        let mut cover = 0u8;
+        let mut terms = 0u32;
+        let mut literals = 0u32;
+        for (index, implicant) in implicants.iter().enumerate() {
+            if subset & (1u64 << index) != 0 {
+                cover |= implicant.covers;
+                terms += 1;
+                literals += u32::from(implicant.literals);
+            }
+        }
+        if cover == minterm {
+            let score = (terms, literals, subset);
+            if best.is_none_or(|old| score < old) {
+                best = Some(score);
+            }
+        }
+    }
+    let subset = best
+        .expect("every non-zero truth table has a minterm cover")
+        .2;
+    let names = ['A', 'B', 'C'];
+    implicants
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| subset & (1u64 << index) != 0)
+        .map(|(_, implicant)| {
+            let terms: Vec<String> = (0..3)
+                .filter(|bit| implicant.mask & (1 << bit) != 0)
+                .map(|bit| {
+                    let name = names[2 - bit];
+                    if implicant.value & (1 << bit) != 0 {
+                        name.to_string()
+                    } else {
+                        format!("!{name}")
+                    }
+                })
+                .collect();
+            terms.join(" & ")
+        })
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+fn minterm_word(minterm: u8, a: u16, b: u16, c: u16) -> u16 {
+    let mut out = 0u16;
+    for abc in 0..8 {
+        if minterm & (1 << abc) == 0 {
+            continue;
+        }
+        let av = if abc & 4 != 0 { a } else { !a };
+        let bv = if abc & 2 != 0 { b } else { !b };
+        let cv = if abc & 1 != 0 { c } else { !c };
+        out |= av & bv & cv;
+    }
+    out
+}
+
+/// Plane count used by the visualiser: a registered bitmap containing the
+/// destination wins, otherwise the frame-start Denise BPU decode does.
+pub fn plane_count_for_blit(
+    blit: &FrameBlitRecord,
+    resources: &[DebugResource],
+    base: RenderRegisterSnapshot,
+) -> (usize, &'static str) {
+    if let Some(planes) = resources.iter().find_map(|resource| {
+        let end = resource.address.saturating_add(resource.size);
+        if !(resource.address..end).contains(&blit.dpt) {
+            return None;
+        }
+        match resource.kind {
+            ResourceKind::Bitmap { planes, .. } => Some(usize::from(planes).clamp(1, 8)),
+            _ => None,
+        }
+    }) {
+        return (planes, "resource");
+    }
+    let aga = matches!(
+        base.agnus_revision,
+        crate::chipset::agnus::AgnusRevision::AgaAlice
+    );
+    (
+        BitplaneMode::from_bplcon0(base.bplcon0, aga)
+            .display_planes()
+            .max(1),
+        "BPLCON0",
+    )
+}
+
+fn channel_words(blit: &FrameBlitRecord, channel: BlitChannel, count: usize) -> Vec<u16> {
+    if let Some(index) = channel.index() {
+        if blit.channels[index] {
+            return blit.channel_words[index].clone();
+        }
+        if index < 3 {
+            return vec![blit.data[index]; count];
+        }
+        return Vec::new();
+    }
+    if !blit.channel_words[3].is_empty() {
+        return blit.channel_words[3].clone();
+    }
+    let inputs: [Vec<u16>; 3] = std::array::from_fn(|index| {
+        if blit.channels[index] {
+            blit.channel_words[index].clone()
+        } else {
+            vec![blit.data[index]; count]
+        }
+    });
+    (0..count)
+        .map(|index| {
+            minterm_word(
+                blit.minterm,
+                inputs[0].get(index).copied().unwrap_or(blit.data[0]),
+                inputs[1].get(index).copied().unwrap_or(blit.data[1]),
+                inputs[2].get(index).copied().unwrap_or(blit.data[2]),
+            )
+        })
+        .collect()
+}
+
+fn indexed_colour(index: usize, planes: usize) -> u32 {
+    if index == 0 {
+        return rgb24_to_rgba8(0x101418);
+    }
+    let max = (1usize << planes.min(8)).saturating_sub(1).max(1);
+    let level = (index * 255 / max) as u32;
+    let rgb = if planes == 1 {
+        (level << 16) | (level << 8) | level
+    } else {
+        let r = ((index.wrapping_mul(97) & 0xFF) as u32 + level) / 2;
+        let g = ((index.wrapping_mul(57) & 0xFF) as u32 + level) / 2;
+        let b = ((index.wrapping_mul(23) & 0xFF) as u32 + level) / 2;
+        (r << 16) | (g << 8) | b
+    };
+    rgb24_to_rgba8(rgb)
+}
+
+pub fn render_blit(
+    blit: &FrameBlitRecord,
+    channel: BlitChannel,
+    planes: usize,
+) -> Result<BitmapPreview, String> {
+    if blit.line_mode
+        && !matches!(
+            channel,
+            BlitChannel::C | BlitChannel::D | BlitChannel::Result
+        )
+    {
+        // Line mode's A/B values are Bresenham state rather than a rectangle;
+        // still render them when DMA produced a stream, but say so below.
+    }
+    let width_words = usize::try_from(blit.width_words).unwrap_or(usize::MAX);
+    let transfer_rows = usize::try_from(blit.height).unwrap_or(usize::MAX);
+    let width = width_words
+        .checked_mul(16)
+        .ok_or_else(|| "blit width overflows the preview".to_string())?;
+    if width == 0 || transfer_rows == 0 || width > PREVIEW_MAX_WIDTH {
+        return Err(format!(
+            "blit geometry {}x{} words is outside the preview limit",
+            blit.width_words, blit.height
+        ));
+    }
+    let planes = planes.clamp(1, 8);
+    let height = transfer_rows.div_ceil(planes);
+    if width
+        .checked_mul(height)
+        .is_none_or(|pixels| pixels > PREVIEW_MAX_PIXELS)
+    {
+        return Err(format!(
+            "blit preview {}x{} exceeds the pixel limit",
+            width, height
+        ));
+    }
+    let word_count = width_words.saturating_mul(transfer_rows);
+    let words = channel_words(blit, channel, word_count);
+    let mut plane_words = vec![0u16; word_count];
+    for (sequence, word) in words.iter().copied().take(word_count).enumerate() {
+        let transfer_row = sequence / width_words;
+        let transfer_col = sequence % width_words;
+        let (row, col) = if blit.descending {
+            (
+                transfer_rows - 1 - transfer_row,
+                width_words - 1 - transfer_col,
+            )
+        } else {
+            (transfer_row, transfer_col)
+        };
+        plane_words[row * width_words + col] = word;
+    }
+    let mut pixels = vec![rgb24_to_rgba8(0x101418); width * height];
+    for y in 0..height {
+        for x in 0..width {
+            let mut index = 0usize;
+            for plane in 0..planes {
+                let transfer_row = y * planes + plane;
+                if transfer_row >= transfer_rows {
+                    continue;
+                }
+                let word = plane_words[transfer_row * width_words + x / 16];
+                index |= usize::from((word >> (15 - x % 16)) & 1) << plane;
+            }
+            pixels[y * width + x] = indexed_colour(index, planes);
+        }
+    }
+    let expected = if matches!(channel, BlitChannel::D | BlitChannel::Result) && !blit.channels[3] {
+        word_count
+    } else if let Some(index) = channel.index() {
+        if blit.channels[index] {
+            word_count
+        } else {
+            words.len()
+        }
+    } else {
+        word_count
+    };
+    let mut notes = vec![format!("{} plane(s)", planes)];
+    if words.len() < expected {
+        notes.push(format!(
+            "{} of {} DMA words captured",
+            words.len(),
+            expected
+        ));
+    }
+    if blit.render_truncated {
+        notes.push("transfer record truncated".to_string());
+    }
+    if blit.line_mode {
+        notes.push("line-mode transfer".to_string());
+    }
+    Ok(BitmapPreview {
+        width,
+        height,
+        pixels,
+        note: Some(notes.join("; ")),
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DestinationPixel {
+    pub x: usize,
+    pub y: usize,
+}
+
+/// Map a D-channel word address into a registered bitmap's first pixel.
+/// This is the same planar/interleaved layout used by the Resources tab.
+pub fn destination_word_pixel(
+    address: u32,
+    resources: &[DebugResource],
+) -> Option<(DestinationPixel, usize, usize)> {
+    resources.iter().find_map(|resource| {
+        let ResourceKind::Bitmap {
+            width,
+            height,
+            planes,
+        } = resource.kind
+        else {
+            return None;
+        };
+        let end = resource.address.saturating_add(resource.size);
+        if !(resource.address..end).contains(&address) || width == 0 || height == 0 || planes == 0 {
+            return None;
+        }
+        let row_bytes = usize::from(width).div_ceil(16) * 2;
+        let offset = usize::try_from(address - resource.address).ok()?;
+        let (row, plane_offset) = if resource.flags & RESOURCE_FLAG_INTERLEAVED != 0 {
+            let row_stride = row_bytes * usize::from(planes);
+            (offset / row_stride, offset % row_stride % row_bytes)
+        } else {
+            let plane_size = row_bytes * usize::from(height);
+            (offset % plane_size / row_bytes, offset % row_bytes)
+        };
+        (row < usize::from(height)).then_some((
+            DestinationPixel {
+                x: plane_offset / 2 * 16,
+                y: row,
+            },
+            usize::from(width),
+            usize::from(height),
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn minterm_simplifier_handles_copy_cookie_cut_and_constants() {
+        assert_eq!(minterm_formula(0x00), "0");
+        assert_eq!(minterm_formula(0xFF), "1");
+        assert_eq!(minterm_formula(0xF0), "A");
+        assert_eq!(minterm_formula(0xCC), "B");
+        assert_eq!(minterm_formula(0xAA), "C");
+        let cookie = minterm_formula(0xCA);
+        assert!(cookie.contains('A') && cookie.contains('B') && cookie.contains('C'));
+    }
+
+    fn recorded_blit() -> FrameBlitRecord {
+        FrameBlitRecord {
+            id: 7,
+            bltcon0: 0x01F0,
+            bltcon1: 0,
+            width_words: 1,
+            height: 2,
+            descending: false,
+            line_mode: false,
+            fill_mode: false,
+            channels: [false, false, false, true],
+            apt: 0,
+            bpt: 0,
+            cpt: 0,
+            dpt: 0x1000,
+            modulos: [0; 4],
+            shifts: [0; 2],
+            masks: [0xFFFF; 2],
+            minterm: 0xF0,
+            data: [0; 3],
+            start_frame: 2,
+            end_frame: Some(2),
+            start: (10, 20),
+            end: Some((10, 30)),
+            cycles_used: 8,
+            cycles_stalled: 2,
+            channel_words: [Vec::new(), Vec::new(), Vec::new(), vec![0x8000, 0x0001]],
+            channel_addrs: [Vec::new(), Vec::new(), Vec::new(), vec![0x1000, 0x1002]],
+            render_truncated: false,
+        }
+    }
+
+    #[test]
+    fn recorded_dma_words_render_without_live_memory() {
+        let preview = render_blit(&recorded_blit(), BlitChannel::D, 1).unwrap();
+        assert_eq!((preview.width, preview.height), (16, 2));
+        assert_ne!(preview.pixels[0], preview.pixels[1]);
+        assert_ne!(preview.pixels[31], preview.pixels[30]);
+    }
+
+    #[test]
+    fn destination_addresses_map_through_registered_bitmap_layout() {
+        let resource = DebugResource {
+            address: 0x1000,
+            size: 80,
+            flags: 0,
+            kind: ResourceKind::Bitmap {
+                width: 32,
+                height: 10,
+                planes: 2,
+            },
+            name: "bitmap".to_string(),
+            registered_frame: 0,
+        };
+        let (pixel, width, height) = destination_word_pixel(0x1006, &[resource]).unwrap();
+        assert_eq!((pixel.x, pixel.y, width, height), (16, 1, 32, 10));
+    }
+}

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -9,7 +9,7 @@ use crate::chipset::agnus::{
     Agnus, AgnusRevision, AgnusTick, VideoStandard, BEAMCON0_DUAL, BEAMCON0_HARDDIS,
     COLORCLOCKS_PER_LINE, NTSC_LINES, NTSC_LONG_COLORCLOCKS_PER_LINE, PAL_LINES,
 };
-use crate::chipset::blitter::Blitter;
+use crate::chipset::blitter::{BlitBusAccess, Blitter};
 use crate::chipset::cia::{
     reg_from_addr, Cia, CiaSideEffect, Which, REG_DDRA, REG_DDRB, REG_PRA, REG_PRB, REG_TODLO,
 };
@@ -241,11 +241,14 @@ const DMACON_SPREN: u16 = 1 << 5;
 const DMACON_BLTEN: u16 = 1 << 6;
 const DMACON_BPLEN: u16 = 1 << 8;
 const DMACON_BLTPRI: u16 = 1 << 10;
-#[cfg(test)]
 const BLTCON0_USE_A: u16 = 1 << 11;
+const BLTCON0_USE_B: u16 = 1 << 10;
 const BLTCON0_USE_C: u16 = 1 << 9;
 const BLTCON0_USE_D: u16 = 1 << 8;
 const BLTCON1_LINE: u16 = 1 << 0;
+const BLTCON1_DESC: u16 = 1 << 1;
+const BLTCON1_IFE: u16 = 1 << 3;
+const BLTCON1_EFE: u16 = 1 << 4;
 const BLTCON1_DOFF: u16 = 1 << 7;
 // The Copper cannot take (or hold) a bus slot on the last-but-two color
 // clock of the line: $E0 on short lines, $E1 on NTSC long lines (vAmiga
@@ -1133,6 +1136,12 @@ pub struct Bus {
     current_frame_bus_trace: FrameBusTrace,
     #[serde(skip)]
     last_frame_bus_trace: Option<FrameBusTrace>,
+    /// Identity of the blit currently represented in the analyzer traces.
+    /// Host-only diagnostic state: the real pending blit lives in `blitter`.
+    #[serde(skip)]
+    active_frame_blit: Option<u64>,
+    #[serde(skip)]
+    next_frame_blit_id: u64,
     #[serde(skip)]
     bus_event_observers: u32,
     #[serde(skip)]
@@ -2073,21 +2082,49 @@ pub struct FrameRegisterSnapshot {
     pub chipset_flags: u32,
 }
 
-/// One blit started during the traced frame (Frame Analyzer / console
-/// BLITS). `end` stays None while the blit is still running (or when it
-/// finishes in a later frame).
+/// One blit referenced by the traced frame (Frame Analyzer / console BLITS).
+/// `end` stays None while the blit is still running; an in-flight record is
+/// carried across a frame boundary under the same stable id.
 #[derive(Clone, Debug)]
 pub struct FrameBlitRecord {
+    /// Stable across frame boundaries, so a blit present in two frame
+    /// records can be joined without guessing from its pointers.
+    pub id: u64,
     pub bltcon0: u16,
     pub bltcon1: u16,
     pub width_words: u32,
     pub height: u32,
+    pub descending: bool,
+    pub line_mode: bool,
+    pub fill_mode: bool,
+    pub channels: [bool; 4],
     pub apt: u32,
     pub bpt: u32,
     pub cpt: u32,
     pub dpt: u32,
+    pub modulos: [i16; 4],
+    /// A and B shifts, in bits.
+    pub shifts: [u8; 2],
+    /// First/last A word masks.
+    pub masks: [u16; 2],
+    pub minterm: u8,
+    /// BLTADAT, BLTBDAT and BLTCDAT as latched at the start. Disabled DMA
+    /// channels use these constant inputs.
+    pub data: [u16; 3],
+    pub start_frame: u64,
+    pub end_frame: Option<u64>,
     pub start: (u16, u16),
     pub end: Option<(u16, u16)>,
+    /// Colour clocks on which the blitter pipeline advanced, and clocks on
+    /// which a requested pipeline cycle was held by contention/DMA disable.
+    pub cycles_used: u64,
+    pub cycles_stalled: u64,
+    /// Exact DMA transfer stream per channel, retained only while the frame
+    /// analyzer is armed. It drives `blit.render` and remains bounded by the
+    /// number of colour clocks captured in the frame.
+    pub(crate) channel_words: [Vec<u16>; 4],
+    pub(crate) channel_addrs: [Vec<u32>; 4],
+    pub render_truncated: bool,
 }
 
 /// Per-frame chip-bus ownership trace for the interactive frame analyzer.
@@ -2110,7 +2147,8 @@ pub struct FrameBusTrace {
     pub blitter_busy_cck: u64,
     pub blitter_starve_cck: [u64; 9],
     pub partial: bool,
-    /// Blits started this frame (capped; see FRAME_BLIT_RECORD_CAP).
+    /// Blits referenced by this frame (capped; see FRAME_BLIT_RECORD_CAP).
+    /// An in-flight cross-frame record appears in both adjacent traces.
     pub blits: Vec<FrameBlitRecord>,
     owners: Vec<u8>,
     /// Full Bartman-style records. Absent at the cheap owner-only level.
@@ -2135,6 +2173,9 @@ pub struct FrameBusTrace {
 
 /// Blit records kept per traced frame.
 pub const FRAME_BLIT_RECORD_CAP: usize = 64;
+/// A malformed maximum-size ECS blit must not turn the diagnostic record
+/// into an unbounded allocation. A normal PAL frame cannot reach this cap.
+pub const FRAME_BLIT_RENDER_WORD_CAP: usize = 262_144;
 
 impl Default for FrameBusTrace {
     fn default() -> Self {
@@ -3444,6 +3485,8 @@ impl Bus {
             trace_intreq: 0,
             current_frame_bus_trace: FrameBusTrace::default(),
             last_frame_bus_trace: None,
+            active_frame_blit: None,
+            next_frame_blit_id: 0,
             bus_event_observers: 0,
             bus_events: std::collections::VecDeque::new(),
             bus_event_next_sequence: 0,
@@ -4570,6 +4613,8 @@ impl Bus {
         self.last_frame_sprite_dma_observed = false;
         self.current_frame_bus_trace.clear();
         self.last_frame_bus_trace = None;
+        self.active_frame_blit = None;
+        self.next_frame_blit_id = 0;
     }
 
     pub fn reset_for_keyboard_reset(&mut self) {
@@ -6498,19 +6543,38 @@ impl Bus {
     fn latch_blitter_completion(&mut self, source: &'static str) {
         self.note_bus_event_named(BUS_EVENT_BLIT_START_FINISH, Some("blitter_finish"));
         if self.frame_analyzer_enabled {
-            if let Some(record) = self
+            let end = (
+                self.agnus.vpos.min(u32::from(u16::MAX)) as u16,
+                self.agnus.hpos.min(u32::from(u16::MAX)) as u16,
+            );
+            let completed = self
                 .current_frame_bus_trace
                 .blits
                 .iter_mut()
                 .rev()
-                .find(|record| record.end.is_none())
+                .find(|record| Some(record.id) == self.active_frame_blit)
+                .map(|record| {
+                    record.end = Some(end);
+                    record.end_frame = Some(self.emulated_frames);
+                    record.clone()
+                });
+            // A blit crossing a frame boundary is visible from both the
+            // just-finished and current frame. Finalise the older reference
+            // too, with the same totals and transfer stream.
+            if let (Some(last), Some(completed)) =
+                (self.last_frame_bus_trace.as_mut(), completed.as_ref())
             {
-                record.end = Some((
-                    self.agnus.vpos.min(u32::from(u16::MAX)) as u16,
-                    self.agnus.hpos.min(u32::from(u16::MAX)) as u16,
-                ));
+                if let Some(record) = last
+                    .blits
+                    .iter_mut()
+                    .rev()
+                    .find(|record| record.id == completed.id)
+                {
+                    *record = completed.clone();
+                }
             }
         }
+        self.active_frame_blit = None;
         if diag_blt_slots() {
             eprintln!(
                 "BLTP {} {} {} END source={source}",
@@ -7490,6 +7554,7 @@ impl Bus {
         } else {
             self.current_frame_bus_trace.clear();
             self.last_frame_bus_trace = None;
+            self.active_frame_blit = None;
         }
     }
 
@@ -8662,21 +8727,110 @@ impl Bus {
         {
             return;
         }
+        let id = self.next_frame_blit_id;
+        self.next_frame_blit_id = self.next_frame_blit_id.saturating_add(1);
+        self.active_frame_blit = Some(id);
+        let con0 = self.blitter.bltcon0;
+        let con1 = self.blitter.bltcon1;
         self.current_frame_bus_trace.blits.push(FrameBlitRecord {
-            bltcon0: self.blitter.bltcon0,
-            bltcon1: self.blitter.bltcon1,
+            id,
+            bltcon0: con0,
+            bltcon1: con1,
             width_words,
             height,
+            descending: con1 & BLTCON1_DESC != 0,
+            line_mode: con1 & BLTCON1_LINE != 0,
+            fill_mode: con1 & (BLTCON1_IFE | BLTCON1_EFE) != 0,
+            channels: [
+                con0 & BLTCON0_USE_A != 0,
+                con0 & BLTCON0_USE_B != 0,
+                con0 & BLTCON0_USE_C != 0,
+                con0 & BLTCON0_USE_D != 0 && con1 & BLTCON1_DOFF == 0,
+            ],
             apt: self.blitter.bltapt,
             bpt: self.blitter.bltbpt,
             cpt: self.blitter.bltcpt,
             dpt: self.blitter.bltdpt,
+            modulos: [
+                self.blitter.bltamod,
+                self.blitter.bltbmod,
+                self.blitter.bltcmod,
+                self.blitter.bltdmod,
+            ],
+            shifts: [(con0 >> 12) as u8, (con1 >> 12) as u8],
+            masks: [self.blitter.bltafwm, self.blitter.bltalwm],
+            minterm: con0 as u8,
+            data: [
+                self.blitter.bltadat,
+                self.blitter.bltbdat,
+                self.blitter.bltcdat,
+            ],
+            start_frame: self.emulated_frames,
+            end_frame: None,
             start: (
                 self.agnus.vpos.min(u32::from(u16::MAX)) as u16,
                 self.agnus.hpos.min(u32::from(u16::MAX)) as u16,
             ),
             end: None,
+            cycles_used: 0,
+            cycles_stalled: 0,
+            channel_words: std::array::from_fn(|_| Vec::new()),
+            channel_addrs: std::array::from_fn(|_| Vec::new()),
+            render_truncated: false,
         });
+    }
+
+    /// Account one elapsed colour clock to the active blit. `advanced`
+    /// means the sequencer processed its pending bus/internal micro-cycle;
+    /// otherwise the clock extended the blit through contention or disabled
+    /// DMA. Called from the same arbitration decision that ticks the blitter.
+    pub(super) fn record_frame_blit_quantum(&mut self, cck: u32, advanced: bool) {
+        let Some(id) = self.active_frame_blit else {
+            return;
+        };
+        let Some(record) = self
+            .current_frame_bus_trace
+            .blits
+            .iter_mut()
+            .rev()
+            .find(|record| record.id == id)
+        else {
+            return;
+        };
+        let counter = if advanced {
+            &mut record.cycles_used
+        } else {
+            &mut record.cycles_stalled
+        };
+        *counter = counter.saturating_add(u64::from(cck));
+    }
+
+    /// Retain the exact word/address transferred by a blitter DMA slot for
+    /// the channel visualisers. Disabled channels need no entries: their
+    /// BLTxDAT constants are already in the record.
+    pub(super) fn record_frame_blit_access(&mut self, access: BlitBusAccess) {
+        let Some(id) = self.active_frame_blit else {
+            return;
+        };
+        let Some(record) = self
+            .current_frame_bus_trace
+            .blits
+            .iter_mut()
+            .rev()
+            .find(|record| record.id == id)
+        else {
+            return;
+        };
+        let channel = usize::from(access.channel);
+        if channel >= 4 {
+            return;
+        }
+        if record.channel_words[channel].len() >= FRAME_BLIT_RENDER_WORD_CAP {
+            record.render_truncated = true;
+            return;
+        }
+        record.channel_words[channel].push(access.data);
+        record.channel_addrs[channel].push(access.addr);
     }
 
     fn record_blit_accounting(&mut self) {
@@ -8966,6 +9120,17 @@ impl Bus {
         if !self.frame_analyzer_enabled {
             return;
         }
+        // Carry an in-flight blit into the next trace before reset. It keeps
+        // the same id/start position and accumulated transfers so the two
+        // frame records join losslessly.
+        let carried_blit = self.active_frame_blit.and_then(|id| {
+            self.current_frame_bus_trace
+                .blits
+                .iter()
+                .rev()
+                .find(|record| record.id == id)
+                .cloned()
+        });
         let registers = self.frame_register_snapshot();
         self.current_frame_bus_trace.reset_for_frame_with_level(
             self.emulated_frames,
@@ -8978,6 +9143,9 @@ impl Bus {
             self.frame_analyzer_full,
             registers,
         );
+        if let Some(blit) = carried_blit {
+            self.current_frame_bus_trace.blits.push(blit);
+        }
     }
 
     fn frame_register_snapshot(&self) -> FrameRegisterSnapshot {

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -2108,8 +2108,9 @@ pub struct FrameBlitRecord {
     /// First/last A word masks.
     pub masks: [u16; 2],
     pub minterm: u8,
-    /// BLTADAT, BLTBDAT and BLTCDAT as latched at the start. Disabled DMA
-    /// channels use these constant inputs.
+    /// Effective A, B and C constant inputs at the start. For USEB-off area
+    /// blits, B is BLTBDAT's write-time-shifted hold latch rather than the
+    /// raw register; disabled DMA channels use these values.
     pub data: [u16; 3],
     pub start_frame: u64,
     pub end_frame: Option<u64>,
@@ -8732,15 +8733,16 @@ impl Bus {
         self.active_frame_blit = Some(id);
         let con0 = self.blitter.bltcon0;
         let con1 = self.blitter.bltcon1;
+        let line_mode = con1 & BLTCON1_LINE != 0;
         self.current_frame_bus_trace.blits.push(FrameBlitRecord {
             id,
             bltcon0: con0,
             bltcon1: con1,
             width_words,
             height,
-            descending: con1 & BLTCON1_DESC != 0,
-            line_mode: con1 & BLTCON1_LINE != 0,
-            fill_mode: con1 & (BLTCON1_IFE | BLTCON1_EFE) != 0,
+            descending: !line_mode && con1 & BLTCON1_DESC != 0,
+            line_mode,
+            fill_mode: !line_mode && con1 & (BLTCON1_IFE | BLTCON1_EFE) != 0,
             channels: [
                 con0 & BLTCON0_USE_A != 0,
                 con0 & BLTCON0_USE_B != 0,
@@ -8762,7 +8764,11 @@ impl Bus {
             minterm: con0 as u8,
             data: [
                 self.blitter.bltadat,
-                self.blitter.bltbdat,
+                if con0 & BLTCON0_USE_B != 0 || line_mode {
+                    self.blitter.bltbdat
+                } else {
+                    self.blitter.b_hold_latch()
+                },
                 self.blitter.bltcdat,
             ],
             start_frame: self.emulated_frames,
@@ -8809,6 +8815,9 @@ impl Bus {
     /// the channel visualisers. Disabled channels need no entries: their
     /// BLTxDAT constants are already in the record.
     pub(super) fn record_frame_blit_access(&mut self, access: BlitBusAccess) {
+        if access.size == 0 {
+            return;
+        }
         let Some(id) = self.active_frame_blit else {
             return;
         };

--- a/src/bus/dma_slots.rs
+++ b/src/bus/dma_slots.rs
@@ -164,6 +164,36 @@ impl Bus {
                 self.blitter.current_slot_needs_bus()
             );
         }
+        // Decide once whether a bus-free/internal blitter cycle advances on
+        // this quantum. The same answer drives both the sequencer below and
+        // the per-blit used/stalled accounting, so the visualiser cannot
+        // drift from the hardware timeline.
+        let blitter_non_bus_advanced = !matches!(owner, ChipBusOwner::Blitter)
+            && self.blitter.busy
+            && self.blitter_dma_enabled()
+            && match self.blitter.current_slot_class() {
+                crate::chipset::blitter::BlitSlotClass::Bus => false,
+                crate::chipset::blitter::BlitSlotClass::Internal => true,
+                crate::chipset::blitter::BlitSlotClass::BusFree => match owner {
+                    ChipBusOwner::Idle => true,
+                    ChipBusOwner::Cpu => {
+                        !(matches!(forced_owner, Some(ChipBusOwner::Cpu))
+                            && self.blitter_yields_to_waiting_cpu())
+                    }
+                    _ => false,
+                },
+            };
+        if self.frame_analyzer_enabled && self.blitter.busy {
+            self.record_frame_blit_quantum(
+                cck,
+                matches!(owner, ChipBusOwner::Blitter) || blitter_non_bus_advanced,
+            );
+            if matches!(owner, ChipBusOwner::Blitter) {
+                if let Some(access) = self.blitter.current_bus_access(&self.mem.chip_ram) {
+                    self.record_frame_blit_access(access);
+                }
+            }
+        }
         self.last_chip_bus_owner = owner;
         if self.chip_bus_observers_on {
             self.observe_chip_bus_quantum(owner, cck, hpos);
@@ -277,37 +307,21 @@ impl Bus {
         if !matches!(owner, ChipBusOwner::Blitter)
             && self.blitter.busy
             && self.blitter_dma_enabled()
+            && blitter_non_bus_advanced
         {
-            let ticks = match self.blitter.current_slot_class() {
-                crate::chipset::blitter::BlitSlotClass::Bus => false,
-                crate::chipset::blitter::BlitSlotClass::Internal => true,
-                crate::chipset::blitter::BlitSlotClass::BusFree => match owner {
-                    ChipBusOwner::Idle => true,
-                    ChipBusOwner::Cpu => {
-                        // A starvation grant is the cck where BLS denies the
-                        // blitter; an ordinary CPU access on a free clock
-                        // does not stall the bus-free cycle.
-                        !(matches!(forced_owner, Some(ChipBusOwner::Cpu))
-                            && self.blitter_yields_to_waiting_cpu())
-                    }
-                    _ => false,
-                },
-            };
-            if ticks {
-                if diag_blt_slots() {
-                    eprintln!(
-                        "BLTP {} {} {} TICK {} bus=0 owner={owner:?}",
-                        self.emulated_frames,
-                        self.agnus.vpos,
-                        self.agnus.hpos,
-                        self.blitter.current_slot_label()
-                    );
-                }
-                if self.blitter.tick_scheduled_slot(&mut self.mem.chip_ram) {
-                    self.latch_blitter_completion("idle_pipeline");
-                }
-                self.note_blitter_slot_ticked();
+            if diag_blt_slots() {
+                eprintln!(
+                    "BLTP {} {} {} TICK {} bus=0 owner={owner:?}",
+                    self.emulated_frames,
+                    self.agnus.vpos,
+                    self.agnus.hpos,
+                    self.blitter.current_slot_label()
+                );
             }
+            if self.blitter.tick_scheduled_slot(&mut self.mem.chip_ram) {
+                self.latch_blitter_completion("idle_pipeline");
+            }
+            self.note_blitter_slot_ticked();
         }
         let tick = self.advance_beam(cck);
         self.audio_pending_cck = self.audio_pending_cck.saturating_add(cck);

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -874,6 +874,42 @@ fn frame_analyzer_records_owner_spans_and_blitter_wait_cck() {
 }
 
 #[test]
+fn frame_analyzer_finalises_a_cross_frame_blit_in_both_traces() {
+    let mut bus = empty_bus();
+    bus.mem.overlay = false;
+    bus.set_frame_analyzer_full(true);
+    bus.agnus.dmacon = DMACON_DMAEN | DMACON_BLTEN;
+    bus.agnus.vpos = PAL_LINES - 1;
+    bus.agnus.hpos = bus.agnus.current_line_cck() - 2;
+    bus.blitter.bltcon0 = BLTCON0_USE_D | 0x00F0;
+    bus.blitter.bltdpt = 0x400;
+    bus.blitter.start_scheduled((2 << 6) | 2, &bus.mem.chip_ram);
+    bus.record_frame_blit_start(2, 2);
+    let id = bus.active_frame_blit.expect("recorded blit id");
+
+    bus.advance_chipset(32);
+    assert!(!bus.blitter.busy);
+    let older = bus
+        .last_frame_bus_trace
+        .as_ref()
+        .and_then(|trace| trace.blits.iter().find(|blit| blit.id == id))
+        .expect("blit remains referenced from its starting frame");
+    let newer = bus
+        .current_frame_bus_trace
+        .blits
+        .iter()
+        .find(|blit| blit.id == id)
+        .expect("blit remains referenced from its ending frame");
+    assert_eq!(older.end, newer.end);
+    assert_eq!(older.end_frame, newer.end_frame);
+    assert!(older
+        .end_frame
+        .is_some_and(|frame| frame > older.start_frame));
+    assert!(older.cycles_used > 0);
+    assert!(!older.channel_addrs[3].is_empty());
+}
+
+#[test]
 fn frame_analyzer_records_cpu_wait_samples() {
     let mut trace = FrameBusTrace::default();
     trace.reset_for_frame(7, 0.140, 4, 16, 1, 2, false);

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -31,6 +31,7 @@ use crate::chipset::agnus::{
     AgnusRevision, AgnusTick, VideoStandard, BEAMCON0_DUAL, BEAMCON0_HARDDIS, BEAMCON0_PAL,
     BEAMCON0_VARBEAMEN, COLORCLOCKS_PER_LINE, NTSC_LONG_COLORCLOCKS_PER_LINE, PAL_LINES,
 };
+use crate::chipset::blitter::BlitBusAccess;
 use crate::chipset::cia::{
     REG_CRA, REG_CRB, REG_DDRA, REG_DDRB, REG_ICR, REG_PRA, REG_PRB, REG_TAHI, REG_TALO, REG_TBHI,
     REG_TBLO, REG_TODHI, REG_TODLO, REG_TODMID,
@@ -907,6 +908,45 @@ fn frame_analyzer_finalises_a_cross_frame_blit_in_both_traces() {
         .is_some_and(|frame| frame > older.start_frame));
     assert!(older.cycles_used > 0);
     assert!(!older.channel_addrs[3].is_empty());
+}
+
+#[test]
+fn frame_blit_metadata_decodes_modes_constants_and_real_transfers() {
+    let mut bus = empty_bus();
+    bus.set_frame_analyzer_full(true);
+    bus.blitter.bltcon0 = BLTCON0_USE_D | 0x00CC;
+
+    // USEB-off consumes the hold latch shifted when BLTBDAT was written,
+    // even if BSH changes before the blit starts.
+    bus.blitter.write_bltcon1(4 << 12);
+    bus.blitter.write_bltbdat(0x000F);
+    bus.blitter.write_bltbdat(0x0000);
+    bus.blitter.write_bltcon1(0);
+    bus.record_frame_blit_start(1, 1);
+    assert_eq!(bus.current_frame_bus_trace.blits[0].data[1], 0xF000);
+
+    // The same bit positions mean SING/SUL/SUD in line mode, not the area
+    // DESC/fill flags exposed by the analyzer.
+    bus.blitter.write_bltcon1(BLTCON1_LINE | 0x001A);
+    bus.record_frame_blit_start(1, 1);
+    let line = &bus.current_frame_bus_trace.blits[1];
+    assert!(line.line_mode);
+    assert!(!line.descending);
+    assert!(!line.fill_mode);
+
+    // A SING-suppressed D cycle holds the bus but transfers no word.
+    bus.record_frame_blit_access(BlitBusAccess {
+        channel: 3,
+        addr: 0x400,
+        data: 0xFFFF,
+        size: 0,
+        write: false,
+        final_d: false,
+        line: true,
+        fill: false,
+    });
+    assert!(bus.current_frame_bus_trace.blits[1].channel_words[3].is_empty());
+    assert!(bus.current_frame_bus_trace.blits[1].channel_addrs[3].is_empty());
 }
 
 #[test]

--- a/src/chipset/blitter.rs
+++ b/src/chipset/blitter.rs
@@ -559,6 +559,13 @@ impl Blitter {
         self.b_hold_latch = shift_combine(self.bltbold, val, bsh, desc);
     }
 
+    /// Effective constant B input for USEB-off area blits. This is a
+    /// diagnostic snapshot accessor; the sequencer remains its only
+    /// production consumer.
+    pub(crate) fn b_hold_latch(&self) -> u16 {
+        self.b_hold_latch
+    }
+
     pub fn write_bltcdat(&mut self, val: u16) {
         self.bltcdat = val;
     }

--- a/src/control/catalogue.rs
+++ b/src/control/catalogue.rs
@@ -590,6 +590,19 @@ fn build() -> Vec<ToolDef> {
             json!({"row": 100}),
         ),
         entry(
+            "blit.render",
+            "Render one channel of a recorded Frame Analyzer blit as a PNG from its exact DMA word stream. Returns geometry, the registered-resource or BPLCON0 plane-count source, and a simplified minterm formula.",
+            object(
+                vec![
+                    ("index", uint("Zero-based index in the last frame's blit list", Some(0), Some((crate::bus::FRAME_BLIT_RECORD_CAP - 1) as u64))),
+                    ("channel", enumeration("Channel or computed output", &["A", "B", "C", "D", "result"])),
+                    ("path", string("Host path for the PNG (optional)")),
+                ],
+                &["index", "channel"],
+            ),
+            json!({"index": 0, "channel": "result"}),
+        ),
+        entry(
             "display.get",
             "Report the active display: video standard, canvas size and pixel format, \
              the display window and fetch registers as decoded, bitplane count, \
@@ -645,11 +658,14 @@ fn build() -> Vec<ToolDef> {
             "copper.list",
             "Disassemble up to `max` Copper instructions (default 32, at most 256) from \
              `addr` (default: the Copper's current program counter): MOVE, WAIT, SKIP, \
-             with register names and beam positions decoded.",
+             with register names and beam positions decoded. `trace` annotates instructions \
+             with the exact execution slot in the last full Frame Analyzer trace.",
             object(
                 vec![
                     ("addr", addr("Copper list address (default: current Copper PC)")),
+                    ("resource", string("Registered Copperlist resource name")),
                     ("max", uint("Instructions to list", Some(1), Some(256))),
+                    ("trace", boolean("Include last-frame execution positions")),
                 ],
                 &[],
             ),
@@ -1308,8 +1324,22 @@ fn build() -> Vec<ToolDef> {
             "Render the current frame as a PNG. Through this bridge the image is also \
              returned as an image content block so you can look at the screen; with no \
              `path` the file is temporary and deleted after it is read, with a `path` it \
-             is kept there. Returns the path, width and height.",
-            object(vec![("path", string("Host path for the PNG (optional)"))], &[]),
+             is kept there. `overlays` may contain `blits`, `overdraw`, and `sources` \
+             (playfield 1/2, sprite number, background, outside DIW); overdraw uses full \
+             chip-memory write records when registered bitmap geometry is available. Returns the path, \
+             width and height.",
+            object(
+                vec![
+                    ("path", string("Host path for the PNG (optional)")),
+                    ("overlays", json!({
+                        "description": "Diagnostic layers painted over the captured frame",
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {"type": "string", "enum": ["blits", "overdraw", "sources"]}
+                    })),
+                ],
+                &[],
+            ),
             json!({}),
         ),
         entry(

--- a/src/control/catalogue.rs
+++ b/src/control/catalogue.rs
@@ -591,7 +591,7 @@ fn build() -> Vec<ToolDef> {
         ),
         entry(
             "blit.render",
-            "Render one channel of a recorded Frame Analyzer blit as a PNG from its exact DMA word stream. Returns geometry, the registered-resource or BPLCON0 plane-count source, and a simplified minterm formula.",
+            "Render one channel of a recorded Frame Analyzer blit as a PNG from its exact DMA word stream. Returns geometry, the registered-resource or BPLCON0 plane-count source, safe render plane count, and a simplified minterm formula. Result rendering requires captured D writes.",
             object(
                 vec![
                     ("index", uint("Zero-based index in the last frame's blit list", Some(0), Some((crate::bus::FRAME_BLIT_RECORD_CAP - 1) as u64))),

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -2265,12 +2265,12 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
                     trace.blits.len().saturating_sub(1)
                 ))
             })?;
-            let (planes, plane_source) = crate::blitviz::plane_count_for_blit(
+            let layout = crate::blitviz::plane_layout_for_blit(
                 blit,
                 emu.uaelib_resources(),
                 bus.frame_render_base(),
             );
-            let preview = crate::blitviz::render_blit(blit, *channel, planes)
+            let preview = crate::blitviz::render_blit(blit, *channel, layout.render_planes)
                 .map_err(CtlError::invalid_state)?;
             let path = path
                 .clone()
@@ -2290,8 +2290,10 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
                 "channel": channel.name(),
                 "width": preview.width,
                 "height": preview.height,
-                "planes": planes,
-                "plane_source": plane_source,
+                "planes": layout.planes,
+                "render_planes": layout.render_planes,
+                "plane_source": layout.source,
+                "interleaved": layout.interleaved,
                 "minterm": format!("0x{:02X}", blit.minterm),
                 "formula": crate::blitviz::minterm_formula(blit.minterm),
                 "note": preview.note,
@@ -3449,8 +3451,9 @@ fn paint_blit_overlays(
     let resources = emu.uaelib_resources();
     let mut overdraw = vec![0u16; width * height];
     for (index, blit) in trace.blits.iter().enumerate() {
-        let (planes, _) =
-            crate::blitviz::plane_count_for_blit(blit, resources, emu.bus().frame_render_base());
+        let planes =
+            crate::blitviz::plane_layout_for_blit(blit, resources, emu.bus().frame_render_base())
+                .render_planes;
         let mut bounds: Option<(usize, usize, usize, usize)> = None;
         for (sequence, &address) in blit.channel_addrs[3].iter().enumerate() {
             let Some((x, y, x_scale)) =
@@ -3488,6 +3491,12 @@ fn paint_blit_overlays(
         if let Some(records) = trace.records() {
             for record in records
                 .iter()
+                .chain(
+                    trace
+                        .instantaneous_records()
+                        .iter()
+                        .map(|entry| &entry.record),
+                )
                 .filter(|record| record_writes_chip_memory(record))
             {
                 let bytes = usize::from(record.size).max(2);
@@ -3514,11 +3523,12 @@ fn paint_blit_overlays(
         }
         if !mapped_write {
             for blit in &trace.blits {
-                let (planes, _) = crate::blitviz::plane_count_for_blit(
+                let planes = crate::blitviz::plane_layout_for_blit(
                     blit,
                     resources,
                     emu.bus().frame_render_base(),
-                );
+                )
+                .render_planes;
                 for (sequence, &address) in blit.channel_addrs[3].iter().enumerate() {
                     if let Some((x, y, x_scale)) = blit_destination_pixel(
                         blit, sequence, address, resources, planes, width, height,

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -149,6 +149,15 @@ pub enum CoreOp {
         /// Start at a guest-registered Copperlist resource instead.
         resource: Option<String>,
         max: usize,
+        /// Annotate each instruction with where it executed in the last
+        /// full Frame Analyzer trace.
+        trace: bool,
+    },
+    /// Reconstruct one recorded blitter channel without reading live RAM.
+    BlitRender {
+        index: usize,
+        channel: crate::blitviz::BlitChannel,
+        path: Option<PathBuf>,
     },
     LastWriter {
         addr: u32,
@@ -199,6 +208,7 @@ pub enum CoreOp {
     },
     Screenshot {
         path: Option<PathBuf>,
+        overlays: Vec<CaptureOverlay>,
     },
     ReverseStep {
         n: u64,
@@ -253,6 +263,7 @@ impl CoreOp {
                 | CoreOp::DebugResources
                 | CoreOp::DebugIdle
                 | CoreOp::CopperList { .. }
+                | CoreOp::BlitRender { .. }
                 | CoreOp::PcHistory
                 | CoreOp::SegmentsList
                 | CoreOp::BreakList
@@ -265,6 +276,33 @@ impl CoreOp {
                 | CoreOp::RegionDigest { .. }
                 | CoreOp::Screenshot { .. }
         )
+    }
+}
+
+/// Optional diagnostic layers painted onto a side-effect-free screenshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureOverlay {
+    Blits,
+    Overdraw,
+    Sources,
+}
+
+impl CaptureOverlay {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "blits" => Some(Self::Blits),
+            "overdraw" => Some(Self::Overdraw),
+            "sources" => Some(Self::Sources),
+            _ => None,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Blits => "blits",
+            Self::Overdraw => "overdraw",
+            Self::Sources => "sources",
+        }
     }
 }
 
@@ -997,6 +1035,16 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
         "frame.slots" => core(CoreOp::FrameSlots {
             row: p.usize_or("row", 0)?,
         }),
+        "blit.render" => {
+            let channel = p.str_req("channel")?;
+            let channel = crate::blitviz::BlitChannel::parse(&channel)
+                .ok_or_else(|| CtlError::invalid_params("channel must be A|B|C|D|result"))?;
+            core(CoreOp::BlitRender {
+                index: p.usize_req("index")?,
+                channel,
+                path: p.str_opt("path")?.map(PathBuf::from),
+            })
+        }
         "display.get" => core(CoreOp::DisplayGet),
         "rtc.get" => core(CoreOp::RtcGet),
         "rtc.set" => {
@@ -1044,6 +1092,7 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
                 addr,
                 resource,
                 max: p.usize_or("max", 32)?.clamp(1, 256),
+                trace: p.bool_or("trace", false)?,
             })
         }
         "last_writer" => core(CoreOp::LastWriter {
@@ -1417,9 +1466,21 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
         "state.load" => host(HostOp::StateLoad {
             path: PathBuf::from(p.str_req("path")?),
         }),
-        "capture.screenshot" => core(CoreOp::Screenshot {
-            path: p.str_opt("path")?.map(PathBuf::from),
-        }),
+        "capture.screenshot" => {
+            let mut overlays = Vec::new();
+            for value in p.str_array("overlays")? {
+                let overlay = CaptureOverlay::parse(&value).ok_or_else(|| {
+                    CtlError::invalid_params("overlays entries must be blits|overdraw|sources")
+                })?;
+                if !overlays.contains(&overlay) {
+                    overlays.push(overlay);
+                }
+            }
+            core(CoreOp::Screenshot {
+                path: p.str_opt("path")?.map(PathBuf::from),
+                overlays,
+            })
+        }
         "capture.digest" => core(CoreOp::Digest),
         "capture.region_digest" => core(CoreOp::RegionDigest {
             rect: parse_frame_rect(&p)?,
@@ -1963,6 +2024,21 @@ impl<'a> ParamReader<'a> {
                 .ok_or_else(|| CtlError::invalid_params(format!("bad {key}"))),
         }
     }
+
+    fn str_array(&self, key: &str) -> Result<Vec<String>, CtlError> {
+        match self.get(key) {
+            None | Some(Value::Null) => Ok(Vec::new()),
+            Some(Value::Array(values)) => values
+                .iter()
+                .map(|value| {
+                    value.as_str().map(str::to_string).ok_or_else(|| {
+                        CtlError::invalid_params(format!("{key} must contain strings"))
+                    })
+                })
+                .collect(),
+            Some(_) => Err(CtlError::invalid_params(format!("{key} must be an array"))),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------
@@ -2172,6 +2248,55 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
                 "instantaneous_records": instantaneous_records,
             }))
         }
+        CoreOp::BlitRender {
+            index,
+            channel,
+            path,
+        } => {
+            let bus = emu.bus();
+            let trace = bus.frame_bus_trace().ok_or_else(|| {
+                CtlError::invalid_state(
+                    "no frame trace is available; open the Frame Analyzer or start a profile",
+                )
+            })?;
+            let blit = trace.blits.get(*index).ok_or_else(|| {
+                CtlError::invalid_params(format!(
+                    "index must select a recorded blit (0..{})",
+                    trace.blits.len().saturating_sub(1)
+                ))
+            })?;
+            let (planes, plane_source) = crate::blitviz::plane_count_for_blit(
+                blit,
+                emu.uaelib_resources(),
+                bus.frame_render_base(),
+            );
+            let preview = crate::blitviz::render_blit(blit, *channel, planes)
+                .map_err(CtlError::invalid_state)?;
+            let path = path
+                .clone()
+                .unwrap_or_else(crate::screenshot::auto_filename);
+            crate::screenshot::save(
+                &path,
+                &preview.pixels,
+                preview.width as u32,
+                preview.height as u32,
+            )
+            .map_err(|e| CtlError::io(format!("saving blit render: {e:#}")))?;
+            Ok(json!({
+                "path": path.display().to_string(),
+                "frame": trace.frame,
+                "index": index,
+                "id": blit.id,
+                "channel": channel.name(),
+                "width": preview.width,
+                "height": preview.height,
+                "planes": planes,
+                "plane_source": plane_source,
+                "minterm": format!("0x{:02X}", blit.minterm),
+                "formula": crate::blitviz::minterm_formula(blit.minterm),
+                "note": preview.note,
+            }))
+        }
         CoreOp::DisplayGet => {
             let bus = emu.bus();
             Ok(json!({
@@ -2297,6 +2422,7 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
             addr,
             resource,
             max,
+            trace,
         } => {
             let start = match (addr, resource) {
                 (Some(addr), _) => Some(*addr),
@@ -2314,19 +2440,46 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
             let bus = emu.bus();
             let copper_pc = bus.copper.pc();
             let start = start.unwrap_or_else(|| copper_pc.saturating_sub(4 * 4));
-            let entries: Vec<Value> = crate::disasm::dump_copper_list(
-                |a| bus.peek_word_any(a),
-                start,
-                *max,
-            )
-            .into_iter()
-            .map(|(addr, text)| json!({"addr": addr, "text": text, "cursor": addr == copper_pc}))
-            .collect();
+            let traced = (*trace)
+                .then(|| {
+                    bus.frame_bus_trace().and_then(|frame| {
+                        frame
+                            .records()
+                            .map(|records| (frame.frame, frame.cols, records))
+                    })
+                })
+                .flatten();
+            let entries: Vec<Value> =
+                crate::disasm::dump_copper_list(|a| bus.peek_word_any(a), start, *max)
+                    .into_iter()
+                    .map(|(addr, text)| {
+                        let beam = traced.and_then(|(frame, cols, records)| {
+                            records.iter().enumerate().find_map(|(slot, record)| {
+                                (record.kind == crate::bus::BUS_RECORD_COPPER
+                                    && record.addr == addr.saturating_add(2))
+                                .then(|| {
+                                    json!({
+                                        "frame": frame,
+                                        "vpos": slot / cols,
+                                        "hpos": slot % cols,
+                                    })
+                                })
+                            })
+                        });
+                        json!({
+                            "addr": addr,
+                            "text": text,
+                            "cursor": addr == copper_pc,
+                            "trace": beam,
+                        })
+                    })
+                    .collect();
             Ok(json!({
                 "cop1lc": bus.agnus.cop1lc,
                 "cop2lc": bus.agnus.cop2lc,
                 "coppc": copper_pc,
                 "running": bus.copper.is_running(),
+                "trace_frame": traced.map(|(frame, _, _)| frame),
                 "entries": entries,
             }))
         }
@@ -2637,8 +2790,8 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
         }
         CoreOp::Digest => Ok(digest_value(emu)),
         CoreOp::RegionDigest { rect } => region_digest_value(emu, *rect),
-        CoreOp::Screenshot { path } => {
-            let (fb, lines, width) = render_frame(emu);
+        CoreOp::Screenshot { path, overlays } => {
+            let (fb, lines, width) = render_frame_with_overlays(emu, overlays);
             let path = path
                 .clone()
                 .unwrap_or_else(crate::screenshot::auto_filename);
@@ -2648,6 +2801,15 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
                 "path": path.display().to_string(),
                 "width": width,
                 "height": lines,
+                "overlays": overlays.iter().map(|overlay| overlay.name()).collect::<Vec<_>>(),
+                "source_legend": overlays.contains(&CaptureOverlay::Sources).then(|| json!({
+                    "outside_diw": crate::video::bitplane::PIXEL_SOURCE_OUTSIDE_DIW,
+                    "background": crate::video::bitplane::PIXEL_SOURCE_BACKGROUND,
+                    "playfield1": crate::video::bitplane::PIXEL_SOURCE_PLAYFIELD1,
+                    "playfield2": crate::video::bitplane::PIXEL_SOURCE_PLAYFIELD2,
+                    "sprite0": crate::video::bitplane::PIXEL_SOURCE_SPRITE0,
+                    "sprite7": crate::video::bitplane::PIXEL_SOURCE_SPRITE0 + 7,
+                })),
             }))
         }
         CoreOp::ReverseStep { n } => {
@@ -3120,6 +3282,262 @@ pub(crate) fn render_frame(emu: &Emulator) -> (Vec<u32>, usize, usize) {
     (fb, lines, width)
 }
 
+fn render_frame_with_overlays(
+    emu: &Emulator,
+    overlays: &[CaptureOverlay],
+) -> (Vec<u32>, usize, usize) {
+    if overlays.is_empty() {
+        return render_frame(emu);
+    }
+    // RTG has no Denise provenance, but recorded blitter writes can still be
+    // projected onto its presented image when the guest registered a bitmap.
+    let mut fb = Vec::new();
+    let mut scratch = Vec::new();
+    let (lines, width, sources) = if let Some((rows, _, _)) =
+        crate::video::present_common::compose_rtg_present(emu.bus(), &mut scratch, &mut fb)
+    {
+        (rows, FB_WIDTH, Vec::new())
+    } else {
+        fb = vec![0u32; MAX_CANVAS_PIXELS];
+        let sources = if overlays.contains(&CaptureOverlay::Sources) {
+            crate::video::bitplane::render_display_diagnostics(emu.bus(), &mut fb)
+        } else {
+            crate::video::bitplane::render_display_only(emu.bus(), &mut fb);
+            Vec::new()
+        };
+        (
+            emu.bus().frame_geometry().visible_lines,
+            FB_WIDTH * emu.bus().frame_canvas_scale(),
+            sources,
+        )
+    };
+    if overlays.contains(&CaptureOverlay::Sources) && sources.len() >= width * lines {
+        for (pixel, source) in fb[..width * lines].iter_mut().zip(sources) {
+            *pixel = overlay_blend(*pixel, source_colour(source), 142);
+        }
+    }
+    if overlays.contains(&CaptureOverlay::Overdraw) || overlays.contains(&CaptureOverlay::Blits) {
+        paint_blit_overlays(emu, &mut fb[..width * lines], width, lines, overlays);
+    }
+    (fb, lines, width)
+}
+
+fn source_colour(source: u8) -> u32 {
+    let rgb = match source {
+        crate::video::bitplane::PIXEL_SOURCE_OUTSIDE_DIW => [54, 58, 66],
+        crate::video::bitplane::PIXEL_SOURCE_BACKGROUND => [30, 38, 54],
+        crate::video::bitplane::PIXEL_SOURCE_PLAYFIELD1 => [36, 176, 238],
+        crate::video::bitplane::PIXEL_SOURCE_PLAYFIELD2 => [238, 166, 42],
+        sprite if sprite >= crate::video::bitplane::PIXEL_SOURCE_SPRITE0 => {
+            const SPRITE: [[u8; 3]; 8] = [
+                [244, 72, 90],
+                [222, 92, 238],
+                [156, 92, 244],
+                [92, 116, 244],
+                [72, 210, 190],
+                [104, 220, 92],
+                [222, 214, 72],
+                [244, 134, 72],
+            ];
+            SPRITE[usize::from(sprite - crate::video::bitplane::PIXEL_SOURCE_SPRITE0).min(7)]
+        }
+        _ => [255, 255, 255],
+    };
+    u32::from_le_bytes([rgb[0], rgb[1], rgb[2], 0xFF])
+}
+
+fn overlay_blend(base: u32, over: u32, alpha: u8) -> u32 {
+    let base = base.to_le_bytes();
+    let over = over.to_le_bytes();
+    let a = u16::from(alpha);
+    let mix =
+        |index| ((u16::from(base[index]) * (255 - a) + u16::from(over[index]) * a) / 255) as u8;
+    u32::from_le_bytes([mix(0), mix(1), mix(2), 0xFF])
+}
+
+fn blit_destination_pixel(
+    blit: &crate::bus::FrameBlitRecord,
+    sequence: usize,
+    address: u32,
+    resources: &[crate::uaelib::DebugResource],
+    planes: usize,
+    frame_width: usize,
+    frame_height: usize,
+) -> Option<(usize, usize, usize)> {
+    let (pixel, bitmap_width, bitmap_height) =
+        crate::blitviz::destination_word_pixel(address, resources).unwrap_or_else(|| {
+            let words = usize::try_from(blit.width_words).unwrap_or(1).max(1);
+            let transfer_rows = usize::try_from(blit.height).unwrap_or(1).max(1);
+            let transfer_row = sequence / words;
+            let transfer_col = sequence % words;
+            let row = if blit.descending {
+                transfer_rows - 1 - transfer_row.min(transfer_rows - 1)
+            } else {
+                transfer_row
+            } / planes.max(1);
+            let col = if blit.descending {
+                words - 1 - transfer_col
+            } else {
+                transfer_col
+            } * 16;
+            (
+                crate::blitviz::DestinationPixel { x: col, y: row },
+                words * 16,
+                usize::try_from(blit.height)
+                    .unwrap_or(1)
+                    .div_ceil(planes.max(1)),
+            )
+        });
+    project_destination_pixel(
+        pixel,
+        bitmap_width,
+        bitmap_height,
+        frame_width,
+        frame_height,
+    )
+}
+
+fn project_destination_pixel(
+    pixel: crate::blitviz::DestinationPixel,
+    bitmap_width: usize,
+    bitmap_height: usize,
+    frame_width: usize,
+    frame_height: usize,
+) -> Option<(usize, usize, usize)> {
+    let x_scale = if bitmap_width.saturating_mul(2) <= frame_width {
+        2
+    } else {
+        1
+    };
+    let scaled_width = bitmap_width.saturating_mul(x_scale);
+    let x0 = frame_width.saturating_sub(scaled_width) / 2;
+    let y0 = frame_height.saturating_sub(bitmap_height) / 2;
+    let x = x0.saturating_add(pixel.x.saturating_mul(x_scale));
+    let y = y0.saturating_add(pixel.y);
+    (x < frame_width && y < frame_height).then_some((x, y, x_scale))
+}
+
+fn increment_overdraw_word(overdraw: &mut [u16], width: usize, x: usize, y: usize, x_scale: usize) {
+    let stop = (x + 16 * x_scale).min(width);
+    for cell in &mut overdraw[y * width + x..y * width + stop] {
+        *cell = cell.saturating_add(1);
+    }
+}
+
+fn record_writes_chip_memory(record: &crate::bus::BusSlotRecord) -> bool {
+    if record.flags & 1 == 0 {
+        return false;
+    }
+    match record.kind {
+        crate::bus::BUS_RECORD_CPU => record.reg == 0x1000,
+        crate::bus::BUS_RECORD_BLITTER => record.subtype & 0x0F == 3,
+        crate::bus::BUS_RECORD_DISK => true,
+        _ => false,
+    }
+}
+
+fn paint_blit_overlays(
+    emu: &Emulator,
+    fb: &mut [u32],
+    width: usize,
+    height: usize,
+    overlays: &[CaptureOverlay],
+) {
+    let Some(trace) = emu.bus().frame_bus_trace() else {
+        return;
+    };
+    let resources = emu.uaelib_resources();
+    let mut overdraw = vec![0u16; width * height];
+    for (index, blit) in trace.blits.iter().enumerate() {
+        let (planes, _) =
+            crate::blitviz::plane_count_for_blit(blit, resources, emu.bus().frame_render_base());
+        let mut bounds: Option<(usize, usize, usize, usize)> = None;
+        for (sequence, &address) in blit.channel_addrs[3].iter().enumerate() {
+            let Some((x, y, x_scale)) =
+                blit_destination_pixel(blit, sequence, address, resources, planes, width, height)
+            else {
+                continue;
+            };
+            let stop = (x + 16 * x_scale).min(width);
+            bounds = Some(match bounds {
+                None => (x, y, stop, y + 1),
+                Some((x0, y0, x1, y1)) => (x0.min(x), y0.min(y), x1.max(stop), y1.max(y + 1)),
+            });
+        }
+        if overlays.contains(&CaptureOverlay::Blits) {
+            if let Some((x0, y0, x1, y1)) = bounds {
+                let colour =
+                    source_colour(crate::video::bitplane::PIXEL_SOURCE_SPRITE0 + (index % 8) as u8);
+                for x in x0..x1 {
+                    fb[y0 * width + x] = colour;
+                    fb[(y1 - 1) * width + x] = colour;
+                }
+                for y in y0..y1 {
+                    fb[y * width + x0] = colour;
+                    fb[y * width + x1 - 1] = colour;
+                }
+            }
+        }
+    }
+    if overlays.contains(&CaptureOverlay::Overdraw) {
+        // Phase 2's full write records are the authoritative overdraw
+        // source: this includes CPU and every DMA writer, not just blitter D.
+        // Without registered bitmap geometry, retain the useful geometric
+        // blit fallback used by a cheap (owner-only) analyzer trace.
+        let mut mapped_write = false;
+        if let Some(records) = trace.records() {
+            for record in records
+                .iter()
+                .filter(|record| record_writes_chip_memory(record))
+            {
+                let bytes = usize::from(record.size).max(2);
+                for offset in (0..bytes).step_by(2) {
+                    let address = record.addr.saturating_add(offset as u32);
+                    let Some((pixel, bitmap_width, bitmap_height)) =
+                        crate::blitviz::destination_word_pixel(address, resources)
+                    else {
+                        continue;
+                    };
+                    let Some((x, y, x_scale)) = project_destination_pixel(
+                        pixel,
+                        bitmap_width,
+                        bitmap_height,
+                        width,
+                        height,
+                    ) else {
+                        continue;
+                    };
+                    increment_overdraw_word(&mut overdraw, width, x, y, x_scale);
+                    mapped_write = true;
+                }
+            }
+        }
+        if !mapped_write {
+            for blit in &trace.blits {
+                let (planes, _) = crate::blitviz::plane_count_for_blit(
+                    blit,
+                    resources,
+                    emu.bus().frame_render_base(),
+                );
+                for (sequence, &address) in blit.channel_addrs[3].iter().enumerate() {
+                    if let Some((x, y, x_scale)) = blit_destination_pixel(
+                        blit, sequence, address, resources, planes, width, height,
+                    ) {
+                        increment_overdraw_word(&mut overdraw, width, x, y, x_scale);
+                    }
+                }
+            }
+        }
+        for (pixel, count) in fb.iter_mut().zip(overdraw) {
+            if count != 0 {
+                let strength = (48u16 + count.saturating_mul(42)).min(224) as u8;
+                let colour = u32::from_le_bytes([255, 48, 24, 0xFF]);
+                *pixel = overlay_blend(*pixel, colour, strength);
+            }
+        }
+    }
+}
+
 const FNV1A64_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
 
 /// FNV-1a over the framebuffer words (little-endian byte order), for
@@ -3217,6 +3635,29 @@ mod tests {
             core("symbols.resolve", json!({"addr": "$F80010"})),
             CoreOp::SymbolsResolve { addr: 0xF80010 }
         );
+    }
+
+    #[test]
+    fn overdraw_accepts_memory_writes_but_not_custom_register_moves() {
+        let mut record = crate::bus::BusSlotRecord {
+            flags: 1,
+            size: 2,
+            ..crate::bus::BusSlotRecord::default()
+        };
+        record.kind = crate::bus::BUS_RECORD_COPPER;
+        record.reg = 0x0180;
+        assert!(!record_writes_chip_memory(&record));
+
+        record.kind = crate::bus::BUS_RECORD_CPU;
+        record.reg = 0x1000;
+        assert!(record_writes_chip_memory(&record));
+
+        record.kind = crate::bus::BUS_RECORD_BLITTER;
+        record.reg = 0x0054;
+        record.subtype = 0x23;
+        assert!(record_writes_chip_memory(&record));
+        record.subtype = 0x20;
+        assert!(!record_writes_chip_memory(&record));
     }
 
     #[test]
@@ -5032,6 +5473,7 @@ mod tests {
                 addr: None,
                 resource: Some("cop".into()),
                 max: 8,
+                trace: false,
             },
         )
         .unwrap();
@@ -5046,10 +5488,107 @@ mod tests {
                 addr: None,
                 resource: Some("nope".into()),
                 max: 8,
+                trace: false,
             },
         )
         .unwrap_err();
         assert_eq!(err.code, proto::NOT_FOUND);
+    }
+
+    #[test]
+    fn blit_render_and_capture_overlays_write_pngs_from_a_full_trace() {
+        let mut emu = test_emulator();
+        emu.bus_mut().set_frame_analyzer_full(true);
+        {
+            let bus = emu.bus_mut();
+            bus.mem.overlay = false;
+            bus.custom_write(0x096, 2, 0x8240); // DMAEN|BLTEN
+            bus.custom_write(0x040, 2, 0x01F0); // D, A truth table
+            bus.custom_write(0x042, 2, 0);
+            bus.custom_write(0x054, 4, 0x0006_0000);
+            bus.custom_write(0x058, 2, 0x0082); // 2 rows x 2 words
+        }
+        emu.step_frame().unwrap();
+        assert!(!emu.bus().frame_bus_trace().unwrap().blits.is_empty());
+        let mut diagnostic_fb = vec![0; crate::video::MAX_CANVAS_PIXELS];
+        let sources =
+            crate::video::bitplane::render_display_diagnostics(emu.bus(), &mut diagnostic_fb);
+        assert_eq!(
+            sources.len(),
+            emu.bus().frame_geometry().visible_lines
+                * crate::video::FB_WIDTH
+                * emu.bus().frame_canvas_scale()
+        );
+
+        let base = std::env::temp_dir().join(format!("copperline-blitviz-{}", std::process::id()));
+        let blit_path = base.with_extension("blit.png");
+        let shot_path = base.with_extension("overlay.png");
+        let mut ctx = SessionCtx::new();
+        let blit = exec_core(
+            &mut emu,
+            &mut ctx,
+            &CoreOp::BlitRender {
+                index: 0,
+                channel: crate::blitviz::BlitChannel::Result,
+                path: Some(blit_path.clone()),
+            },
+        )
+        .unwrap();
+        assert_eq!(blit["formula"], "A");
+        assert_eq!(
+            &std::fs::read(&blit_path).unwrap()[..8],
+            b"\x89PNG\r\n\x1a\n"
+        );
+
+        let shot = exec_core(
+            &mut emu,
+            &mut ctx,
+            &CoreOp::Screenshot {
+                path: Some(shot_path.clone()),
+                overlays: vec![
+                    CaptureOverlay::Blits,
+                    CaptureOverlay::Overdraw,
+                    CaptureOverlay::Sources,
+                ],
+            },
+        )
+        .unwrap();
+        assert_eq!(shot["overlays"].as_array().unwrap().len(), 3);
+        assert_eq!(
+            &std::fs::read(&shot_path).unwrap()[..8],
+            b"\x89PNG\r\n\x1a\n"
+        );
+        let _ = std::fs::remove_file(blit_path);
+        let _ = std::fs::remove_file(shot_path);
+    }
+
+    #[test]
+    fn copper_list_trace_links_an_instruction_to_its_execution_slot() {
+        let mut emu = test_emulator();
+        emu.bus_mut().set_frame_analyzer_full(true);
+        {
+            let bus = emu.bus_mut();
+            bus.mem.chip_ram[0x100..0x108]
+                .copy_from_slice(&[0x01, 0x80, 0x0F, 0x00, 0xFF, 0xFF, 0xFF, 0xFE]);
+            bus.custom_write(0x096, 2, 0x8280); // DMAEN|COPEN
+            bus.custom_write(0x080, 2, 0);
+            bus.custom_write(0x082, 2, 0x0100);
+            bus.custom_write(0x088, 2, 0);
+            bus.advance_chipset(32);
+        }
+        let value = exec_core(
+            &mut emu,
+            &mut SessionCtx::new(),
+            &CoreOp::CopperList {
+                addr: Some(0x100),
+                resource: None,
+                max: 2,
+                trace: true,
+            },
+        )
+        .unwrap();
+        assert!(value["entries"][0]["trace"]["hpos"].is_u64(), "{value}");
+        assert_eq!(value["entries"][0]["trace"]["frame"], value["trace_frame"]);
     }
 
     #[test]
@@ -5065,12 +5604,41 @@ mod tests {
             CoreOp::CopperList {
                 addr: None,
                 resource: Some("cop".into()),
-                max: 32
+                max: 32,
+                trace: false,
             }
         );
         let err =
             parse_method("copper.list", &json!({"addr": 100, "resource": "cop"})).unwrap_err();
         assert_eq!(err.code, proto::INVALID_PARAMS);
+        assert_eq!(
+            core("blit.render", json!({"index": 2, "channel": "result"})),
+            CoreOp::BlitRender {
+                index: 2,
+                channel: crate::blitviz::BlitChannel::Result,
+                path: None,
+            }
+        );
+        assert_eq!(
+            core("copper.list", json!({"trace": true})),
+            CoreOp::CopperList {
+                addr: None,
+                resource: None,
+                max: 32,
+                trace: true,
+            }
+        );
+        assert!(parse_method("blit.render", &json!({"index": 0, "channel": "X"})).is_err());
+        assert_eq!(
+            core(
+                "capture.screenshot",
+                json!({"overlays": ["sources", "overdraw", "sources"]})
+            ),
+            CoreOp::Screenshot {
+                path: None,
+                overlays: vec![CaptureOverlay::Sources, CaptureOverlay::Overdraw],
+            }
+        );
     }
 
     #[test]

--- a/src/control/mcp.rs
+++ b/src/control/mcp.rs
@@ -648,9 +648,11 @@ fn screenshot(session: &mut Session, args: &Value, seq: u64) -> ToolResult {
         }
         Some(other) => (other.clone(), None),
     };
+    let mut params = args.as_object().cloned().unwrap_or_default();
+    params.insert("path".to_string(), param);
     let reply = session
         .bridge
-        .call("capture.screenshot", json!({"path": param}));
+        .call("capture.screenshot", Value::Object(params));
     let mut result = match reply {
         Ok(Reply::Ok(result)) => result,
         Ok(Reply::Err { code, message }) => return ToolResult::ccp_error(code, message),

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -786,16 +786,33 @@ impl Emulator {
                 .iter()
                 .map(|blit| {
                     json!({
+                        "id": blit.id,
                         "bltcon0": format!("{:#06X}", blit.bltcon0),
                         "bltcon1": format!("{:#06X}", blit.bltcon1),
                         "width_words": blit.width_words,
                         "height": blit.height,
+                        "descending": blit.descending,
+                        "line_mode": blit.line_mode,
+                        "fill_mode": blit.fill_mode,
+                        "channels": blit.channels,
                         "apt": format!("{:#010X}", blit.apt),
                         "bpt": format!("{:#010X}", blit.bpt),
                         "cpt": format!("{:#010X}", blit.cpt),
                         "dpt": format!("{:#010X}", blit.dpt),
+                        "modulos": blit.modulos,
+                        "shifts": blit.shifts,
+                        "masks": blit.masks.map(|value| format!("0x{value:04X}")),
+                        "minterm": format!("0x{:02X}", blit.minterm),
+                        "formula": crate::blitviz::minterm_formula(blit.minterm),
+                        "data": blit.data.map(|value| format!("0x{value:04X}")),
+                        "start_frame": blit.start_frame,
+                        "end_frame": blit.end_frame,
                         "start": [blit.start.0, blit.start.1],
                         "end": blit.end.map(|(v, h)| json!([v, h])),
+                        "cycles_used": blit.cycles_used,
+                        "cycles_stalled": blit.cycles_stalled,
+                        "captured_words": blit.channel_words.each_ref().map(Vec::len),
+                        "render_truncated": blit.render_truncated,
                     })
                 })
                 .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod audio;
 // Host block devices: a real disk (an SD card, a CF card, an Amiga's own
 // hard drive) standing in for a hard-drive image. Not built for wasm32,
 // which has no such thing to reach.
+pub mod blitviz;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod blockdev;
 pub mod bus;

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -6053,6 +6053,7 @@ fn render_fast_playfield_run(
         let fb_idx = row_fb + x;
         let out_base = row_out + x;
         let pf = collision.playfield_mask();
+        let source = pixel_source_for_playfield(output.pf_mask);
         for dx in 0..pixel_repeat {
             collision_pixels[fb_idx + dx] = collision;
             if pf != 0 {
@@ -6061,7 +6062,7 @@ fn render_fast_playfield_run(
             fb[out_base + dx] = pixel;
             sprite_subpixels.playfield_masks[fb_idx + dx] = [pf; 2];
             sprite_subpixels.pixels[fb_idx + dx] = [pixel; 2];
-            sprite_subpixels.set_source(fb_idx + dx, [pixel_source_for_playfield(pf); 2]);
+            sprite_subpixels.set_source(fb_idx + dx, [source; 2]);
         }
     }
     *clxdat = clx;
@@ -6629,8 +6630,8 @@ fn render_planned_playfield_line_impl(
                     sprite_subpixels.set_source(
                         fb_idx,
                         [
-                            pixel_source_for_playfield(left_collision.playfield_mask()),
-                            pixel_source_for_playfield(right_collision.playfield_mask()),
+                            pixel_source_for_playfield(left_out.pf_mask),
+                            pixel_source_for_playfield(right_out.pf_mask),
                         ],
                     );
                     if canvas_scale == 2 {
@@ -6647,7 +6648,8 @@ fn render_planned_playfield_line_impl(
                 let pixel = rgb24_to_rgba8_alpha(output.color, !transparent);
                 sprite_subpixels.playfield_masks[fb_idx] = [pf_mask; 2];
                 sprite_subpixels.pixels[fb_idx] = [pixel; 2];
-                sprite_subpixels.set_source(fb_idx, [pixel_source_for_playfield(pf_mask); 2]);
+                sprite_subpixels
+                    .set_source(fb_idx, [pixel_source_for_playfield(output.pf_mask); 2]);
                 if canvas_scale == 1 {
                     fb[out_base] = pixel;
                 } else {

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -4322,7 +4322,19 @@ pub struct RenderResult {
     /// Playfield content envelope of this field, or `None` for a
     /// border-only frame (see [`ContentRect`]).
     pub content_rect: Option<ContentRect>,
+    /// Final output-stage provenance at the presented pixel pitch. Present
+    /// only for [`render_display_diagnostics`], so ordinary rendering pays
+    /// neither the allocation nor the per-pixel bookkeeping cost.
+    pub pixel_sources: Option<Vec<u8>>,
 }
+
+/// Values in [`RenderResult::pixel_sources`]. Sprite sources are the base
+/// plus the hardware sprite number (0..7).
+pub const PIXEL_SOURCE_OUTSIDE_DIW: u8 = 0;
+pub const PIXEL_SOURCE_BACKGROUND: u8 = 1;
+pub const PIXEL_SOURCE_PLAYFIELD1: u8 = 2;
+pub const PIXEL_SOURCE_PLAYFIELD2: u8 = 3;
+pub const PIXEL_SOURCE_SPRITE0: u8 = 4;
 
 /// Large renderer work buffers retained per host thread. The browser calls
 /// the synchronous renderer on every presented frame; rebuilding the
@@ -4361,6 +4373,7 @@ struct RenderScratch {
 struct SpriteSubpixelState {
     playfield_masks: Vec<[u8; 2]>,
     pixels: Vec<[u32; 2]>,
+    sources: Vec<[u8; 2]>,
 }
 
 impl SpriteSubpixelState {
@@ -4375,6 +4388,13 @@ impl SpriteSubpixelState {
             } else {
                 [fb[out]; 2]
             };
+        }
+        if render_diagnostics_active() {
+            self.sources
+                .resize(logical_len, [PIXEL_SOURCE_OUTSIDE_DIW; 2]);
+            self.sources.fill([PIXEL_SOURCE_OUTSIDE_DIW; 2]);
+        } else {
+            self.sources.clear();
         }
     }
 
@@ -4392,6 +4412,14 @@ impl SpriteSubpixelState {
                     }
                 })
                 .collect(),
+            sources: Vec::new(),
+        }
+    }
+
+    #[inline]
+    fn set_source(&mut self, index: usize, pair: [u8; 2]) {
+        if let Some(source) = self.sources.get_mut(index) {
+            *source = pair;
         }
     }
 }
@@ -4512,6 +4540,24 @@ pub fn render_display_only(bus: &Bus, fb: &mut [u32]) {
     });
 }
 
+/// Side-effect-free display render with final Denise/Lisa output provenance.
+/// The normal render path remains unchanged; this diagnostic switch is
+/// thread-local and is consumed by the same painter used for screenshots.
+pub fn render_display_diagnostics(bus: &Bus, fb: &mut [u32]) -> Vec<u8> {
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            ACTIVE_RENDER_DIAGNOSTICS.with(|active| active.set(false));
+        }
+    }
+    ACTIVE_RENDER_DIAGNOSTICS.with(|active| active.set(true));
+    let _reset = Reset;
+    let input = RenderInput::from_bus(bus);
+    render_from_input(&input, fb)
+        .pixel_sources
+        .unwrap_or_default()
+}
+
 thread_local! {
     /// The running render's debug layer masks (plane, sprite), captured
     /// from the [`RenderInput`] at [`render_from_input`]'s entry so the
@@ -4519,6 +4565,24 @@ thread_local! {
     /// another thread (the worker, a parallel test) sees only its own.
     static ACTIVE_DEBUG_MASKS: std::cell::Cell<(u8, u8)> =
         const { std::cell::Cell::new((0xFF, 0xFF)) };
+}
+
+thread_local! {
+    static ACTIVE_RENDER_DIAGNOSTICS: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[inline]
+fn render_diagnostics_active() -> bool {
+    ACTIVE_RENDER_DIAGNOSTICS.with(std::cell::Cell::get)
+}
+
+#[inline]
+fn pixel_source_for_playfield(mask: u8) -> u8 {
+    match mask {
+        1 => PIXEL_SOURCE_PLAYFIELD1,
+        2 => PIXEL_SOURCE_PLAYFIELD2,
+        _ => PIXEL_SOURCE_BACKGROUND,
+    }
 }
 
 thread_local! {
@@ -5610,6 +5674,17 @@ fn render_from_input_with_scratch(
     );
     render_timing.total_nanos = render_timing_elapsed(render_started);
     let chip_ram_reads = ram.into_read_dependencies();
+    let pixel_sources = (!sprite_subpixels.sources.is_empty()).then(|| {
+        let mut sources = Vec::with_capacity(rows * out_w);
+        for pair in sprite_subpixels.sources.iter().take(rows * FB_WIDTH) {
+            if canvas_scale == 2 {
+                sources.extend_from_slice(pair);
+            } else {
+                sources.push(pair[0]);
+            }
+        }
+        sources
+    });
     scratch.base_palettes = base_palettes;
     scratch.palette_segments = palette_segments;
     scratch.base_controls = base_controls;
@@ -5646,6 +5721,7 @@ fn render_from_input_with_scratch(
         clxdat,
         chip_ram_reads,
         content_rect,
+        pixel_sources,
     }
 }
 
@@ -5985,6 +6061,7 @@ fn render_fast_playfield_run(
             fb[out_base + dx] = pixel;
             sprite_subpixels.playfield_masks[fb_idx + dx] = [pf; 2];
             sprite_subpixels.pixels[fb_idx + dx] = [pixel; 2];
+            sprite_subpixels.set_source(fb_idx + dx, [pixel_source_for_playfield(pf); 2]);
         }
     }
     *clxdat = clx;
@@ -6549,6 +6626,13 @@ fn render_planned_playfield_line_impl(
                         rgb24_to_rgba8_alpha(right_out.color, !right_transparent),
                     ];
                     sprite_subpixels.pixels[fb_idx] = pair;
+                    sprite_subpixels.set_source(
+                        fb_idx,
+                        [
+                            pixel_source_for_playfield(left_collision.playfield_mask()),
+                            pixel_source_for_playfield(right_collision.playfield_mask()),
+                        ],
+                    );
                     if canvas_scale == 2 {
                         // 35 ns canvas: each half of the SHRES pair is its
                         // own output pixel.
@@ -6563,6 +6647,7 @@ fn render_planned_playfield_line_impl(
                 let pixel = rgb24_to_rgba8_alpha(output.color, !transparent);
                 sprite_subpixels.playfield_masks[fb_idx] = [pf_mask; 2];
                 sprite_subpixels.pixels[fb_idx] = [pixel; 2];
+                sprite_subpixels.set_source(fb_idx, [pixel_source_for_playfield(pf_mask); 2]);
                 if canvas_scale == 1 {
                     fb[out_base] = pixel;
                 } else {
@@ -7148,6 +7233,13 @@ fn draw_manual_bpl_word(
                     rgb24_to_rgba8_alpha(right_out.color, !right_transparent),
                 ];
                 sprite_subpixels.pixels[fb_idx] = pair;
+                sprite_subpixels.set_source(
+                    fb_idx,
+                    [
+                        pixel_source_for_playfield(left_out.pf_mask),
+                        pixel_source_for_playfield(right_out.pf_mask),
+                    ],
+                );
                 if canvas_scale == 2 {
                     fb[out_base..out_base + 2].copy_from_slice(&pair);
                 } else {
@@ -7159,6 +7251,10 @@ fn draw_manual_bpl_word(
                 pixel_control.genlock_transparent(pixel_color_latch, Some(sample), false);
             let pixel = rgb24_to_rgba8_alpha(pixel_color, !transparent);
             sprite_subpixels.pixels[fb_idx] = [pixel; 2];
+            sprite_subpixels.set_source(
+                fb_idx,
+                [pixel_source_for_playfield(source_output.pf_mask); 2],
+            );
             fb[out_base..out_base + canvas_scale].fill(pixel);
         }
         x_cursor += pixel_repeat as i32;

--- a/src/video/bitplane/sprite.rs
+++ b/src/video/bitplane/sprite.rs
@@ -1339,6 +1339,8 @@ pub(super) fn render_attached_sprite_pair_lines(
                 out_base,
                 canvas_scale,
                 &mut sprite_subpixels.pixels[fb_idx],
+                sprite_subpixels.sources.get_mut(fb_idx),
+                even_sprite,
                 left,
                 right,
             );
@@ -1448,6 +1450,8 @@ fn paint_sprite_subpixel_pair(
     out_base: usize,
     canvas_scale: usize,
     composite: &mut [u32; 2],
+    sources: Option<&mut [u8; 2]>,
+    sprite: usize,
     left: Option<u32>,
     right: Option<u32>,
 ) {
@@ -1456,6 +1460,15 @@ fn paint_sprite_subpixel_pair(
     }
     if let Some(pixel) = right {
         composite[1] = pixel;
+    }
+    if let Some(sources) = sources {
+        let source = super::PIXEL_SOURCE_SPRITE0 + sprite.min(7) as u8;
+        if left.is_some() {
+            sources[0] = source;
+        }
+        if right.is_some() {
+            sources[1] = source;
+        }
     }
     if left.is_none() && right.is_none() {
         return;
@@ -1572,6 +1585,8 @@ pub(super) fn draw_sprite_line(
             out_base,
             canvas_scale,
             &mut sprite_subpixels.pixels[fb_idx],
+            sprite_subpixels.sources.get_mut(fb_idx),
+            sprite,
             left,
             right,
         );

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -61,6 +61,7 @@ fn repeated_frame_test_result(chip_ram_reads: Option<Vec<ChipRamReadDependency>>
         clxdat: 0x1234,
         chip_ram_reads,
         content_rect: None,
+        pixel_sources: None,
     }
 }
 

--- a/src/video/bitplane/tests.rs
+++ b/src/video/bitplane/tests.rs
@@ -8975,6 +8975,49 @@ fn fast_playfield_interior_matches_scalar_oracle() {
     }
 }
 
+#[test]
+fn fast_playfield_provenance_uses_the_resolved_dual_playfield_winner() {
+    let mut outputs = [DenisePlayfieldOutput {
+        color: 0,
+        color_latch: 0,
+        pf_mask: 0,
+    }; 256];
+    outputs[3].pf_mask = 1;
+    let mut collision_table = [CollisionPixel::default(); 256];
+    collision_table[3] = CollisionPixel::new(true, true, false, false);
+    let mut fb = vec![0u32; FB_WIDTH];
+    let mut playfield_mask = vec![0u8; FB_WIDTH];
+    let mut sprite_subpixels = SpriteSubpixelState {
+        playfield_masks: vec![[0; 2]; FB_WIDTH],
+        pixels: vec![[0; 2]; FB_WIDTH],
+        sources: vec![[PIXEL_SOURCE_OUTSIDE_DIW; 2]; FB_WIDTH],
+    };
+    let mut collision_pixels = vec![CollisionPixel::default(); FB_WIDTH];
+    let mut clxdat = 0;
+    let mut ham_color = 0;
+
+    render_fast_playfield_run(
+        &[3],
+        u8::MAX,
+        &outputs,
+        &collision_table,
+        &mut fb,
+        &mut playfield_mask,
+        &mut sprite_subpixels,
+        &mut collision_pixels,
+        &mut clxdat,
+        &mut ham_color,
+        0,
+        0,
+        1,
+        FB_WIDTH,
+        1,
+    );
+
+    assert_eq!(playfield_mask[0], 3);
+    assert_eq!(sprite_subpixels.sources[0], [PIXEL_SOURCE_PLAYFIELD1; 2]);
+}
+
 /// The oracle above would pass vacuously if the eligibility check always
 /// fell back to the scalar loop; a plain 4-plane lores screen must
 /// actually produce a fast interior covering most of its window.

--- a/src/video/ui.rs
+++ b/src/video/ui.rs
@@ -250,14 +250,17 @@ impl Default for DebuggerPanel {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum AnalyzerTab {
     Beam,
+    /// Recorded blits with exact source/result reconstruction.
+    Blits,
     Memory,
     /// The debug resources the guest registered through the uaelib trap
     /// (crate::uaelib): a table plus a decoded preview of the selection.
     Resources,
 }
 
-pub const ANALYZER_TABS: [AnalyzerTab; 3] = [
+pub const ANALYZER_TABS: [AnalyzerTab; 4] = [
     AnalyzerTab::Beam,
+    AnalyzerTab::Blits,
     AnalyzerTab::Memory,
     AnalyzerTab::Resources,
 ];
@@ -265,6 +268,7 @@ pub const ANALYZER_TABS: [AnalyzerTab; 3] = [
 fn analyzer_tab_label(tab: AnalyzerTab) -> &'static str {
     match tab {
         AnalyzerTab::Beam => "Beam",
+        AnalyzerTab::Blits => "Blits",
         AnalyzerTab::Memory => "Memory",
         AnalyzerTab::Resources => "Resources",
     }
@@ -307,6 +311,11 @@ pub struct FrameAnalyzerPanel {
     /// Resources tab: the first listed registry entry (cursor keys
     /// scroll), so a registry larger than the table stays reachable.
     pub resource_scroll: usize,
+    /// Blits tab selection, stable across the same cross-frame record.
+    pub blit_selected: Option<u64>,
+    /// Blits tab: first listed record, kept in step with the keyboard
+    /// selection so every captured blit remains reachable.
+    pub blit_scroll: usize,
 }
 
 impl FrameAnalyzerPanel {
@@ -322,6 +331,8 @@ impl FrameAnalyzerPanel {
             heat_selected: None,
             resource_selected: None,
             resource_scroll: 0,
+            blit_selected: None,
+            blit_scroll: 0,
         }
     }
 
@@ -652,6 +663,13 @@ pub fn panel_control_at(panel: &Panel, pos: (i32, i32)) -> Option<UiControl> {
                         return Some(UiControl::AnalyzerCpuWait);
                     }
                 }
+                AnalyzerTab::Blits => {
+                    for (control, row_rect) in analyzer_blit_row_rects(rect) {
+                        if row_rect.contains(pos) {
+                            return Some(control);
+                        }
+                    }
+                }
                 AnalyzerTab::Memory => {
                     for (control, button_rect) in analyzer_preset_rects(rect, &panel.heat_presets) {
                         if button_rect.contains(pos) {
@@ -826,6 +844,8 @@ pub enum UiControl {
     AnalyzerResourceRow(u8),
     /// Save the selected bitmap or palette resource as PNG.
     AnalyzerResourceSave,
+    /// A row of the Blits tab's recorded-transfer table.
+    AnalyzerBlitRow(u8),
     AnalyzerHeatPick {
         x: u8,
         y: u8,
@@ -1485,6 +1505,37 @@ fn analyzer_preset_rects(rect: Rect, presets: &[HeatPreset]) -> Vec<(UiControl, 
 /// Height of one Resources-tab table row, and how many the panel lists.
 const ANALYZER_RESOURCE_ROW_H: usize = 12;
 pub const ANALYZER_RESOURCE_ROWS_MAX: usize = 10;
+const ANALYZER_BLIT_ROW_H: usize = 14;
+pub const ANALYZER_BLIT_ROWS_MAX: usize = 8;
+
+fn analyzer_blit_row_rects(rect: Rect) -> Vec<(UiControl, Rect)> {
+    let top = analyzer_content_top(rect) + 16;
+    (0..ANALYZER_BLIT_ROWS_MAX)
+        .map(|index| {
+            (
+                UiControl::AnalyzerBlitRow(index as u8),
+                Rect {
+                    x: rect.x + 10,
+                    y: top + index * ANALYZER_BLIT_ROW_H,
+                    w: rect.w - 20,
+                    h: ANALYZER_BLIT_ROW_H,
+                },
+            )
+        })
+        .collect()
+}
+
+fn analyzer_blit_detail_rect(rect: Rect) -> Rect {
+    let top = analyzer_content_top(rect) + 16 + ANALYZER_BLIT_ROWS_MAX * ANALYZER_BLIT_ROW_H + 26;
+    Rect {
+        x: rect.x + 10,
+        y: top,
+        w: rect.w - 20,
+        h: (rect.y + rect.h)
+            .saturating_sub(DEBUG_BUTTON_H + 12)
+            .saturating_sub(top),
+    }
+}
 
 /// The Resources tab's table rows, top to bottom under the header line.
 fn analyzer_resource_row_rects(rect: Rect) -> Vec<(UiControl, Rect)> {
@@ -1561,6 +1612,7 @@ fn analyzer_tab_button_rects(rect: Rect, tab: AnalyzerTab) -> Vec<(UiControl, Re
     let all = analyzer_button_rects(rect);
     match tab {
         AnalyzerTab::Beam => all.to_vec(),
+        AnalyzerTab::Blits => all[..2].to_vec(),
         AnalyzerTab::Memory => all[..2].to_vec(),
         AnalyzerTab::Resources => vec![all[0], all[1], (UiControl::AnalyzerResourceSave, all[2].1)],
     }
@@ -1839,17 +1891,24 @@ pub struct AnalyzerMarker {
     /// Writer: "cpu", "irq" (CPU inside the Copper-triggered interrupt
     /// window), or "copper".
     pub source: &'static str,
+    /// MOVE instruction address for reciprocal slot/list navigation.
+    pub copper_addr: Option<u32>,
+    /// Register-class colour for Copper MOVE markers.
+    pub colour: u32,
 }
 
 impl AnalyzerMarker {
     fn label(&self) -> String {
         format!(
-            "{} {}=${:04X} v{} h{}",
+            "{} {}=${:04X} v{} h{}{}",
             self.source,
             crate::debugger::custom_reg_name(self.offset & 0x01FE),
             self.value,
             self.vpos,
             self.hpos,
+            self.copper_addr
+                .map(|addr| format!(" @${addr:06X}"))
+                .unwrap_or_default(),
         )
     }
 
@@ -2048,6 +2107,23 @@ pub struct AnalyzerResourcesView {
     pub exportable: bool,
 }
 
+/// The Blits tab's table plus the selected source/result pair.
+pub struct AnalyzerBlitsView {
+    pub rows: Vec<AnalyzerBlitRowView>,
+    pub hidden_above: usize,
+    pub hidden_below: usize,
+    pub source_label: &'static str,
+    pub source: Option<crate::video::resource_preview::BitmapPreview>,
+    pub destination: Option<crate::video::resource_preview::BitmapPreview>,
+    pub formula: String,
+    pub detail: String,
+}
+
+pub struct AnalyzerBlitRowView {
+    pub text: String,
+    pub selected: bool,
+}
+
 pub struct AnalyzerResourceRowView {
     pub text: String,
     pub selected: bool,
@@ -2071,6 +2147,8 @@ pub struct FrameAnalyzerView {
     pub heat: Option<AnalyzerHeatView>,
     /// The Resources tab's data; built only while that tab is up.
     pub resources: Option<AnalyzerResourcesView>,
+    /// The Blits tab's data; built only while that tab is up.
+    pub blits: Option<AnalyzerBlitsView>,
 }
 
 pub enum PanelViewData {
@@ -3908,7 +3986,7 @@ fn draw_owner_heatmap(
                 h: 1,
             },
             rect,
-            PANEL_TEXT_ACCENT,
+            marker.colour,
             scale,
         );
         fill_rect_clipped(
@@ -3920,7 +3998,7 @@ fn draw_owner_heatmap(
                 h: 3,
             },
             rect,
-            PANEL_TEXT_ACCENT,
+            marker.colour,
             scale,
         );
     }
@@ -4441,6 +4519,7 @@ fn draw_frame_analyzer(
     // show whether or not a beam trace has ever been captured.
     match panel.tab {
         AnalyzerTab::Beam => draw_analyzer_beam_tab(frame, rect, panel, view, hover, scale),
+        AnalyzerTab::Blits => draw_analyzer_blits_tab(frame, rect, view, hover, scale),
         AnalyzerTab::Memory => draw_analyzer_heat_tab(frame, rect, panel, view, hover, scale),
         AnalyzerTab::Resources => draw_analyzer_resources_tab(frame, rect, view, hover, scale),
     }
@@ -4638,8 +4717,18 @@ fn draw_analyzer_beam_tab(
     };
     let slot_detail_drawn = if let Some(record) = trace.record_at(probe_vpos, probe_hpos) {
         let event_names = crate::bus::bus_event_names(record.events).join("|");
+        let copper_instruction = if record.kind == crate::bus::BUS_RECORD_COPPER {
+            let addr = if record.flags & 1 != 0 || record.subtype != 0 {
+                record.addr.saturating_sub(2)
+            } else {
+                record.addr
+            };
+            format!(" copper=@${addr:06X}")
+        } else {
+            String::new()
+        };
         let detail = format!(
-            "reg=${:04X} addr=${:08X} data=${:016X}/{} kind={}:{} ipl={} events={}",
+            "reg=${:04X} addr=${:08X} data=${:016X}/{} kind={}:{} ipl={} events={}{}",
             record.reg,
             record.addr,
             record.data,
@@ -4652,6 +4741,7 @@ fn draw_analyzer_beam_tab(
             } else {
                 &event_names
             },
+            copper_instruction,
         );
         draw_panel_text(
             frame,
@@ -4796,6 +4886,125 @@ fn heat_resource_suffix(view: &AnalyzerHeatView, cell: usize) -> String {
     heat_resource_at(view, cell)
         .map(|resource| format!("  in '{}' ({})", resource.name, resource.kind))
         .unwrap_or_default()
+}
+
+fn draw_analyzer_blits_tab(
+    frame: &mut [u8],
+    rect: Rect,
+    view: &FrameAnalyzerView,
+    hover: Option<UiControl>,
+    scale: usize,
+) {
+    let content_top = analyzer_content_top(rect);
+    let Some(blits) = &view.blits else {
+        draw_panel_text(
+            frame,
+            rect.x + 10,
+            content_top,
+            "No blits captured in the current frame trace.",
+            PANEL_TEXT_DIM,
+            1,
+            scale,
+        );
+        return;
+    };
+    draw_panel_text(
+        frame,
+        rect.x + 10,
+        content_top,
+        "#  beam span        mode/channels    size       used/stall   destination",
+        PANEL_TEXT_DIM,
+        1,
+        scale,
+    );
+    for ((control, row_rect), row) in analyzer_blit_row_rects(rect).into_iter().zip(&blits.rows) {
+        if row.selected {
+            fill_rect(frame, scale_rect(row_rect, scale), ENTRY_BG, scale);
+        }
+        draw_panel_text(
+            frame,
+            row_rect.x,
+            row_rect.y + 3,
+            &row.text,
+            if row.selected {
+                PANEL_TEXT_HILIGHT
+            } else if hover == Some(control) {
+                PANEL_TEXT_ACCENT
+            } else {
+                PANEL_TEXT
+            },
+            1,
+            scale,
+        );
+    }
+    if blits.hidden_above > 0 || blits.hidden_below > 0 {
+        draw_panel_text(
+            frame,
+            rect.x + rect.w.saturating_sub(214),
+            content_top,
+            &format!(
+                "up/down: {} above, {} below",
+                blits.hidden_above, blits.hidden_below
+            ),
+            PANEL_TEXT_DIM,
+            1,
+            scale,
+        );
+    }
+    let detail = analyzer_blit_detail_rect(rect);
+    draw_panel_text(
+        frame,
+        detail.x,
+        detail.y - 20,
+        &format!("{}    {}", blits.detail, blits.formula),
+        PANEL_TEXT_ACCENT,
+        1,
+        scale,
+    );
+    let gap = 8;
+    let half = detail.w.saturating_sub(gap) / 2;
+    let source_rect = Rect {
+        x: detail.x,
+        y: detail.y,
+        w: half,
+        h: detail.h,
+    };
+    let dest_rect = Rect {
+        x: detail.x + half + gap,
+        y: detail.y,
+        w: half,
+        h: detail.h,
+    };
+    draw_panel_text(
+        frame,
+        source_rect.x,
+        source_rect.y,
+        blits.source_label,
+        PANEL_TEXT_DIM,
+        1,
+        scale,
+    );
+    draw_panel_text(
+        frame,
+        dest_rect.x,
+        dest_rect.y,
+        "result / D",
+        PANEL_TEXT_DIM,
+        1,
+        scale,
+    );
+    let inset = |area: Rect| Rect {
+        x: area.x,
+        y: area.y + 14,
+        w: area.w,
+        h: area.h.saturating_sub(14),
+    };
+    if let Some(preview) = &blits.source {
+        draw_resource_bitmap_preview(frame, inset(source_rect), preview, scale);
+    }
+    if let Some(preview) = &blits.destination {
+        draw_resource_bitmap_preview(frame, inset(dest_rect), preview, scale);
+    }
 }
 
 fn draw_analyzer_resources_tab(

--- a/src/video/ui/tests.rs
+++ b/src/video/ui/tests.rs
@@ -572,6 +572,7 @@ fn analyzer_view(
         scrub: false,
         heat,
         resources: None,
+        blits: None,
     })
 }
 
@@ -951,6 +952,8 @@ fn analyzer_marker_radius_and_label() {
         offset: 0x180,
         value: 0x0F00,
         source: "copper",
+        copper_addr: None,
+        colour: PANEL_TEXT_ACCENT,
     };
     // Within a line and two colour clocks counts as near.
     assert!(marker.near(100, 50));
@@ -1556,6 +1559,8 @@ fn frame_analyzer_top_edge_overlays_clip_to_raster() {
             offset: 0x096,
             value: 0x0000,
             source: "copper",
+            copper_addr: None,
+            colour: PANEL_TEXT_ACCENT,
         }],
         selected_blit: None,
         diw_v: None,
@@ -2567,6 +2572,8 @@ fn panels_render_into_their_rects() {
             offset: 0x180,
             value: 0x0F00,
             source: "copper",
+            copper_addr: None,
+            colour: PANEL_TEXT_ACCENT,
         }],
         selected_blit: Some("in blit #2 (20x100 D $060000)".to_string()),
         // A standard PAL display window and fetch bounds, so the
@@ -2591,6 +2598,7 @@ fn panels_render_into_their_rects() {
         scrub: true,
         heat: None,
         resources: None,
+        blits: None,
         trace: Some(trace),
         underlay: Some(AnalyzerUnderlayView {
             fb: std::rc::Rc::new(under_fb),
@@ -2746,6 +2754,7 @@ fn panels_render_into_their_rects() {
         scrub: false,
         heat: None,
         resources: Some(resources_view),
+        blits: None,
     }));
     let mut panel = FrameAnalyzerPanel::new();
     panel.tab = AnalyzerTab::Resources;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -6458,6 +6458,7 @@ impl App {
             | UiControl::AnalyzerHeatPreset(_)
             | UiControl::AnalyzerResourceRow(_)
             | UiControl::AnalyzerResourceSave
+            | UiControl::AnalyzerBlitRow(_)
             | UiControl::AnalyzerCpuWait
             | UiControl::AnalyzerHeatPick { .. } => {
                 self.activate_tool_control(ToolPanelKind::FrameAnalyzer, control)

--- a/src/video/window/app_debugger.rs
+++ b/src/video/window/app_debugger.rs
@@ -16,6 +16,33 @@ fn copper_register_colour(offset: u16) -> u32 {
     u32::from_le_bytes([rgb[0], rgb[1], rgb[2], 0xFF])
 }
 
+fn analyzer_blit_selection(
+    panel: &ui::FrameAnalyzerPanel,
+    trace: &crate::bus::FrameBusTrace,
+) -> Option<(u64, usize)> {
+    let selected_id = panel
+        .blit_selected
+        .filter(|id| trace.blits.iter().any(|blit| blit.id == *id))
+        .or_else(|| trace.blits.first().map(|blit| blit.id))?;
+    let selected_index = trace
+        .blits
+        .iter()
+        .position(|blit| blit.id == selected_id)
+        .unwrap_or(0);
+    let scroll = analyzer_blit_scroll(trace.blits.len(), selected_index, panel.blit_scroll);
+    Some((selected_id, scroll))
+}
+
+fn analyzer_blit_scroll(len: usize, selected: usize, requested: usize) -> usize {
+    let mut scroll = requested.min(len.saturating_sub(ui::ANALYZER_BLIT_ROWS_MAX));
+    if selected < scroll {
+        scroll = selected;
+    } else if selected >= scroll + ui::ANALYZER_BLIT_ROWS_MAX {
+        scroll = selected + 1 - ui::ANALYZER_BLIT_ROWS_MAX;
+    }
+    scroll
+}
+
 impl App {
     pub(super) fn ui_handle_debugger_key(&mut self, code: KeyCode) -> bool {
         let Some(panel) = self.debugger_panel.as_mut() else {
@@ -365,15 +392,19 @@ impl App {
     }
 
     pub(super) fn frame_analyzer_select_blit(&mut self, index: u8) {
-        let scroll = self
+        let Some(trace) = self.emu.bus().frame_bus_trace() else {
+            return;
+        };
+        let Some((_, scroll)) = self
             .frame_analyzer_panel
             .as_ref()
-            .map_or(0, |panel| panel.blit_scroll);
-        let Some(id) = self
-            .emu
-            .bus()
-            .frame_bus_trace()
-            .and_then(|trace| trace.blits.get(scroll + usize::from(index)))
+            .and_then(|panel| analyzer_blit_selection(panel, trace))
+        else {
+            return;
+        };
+        let Some(id) = trace
+            .blits
+            .get(scroll + usize::from(index))
             .map(|blit| blit.id)
         else {
             return;
@@ -417,22 +448,7 @@ impl App {
         panel: &ui::FrameAnalyzerPanel,
         trace: &crate::bus::FrameBusTrace,
     ) -> Option<ui::AnalyzerBlitsView> {
-        let selected_id = panel
-            .blit_selected
-            .filter(|id| trace.blits.iter().any(|blit| blit.id == *id))
-            .or_else(|| trace.blits.first().map(|blit| blit.id))?;
-        let selected_index = trace
-            .blits
-            .iter()
-            .position(|blit| blit.id == selected_id)
-            .unwrap_or(0);
-        let max_scroll = trace.blits.len().saturating_sub(ui::ANALYZER_BLIT_ROWS_MAX);
-        let mut scroll = panel.blit_scroll.min(max_scroll);
-        if selected_index < scroll {
-            scroll = selected_index;
-        } else if selected_index >= scroll + ui::ANALYZER_BLIT_ROWS_MAX {
-            scroll = selected_index + 1 - ui::ANALYZER_BLIT_ROWS_MAX;
-        }
+        let (selected_id, scroll) = analyzer_blit_selection(panel, trace)?;
         let rows = trace
             .blits
             .iter()
@@ -475,7 +491,7 @@ impl App {
             })
             .collect();
         let blit = trace.blits.iter().find(|blit| blit.id == selected_id)?;
-        let (planes, plane_source) = crate::blitviz::plane_count_for_blit(
+        let layout = crate::blitviz::plane_layout_for_blit(
             blit,
             self.emu.uaelib_resources(),
             self.emu.bus().frame_render_base(),
@@ -503,11 +519,11 @@ impl App {
                 .len()
                 .saturating_sub(scroll + ui::ANALYZER_BLIT_ROWS_MAX),
             source_label: source_channel.name(),
-            source: crate::blitviz::render_blit(blit, source_channel, planes).ok(),
+            source: crate::blitviz::render_blit(blit, source_channel, layout.render_planes).ok(),
             destination: crate::blitviz::render_blit(
                 blit,
                 crate::blitviz::BlitChannel::Result,
-                planes,
+                layout.render_planes,
             )
             .ok(),
             formula: format!(
@@ -516,8 +532,18 @@ impl App {
                 crate::blitviz::minterm_formula(blit.minterm)
             ),
             detail: format!(
-                "{} plane(s), {plane_source}; shifts A{} B{} masks ${:04X}/${:04X}",
-                planes, blit.shifts[0], blit.shifts[1], blit.masks[0], blit.masks[1]
+                "{} plane(s), {}; {}; shifts A{} B{} masks ${:04X}/${:04X}",
+                layout.planes,
+                layout.source,
+                if layout.interleaved {
+                    "interleaved preview"
+                } else {
+                    "single-plane preview"
+                },
+                blit.shifts[0],
+                blit.shifts[1],
+                blit.masks[0],
+                blit.masks[1]
             ),
         })
     }
@@ -2864,5 +2890,17 @@ impl App {
             video,
             audio,
         }
+    }
+}
+
+#[cfg(test)]
+mod analyzer_blit_tests {
+    use super::analyzer_blit_scroll;
+
+    #[test]
+    fn stale_scroll_is_clamped_to_the_rows_that_are_actually_drawn() {
+        assert_eq!(analyzer_blit_scroll(2, 0, 55), 0);
+        assert_eq!(analyzer_blit_scroll(20, 12, 0), 5);
+        assert_eq!(analyzer_blit_scroll(20, 3, 9), 3);
     }
 }

--- a/src/video/window/app_debugger.rs
+++ b/src/video/window/app_debugger.rs
@@ -4,6 +4,18 @@
 
 use super::*;
 
+fn copper_register_colour(offset: u16) -> u32 {
+    let rgb = match offset & 0x01FE {
+        0x040..=0x074 => [244, 96, 88],   // blitter
+        0x0A0..=0x0DA => [112, 208, 244], // audio
+        0x0E0..=0x11E => [92, 224, 150],  // bitplanes/display data
+        0x120..=0x17E => [212, 112, 244], // sprites
+        0x180..=0x1BE => [244, 208, 80],  // palette
+        _ => [184, 190, 202],             // timing/control
+    };
+    u32::from_le_bytes([rgb[0], rgb[1], rgb[2], 0xFF])
+}
+
 impl App {
     pub(super) fn ui_handle_debugger_key(&mut self, code: KeyCode) -> bool {
         let Some(panel) = self.debugger_panel.as_mut() else {
@@ -158,6 +170,21 @@ impl App {
             };
             if let Some(rows) = rows {
                 self.frame_analyzer_scroll_resources(rows);
+                return true;
+            }
+        }
+        if self
+            .frame_analyzer_panel
+            .as_ref()
+            .is_some_and(|panel| panel.tab == ui::AnalyzerTab::Blits)
+        {
+            let delta = match code {
+                KeyCode::ArrowUp => Some(-1),
+                KeyCode::ArrowDown => Some(1),
+                _ => None,
+            };
+            if let Some(delta) = delta {
+                self.frame_analyzer_move_blit_selection(delta);
                 return true;
             }
         }
@@ -335,6 +362,164 @@ impl App {
             panel.resource_selected = Some(address);
         }
         self.request_redraw();
+    }
+
+    pub(super) fn frame_analyzer_select_blit(&mut self, index: u8) {
+        let scroll = self
+            .frame_analyzer_panel
+            .as_ref()
+            .map_or(0, |panel| panel.blit_scroll);
+        let Some(id) = self
+            .emu
+            .bus()
+            .frame_bus_trace()
+            .and_then(|trace| trace.blits.get(scroll + usize::from(index)))
+            .map(|blit| blit.id)
+        else {
+            return;
+        };
+        if let Some(panel) = self.frame_analyzer_panel.as_mut() {
+            panel.blit_selected = Some(id);
+        }
+        self.request_redraw();
+    }
+
+    pub(super) fn frame_analyzer_move_blit_selection(&mut self, delta: isize) {
+        let Some(trace) = self.emu.bus().frame_bus_trace() else {
+            return;
+        };
+        if trace.blits.is_empty() {
+            return;
+        }
+        let selected = self
+            .frame_analyzer_panel
+            .as_ref()
+            .and_then(|panel| panel.blit_selected)
+            .and_then(|id| trace.blits.iter().position(|blit| blit.id == id))
+            .unwrap_or(0);
+        let next = selected
+            .saturating_add_signed(delta)
+            .min(trace.blits.len().saturating_sub(1));
+        let id = trace.blits[next].id;
+        if let Some(panel) = self.frame_analyzer_panel.as_mut() {
+            panel.blit_selected = Some(id);
+            if next < panel.blit_scroll {
+                panel.blit_scroll = next;
+            } else if next >= panel.blit_scroll + ui::ANALYZER_BLIT_ROWS_MAX {
+                panel.blit_scroll = next + 1 - ui::ANALYZER_BLIT_ROWS_MAX;
+            }
+        }
+        self.request_redraw();
+    }
+
+    fn build_analyzer_blits_view(
+        &self,
+        panel: &ui::FrameAnalyzerPanel,
+        trace: &crate::bus::FrameBusTrace,
+    ) -> Option<ui::AnalyzerBlitsView> {
+        let selected_id = panel
+            .blit_selected
+            .filter(|id| trace.blits.iter().any(|blit| blit.id == *id))
+            .or_else(|| trace.blits.first().map(|blit| blit.id))?;
+        let selected_index = trace
+            .blits
+            .iter()
+            .position(|blit| blit.id == selected_id)
+            .unwrap_or(0);
+        let max_scroll = trace.blits.len().saturating_sub(ui::ANALYZER_BLIT_ROWS_MAX);
+        let mut scroll = panel.blit_scroll.min(max_scroll);
+        if selected_index < scroll {
+            scroll = selected_index;
+        } else if selected_index >= scroll + ui::ANALYZER_BLIT_ROWS_MAX {
+            scroll = selected_index + 1 - ui::ANALYZER_BLIT_ROWS_MAX;
+        }
+        let rows = trace
+            .blits
+            .iter()
+            .enumerate()
+            .skip(scroll)
+            .take(ui::ANALYZER_BLIT_ROWS_MAX)
+            .map(|(index, blit)| {
+                let channels: String = blit
+                    .channels
+                    .iter()
+                    .zip(['A', 'B', 'C', 'D'])
+                    .filter_map(|(enabled, name)| enabled.then_some(name))
+                    .collect();
+                let end = blit
+                    .end
+                    .map(|(v, h)| format!("{v:03}:{h:03}"))
+                    .unwrap_or_else(|| "running".to_string());
+                let mode = if blit.line_mode {
+                    "line"
+                } else if blit.fill_mode {
+                    "fill"
+                } else if blit.descending {
+                    "desc"
+                } else {
+                    "copy"
+                };
+                ui::AnalyzerBlitRowView {
+                    text: format!(
+                        "{index:<2} {:03}:{:03}->{end:<7} {mode:<4}/{channels:<4} {:>3}x{:<4} {:>5}/{:<5} ${:06X}",
+                        blit.start.0,
+                        blit.start.1,
+                        blit.width_words,
+                        blit.height,
+                        blit.cycles_used,
+                        blit.cycles_stalled,
+                        blit.dpt & 0x00FF_FFFF,
+                    ),
+                    selected: blit.id == selected_id,
+                }
+            })
+            .collect();
+        let blit = trace.blits.iter().find(|blit| blit.id == selected_id)?;
+        let (planes, plane_source) = crate::blitviz::plane_count_for_blit(
+            blit,
+            self.emu.uaelib_resources(),
+            self.emu.bus().frame_render_base(),
+        );
+        let source_channel = [
+            crate::blitviz::BlitChannel::A,
+            crate::blitviz::BlitChannel::B,
+            crate::blitviz::BlitChannel::C,
+        ]
+        .into_iter()
+        .find(|channel| {
+            let index = match channel {
+                crate::blitviz::BlitChannel::A => 0,
+                crate::blitviz::BlitChannel::B => 1,
+                _ => 2,
+            };
+            blit.channels[index]
+        })
+        .unwrap_or(crate::blitviz::BlitChannel::A);
+        Some(ui::AnalyzerBlitsView {
+            rows,
+            hidden_above: scroll,
+            hidden_below: trace
+                .blits
+                .len()
+                .saturating_sub(scroll + ui::ANALYZER_BLIT_ROWS_MAX),
+            source_label: source_channel.name(),
+            source: crate::blitviz::render_blit(blit, source_channel, planes).ok(),
+            destination: crate::blitviz::render_blit(
+                blit,
+                crate::blitviz::BlitChannel::Result,
+                planes,
+            )
+            .ok(),
+            formula: format!(
+                "minterm ${:02X}: {}",
+                blit.minterm,
+                crate::blitviz::minterm_formula(blit.minterm)
+            ),
+            detail: format!(
+                "{} plane(s), {plane_source}; shifts A{} B{} masks ${:04X}/${:04X}",
+                planes, blit.shifts[0], blit.shifts[1], blit.masks[0], blit.masks[1]
+            ),
+        })
     }
 
     /// Scroll the Resources tab's table window by `rows`, clamped to the
@@ -1598,8 +1783,12 @@ impl App {
                 scrub: false,
                 heat,
                 resources,
+                blits: None,
             };
         };
+        let blits = (panel.tab == ui::AnalyzerTab::Blits)
+            .then(|| self.build_analyzer_blits_view(panel, trace))
+            .flatten();
         let underlay = (panel.underlay_active() && self.analyzer_underlay_rows > 0).then(|| {
             ui::AnalyzerUnderlayView {
                 fb: std::rc::Rc::clone(&self.analyzer_underlay_fb),
@@ -1626,9 +1815,10 @@ impl App {
         // seeing: a Copper writing a palette split on every line stays
         // well inside it.
         const MARKER_CAP: usize = 4000;
-        let markers = bus
+        let mut markers: Vec<ui::AnalyzerMarker> = bus
             .frame_render_events()
             .iter()
+            .filter(|event| !matches!(event.source, BeamWriteSource::Copper))
             .take(MARKER_CAP)
             .map(|event| ui::AnalyzerMarker {
                 vpos: event.vpos.min(u32::from(u16::MAX)) as u16,
@@ -1638,10 +1828,32 @@ impl App {
                 source: match event.source {
                     BeamWriteSource::Cpu => "cpu",
                     BeamWriteSource::CpuCopperIrq => "irq",
-                    BeamWriteSource::Copper => "copper",
+                    BeamWriteSource::Copper => unreachable!("filtered above"),
                 },
+                copper_addr: None,
+                colour: u32::from_le_bytes([238, 166, 42, 0xFF]),
             })
             .collect();
+        if let Some(records) = trace.records() {
+            markers.extend(
+                records
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, record)| {
+                        record.kind == crate::bus::BUS_RECORD_COPPER && record.flags & 1 != 0
+                    })
+                    .take(MARKER_CAP.saturating_sub(markers.len()))
+                    .map(|(slot, record)| ui::AnalyzerMarker {
+                        vpos: (slot / trace.cols).min(usize::from(u16::MAX)) as u16,
+                        hpos: (slot % trace.cols).min(usize::from(u16::MAX)) as u16,
+                        offset: record.reg & 0x01FE,
+                        value: record.data as u16,
+                        source: "copper",
+                        copper_addr: Some(record.addr.saturating_sub(2)),
+                        colour: copper_register_colour(record.reg),
+                    }),
+            );
+        }
         // Frame-start DIW/DDF overlays, decoded with the display model's
         // own rules (DiwHigh carries the OCS implicit bits or the ECS
         // DIWHIGH extension; DIW h units are lores pixels, two per cck).
@@ -1666,8 +1878,15 @@ impl App {
         // contains it, so clicking a blitter run names the blit.
         let selected_beam = (selected_vpos as u16, selected_hpos as u16);
         let selected_blit = trace.blits.iter().enumerate().find_map(|(i, blit)| {
-            let end = blit.end?;
-            (blit.start <= selected_beam && selected_beam <= end).then(|| {
+            let starts_before_slot = trace.frame > blit.start_frame
+                || (trace.frame == blit.start_frame && selected_beam >= blit.start);
+            let ends_after_slot = match (blit.end_frame, blit.end) {
+                (Some(end_frame), Some(end)) => {
+                    trace.frame < end_frame || (trace.frame == end_frame && selected_beam <= end)
+                }
+                _ => true,
+            };
+            (starts_before_slot && ends_after_slot).then(|| {
                 format!(
                     "in blit #{i} ({}x{} D ${:06X})",
                     blit.width_words,
@@ -1692,6 +1911,7 @@ impl App {
             scrub: panel.show_scrub,
             heat,
             resources,
+            blits,
             trace: Some(ui::AnalyzerTraceView {
                 frame: trace.frame,
                 seconds: trace.seconds,

--- a/src/video/window/app_panels.rs
+++ b/src/video/window/app_panels.rs
@@ -1090,6 +1090,9 @@ impl App {
             (ToolPanelKind::FrameAnalyzer, UiControl::AnalyzerResourceSave) => {
                 self.frame_analyzer_save_resource()
             }
+            (ToolPanelKind::FrameAnalyzer, UiControl::AnalyzerBlitRow(index)) => {
+                self.frame_analyzer_select_blit(index)
+            }
             _ => {}
         }
         self.request_redraw();

--- a/src/video/window/console.rs
+++ b/src/video/window/console.rs
@@ -850,7 +850,7 @@ impl App {
                 };
                 if trace.blits.is_empty() {
                     return ConsoleOutcome::one(format!(
-                        "no blits started in frame {}",
+                        "no blits referenced by frame {}",
                         trace.frame
                     ));
                 }
@@ -866,7 +866,9 @@ impl App {
                     };
                     let c1 = blit.bltcon1;
                     lines.push(format!(
-                        "#{i:<2} v{} h{} -> {end}  con0 {:04X} con1 {:04X}  {}x{}{}{}{}",
+                        "#{i:<2} id={} f{} v{} h{} -> {end}  con0 {:04X} con1 {:04X}  {}x{}{}{}{}  used/stall={}/{}",
+                        blit.id,
+                        blit.start_frame,
                         blit.start.0,
                         blit.start.1,
                         blit.bltcon0,
@@ -876,13 +878,24 @@ impl App {
                         if c1 & 0x0001 != 0 { "  LINE" } else { "" },
                         if c1 & 0x0008 != 0 { "  FILL" } else { "" },
                         if c1 & 0x0002 != 0 { "  DESC" } else { "" },
+                        blit.cycles_used,
+                        blit.cycles_stalled,
                     ));
                     lines.push(format!(
-                        "     A ${:06X}  B ${:06X}  C ${:06X}  D ${:06X}",
+                        "     A ${:06X}/{:+} B ${:06X}/{:+} C ${:06X}/{:+} D ${:06X}/{:+} shifts={:?} masks={:04X}/{:04X} minterm={:02X} ({})",
                         blit.apt & 0x00FF_FFFF,
+                        blit.modulos[0],
                         blit.bpt & 0x00FF_FFFF,
+                        blit.modulos[1],
                         blit.cpt & 0x00FF_FFFF,
+                        blit.modulos[2],
                         blit.dpt & 0x00FF_FFFF,
+                        blit.modulos[3],
+                        blit.shifts,
+                        blit.masks[0],
+                        blit.masks[1],
+                        blit.minterm,
+                        crate::blitviz::minterm_formula(blit.minterm),
                     ));
                 }
                 ConsoleOutcome::lines(lines)


### PR DESCRIPTION
## Summary

- retain complete cross-frame blit records and render captured channel/result rectangles
- add a scrollable Frame Analyzer Blits tab plus traced, register-class-coloured Copper markers
- add CCP blit.render, copper.list trace annotations, and headless screenshot overlays for blits, write overdraw, and Denise pixel provenance
- document the new console, CCP, profiling, and Frame Analyzer surfaces

## Validation

- cargo fmt --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-features --locked
- cargo build --release --all-features --locked
- deterministic factory headless boot through 20 emulated seconds with a scheduled screenshot