### PR TITLE
Speed up native CI builds and isolate packaging caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,13 +411,26 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends iproute2 libasound2-dev libudev-dev
       - name: Unit tests and probe golden renders
-        run: cargo test --profile ci --locked --timings
+        # Keep Cargo's artifact paths for the extra ignored tests below.
+        # Selecting another target with a second Cargo invocation can rerun
+        # build.rs and recompile the core even though its tests already exist.
+        # Explicit bash enables pipefail so tee cannot hide a test failure.
+        shell: bash
+        run: cargo test --profile ci --locked --timings --message-format=json | tee cargo-test-results.log
       - name: Audio stems determinism
         # tests/audio_stems_determinism.rs needs no external assets (the
         # bundled AROS ROM booting with an empty DF0 is enough), but like
         # every emulator-driving test it is #[ignore]d so ordinary cargo
         # test runs stay fast; it is invoked explicitly here instead.
-        run: cargo test --profile ci --locked --test audio_stems_determinism -- --ignored
+        run: |
+          audio_test="$(
+            jq -Rr 'fromjson? | select(.reason == "compiler-artifact"
+              and .target.name == "audio_stems_determinism"
+              and .target.kind[0] == "test" and .profile.test == true
+              and .executable != null) | .executable' cargo-test-results.log
+          )"
+          test -x "$audio_test"
+          "$audio_test" --ignored
       - name: A2065 bridge round trip over a veth pair
         # The ordinary suite covers the platform-independent bridge worker
         # with an in-memory Ethernet adapter. This privileged Linux-only
@@ -434,11 +447,9 @@ jobs:
           sudo ip link set cl-a2065 up
           sudo ip link set cl-peer up
           libtest="$(
-            cargo test --profile ci --locked --lib --no-run --message-format=json |
-              jq -r 'select(.reason == "compiler-artifact" and .target.name == "copperline"
+            jq -Rr 'fromjson? | select(.reason == "compiler-artifact" and .target.name == "copperline"
                 and .target.kind[0] == "lib" and .profile.test == true
-                and .executable != null) | .executable' |
-              tail -n1
+                and .executable != null) | .executable' cargo-test-results.log
           )"
           test -x "$libtest"
           sudo "$libtest" a2065_bridge_veth_round_trip_reaches_the_rx_ring \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+# Only main saves Rust caches. PRs can restore main's caches, while caches
+# saved on a PR merge ref cannot serve other PRs and evict reusable entries
+# when several of these large build matrices run concurrently.
 jobs:
   build:
     # Keep the existing check name for branch-protection rules. The ci
@@ -33,6 +36,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           # The macOS packaging workflow also has a job called build, but
           # its explicit --target artifacts cannot warm this native build.
           key: ci-macos
@@ -83,6 +87,8 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Formatting
         run: cargo fmt --check
       - name: Clippy
@@ -112,6 +118,7 @@ jobs:
           cargo generate-lockfile
       - uses: Swatinem/rust-cache@v2
         with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: fuzz
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
@@ -138,6 +145,7 @@ jobs:
           rustup toolchain install "$msrv" --profile minimal
       - uses: Swatinem/rust-cache@v2
         with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: msrv
       - name: Build with MSRV
         run: cargo +"$MSRV" build --locked
@@ -254,6 +262,7 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
         with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: crates/hostsocket-plugin
       - name: Build (wasm32-unknown-unknown)
         working-directory: crates/hostsocket-plugin
@@ -283,6 +292,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: crates/zz9k-plugin
       - name: Formatting
         working-directory: crates/zz9k-plugin
@@ -391,6 +401,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: ci-linux
       - name: Install build dependencies
         # ALSA (cpal) + udev (gilrs) headers, plus iproute2 for the A2065
@@ -465,6 +476,8 @@ jobs:
           targets: wasm32-unknown-unknown
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Core without the desktop frontend
         run: cargo check --no-default-features --locked
       - name: Headless benchmark binary
@@ -494,6 +507,8 @@ jobs:
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Frontend without the debug and library features
         run: cargo check --no-default-features --features frontend,cpu-jit --locked
       - name: Player crate (example manifest)
@@ -547,6 +562,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: RSP unit tests
         # The RSP tests live in the library; selecting it avoids compiling
         # every integration-test executable just to filter out its tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ env:
 
 jobs:
   build:
+    # Keep the existing check name for branch-protection rules. The ci
+    # profile inherits release semantics without shipping-only fat LTO.
     name: Build (release)
     # Copperline is developed on macOS, so the main fan-out runs there. The
     # other platforms have their own functional coverage: the linux-tests
@@ -30,19 +32,20 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Build (release)
-        run: cargo build --release --locked
+        with:
+          # The macOS packaging workflow also has a job called build, but
+          # its explicit --target artifacts cannot warm this native build.
+          key: ci-macos
       - name: Compile test binaries
-        # cargo build does not compile #[test] targets. This is also the
-        # step that keeps the asset-gated integration tests under tests/
-        # compiling on a clean checkout (they are #[ignore]d at run time,
-        # not excluded from the build). The JSON build plan maps each test
-        # target to its hash-suffixed executable so the binaries can be
-        # staged under stable names for the fan-out jobs.
+        # cargo test also builds the ordinary binaries for integration tests,
+        # so a separate cargo build would duplicate work. Keep all asset-gated
+        # tests compiling (#[ignore] only affects execution). The JSON output
+        # maps each test target to its hash-suffixed executable so the binaries
+        # can be staged under stable names for the fan-out jobs.
         run: |
-          cargo test --release --locked --no-run --message-format=json > cargo-test-build.json
+          cargo test --profile ci --locked --no-run --timings --message-format=json > cargo-test-build.json
           mkdir -p ci-bins
-          cp target/release/copperline ci-bins/
+          cp target/ci/copperline ci-bins/
           jq -r 'select(.reason == "compiler-artifact" and .profile.test == true and .executable != null)
                    | [.target.kind[0], .target.name, .executable] | @tsv' cargo-test-build.json \
             | while IFS=$'\t' read -r kind name exe; do
@@ -60,6 +63,14 @@ jobs:
         with:
           name: ci-bins
           path: ci-bins/
+      - name: Upload build timings
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cargo-timings-macos
+          path: target/cargo-timings/
+          if-no-files-found: ignore
+          retention-days: 7
 
   lint:
     name: Rustfmt and clippy
@@ -209,11 +220,11 @@ jobs:
         # The test harness spawns the emulator through the compile-time
         # CARGO_BIN_EXE_copperline path, which on hosted runners is the
         # same absolute path in every job of this repo -- hence the copy
-        # into target/release before running.
+        # into target/ci before running.
         run: |
           chmod +x ci-bins/*
-          mkdir -p target/release
-          cp ci-bins/copperline target/release/copperline
+          mkdir -p target/ci
+          cp ci-bins/copperline target/ci/copperline
           ./ci-bins/probe_golden
       - name: Upload probe render diffs
         # On a golden mismatch the test writes the actual renders and diff
@@ -307,11 +318,11 @@ jobs:
         # The image-regression harness spawns the emulator through the
         # compile-time CARGO_BIN_EXE_copperline path, which on hosted
         # runners is the same absolute path in every job of this repo --
-        # hence the copy into target/release.
+        # hence the copy into target/ci.
         run: |
           chmod +x ci-bins/*
-          mkdir -p target/release
-          cp ci-bins/copperline target/release/copperline
+          mkdir -p target/ci
+          cp ci-bins/copperline target/ci/copperline
       - name: Restore cached DiagROM
         id: diagrom-cache
         uses: actions/cache@v6
@@ -343,7 +354,7 @@ jobs:
         # proves the ROM's boot code actually executed, which a non-empty
         # PNG alone does not (a black screen still writes one).
         run: |
-          ./target/release/copperline diagrom.rom --noaudio --screenshot-after 6 diag.png > serial.log
+          ./target/ci/copperline diagrom.rom --noaudio --screenshot-after 6 diag.png > serial.log
           grep -q "Amiga DiagROM" serial.log
           test -s diag.png
       - name: DiagROM menu image regression
@@ -364,6 +375,7 @@ jobs:
           if-no-files-found: ignore
 
   linux-tests:
+    # Preserve the required check name; the ci profile is release-derived.
     name: Linux tests (release)
     # Functional coverage on Linux: the inline unit suites and
     # tests/probe_golden.rs, whose pixel-exact golden comparisons prove the
@@ -378,6 +390,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ci-linux
       - name: Install build dependencies
         # ALSA (cpal) + udev (gilrs) headers, plus iproute2 for the A2065
         # veth probe below. Winit needs no X headers at build time (it dlopens
@@ -386,13 +400,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends iproute2 libasound2-dev libudev-dev
       - name: Unit tests and probe golden renders
-        run: cargo test --release --locked
+        run: cargo test --profile ci --locked --timings
       - name: Audio stems determinism
         # tests/audio_stems_determinism.rs needs no external assets (the
         # bundled AROS ROM booting with an empty DF0 is enough), but like
         # every emulator-driving test it is #[ignore]d so ordinary cargo
         # test runs stay fast; it is invoked explicitly here instead.
-        run: cargo test --release --locked --test audio_stems_determinism -- --ignored
+        run: cargo test --profile ci --locked --test audio_stems_determinism -- --ignored
       - name: A2065 bridge round trip over a veth pair
         # The ordinary suite covers the platform-independent bridge worker
         # with an in-memory Ethernet adapter. This privileged Linux-only
@@ -409,7 +423,7 @@ jobs:
           sudo ip link set cl-a2065 up
           sudo ip link set cl-peer up
           libtest="$(
-            cargo test --release --locked --lib --no-run --message-format=json |
+            cargo test --profile ci --locked --lib --no-run --message-format=json |
               jq -r 'select(.reason == "compiler-artifact" and .target.name == "copperline"
                 and .target.kind[0] == "lib" and .profile.test == true
                 and .executable != null) | .executable' |
@@ -427,6 +441,14 @@ jobs:
           name: probe-golden-diffs-linux
           path: target/probe-golden/
           if-no-files-found: ignore
+      - name: Upload build timings
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cargo-timings-linux
+          path: target/cargo-timings/
+          if-no-files-found: ignore
+          retention-days: 7
 
   wasm:
     name: Headless core and browser build
@@ -526,4 +548,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: RSP unit tests
-        run: cargo test --locked gdbstub
+        # The RSP tests live in the library; selecting it avoids compiling
+        # every integration-test executable just to filter out its tests.
+        run: cargo test --locked --lib gdbstub

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -64,6 +64,8 @@ jobs:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
       - uses: Swatinem/rust-cache@v2
         with:
+          # PRs restore main's cache without uploading a competing copy.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           # Separate explicit architecture builds from ci.yml's native
           # test build, which otherwise shares this job's default key.
           key: macos-dmg

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -63,6 +63,10 @@ jobs:
           # Both Apple architectures so build-dmg.sh can lipo a universal binary.
           targets: aarch64-apple-darwin,x86_64-apple-darwin
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Separate explicit architecture builds from ci.yml's native
+          # test build, which otherwise shares this job's default key.
+          key: macos-dmg
       - name: Build dmg
         run: packaging/macos/build-dmg.sh
       - name: Locate artifact

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,6 +54,8 @@ concurrency:
   group: windows-${{ github.ref }}
   cancel-in-progress: true
 
+# Seed each native build cache on main; PR copies cannot serve other PRs
+# and crowd out the shared entries when several matrices run together.
 jobs:
   build:
     name: Build Windows zip (${{ matrix.arch }})
@@ -96,6 +98,7 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: windows-zip-${{ matrix.target }}
       - name: Build release zip
         shell: pwsh
@@ -160,6 +163,7 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           key: windows-tests-${{ matrix.target }}
       - name: Compile test binaries
         shell: pwsh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,12 +4,12 @@ name: Windows
 # ARM64 on the windows-11-arm runner, each leg building natively for its own
 # architecture (no cross-compiling). Per architecture, two parallel builder
 # jobs produce the portable Windows zip and the prebuilt test executables
-# (both are full release compiles and roughly equally expensive, so
-# splitting them halves the critical path), then the checks fan out in
+# (the zip uses the shipping release profile; tests use the optimized ci
+# profile without fat LTO), then the checks fan out in
 # parallel against those artifacts, mirroring ci.yml: the packaged zip is
 # booted from a clean directory, and the unit suites plus the probe golden
 # renders (pixel-exact deterministic boots on the bundled AROS ROM) run
-# against the same release binaries. This is also the only Windows coverage
+# against the prebuilt test binaries. This is also the only Windows coverage
 # (the main CI runs on macOS and Linux), so the code-path triggers below run
 # the full release build on pull requests too. On a v* tag push (or a manual
 # run with release_tag) both zips are attached to the GitHub Release by the
@@ -95,6 +95,8 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-zip-${{ matrix.target }}
       - name: Build release zip
         shell: pwsh
         run: packaging/windows/build-zip.ps1 -Target ${{ matrix.target }}
@@ -124,9 +126,8 @@ jobs:
     # binary here too (the integration tests spawn it through the
     # compile-time CARGO_BIN_EXE_copperline path), so the staged
     # copperline.exe pairs with the probe_golden harness compiled alongside
-    # it and this job needs nothing from the zip build. Swatinem/rust-cache
-    # keys per job and per toolchain, so each builder keeps its own warm
-    # cache.
+    # it and this job needs nothing from the zip build. Separate cache keys
+    # keep the shipping and CI profiles warm independently.
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -158,6 +159,8 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-tests-${{ matrix.target }}
       - name: Compile test binaries
         shell: pwsh
         # The JSON build plan maps each test target to its hash-suffixed
@@ -167,10 +170,10 @@ jobs:
         # excluded from the build).
         run: |
           $ErrorActionPreference = "Stop"
-          cargo test --release --locked --target ${{ matrix.target }} --no-run --message-format=json > cargo-test-build.json
+          cargo test --profile ci --locked --target ${{ matrix.target }} --no-run --timings --message-format=json > cargo-test-build.json
           if ($LASTEXITCODE -ne 0) { throw "cargo test --no-run exited with $LASTEXITCODE" }
           New-Item -ItemType Directory -Force -Path ci-bins | Out-Null
-          Copy-Item target\${{ matrix.target }}\release\copperline.exe ci-bins\
+          Copy-Item target\${{ matrix.target }}\ci\copperline.exe ci-bins\
           Get-Content cargo-test-build.json | ForEach-Object {
             $msg = $_ | ConvertFrom-Json
             if ($msg.reason -eq "compiler-artifact" -and $msg.profile.test -and $msg.executable) {
@@ -188,6 +191,14 @@ jobs:
         with:
           name: windows-test-bins-${{ matrix.arch }}
           path: ci-bins/
+      - name: Upload build timings
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cargo-timings-windows-${{ matrix.arch }}
+          path: target/cargo-timings/
+          if-no-files-found: ignore
+          retention-days: 7
 
   zip-smoke:
     name: Packaged zip boot smoke (${{ matrix.arch }})
@@ -306,8 +317,8 @@ jobs:
         # --target build directory before running.
         run: |
           $ErrorActionPreference = "Stop"
-          New-Item -ItemType Directory -Force -Path target\${{ matrix.target }}\release | Out-Null
-          Copy-Item ci-bins\copperline.exe target\${{ matrix.target }}\release\copperline.exe
+          New-Item -ItemType Directory -Force -Path target\${{ matrix.target }}\ci | Out-Null
+          Copy-Item ci-bins\copperline.exe target\${{ matrix.target }}\ci\copperline.exe
           ./ci-bins/probe_golden.exe
           if ($LASTEXITCODE -ne 0) { throw "probe_golden exited with $LASTEXITCODE" }
       - name: Upload probe render diffs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,3 +400,12 @@ opt-level = 3
 # rendering than thin LTO, and the resulting executable is smaller.
 lto = "fat"
 codegen-units = 1
+
+# CI needs optimized emulation, but linking every test executable with fat
+# LTO dominates build time. Keep release semantics (including disabled debug
+# assertions/overflow checks) while allowing parallel code generation. The
+# packaged release binaries continue to use the profile above.
+[profile.ci]
+inherits = "release"
+lto = "off"
+codegen-units = 16

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -95,6 +95,13 @@ cargo test                          # Unit tests (no external assets required)
 cargo test --release -- --ignored   # Integration tests (requires local test media)
 ```
 
+For the optimized native CI suite, including the deterministic golden renders,
+use `cargo test --profile ci --locked`. The `ci` profile inherits release
+settings but disables LTO and uses parallel code generation to compile test
+executables faster. Its binaries are in `target/ci/`; normal builds and
+performance benchmarks continue to use `--release`. Add `--timings` to write
+a build report to `target/cargo-timings/cargo-timing.html`.
+
 ## First boot
 
 Run Copperline from the terminal:

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,7 +35,9 @@ to avoid repeating expensive whole-program optimization for every test
 executable. It builds the emulator too, so no preceding `cargo build` is
 needed. Outputs live in `target/ci/` (or `target/<triple>/ci/` with
 `--target`). Packaged binaries and performance benchmarks still use
-`--release` and its fat LTO.
+`--release` and its fat LTO. Linux retains Cargo's artifact paths from the
+full suite and directly reuses those executables for the extra ignored
+audio and network checks, avoiding further build-script runs and recompiles.
 
 The native CI builders publish `cargo-timings-*` artifacts from `--timings`
 for seven days. To inspect build costs locally, add `--timings` and open

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,6 +28,21 @@ cargo clippy --all-targets --all-features --locked -- -D warnings
 git diff --check
 ```
 
+CI uses `cargo test --profile ci --locked` for the native suites. This
+release-derived profile keeps optimization level 3 and disables debug
+assertions and overflow checks, but turns off LTO and uses 16 codegen units
+to avoid repeating expensive whole-program optimization for every test
+executable. It builds the emulator too, so no preceding `cargo build` is
+needed. Outputs live in `target/ci/` (or `target/<triple>/ci/` with
+`--target`). Packaged binaries and performance benchmarks still use
+`--release` and its fat LTO.
+
+The native CI builders publish `cargo-timings-*` artifacts from `--timings`
+for seven days. To inspect build costs locally, add `--timings` and open
+`target/cargo-timings/cargo-timing.html`. CI and packaging use distinct
+cache keys because an explicit `--target` build cannot populate the native
+build's output directory.
+
 The golden renders live under `timing-test/golden/`. A hardware-model change
 that intentionally alters them must be re-blessed with
 `COPPERLINE_BLESS_GOLDEN=1 cargo test --release --test probe_golden`, with the

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,11 @@ The native CI builders publish `cargo-timings-*` artifacts from `--timings`
 for seven days. To inspect build costs locally, add `--timings` and open
 `target/cargo-timings/cargo-timing.html`. CI and packaging use distinct
 cache keys because an explicit `--target` build cannot populate the native
-build's output directory.
+build's output directory. These Rust caches are saved only on `main` and
+restored by pull requests. This avoids filling the repository cache budget
+with copies scoped to individual PRs, which cannot be reused by other PRs.
+New dependency/profile combinations first populate the shared cache after
+merging; until then, a PR may need a cold build.
 
 The golden renders live under `timing-test/golden/`. A hardware-model change
 that intentionally alters them must be re-blessed with


### PR DESCRIPTION
Native test jobs spent most of their build time applying shipping fat-LTO settings to every test executable. The macOS CI and DMG jobs also shared a cache key despite using incompatible target directories, concurrent PRs crowded out reusable caches, and Linux recompiled the core before running already-built audio/network tests.

Add a release-derived `ci` profile with LTO disabled and 16 codegen units for macOS, Linux, and both Windows test builds. Keep every existing test target, update the artifact consumers to the matching paths, and retain the shipping fat-LTO profile for packaged binaries. Isolate build caches and populate them only on `main`; PRs restore available caches without uploading competing copies. Remove the separate macOS build, reuse Linux test executables for its extra checks, restrict the dedicated GDB unit job to `--lib`, and publish seven-day Cargo timing reports. Existing check names remain unchanged.

Measured job durations, excluding runner queues, compare main at `3d334a11` with the final PR commit `3fa29ea9`:

| Job | Before | After | Reduction |
|---|---:|---:|---:|
| [macOS CI build](https://github.com/CopperlineHQ/Copperline/actions/runs/33966664673/job/101307889259) | 40m 28s | 3m 51s | 90.5% |
| [Linux tests](https://github.com/CopperlineHQ/Copperline/actions/runs/33966664673/job/101307889249) | 36m 45s | 9m 37s | 73.8% |
| [Windows x64 tests](https://github.com/CopperlineHQ/Copperline/actions/runs/33966664825/job/101307888188) | 40m 17s | 13m 44s | 65.9% |
| [Windows ARM64 tests](https://github.com/CopperlineHQ/Copperline/actions/runs/33966664825/job/101307888387) | 19m 32s | 9m 44s | 50.2% |

The final macOS/Linux runs restored their new caches; both Windows builds missed theirs. The first macOS build with an empty cache took 9m 12s. New dependency/profile combinations populate the shared cache after merging to `main`. Linux's extra audio/network checks dropped from roughly three minutes of recompilation to seconds by reusing executables.

Validation on final head `3fa29ea9a93a82486dd45361cc02e792719e7922`: **32 hosted checks passed**, with the expected release-upload skip. This includes the native unit/golden suites, Linux audio and veth checks, DiagROM, both Windows architectures, package smoke tests, Flatpak, browser/plugin builds, MSRV, Clippy, and documentation. No unresolved review threads.

Local validation: clean CI-profile compilation in 2m 48s with all 33 integration-test targets; 3,665 tests passed (104 ignored), including all 44 probe goldens; all 3 explicit audio tests passed. Strict Clippy, formatting, whitespace, and MyST HTML/link checks passed. Artifact extraction and pipeline failure propagation were verified. Actionlint passes with the two pre-existing SC2012 warnings excluded; unfiltered warnings match the base branch's unchanged packaging scripts.
