### PR TITLE
Refresh documentation and custom-register reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ It boots out of the box with the bundled open-source AROS Kickstart replacement,
 
 - **Chipset and machine models**: OCS, ECS, and AGA support with profiles from the A500 through the A4000, plus CDTV and CD32.
 - **Configurable CPU and memory**: Motorola 68000 through 68060, optional FPU and MMU support, and configurable Chip, Fast, and Slow RAM.
-- **Storage and media**: Floppy disk images (ADF, ADZ, DMS, IPF, SCP), physical floppy drives via Greaseweazle (FluxBridge), IDE (Gayle/A4000), SCSI (A2091, A3000, A4091), CD-ROM, and host directory filesystem mounting.
+- **Storage and media**: Floppy disk images (ADF, ADZ, DMS, IPF, SCP), physical floppy drives via Greaseweazle (FluxBridge), IDE (Gayle/A4000 and expansion boards), SCSI (A2091, A3000, A4091), virtual hard disks (`copperhf.device`), CD-ROM, and host directory mounts.
 - **Audio and video**: 4-channel Paula audio, RTG graphics cards (Picasso II/II+, Z3660), host MIDI in/out bridging, and built-in Roland MT-32 and General MIDI synthesis.
 - **Expansion and networking**: Zorro II/III autoconfig, A2065 Ethernet, host-backed bsdsocket.library, and sandboxed WebAssembly expansion plugins.
-- **Debugging and automation**: In-window interactive debugger with reverse stepping and live Kickstart/AROS symbol names, signal waveform export (VCD), GDB remote stub (including [Bartman extension compatibility](docs/debugger/gdb.md#bartman-extension-backend) with launches that wait for the debugger), a Debug Adapter Protocol server for VS Code and other IDEs (`copperline-ctl --dap`, source-level from the hunk executable's own debug information or a linked/relocatable ELF sibling), [deterministic save states](docs/guide/ui.md#save-states) with atomic file replacement, [WinUAE USS import for frame profiling](docs/guide/winuae-state.md), headless scripting, and a JSON-RPC control protocol (`copperline-ctl`, with an MCP server mode for AI coding agents via `copperline-ctl --mcp`).
+- **Debugging**: CPU and chipset debugger, reverse stepping, live Kickstart/AROS symbols, frame and instruction profiling, VCD waveforms, and source debugging through GDB or DAP. Both the native VS Code extension and the [Copperline fork of Bartman's extension](docs/debugger/vscode-bartman.md) are supported.
+- **Automation and replay**: [Save states](docs/guide/ui.md#save-states), [WinUAE state import](docs/guide/winuae-state.md), headless input scripts and captures, and a JSON-RPC control protocol. `copperline-ctl` also provides DAP (`--dap`) and MCP (`--mcp`) servers.
 - **Freezer cartridge**: Action Replay-style cartridge support with bundled HRTMon (`--cartridge hrtmon`), allowing running software to be frozen into the monitor via the menu, a hotkey, headless `--freeze-after`, or the control protocol.
 - **Direct launching**: Boot directly into WHDLoad game packages (`--whdload`) or host-built Amiga executables (`--run`), with a WinUAE-compatible `uaelib` trap allowing guest code to control warp speed, log debug messages, and register debug resources.
 - **WebAssembly build**: Run directly in modern web browsers at [copperline.dev/try](https://copperline.dev/try/).
@@ -55,9 +56,11 @@ Standalone AppImage binaries are also available on the [releases page](https://g
 cargo build --release
 ```
 
-Always run Copperline with `--release`, as unoptimized debug builds are too slow for real-time emulation.
+Run the resulting `target/release/copperline` binary. `--release` is a Cargo
+build option; unoptimized debug builds are too slow for real-time emulation.
 
 Dependencies:
+
 - Rust 1.95+ (tested on stable)
 - Fedora build dependencies: `sudo dnf install alsa-lib-devel systemd-devel gcc`
 - Debian/Ubuntu build dependencies: `sudo apt install libasound2-dev libsystemd-dev gcc`
@@ -116,7 +119,7 @@ See the [configuration guide](docs/guide/configuration.md) for the complete refe
 
 ## Documentation
 
-Comprehensive documentation is published at [copperline.dev](https://copperline.dev/) and available under `docs/`:
+The manual is published at [copperline.dev/docs](https://copperline.dev/docs/) and available under `docs/`:
 
 - [Getting Started](docs/guide/getting-started.md) - Installation and setup
 - [Configuration](docs/guide/configuration.md) - Configuration file reference and CLI options

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ The documentation under this directory is written in
 
 ## Dependencies
 
-- [Node.js](https://nodejs.org/) and the MyST CLI:
+- [Node.js](https://nodejs.org/) (CI uses Node 24) and the MyST CLI:
 
   ```sh
   npm install -g mystmd
@@ -45,8 +45,24 @@ cd docs
 myst build --pdf         # writes docs/_build/exports/copperline.pdf
 ```
 
-The PDF export collects every chapter into a single document, as listed in
-`myst.yml` under `exports`.
+The PDF export collects the chapters listed in `myst.yml` under `exports`.
+The individual custom-register reference pages are available in the HTML manual
+and embedded debugger help; they are not included in the PDF.
+
+## Validation
+
+Run the same checks as CI before submitting documentation changes:
+
+```sh
+cd docs
+myst build --html --ci --strict --check-links
+myst build --pdf --ci --strict
+test -s _build/exports/copperline.pdf
+```
+
+The custom-register pages also feed generated Rust data. When editing them,
+run `cargo test --profile ci --locked --lib custom` from the repository root
+to check their format and control-protocol integration.
 
 ## Conventions
 

--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -75,7 +75,7 @@ Commands are case-insensitive. Addresses and data values use hexadecimal notatio
 | `BLITS` | List all blits referenced by the traced frame, including stable ID, cross-frame beam span, direction/fill/line mode, channels, pointers/modulos, shifts/masks/minterm, and clocks used versus stalled (requires Frame Analyzer) |
 | `CPUWAIT` | Summarise the traced frame's CPU chip-bus waits: waited clocks by denier (bitplane, Copper, blitter with BLTPRI clear or set, ...) and by access kind, and the instructions that waited longest (requires Frame Analyzer; see [the CPU wait view](window.md#frame-analyzer-pane)) |
 | `FIND HEXBYTES [START]` | Search CPU-visible memory (RAM and ROM) for byte sequence |
-| `WRITER ADDR` | Query last instruction that modified memory at `ADDR` |
+| `WRITER ADDR` | Replay retained snapshots to the last observed change of the word at `ADDR`; moves execution back to that point |
 | `DBGRES` | List debug resources (bitmaps, palettes, copper lists) registered by guest code via the uaelib trap (distinct from `RESOURCES`, which lists Exec OS resource nodes) |
 | `OUTROM` | Run until PC leaves the default Kickstart ROM window (`$F80000-$FFFFFF`) |
 | `HISTORY [N]` (or `H`) | Display recent instruction history |
@@ -87,6 +87,12 @@ Commands are case-insensitive. Addresses and data values use hexadecimal notatio
 | `WAVE START [ARGS]` | Arm VCD logic analyzer capture (see [](waveform.md)) |
 | `WAVE STOP` | Stop VCD capture |
 | `HELP` (or `?`) | Display command summary |
+
+`WRITER` compares the word after each CPU step. It misses writes that leave
+the value unchanged, and its reported PC is the CPU instruction around the
+change; that alone does not establish whether the CPU or DMA wrote it.
+Use a source-filtered `WATCH` when that distinction matters. `RWATCH` watches
+custom-register writes; it is not a reverse memory query.
 
 ### Memory delta search (Trainer / Value hunter)
 

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -57,7 +57,6 @@ copperline-ctl --info /tmp/ccp.json continue
 copperline-ctl --info /tmp/ccp.json --repl
 ```
 
-(mcp-server)=
 ## Debug adapter
 
 `copperline-ctl --dap` serves the [Debug Adapter Protocol](dap.md) over the
@@ -65,6 +64,7 @@ same bridge: an IDE debugs a program in the emulator with source-level
 breakpoints, variables and reverse stepping, while the control protocol
 underneath stays available from the Debug Console (`!status`, `!beam.get`).
 
+(mcp-server)=
 ## MCP server
 
 `copperline-ctl --mcp` exposes the control protocol over standard I/O as a

--- a/docs/debugger/dap.md
+++ b/docs/debugger/dap.md
@@ -94,8 +94,8 @@ configuration says. Arguments:
 | `program` | The hunk executable on the host (required). Its directory is mounted in the guest. |
 | `args` | Command-line arguments for the program (a string or an array). |
 | `copperline` | The emulator binary. Default: `COPPERLINE_BIN`, then a `copperline` next to `copperline-ctl`, then PATH. |
-| `config` | A TOML configuration file (`--config`). Default: the launcher's saved default. |
-| `rom` | A Kickstart ROM supplied as Copperline's positional ROM argument. Omit it to use the bundled AROS ROM. |
+| `config` | A TOML configuration file (`--config`). If omitted, Copperline checks `copperline.toml` in its working directory, then the launcher's saved default, then built-in settings. |
+| `rom` | A Kickstart ROM supplied as Copperline's positional ROM argument. If omitted, the selected configuration's ROM is used, falling back to bundled AROS. |
 | `factory` | Ignore the saved default configuration (`--factory`). |
 | `model`, `chipset`, `cpu`, `chip`, `fast`, `slow` | The matching `copperline` flags. |
 | `memoryFill` | `--ram-init`: `zero`, `random[:SEED]`, `pattern:WORD`, or `0xWORD` for uninitialised-read testing. |

--- a/docs/debugger/reverse.md
+++ b/docs/debugger/reverse.md
@@ -7,10 +7,13 @@ nearest preceding snapshot and replaying forward to the exact requested instruct
 or beam cycle.
 
 Reverse debugging is available through:
+
 - **Interactive UI:** `< Step`, `< Frame`, and `< Run` in the [debugger window](window).
-- **Console commands:** `RSTEP`, `RFRAME`, `RRUN`, and `RWATCH` in the [debugger console](console).
+- **Console commands:** `RSTEP`, `RFRAME`, `RRUN`, and `WRITER` in the [debugger console](console).
 - **Headless analysis:** Automated "last writer" reverse watchpoints via `COPPERLINE_DBG_RWATCH`.
-- **GDB remote stub:** Standard GDB `reverse-step` and `reverse-continue` commands.
+- **GDB remote stub:** `reverse-stepi` and `reverse-continue` (or source-level
+  `reverse-step` when GDB has debug information).
+- **Control protocol and DAP:** Reverse commands in CCP and Step Back / Reverse Continue in IDEs.
 - **Gameplay rewind:** The `Cmd+Z` / `Alt+Z` shortcut during normal gameplay.
 
 ## Headless "last writer" reverse watchpoints
@@ -64,6 +67,7 @@ stopping at the most recent triggering event.
 ## Rewind in normal sessions
 
 Rewind functionality can be used during gameplay:
+
 - Set `[emulation] rewind = true` in `copperline.toml` or enable **Rewind** in the UI menu.
 - Press `Cmd+Z` (macOS) or `Alt+Z` (Linux/Windows) to step backward by intervals
   defined in `rewind_interval_frames`.
@@ -79,7 +83,8 @@ For reverse replay to be exact:
 3. **Storage:** RAM contents and floppy disk states are captured directly in memory
    snapshots. However, hard drive and CD images, and host directory mounts (including
    the volumes `--run` and `--whdload` stage), are accessed live from the host and are
-   not rolled back on restore; guest disk traffic or host-side modifications occurring
-   after a snapshot point will cause replayed execution to diverge. A debugger avoids
-   this by taking a fresh snapshot at the stop it steps back from (the control
-   protocol's `reverse_anchor`; the DAP adapter does so at every run stop).
+   not rolled back on restore; guest disk writes or host-side modifications after a snapshot can make replay
+   diverge. Taking a fresh snapshot after I/O gives later steps a new replay
+   starting point (`reverse_anchor` in CCP; DAP does this at every run stop).
+   This does not make earlier external I/O reversible. Physical devices and live network, serial, MIDI,
+   or sampler input have the same limitation.

--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -6,8 +6,9 @@ Closing the window restores the previous execution state.
 
 The debugger, Frame Analyzer, and [Console](console) operate in separate host
 windows, allowing them to remain open simultaneously while inspecting CPU,
-custom chipset, and bus activity. Emulation and register queries are non-intrusive
-and do not alter hardware state.
+custom chipset, and bus activity. Inspection reads do not acknowledge hardware
+registers or consume emulated bus cycles. Stepping, register edits, and memory
+writes change the machine as requested.
 
 ```{figure} ../images/ui-preview-debugger.png
 :alt: The debugger window on the CPU tab

--- a/docs/debugger/workflows.md
+++ b/docs/debugger/workflows.md
@@ -32,8 +32,10 @@ If the display exhibits raster splits at incorrect scanlines or corrupted palett
    or **To slot** in the Frame Analyzer). Execution halts when the raster beam reaches that line.
 4. **Single-step the Copper:** Switch to the **Copper** tab and use `CStep` (`C`) to execute
    Copper instructions sequentially across `WAIT` boundaries.
-5. **Trace memory modifications:** Use `WRITER ADDR` to scan execution history and identify
-   the last CPU or Blitter instruction that wrote to the Copper list address.
+5. **Find a memory change:** `WRITER ADDR` replays retained snapshots and moves back
+   to the last observed change of that word. Its PC identifies the CPU step
+   around the change; use `WATCH ADDR CPU` or `WATCH ADDR BLITTER` to distinguish
+   the writer on a forward run.
 
 ## Identifying memory corruption
 

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -16,7 +16,7 @@ The web version runs at [copperline.dev/try](https://copperline.dev/try/):
   is running reboots the machine with the selected profile. URL query parameter: `?machine=A1200`.
 - **Video standards:** Toggle between PAL (default) and NTSC. URL query parameter: `?video=NTSC`.
 - **Boot ROMs:** The open-source AROS Kickstart replacement is fetched automatically at load.
-  You can also load standard 512 KiB Kickstart ROM files via the **Kickstart ROM** picker or
+  You can also load 512 KiB or 256 KiB Kickstart ROM files via the **Kickstart ROM** picker or
   drag-and-drop.
 - **Floppy disk images:** Mount disk images in `DF0:` and `DF1:` (ADF, ADZ, DMS, IPF, SCP, or ZIP).
   By default, images mount read-only. Check **Open disks writable** to enable in-memory
@@ -59,7 +59,10 @@ The web version runs at [copperline.dev/try](https://copperline.dev/try/):
 
 The web build uses the same `.clstate` file format as the desktop version:
 
-- **Save state / Load state:** Download or upload state files (`.clstate`) for desktop interoperability.
+- **Save state / Load state:** Download or upload state files (`.clstate`). Transfers
+  between browser and desktop require the same save-state format version and devices
+  supported by both builds. Desktop states that depend on host files or native-only
+  devices are not portable to the browser.
 - **Quick save / Quick load:** Stores the current session in browser local storage (IndexedDB)
   for instant resumption across page reloads.
 - **Saved states panel:** Manage named state slots in browser storage.
@@ -89,14 +92,16 @@ are installed:
 
 ```sh
 rustup target add wasm32-unknown-unknown
-cargo install wasm-bindgen-cli --version 0.2.126 --locked
+# Run from the repository root; the CLI must match the crate exactly.
+bindgen_version=$(sed -n 's/^wasm-bindgen = "=\(.*\)"$/\1/p' crates/copperline-web/Cargo.toml)
+cargo install wasm-bindgen-cli --version "$bindgen_version" --locked
 ```
 
 ### Compilation
 
 ```sh
 cd crates/copperline-web
-cargo build --release --target wasm32-unknown-unknown
+cargo build --release --target wasm32-unknown-unknown --locked
 wasm-bindgen --target web --out-dir pkg \
   target/wasm32-unknown-unknown/release/copperline_web.wasm
 ```
@@ -106,7 +111,11 @@ The compiled JavaScript loader (`copperline_web.js`) and WebAssembly binary
 
 ## Embedding with the WebEmu API
 
-To embed Copperline in a custom web application:
+The example below assumes that the page has loaded the ROM and floppy bytes,
+created a 2D canvas context named `ctx`, and connected an `audioWorkletNode`
+whose processor accepts interleaved stereo samples. Resize the canvas to the
+presentation dimensions when they change. The complete page and audio processor
+are in `crates/copperline-web/www/`.
 
 ```js
 import init, { WebEmu } from './pkg/copperline_web.js';
@@ -226,9 +235,16 @@ The browser build can route Amiga serial communication to remote WebSocket serve
 (benchmarking-the-core-as-wasm)=
 ## Headless WebAssembly benchmarking
 
-To benchmark WebAssembly performance using Wasmtime:
+From the repository root, build the frontend-free WASI benchmark:
 
 ```sh
-cargo build --release --target wasm32-wasip1 --bin copperline-bench --features "bench-bin"
-wasmtime run --dir . target/wasm32-wasip1/release/copperline-bench.wasm -- --config test.toml --benchmark-until 30
+rustup target add wasm32-wasip1
+cargo build --release --locked --target wasm32-wasip1 \
+  --no-default-features --features bench-bin --bin copperline-bench
+wasmtime run --dir . target/wasm32-wasip1/release/copperline-bench.wasm \
+  --config test.toml --seconds 30
 ```
+
+Keep the config and its media under the directory exposed by `--dir`.
+`copperline-bench` uses `--seconds`; it has a separate parser from the desktop
+binary. Add `--render` to include framebuffer rendering and post-processing.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -11,11 +11,12 @@ this reference.
 settings; `--config` and `./copperline.toml` always win over it anyway. With
 no default saved, the flag changes nothing.
 
-The configuration is validated up front and the emulator refuses to start
-with a clear error message rather than guessing (unknown CPU or chipset
-names, out-of-range sizes, missing disk images, and so on).
+Configuration parsing rejects unknown keys, invalid CPU or chipset names,
+and out-of-range sizes. Media are opened during startup; depending on the
+device, an unavailable image either stops startup or leaves the unit absent
+with a warning in the log.
 
-### Paths on Windows
+## Paths on Windows
 
 This applies to every path field below (`rom`, disk images, hard-drive
 files, the SCSI ROMs, and so on). In a TOML double-quoted string the
@@ -30,7 +31,8 @@ rom = "C:/Kickstarts/KICK31.ROM"    # forward slashes also work on Windows
 ```
 
 Single-quoted literal strings are the least error-prone. macOS and Linux paths
-use forward slashes and need none of this.
+use forward slashes and need none of this. TOML paths do not expand `~` or
+shell variables; use an absolute path or a path relative to the working directory.
 
 ## Command-line overrides
 
@@ -165,8 +167,8 @@ with CD32 Kickstart 3.1. The library identifies inserted Video CDs and parses th
 metadata. Under CD32 Kickstart, the bundled version 41 `cdstrap` autoboots Video CDs
 into a track menu: navigate with Up/Down, press Red to play, and press Blue to stop
 or exit. Standard CD32 game discs pass through to the default boot sequence. Bundled
-AROS includes the corresponding PR 1089 MPEG device and Copperline's
-chronological-CDXL fix (commit `ebfc7d9`), but bypasses cartridge diagnostics, so the
+AROS includes its own MPEG device and CDXL playback support, but bypasses
+cartridge diagnostics, so the
 cartridge library and player are currently Kickstart-specific. Neither path requires
 proprietary Commodore code or CL450 microcode, as Copperline models the CL450
 command interface at the host level.

--- a/docs/guide/coppersynth.md
+++ b/docs/guide/coppersynth.md
@@ -116,5 +116,5 @@ To exclude Coppersynth when compiling from source:
 
 ```sh
 cargo build --release --no-default-features \
-  --features "midi,frontend,wasm-boards,control,ctl-bin,import-uae-bin,net-nat,net-bridge,fluxbridge,mt32,cpu-jit,profile-stats,game-library,mhi,cd-mp3,cd32-fmv,gdb"
+  --features "midi,frontend,wasm-boards,control,ctl-bin,import-uae-bin,net-nat,net-bridge,fluxbridge,mt32,cpu-jit,profile-stats,game-library,mhi,cd-mp3,cd32-fmv,gdb,dap"
 ```

--- a/docs/guide/fluxbridge.md
+++ b/docs/guide/fluxbridge.md
@@ -19,7 +19,7 @@ drive support:
 
 ```sh
 cargo build --release --no-default-features \
-  --features "midi,frontend,wasm-boards,control,ctl-bin,import-uae-bin,net-nat,net-bridge,mt32,coppersynth,cpu-jit,profile-stats,game-library,mhi,cd-mp3,cd32-fmv,gdb"
+  --features "midi,frontend,wasm-boards,control,ctl-bin,import-uae-bin,net-nat,net-bridge,mt32,coppersynth,cpu-jit,profile-stats,game-library,mhi,cd-mp3,cd32-fmv,gdb,dap"
 ```
 
 ## Configuration

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -6,16 +6,18 @@ system requirements, installation, building from source, and initial setup.
 
 ## System requirements
 
-- **Rust:** 1.95 or newer (tested with Rust 1.96).
+- **Rust (source builds only):** 1.95 or newer; CI uses the stable toolchain.
 - **Supported operating systems:** macOS, Linux, and Windows.
 - **Graphics backend:** Metal on macOS, Direct3D 12 on Windows, and Vulkan on Linux
   (see [](#vulkan-is-required-on-linux)).
-- **Linux build dependencies (Fedora):** `sudo dnf install alsa-lib-devel systemd-devel gcc`.
+- **Linux build dependencies:** `sudo dnf install alsa-lib-devel systemd-devel gcc`
+  on Fedora, or `sudo apt install libasound2-dev libsystemd-dev gcc` on Debian/Ubuntu.
 - **Boot ROM:** Copperline includes the open-source [AROS](http://www.aros.org/)
   Kickstart replacement and boots it by default. It also supports official
   Commodore Kickstart ROMs (1.3, 2.05, 3.1, plus CDTV and CD32 extended ROMs)
-  and [DiagROM](https://www.diagrom.com/). Standard Kickstart ROM images must
-  be 512 KiB.
+  and [DiagROM](https://www.diagrom.com/). Use a single-file 512 KiB image or
+  a 256 KiB Kickstart 1.x image; Copperline mirrors the latter across its
+  512 KiB ROM window. See [ROM formats](configuration.md#top-level).
 
 ## Installing on macOS (Homebrew)
 
@@ -77,6 +79,13 @@ For virtual machines or older hardware, install the software Vulkan driver (lava
 
 The Flatpak build bundles lavapipe by default.
 
+## Installing on Windows
+
+Download `Copperline-X.Y.Z-win-x64.zip` or `Copperline-X.Y.Z-win-arm64.zip`
+from the [releases page](https://github.com/CopperlineHQ/Copperline/releases),
+matching your Windows architecture. Extract the whole archive and run
+`copperline.exe`; keep the bundled ROMs and other assets alongside it.
+
 ## Building from source
 
 ```sh
@@ -84,8 +93,9 @@ cargo build --release
 ```
 
 ```{warning}
-Always run Copperline with `--release`. Unoptimized debug builds are not fast
-enough for real-time emulation.
+Use the binary in `target/release/` for emulation. `--release` is a Cargo
+build option, not a Copperline command-line flag. Unoptimized debug builds
+are too slow for real-time emulation.
 ```
 
 To run the test suite:
@@ -114,8 +124,11 @@ When started with no arguments and no `copperline.toml` in the current directory
 Copperline displays the interactive launcher screen where you can configure
 machine models, memory, storage, and peripherals.
 
-The default configuration is an Amiga 500 (Rev 6A) with an OCS/ECS chipset,
-512 KiB chip RAM, 512 KiB slow RAM, and the bundled AROS Kickstart replacement.
+With no saved default, the launcher starts with an Amiga 500 (Rev 6A): ECS
+8372A Agnus, OCS 8362 Denise, 512 KiB chip RAM, 512 KiB slow RAM, and the
+bundled AROS Kickstart replacement. **Save default** remembers your settings
+for later launches. `--factory` ignores that saved default; an explicit
+`--config` or a local `copperline.toml` still takes precedence.
 
 To boot directly into a specific Kickstart ROM or configuration file:
 

--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -4,10 +4,11 @@ Copperline supports non-interactive, headless execution for continuous integrati
 automated regression testing, and scripted media capture. Headless runs execute
 unthrottled without creating a window or connecting to a display server.
 
-The exception to unthrottled, deterministic execution is when a physical floppy drive
-is attached via FluxBridge (see [Physical floppy drives](fluxbridge.md)): physical drives
-require real-time wall-clock pacing to match the mechanical drive spindle, and access
-external media that is not captured in emulator state.
+Physical floppy drives attached through [FluxBridge](fluxbridge.md) require
+wall-clock pacing. For repeatable captures, use image-backed media, a fixed
+RTC seed when a clock is fitted, and repeatable inputs. Live networking,
+serial or audio input, and changing host files also affect replay; see the
+[host boundary](../internals/architecture.md#determinism-and-the-host-boundary).
 
 ## Capturing screenshots
 
@@ -27,7 +28,10 @@ Multiple screenshots can be captured during a single execution by repeating the 
   --screenshot-after 60 /tmp/boss.png
 ```
 
-The process exits once the final requested screenshot has been saved.
+For a screenshot-only run, the process exits after the final screenshot.
+When combined with `--dump-frames`, the run exits as soon as either the frame
+dump or the screenshot schedule finishes. Use separate runs if both need
+to reach different end times.
 
 ## Dumping frame sequences
 
@@ -76,7 +80,7 @@ You can schedule keyboard, mouse, and joystick inputs at specific emulated times
 | `--pot-after SECS X Y [PORT]` | Set analogue paddle/pot position (0-255) (default port 2) |
 | `--insert-disk-after SECS DFN PATH` | Insert a disk image into `df0`..`df3` |
 | `--defer-disk-insert SECS DFN` | Delay insertion of configured disk until SECS |
-| `--insert-cd-after SECS PATH` | Swap CD image (`.cue`, `.iso`, `.chd`) in CD drive |
+| `--insert-cd-after SECS PATH` | Swap CD image (`.cue`, `.iso`, `.nrg`, `.chd`) in CD drive |
 | `--freeze-after SECS` | Trigger freezer cartridge button (`--cartridge hrtmon`): HRTMon takes over at SECS |
 | `--script FILE` | Execute script file containing input directives |
 | `--record-input PATH` | Record all inputs to script file on exit |
@@ -107,10 +111,12 @@ freeze-after 120.0
 Run with `--script`:
 
 ```sh
-./target/release/copperline --config myconfig.toml --script test.clscript --screenshot-after 100 /tmp/out.png
+./target/release/copperline --config myconfig.toml --noaudio --cartridge hrtmon \
+  --script test.clscript --screenshot-after 125 /tmp/out.png
 ```
 
 To record an interactive session to a script file:
+
 - Press `Cmd+Shift+R` (macOS) or `Alt+Shift+R` (Linux/Windows) in the emulator window.
 - Or launch with `--record-input /tmp/session.clscript`.
 
@@ -137,7 +143,9 @@ Use `--rtc-frozen` to hold the RTC at the initial seed without advancing.
   - `source`: Individual audio sources conditionally generated based on configured
     hardware: `DIR/paula.wav` and `DIR/drivesounds.wav` are always created, while
     `DIR/cdda.wav`, `DIR/mt32.wav`, `DIR/coppersynth.wav`, `DIR/toccata.wav`, and
-    `DIR/mhi.wav` are exported only when those sound devices are fitted.
+    `DIR/mhi.wav` depend on the configuration and compiled features. With
+    `--load-state`, additional source files are created because the restored
+    machine may have different hardware; unused sources produce silent files.
   - `channel`: Individual physical hardware channels (`DIR/paula-0.wav` through `DIR/paula-3.wav`).
 
 ## Benchmarking CPU performance
@@ -150,6 +158,9 @@ Measure host emulation throughput without rendering to a window:
 
 The emulator runs unthrottled for 30 emulated seconds, prints execution metrics
 (elapsed host time, emulated time, average FPS), and exits.
+
+`--benchmark-until` cannot be combined with scheduled screenshots, frame dumps,
+save-state writes, input events, floppy inserts, or input recording.
 
 ## Automated compatibility testing (vAmigaTS)
 
@@ -164,6 +175,7 @@ cargo test --release --test vamiga_ts -- --ignored --nocapture
 ```
 
 Test options:
+
 - `COPPERLINE_VAMIGATS_LIMIT=N`: Maximum tests to run.
 - `COPPERLINE_VAMIGATS_SECONDS=SECS`: Delay before screenshot (default: 9s).
 - `COPPERLINE_VAMIGATS_OUT=DIR`: Directory to save test screenshots.

--- a/docs/guide/import-uae.md
+++ b/docs/guide/import-uae.md
@@ -62,8 +62,11 @@ annotates the generated TOML file:
   limits, called out with the image's measured size where the file can be
   found), and FS-UAE hardfiles are flagged for manual placement on `[scsi]` or
   `[lide]`.
-- **Read-only hardfiles:** Copperline IDE hardfiles are read-write by default. To
-  enforce read-only access, adjust filesystem permissions on the host file.
+- **Read-only hardfiles:** Regular IDE/SCSI/`copperhf` hardfile images are opened
+  read-write; the converter cannot preserve UAE's read-only setting. Removing
+  host write permission makes the image fail to open. Use a disposable copy
+  when the original must be preserved. Live `[[filesys]]` directory mounts and
+  physical `[[host_disk]]` attachments have their own read-only settings.
 - **Relative paths:** Relative paths in UAE configurations are preserved as written.
   You may need to update paths to match your current working directory.
 - **Host-specific settings:** Display window dimensions, host vsync options, and host

--- a/docs/guide/mt32.md
+++ b/docs/guide/mt32.md
@@ -41,8 +41,8 @@ In `copperline.toml`:
 [serial]
 mode = "midi"
 midi_out = "mt32"
-mt32_control_rom = "~/Amiga/MT32_CONTROL.ROM"
-mt32_pcm_rom = "~/Amiga/MT32_PCM.ROM"
+mt32_control_rom = "/path/to/MT32_CONTROL.ROM"
+mt32_pcm_rom = "/path/to/MT32_PCM.ROM"
 mt32_panel = true          # Show front panel (default: false)
 mt32_lcd = "mt32"          # Display style: mt32, superjv, sseries, or oled
 ```
@@ -145,7 +145,7 @@ To exclude MT-32 support when compiling from source:
 
 ```sh
 cargo build --release --no-default-features \
-  --features "midi,frontend,wasm-boards,control,ctl-bin,net-nat,net-bridge,fluxbridge,coppersynth,cpu-jit,profile-stats,game-library,mhi,cd-mp3"
+  --features "midi,frontend,wasm-boards,control,ctl-bin,import-uae-bin,net-nat,net-bridge,fluxbridge,coppersynth,cpu-jit,profile-stats,game-library,mhi,cd-mp3,cd32-fmv,gdb,dap"
 ```
 
 ## Troubleshooting

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -178,8 +178,8 @@ The keyboard is the way to reach the keys a host keyboard has no
 equivalent of -- Help, both Amiga keys, and the `#`/`~` key beside Return --
 and the way to drive a session entirely with the mouse.
 
-- **Qualifiers latch.** A mouse has one button, so Ctrl, both Shifts, both
-  Alts and both Amiga keys stay down when you click them: click one and it
+- **Qualifiers latch.** To enter keyboard chords with sequential clicks,
+  Ctrl, both Shifts, both Alts and both Amiga keys stay down when clicked: click one and it
   is held for the next keystroke, then released with it. Click it twice in
   quick succession to lock it down until you click it again; click a locked
   one to let it go. Press and *hold* one instead, and it behaves like the
@@ -216,12 +216,13 @@ menu's font size (it follows *Menu Size*), refreshed twice a second:
 | `host 16%` | Share of host wall time spent emulating. In real-time mode this is the share of the frame budget (20.0 ms PAL, 16.7 ms NTSC) used per frame |
 | `audio 148 ms` | Live audio output lead -- the cushion that absorbs host scheduling hiccups (steady state is about 150 ms) |
 | `xrun 0` | Audio underrun frames per second: the audible symptom of the host falling behind |
-| `slip 0` | Times the pacer fell hopelessly behind real time (over ~100 ms, e.g. a host stall) and dropped emulated time instead of chasing it, since the last guest reset |
+| `slip 0` | Times the pacer reset its host-time target after exceeding the catch-up limit (for example, after a host stall), since the last guest reset |
 
 Copperline never skips frames to keep pace: when the host cannot sustain
 real time the machine slows down (fps and the speed factor fall below
-nominal while `host` sits near 100%), and only a stall beyond the pacer's
-catch-up limit drops emulated time, counted by `slip`. Under Warp Speed
+nominal while `host` sits near 100%). After a long stall, the pacer resets
+its host-time target and increments `slip`; guest execution continues from
+the same point. Under Warp Speed
 the presentation shows one frame per burst, but every emulated frame is
 still computed.
 
@@ -262,9 +263,9 @@ Disk images can be dropped anywhere on the emulator window:
   machine straight into the game through the [WHDLoad booter](whdload.md),
   keeping any explicit machine choices; dropped on the configuration
   screen they fill the **WHDLoad** page's game field instead.
-- **Hard disk images and Kickstart ROMs** cannot be swapped at runtime; a
-  notice points at the machine-configuration screen, which also refuses
-  such drops while it is open.
+- **Hard disk images and Kickstart ROMs** are not accepted as drops. Configure
+  hard disks in the machine-configuration screen. To replace a running
+  machine's ROM and cold-reset it, use **Load Kickstart ROM...** from the menu.
 
 The chooser opens after the drop rather than offering per-drive drop
 targets because the windowing layer reports file drops without a cursor
@@ -551,7 +552,7 @@ Shown only when something is on the port.
 ### Application controls
 
 - **Load Kickstart ROM...**: fit a different boot ROM. Pick a 512 KiB
-  Kickstart, then optionally a second file for the extended ROM (512 KiB at
+  Kickstart or a 256 KiB Kickstart 1.x image, then optionally a second file for the extended ROM (512 KiB at
   $E00000 or 256 KiB at $F00000; Cancel to skip and remove any fitted
   extended ROM). The machine then cold-resets, as if the chip had been
   swapped and the power cycled. The OSD names the image it fitted -- the

--- a/docs/guide/whdload.md
+++ b/docs/guide/whdload.md
@@ -43,7 +43,7 @@ with Copperline:
   secondary Kickstart image (typically 1.3) into memory during startup.
 
 Point `kickstarts` (or the launcher's **Kickstart ROMs** directory) to your ROM directory.
-Copperline identifies ROMs by cryptographic hash rather than filename, so filename
+Copperline identifies ROMs by their size and WHDLoad CRC-16 checksum, so filename
 conventions do not matter. Cloanto Amiga Forever ROM images (including encrypted `.rom`
 files with an accompanying `rom.key`) are supported.
 
@@ -72,8 +72,10 @@ args = "ButtonWait NoAutoVec"
 
 ## Machine selection
 
-By default (`machine_type = "auto"`), Copperline configures a standard A1200
-profile with 8 MiB fast RAM, which satisfies the vast majority of WHDLoad packages.
+With `machine_type = "auto"`, Copperline supplies an A1200 profile and 8 MiB
+fast RAM where the configuration has not already selected them. It checks
+the slave's requirements and warns if the declared expansion memory exceeds
+8 MiB. Larger packages may need more RAM.
 
 Explicit CLI overrides or configuration options take precedence:
 
@@ -82,6 +84,7 @@ copperline --whdload game.lha --model A4000
 ```
 
 In the launcher settings:
+
 - **Auto:** Automatically chooses machine parameters suitable for WHDLoad.
 - **Copperline:** Uses the specific machine model defined in your current configuration.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ abstract: |
   Copperline is an Amiga emulator (OCS, ECS, and AGA) written in Rust.
   This documentation covers running and configuring the emulator, setting up
   machines from the A500 to the A4000 and CD32, using expansion boards,
-  running headless test sessions, and exploring internal architecture.
+  running headless test sessions, and understanding the emulator's architecture.
 ---
 
 # Copperline
@@ -38,6 +38,7 @@ Spaceballs' *State of the Art* (1992) running in Copperline.
 - [](guide/coppersynth) -- Built-in General MIDI SoundFont synthesizer.
 - [](guide/modem) -- Hayes-compatible AT modem emulation over TCP.
 - [](guide/import-uae) -- Converting WinUAE, Amiberry, and FS-UAE configurations.
+- [](guide/winuae-state) -- Importing supported WinUAE save states and profiling resumed frames.
 - [](guide/headless) -- Scripted, non-interactive execution for automated testing and CI.
 - [](guide/browser) -- WebAssembly build and web integration details.
 - [](guide/publishing) -- Bundling standalone player packages for specific games.
@@ -46,12 +47,14 @@ Spaceballs' *State of the Art* (1992) running in Copperline.
   command-line, headless, and GDB debugging tools.
 - [](debugger/vscode) and [](debugger/vscode-bartman) -- VS Code setup, source debugging, and illustrated CPU/DMA and graphics profiling using the installable Bartman fork.
 - [](debugger/control) -- JSON-RPC control protocol (`copperline-ctl`) for automation, with an MCP server mode for coding agents.
+- [](debugger/dap) -- DAP launch, attach, stepping, and debug-information reference.
 - [](internals/architecture) -- Emulator internals and subsystem architecture.
 
 ## Core design principles
 
 1. **Hardware-accurate modeling.** Behavior is implemented according to chip
    specifications rather than application-specific hacks or game title detection.
-2. **Determinism.** The emulation core executes deterministically with respect to
-   emulated clock cycles and input events. Given identical media and inputs,
-   headless runs and interactive sessions produce identical results.
+2. **Determinism.** Given the same configuration, media, clock seed, and timed
+   inputs, the core produces the same results in headless and interactive runs.
+   Live host services, such as networking and physical drives, have separate
+   [replay limits](internals/architecture.md#determinism-and-the-host-boundary).

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -1,31 +1,19 @@
 # Architecture overview
 
-This chapter is the map; the following chapters zoom into the
+This chapter describes the source layout, frame loop, and host boundary.
+Related chapters cover the
 [timing model](timing.md), the [chipset modules](chipset.md), the
 [video pipeline](video.md), the [CPU integration](cpu.md), the
 [peripherals](peripherals.md), and the [save-state format](savestate.md).
 
 ## Source layout
 
-The debug-information loader maps ELF allocatable sections onto hunks in
-elf2hunk's section order. For relocatable ELF (`ET_REL`), whose sections can
-all have address zero, it assigns distinct internal 32-bit addresses and
-materializes DWARF and call-frame sections with `R_68K_32` / `R_68K_PC32`
-relocations applied. Section symbols and ordinary symbols retain their
-section identity; references to debug sections remain section offsets.
-RELA uses its explicit signed addend, while REL uses the stored big-endian
-word. These internal addresses map back to hunk offsets and then to the
-runtime bases reported by LoadSeg; guest memory is untouched. Linked ELF
-keeps its linker addresses and already-relocated section bytes, including
-when `--emit-relocs` retains relocation records. Unsupported relocations
-or invalid relocation targets/offsets produce a section-specific diagnostic.
-
 ```
 src/
-  main.rs           # thin CLI binary: config load, boot
+  main.rs           # native binary: config load, boot, execution-mode selection
   cli.rs            # binary-local command-line parser
   bin/bench.rs      # copperline-bench headless benchmark (native + wasm32-wasip1)
-  lib.rs            # the copperline library crate all of src/ lives in
+  lib.rs            # library entry point shared by native and browser frontends
   config/           # TOML config + validation + machine profiles
                     #   (mod.rs, raw.rs, validate.rs, resolve.rs, about.rs, tests.rs)
   envcfg.rs         # cached COPPERLINE_* environment-variable snapshot
@@ -66,6 +54,7 @@ src/
   a2091.rs          # A2091 SCSI controller board (DMAC + boot ROM)
   a4091.rs          # A4091 Zorro III SCSI-2 controller (NCR 53C710)
   scsi.rs           # WD33C93A SBIC + SCSI-2 disk targets
+  copperhf.rs       # virtual hardfile controller with ordered worker-thread I/O
   sdmac.rs          # A3000 Super DMAC fronting the WD33C93
   harddrive.rs      # shared hard-drive image backend (IDE + SCSI)
   dirfs.rs          # host directory -> in-memory FFS/OFS partition image
@@ -76,10 +65,10 @@ src/
   cdtv.rs           # CDTV DMAC + Matshita drive model
   akiko.rs          # CD32 Akiko (C2P, NVRAM, Chinon drive)
   cd32_fmv.rs       # CD32 FMV cartridge (CL450 video + L64111 MPEG audio)
-  rtc.rs            # MSM6242-compatible battery RTC
+  rtc.rs            # MSM6242 and RP5C01 battery RTCs
   serial.rs         # Paula serial sinks (stdout, TCP, pty)
   midi/             # host MIDI serial bridge (CoreMIDI / ALSA / WinMM)
-  audio.rs          # AudioSink trait + cpal/WAV/null outputs
+  audio/            # AudioSink outputs, source/stem mux, and resampler
   priority.rs       # opt-in realtime-like thread scheduling (pacer + audio)
   gamepad.rs        # gilrs input: database layout + calibration override
   screenshot.rs     # PNG export helpers
@@ -118,7 +107,7 @@ src/
     font.rs         # 8x8 overlay font
 crates/copperline-web/   # standalone wasm-bindgen browser frontend (WebEmu + page glue)
 crates/cputest-runner/   # WinUAE cputest instruction-suite runner for the m68k core
-tests/              # ignored integration tests (need local ROM assets)
+tests/              # self-contained integration tests and ignored local-asset tests
 timing-test/        # bootable cross-emulator timing-measurement disk
 ```
 
@@ -187,13 +176,12 @@ The flow of a frame:
    wall-clock; for headless captures it does not. The emulated result is
    identical either way -- pacing only schedules host work.
 
-So an interactive run uses three host threads: the **main thread** (event
-loop, core, and pacer), the **`copperline-render` worker**, and the
-**cpal audio callback** that cpal owns. Only the last two cross a thread
-boundary with the main thread, and both do so through an owned
-`RenderInput`/presentation-buffer envelope (with immutable shared frame
-snapshots) and a lock-free sample ring buffer rather than shared mutable
-state. The pacer and the audio callback are
+The main presentation path uses the **main thread** (event loop, core,
+and pacer), the **`copperline-render` worker**, and the **cpal audio
+callback**. Rendering passes owned buffers and immutable shared snapshots;
+audio passes samples through a lock-free ring buffer. Enabled devices and
+services can create additional workers, including copperhf file I/O and
+debugger socket handling. The pacer and the audio callback are
 latency-critical and can optionally be given above-normal scheduling priority
 (`[emulation] realtime_priority`, `src/priority.rs`); see
 [](timing) for what that does per platform.
@@ -210,13 +198,13 @@ The CPU-visible memory map:
 
 | Range | Contents |
 |---|---|
-| `$000000` - chip top | Chip RAM (512K-2M; ROM overlaid at `$0` after reset until CIA-A releases /OVL) |
+| `$000000` - chip top | Chip RAM (256K-2M; ROM overlaid at `$0` after reset until CIA-A releases /OVL) |
 | `$200000` - | Zorro II space (fast RAM autoconfig boards) |
 | `$A00000` / `$BFxxxx` | CIA-A (odd bytes, /LDS) and CIA-B (even bytes, /UDS) |
 | `$B80000` | Akiko (CD32 only) |
 | `$C00000` | Slow ("ranger") RAM, up to 512K |
 | `$DA0000` / `$DE1000` | Gayle IDE task file / Gayle ID and status (A600/A1200) |
-| `$DC0000` | Battery RTC (MSM6242 view) |
+| `$DC0000` | Battery RTC (MSM6242 or RP5C01, according to configuration) |
 | `$DFF000` | Custom-chip register window |
 | `$E80000` | Zorro autoconfig window (then CDTV DMAC first on CDTV) |
 | `$E00000` / `$F00000` | Extended ROM (CD32 / CDTV) |
@@ -264,20 +252,27 @@ a residue; see the TODO in `read_custom_word`.
 
 ## Determinism and the host boundary
 
-The core's only inputs are the config, the loaded images, and the
-timestamped input events (host keyboard/mouse/gamepad in windowed runs;
-`--press-after`-style scripted events in headless runs). Audio is rendered
-in emulated time and resampled at the host boundary; wall-clock affects
-scheduling only. This is what makes `--screenshot-after` runs exactly
-reproducible, lets the headless debugger replay a failure
-deterministically, and makes [save states](savestate) exact: a restored
-run is byte-identical to one that was never interrupted.
+With fixed configuration, media, clock seeds, and timestamped inputs,
+the core advances deterministically. Audio is generated in emulated time;
+window pacing and render-worker scheduling do not change the guest timeline.
+This supports repeatable headless captures and snapshot replay.
 
-The one host-clock value that reaches emulated state is the battery RTC: a
-guest that reads it (`$DC0000`) sees the host date and time, so RTC reads
-are not reproducible across wall-clock runs. `COPPERLINE_RTC_FIXED_SECS=`
-*unix-seconds* pins the clock to a fixed value, which is what makes
-differential traces against another emulator line up.
+Host services can supply additional inputs or retain effects outside a
+snapshot:
+
+- A fitted RTC reads the host's local time unless seeded with
+  `[machine] rtc_time` / `--rtc-time`. A seed advances in emulated time;
+  `--rtc-frozen` holds it constant. `COPPERLINE_RTC_FIXED_SECS` is the
+  older fixed-UTC override.
+- Live host-directory mounts expose file contents and timestamps. File-backed
+  hard disks and physical disks retain writes made after a snapshot.
+- Network, serial, MIDI, and sampler input can depend on external devices
+  or services. Physical floppy drives also require wall-clock pacing.
+
+Use fixed image files and scripted inputs for deterministic regression
+tests. See [save-state boundaries](savestate.md#determinism-boundaries) for
+what a restore can reproduce. Some audio decoders also have
+[platform-dependent floating-point rounding](mhi.md#copperline-implementation-notes).
 
 ### Input scripting and recording (`inputrec.rs`)
 
@@ -287,9 +282,10 @@ The input recorder (window shortcut / `--record-input`) produces those
 scripts from a live session by combining two capture styles: direct
 hooks where event identity matters (the keyboard choke point
 `handle_amiga_key_event`, floppy inserts) and a once-per-quantum diff of
-the live `InputState` for port-1 mouse buttons, mouse motion (wrapped
-quadrature-counter deltas become `mouse-after` directives), and the
-port-2 joystick/CD32 pad. Two details keep record-then-replay
+the live `InputState` for each port's configured device: mouse buttons and
+motion, joystick/CD32 controls, or analogue positions. Wrapped quadrature
+counter deltas become `mouse-after` directives. Port-device changes themselves
+are not recorded, so replay must use the same port configuration. Two details keep record-then-replay
 byte-identical: recorded timestamps are the emulated times the events
 were *applied* (frame boundaries, not the wall-clock moment the host
 delivered them), and times/holds are floored -- never rounded -- to
@@ -298,6 +294,23 @@ replayed event one frame late. The end-to-end gate is the same as for
 save states: record a scripted run, replay the recording, `cmp` the
 screenshots. User-facing usage is in
 [Input recording and scripts](../guide/headless.md#input-recording-and-script-files).
+
+## Guest debug information
+
+The debug-information loader maps ELF allocatable sections onto hunks in
+elf2hunk's section order. For relocatable ELF (`ET_REL`), whose sections can
+all have address zero, it assigns distinct internal 32-bit addresses and
+materializes DWARF and call-frame sections with `R_68K_32` / `R_68K_PC32`
+relocations applied. Section symbols and ordinary symbols retain their
+section identity; references to debug sections remain section offsets.
+RELA uses its explicit signed addend, while REL uses the stored big-endian
+word. These internal addresses map back to hunk offsets and then to the
+runtime bases reported by LoadSeg; guest memory is untouched. Linked ELF
+keeps its linker addresses and already-relocated section bytes, including
+when `--emit-relocs` retains relocation records. Unsupported relocations
+or invalid relocation targets/offsets produce a section-specific diagnostic.
+See the [DAP reference](../debugger/dap.md#debug-information) for supported
+toolchains and variable-location expressions.
 
 ## envcfg: environment variables are start-up settings
 

--- a/docs/internals/audio.md
+++ b/docs/internals/audio.md
@@ -1,30 +1,20 @@
 # Audio sink service (`src/audio/`)
 
-`src/audio/` is a directory module: `mod.rs` holds the host-facing sink
-implementations (`AudioSink`, `NullSink`, `CpalSink`, `WavSink`), and
-`mux.rs` holds `AudioMux`, the fan-out point every emulated audio producer
-feeds. This page describes the mux/stem-capture layer; the underlying
-mixing arithmetic (channel routing, the LED filter, master volume, stereo
-width) is unchanged and still lives in `Paula::push_mixed_frame`
-(`src/chipset/paula.rs`; see [](chipset.md) for the Paula audio model).
+`src/audio/mod.rs` defines the host-facing sinks (`AudioSink`, `NullSink`,
+`CpalSink`, and `WavSink`). `src/audio/mux.rs` defines `AudioMux`, which
+routes the master mix and individual sources to playback or WAV capture.
+Mixing, LED filtering, volume, and stereo width are applied in
+`Paula::push_mixed_frame` (`src/chipset/paula.rs`).
 
-## Why a mux exists
+(why-a-mux-exists)=
+## Mixing and capture
 
-Every audio-producing device -- Paula's four channels, floppy drive
-noises, CD-DA, the in-process MT-32 synth -- has always been summed inline
-inside `push_mixed_frame` and handed to a single `AudioSink`: live
-playback (`CpalSink`), a mixed-master WAV capture (`WavSink`,
-`--audio-wav`), or nothing (`NullSink`, `--noaudio`). `AudioMux` sits
-between that summation and the sink, without changing it: `Paula::audio`
-is now an `AudioMux` instead of a bare `Box<dyn AudioSink>`, and
-`push_mixed_frame`'s tail calls `push_master`/`push_source`/
-`push_source_channel` instead of pushing straight into the sink. This is
-what lets `--audio-stems` capture the same signal at finer granularity
-with no change to the mixing math, and is the seam boards register
-through as just another named source: the MacroSystem Toccata
-(`src/toccata.rs`, [](toccata.md)) was the first, feeding a `"toccata"` tap
-the same way CD-DA and MT-32 do; the MHI virtual MPEG decoder board
-(`src/mhi.rs`, [](mhi.md)) feeds a `"mhi"` tap the same way.
+`Paula::audio` owns an `AudioMux`. The mixer calls `push_master` for the
+final stereo output, `push_source` for individual devices, and
+`push_source_channel` for Paula's four channels. The master sink selects
+live playback (`CpalSink`), a mixed WAV (`WavSink`, `--audio-wav`), or no
+output (`NullSink`, `--noaudio`). Optional stem writers capture the source
+taps alongside it.
 
 ## The taps
 
@@ -44,12 +34,8 @@ the master mix -- see each entry):
 | `mhi` | One frame popped from `MhiAudioRing` | Already resampled to the mixer rate by the board's own tick; see [](mhi.md) |
 
 The **master** signal (`push_master`) is the final `out_left`/`out_right`
-after master volume and stereo width -- unchanged from what every sink has
-always received, live or `--audio-wav`. This is a structural guarantee,
-not a tested-and-hoped-for one: nothing about the mixing arithmetic
-changed when the mux was introduced, only what happens to the two f32
-values once they're computed, so a `--audio-wav` capture from before and
-after the mux is byte-identical.
+after master volume and stereo width. Live playback and `--audio-wav`
+receive these same samples.
 
 ## Stem capture (`--audio-stems`)
 
@@ -62,68 +48,42 @@ for whichever files the selected `StemGranularity` values and registered
 - `Master` -- `DIR/master.wav`.
 - `Source` -- `DIR/{id}.wav` for each registered source.
 - `Channel` -- `DIR/{id}-{channel}.wav` for each named sub-channel of each
-  registered source. Deliberately never implied by `Source` alone.
+  registered source. Select `Channel` explicitly; `Source` does not include it.
 
-**Source registration is a one-time, config-driven decision**, made in
-`main.rs::configured_audio_stem_sources` right after the machine is built,
-not inferred from whether a source stays silent during the run. `paula`
-and `drivesounds` always register (`drivesounds` simply produces a silent
-stem when `[audio] floppy_sounds = false`, the same as a disabled
-`DriveSounds` today); `cdda`, `mt32` and `coppersynth` register only when this
-run's config plausibly produces them:
+`main.rs::configured_audio_stem_sources` selects sources once at startup:
 
-- `cdda`: a CD32/CDTV machine profile, a configured CD image (`[cd]
-  image` / `cd_image_path`), or a CD image on any `[ide]`/`[lide]`/
-  `[scsi]` drive slot (the same `is_cd_image_path` test
-  `open_ide_target`/`open_scsi_target` use to attach one as an
-  ATAPI/SCSI CD-ROM).
-- `mt32`: `[serial] midi_out = "mt32"` with both `mt32_control_rom` and
-  `mt32_pcm_rom` set.
-- `coppersynth`: `[serial] midi_out = "coppersynth"` in a build carrying
-  the `coppersynth` feature -- it needs no files, so naming it is enough.
+- `paula` and `drivesounds` always register. Disabled drive sounds produce
+  a silent stem.
+- `cdda` registers for CD32/CDTV, a configured `[cd] image`, or a CD image
+  attached through IDE, LIDE, or SCSI.
+- `mt32` registers when selected as MIDI output and both ROMs are configured
+  or remembered from menu selections.
+- `coppersynth` registers when selected and the build includes the feature.
+- `toccata` and `mhi` register when their boards are configured.
 
-This is a **heuristic, not an exhaustive detector** -- a CD swapped into
-an initially empty drive mid-run (`--insert-cd-after`, a control-protocol
-`media` command) is missed, and `cdda.wav` simply won't be written for
-that run even though the hardware ends up producing CD audio. Replacing
-the config test with a query against the actually-built machine is a
-reasonable follow-up if it turns out to matter in practice; it was kept
-config-side for this milestone since getting it exactly right needs
-reaching into feature-gated MIDI/MT-32 construction code that doesn't
-otherwise need to be duplicated in `main.rs`.
-
-A source's stem writer, once opened, is fed unconditionally by
-`push_source`/`push_source_channel` -- there is no per-frame silence
-detection or file cleanup. The one-time registration above is the entire
-mechanism; `AudioMux` itself doesn't know or care why a source was or
-wasn't registered.
+With `--load-state`, all seven sources register because restored hardware
+can differ from the startup configuration. Unused sources produce silent
+files. Registration does not change during capture: adding a source later
+will not create a missing stem writer.
 
 ## Determinism
 
-Every push into `AudioMux` -- master or stem -- originates from
-`Paula::advance_audio`'s emulated-color-clock accumulator, exactly like
-the pre-mux mixing path. Nothing about stem capture depends on wall-clock
-time, so it is warp-safe (a warped run renders the same sample stream
-faster, not differently) and reproducible: two runs of the same scenario
-produce byte-identical stem directories, which is what
-`tests/audio_stems_determinism.rs` checks by reading every file from two
-runs' output directories and comparing the bytes directly.
+`Paula::advance_audio` schedules master and stem samples in emulated time.
+Warp changes host pacing without changing that schedule.
+`tests/audio_stems_determinism.rs` compares the output files from repeated
+runs. Reproducibility still depends on repeatable source input; see the
+[host boundary](architecture.md#determinism-and-the-host-boundary) and
+[MHI's floating-point limits](mhi.md#copperline-implementation-notes).
 
 ## Savestates
 
-`Paula::audio: AudioMux` is `#[serde(skip)]`, same as the `Box<dyn
-AudioSink>` it replaced -- host output (live or file-backed) is not part
-of the emulated machine. `Bus::adopt_host_resources` moves the whole
-`AudioMux` (master sink *and* any open stem writers) across a save-state
-load with `std::mem::swap`, so a capture in progress keeps writing into
-the same open file handles across a `--load-state`, exactly as a
-`--audio-wav` capture already did before this change.
+`Paula::audio: AudioMux` is skipped by serde because it is host output.
+`Bus::adopt_host_resources` moves the live mux, including open stem writers,
+onto the restored Bus. A capture therefore continues in the same files
+across a save-state load.
 
 ## Web build
 
-`AudioMux` and the stem-writer code are platform-agnostic and compile
-unconditionally, same as `WavSink` (`hound`/`std::fs` were never gated
-behind the `frontend` feature). `--audio-stems` is a native-only CLI
-flag; the web frontend (`crates/copperline-web`) simply never calls
-`enable_stems`, so `WebAudioSink` runs as the mux's master sink with no
-stem writers, unaffected.
+`AudioMux` and the stem-writer code compile without the `frontend` feature.
+The browser wrapper uses `WebAudioSink` as the master sink and does not
+call `enable_stems`; `--audio-stems` is available through the native CLI.

--- a/docs/internals/copperhf.md
+++ b/docs/internals/copperhf.md
@@ -1,24 +1,18 @@
 # copperhf.device: register protocol and boot ROM
 
-This page documents Copperline's virtual hardfile controller,
-`copperhf.device` (`[copperhf]` in the config, `src/copperhf.rs`), and its
-guest-side boot ROM (`guest/copperhf/`). The authoritative register map is
-`guest/copperhf/copperhf_board.h`, shared verbatim (by hand-kept convention,
-like every other virtual board in this project) between the Rust host side
-and the 68k guest side; this page summarizes it and adds the milestone
-status and the device stub's behaviour, which the header does not cover.
-Where this page and the header disagree, the header wins for register
-semantics -- fix whichever drifted.
-
-See `COPPERHF-DEVICE-PLAN.md` in the repository root for the full milestone
-plan this board is being built against.
+Copperline's virtual hardfile controller exposes seven units through
+`copperhf.device` (`[copperhf]`, `src/copperhf.rs`). The guest boot ROM lives
+in `guest/copperhf/`. This chapter describes the register protocol, device
+vectors, autoboot mounter, and asynchronous I/O. Register constants are
+maintained in both the Rust implementation and
+`guest/copperhf/copperhf_board.h`; keep them consistent when changing the ABI.
 
 ## Zorro identity
 
 - Zorro II slave, one 64 KiB register/ROM window.
 - Manufacturer **5192** / `0x1448` (the Copperline manufacturer ID; see
   [](../zorro)), product **8**.
-- Autoboot ROM present as of M2: `er_InitDiagVec` points at a DiagArea
+- Autoboot ROM: `er_InitDiagVec` points at a DiagArea
   embedded in the ROM (`guest/copperhf/entry.s`'s `_diag_area`), so the
   board appears in `FindConfigDev` scans and its Romtag is picked up by
   Kickstart's cold-start resident scan like any other autoboot device.
@@ -48,25 +42,25 @@ Rust constant and the ROM's own layout cannot silently drift apart.
 
 See `guest/copperhf/copperhf_board.h` for the full, authoritative table
 (offsets, widths, access, and the exact doorbell/completion/ACK protocol
-description). In summary:
+description):
 
 | Register | Offset | Width | Access | Meaning |
 |---|---|---|---|---|
 | `CHF_MAGIC` | 0x4000 | 32 | RO | `"CPHF"` (0x43504846) |
-| `CHF_VERSION` | 0x4004 | 16 | RO | register-protocol version (2 as of M4) |
+| `CHF_VERSION` | 0x4004 | 16 | RO | register-protocol version (2) |
 | `CHF_UNITS` | 0x4006 | 16 | RO | unit slot count (7) |
 | `CHF_UNIT_PRESENT` | 0x4008 | 16 | RO | bit *n* set = unit *n* configured (a slot stays present after its media is ejected/hot-detached -- see `CHF_UNIT_MEDIA`) |
-| `CHF_UNIT_RDONLY` | 0x400A | 16 | RO | bit *n* set = unit *n* read-only (always 0 through M4 -- see the header's own comment) |
+| `CHF_UNIT_RDONLY` | 0x400A | 16 | RO | bit *n* set = unit *n* read-only (always 0; read-only hardfiles are not implemented) |
 | `CHF_UNIT_SELECT` | 0x400C | 16 | RW | selects the unit `CHF_CHANGE_COUNT`/`CHF_UNIT_BLOCKS` report on |
 | `CHF_CHANGE_COUNT` | 0x400E | 16 | RO | disk-change counter of the selected unit |
 | `CHF_UNIT_BLOCKS` | 0x4010 | 32 | RO | total 512-byte blocks of the selected unit |
-| `CHF_CHANGED_MASK` | 0x4014 | 16 | RO | M4: bit *n* set = unit *n*'s media changed (eject, hot attach/detach) and the guest has not yet acked it |
-| `CHF_CHANGED_ACK` | 0x4016 | 16 | WO | M4: write a mask; clears those `CHF_CHANGED_MASK` bits |
-| `CHF_UNIT_MEDIA` | 0x4018 | 16 | RO | M4: bit *n* set = unit *n* currently has media (distinct from `CHF_UNIT_PRESENT`, "slot configured") |
-| `CHF_DOORBELL` | 0x4020 | 32 | WO | guest pointer to an IOStdReq; enqueues it (executed synchronously through M4, asynchronously on a worker thread as of M5 -- see "Asynchronous I/O (M5)" below; the guest-visible protocol is unchanged) |
+| `CHF_CHANGED_MASK` | 0x4014 | 16 | RO | bit *n* set = unit *n*'s media changed (eject, hot attach/detach) and the guest has not yet acked it |
+| `CHF_CHANGED_ACK` | 0x4016 | 16 | WO | write a mask; clears those `CHF_CHANGED_MASK` bits |
+| `CHF_UNIT_MEDIA` | 0x4018 | 16 | RO | bit *n* set = unit *n* currently has media (distinct from `CHF_UNIT_PRESENT`, "slot configured") |
+| `CHF_DOORBELL` | 0x4020 | 32 | WO | guest pointer to an IOStdReq; queues work for ordered completion at the next board tick |
 | `CHF_COMPLETE_GET` | 0x4028 | 32 | RO | oldest completed request pointer, 0 if empty (idempotent -- does not pop) |
 | `CHF_COMPLETE_ACK` | 0x402C | 16 | WO | any write pops the oldest completion |
-| `CHF_IRQ_STATUS` | 0x4030 | 16 | RO | bit 0 = completion queue non-empty; bit 1 (M4) = `CHF_CHANGED_MASK` non-zero |
+| `CHF_IRQ_STATUS` | 0x4030 | 16 | RO | bit 0 = completion queue non-empty; bit 1 = `CHF_CHANGED_MASK` non-zero |
 | `CHF_IRQ_ENABLE` | 0x4032 | 16 | RW | bit 0 = enable INT2 while `CHF_IRQ_STATUS` is non-zero, any bit (reset: 0) |
 
 `io_Unit` on a request is the raw copperhf unit **number** (0..6), not a
@@ -76,8 +70,8 @@ the guest side.
 A unit's boot-time `[copperhf]` config attach bumps neither
 `CHF_CHANGE_COUNT` nor `CHF_CHANGED_MASK`: a unit configured before the
 guest ever booted has never changed from the guest's point of view, and
-every M1-M3 guest build predates the changed-mask protocol entirely and
-never acks it -- flagging one at boot would latch `CHF_IRQ_STATUS` bit 1
+older guest drivers predate the changed-mask protocol and
+never acknowledge it -- flagging one at boot would latch `CHF_IRQ_STATUS` bit 1
 (and, once the guest enables `CHF_IRQ_ENABLE`, INT2 itself) permanently
 set. Only a *runtime* change -- the guest's own `TD_EJECT`, or a hot
 attach/detach through the control protocol
@@ -86,7 +80,7 @@ either register.
 
 ### Commands
 
-| Command | Value | M4 semantics |
+| Command | Value | Semantics |
 |---|---|---|
 | `CMD_READ` | 2 | read; `IOERR_BADADDRESS` (no wrap) if `io_Offset + io_Length` overflows 32 bits |
 | `CMD_WRITE` | 3 | write, same overflow rule |
@@ -130,8 +124,7 @@ CONDITION, `scsi_SenseData` is filled too when `scsi_Flags` requests
 
 ## The device stub (`guest/copperhf/`)
 
-M2 adds a boot ROM containing a working `copperhf.device` exec-device
-stub, built from:
+The boot ROM contains an Exec device built from:
 
 - `entry.s` -- entry table, DiagArea, and Romtag (`rt_Type = NT_DEVICE`).
   Follows the same PC-relative discipline and DiagPoint/rt_Init deferral
@@ -156,117 +149,57 @@ stub, built from:
 
 `BeginIO` never calls `ReplyMsg` itself: it clears `IOF_QUICK`, writes 0 to
 `io_Error`, and rings `CHF_DOORBELL` with the request pointer as a single
-32-bit write. Through M4 the host-side protocol executed the request
-synchronously (before `CHF_DOORBELL`'s write instruction even retired), but
-the guest was never told that -- it always waited for the INT2 completion
-drain, exactly as it would against genuinely asynchronous hardware. M5 (see
-below) makes that host side actually asynchronous, on a worker thread; the
-guest-visible protocol -- this section included -- is unchanged.
+32-bit write. The request completes through the INT2 handler after the
+host worker has finished and the board applies its result.
 
-## Asynchronous I/O (M5)
+(asynchronous-io-m5)=
+## Asynchronous I/O
 
-As of M5, `CHF_DOORBELL` no longer executes a request inline. The board
-splits each request into a doorbell-time half and a drain-time half:
+Each request passes through three stages:
 
-- **Doorbell time** (`CopperhfBoard::dispatch_request`, on the emulation
-  thread): read the `IOStdReq` header back out of guest memory, validate
-  the unit/range against board-cached state (`present`/`media`/
-  `total_sectors`, kept in sync with the worker's own unit table by the
-  quiesce rule below), copy `CMD_WRITE`/`TD_WRITE64`-style write payloads
-  *out* of guest memory into an owned buffer, and hand the job to the
-  worker over a bounded channel (`WORKER_QUEUE_CAPACITY`, 64 requests). A
-  request with no file I/O and no unit-table dependency (`TD_MOTOR`,
-  `TD_GETGEOMETRY`, `TD_CHANGENUM`/`CHANGESTATE`/`PROTSTATUS`, `TD_SEEK64`,
-  `CMD_CLEAR`, anything unrecognized) still takes a slot in the same
-  in-order queue, answered later from board-cached state rather than the
-  worker. Nothing at doorbell time ever writes a guest-visible result or
-  pushes a completion.
-- **Worker thread**: owns the real backing files (`units:
-  Arc<Mutex<[Option<ScsiDisk>; NUM_UNITS]>>`) and does the actual sector
-  read/write/SCSI-CDB work off the emulation thread, one single-threaded
-  FIFO worker per board, replying on its own result channel in the same
-  order jobs were sent.
-- **Drain time** (`tick`, on the emulation thread, called every scheduler
-  tick): pop the oldest in-flight request and block on the worker's result
-  channel until *that* request's result has arrived, then apply every
-  guest-visible effect -- `io_Error`/`io_Actual`, read data copied back
-  into guest memory, the pointer pushed onto `CHF_COMPLETE_GET`'s queue,
-  `TD_EJECT`'s media-mask/change-counter bookkeeping, and INT2 -- and
-  repeat until nothing already queued as of this tick remains in flight.
+1. **Doorbell** (`dispatch_request`, on the emulation thread): validate the
+   request against cached unit state and copy any write payload out of guest
+   RAM. Submit file I/O to the worker through a bounded channel (64 requests).
+   Requests answered from cached state join the same ordered completion queue.
+2. **Worker**: one FIFO worker per board performs sector reads, writes, and
+   SCSI commands using its backing files. It never accesses guest memory.
+3. **Drain** (`tick`, on the emulation thread): wait for each queued result in
+   order, copy read data into guest RAM, update `io_Error`/`io_Actual`, enqueue
+   the completion pointer, and raise INT2. Media changes are applied in the
+   same order.
 
 ### The determinism model
 
-The core invariant (spelled out in full in `src/copperhf.rs`'s own module
-doc, which this section summarizes): every guest-visible effect of a
-request lands at an emulated time that is a pure function of emulated
-time, never of how fast the worker thread's file I/O happened to run on
-this particular invocation. This holds because a request's due time is, by
-construction, "the first `tick()` call after its own doorbell write" --
-`tick` always blocks on the worker until every request already in flight
-*when tick runs* has actually delivered its result, so a slow disk costs
-host wall-clock time inside that block, not a shift in which emulated tick
-the completion becomes visible at. The bus calls each board at every
-timed-device boundary and samples its IRQ line after that call; Copperhf
-completion uses that tick boundary. All requests -- I/O and
-board-answered alike -- ride one FIFO pipeline end to end (one
-doorbell-ordered queue on the board, matched positionally against the
-worker's own strictly-ordered output), so completions surface in doorbell
-order exactly as M1-M4. `TD_EJECT` is the one command whose *decision*
-(`io_Length != 0`) is made at doorbell time, since that only reads a
-guest-supplied field that cannot change out from under it, but whose
-*execution* (dropping the worker's file handle) is deferred to the
-worker's own queue position, so it can never race file I/O already queued
-against the same unit.
+A request completes on the first board `tick()` after its doorbell write.
+The tick waits for the worker result, so slow host I/O delays the host
+without changing the emulated completion time. The bus samples the board's
+IRQ after that tick. File-I/O and board-answered requests share one FIFO,
+preserving doorbell order.
 
-The doorbell-to-worker channel is bounded (backpressure, not an unbounded
-queue): if the guest floods doorbells faster than the worker drains them,
-the doorbell write itself blocks the emulation thread briefly. This stays
-deterministic-safe because the worker thread never calls back into the
-emulation thread and never waits on anything but its own job queue and its
-own file I/O -- it cannot need the emulation thread to make progress, so
-the emulation thread blocking on it cannot deadlock.
+`TD_EJECT` records the guest's requested action at doorbell time, then
+closes the backing file at its position in the worker queue. It cannot
+race earlier I/O on that unit.
 
-The browser build has no threads (`std::thread::spawn` fails at runtime on
-`wasm32-unknown-unknown`), so there the "worker" runs each job inline at
-dispatch time and buffers its result for the drain -- same FIFO pipeline,
-same call sites, zero concurrency, determinism trivially intact.
+A full worker channel blocks the emulation thread until space is available.
+The worker never calls back into emulation, so it can continue draining
+jobs while emulation waits. In the browser build, jobs run inline and their
+results wait in the same completion queue until the next tick.
 
 ### Quiesce-on-save
 
-The worker thread owns the real file handles, so a save state (or a
-runtime unit mutation) must never race the worker's own view of the unit
-table. `CopperhfBoard::quiesce` blocks until every in-flight request has
-surfaced -- the same drain loop `tick` runs, just repeated until the
-pipeline is empty -- and is a no-op when nothing is in flight.
-`Bus::copperhf_quiesce` calls it on whichever `[copperhf]` board is
-configured; `Emulator::save_state`/`save_state_bytes` call that
-unconditionally before serializing (both methods take `&mut self` as of
-M5, to allow it), and the CCP `copperhf.attach`/`copperhf.eject` handlers
-(`src/control/exec.rs`) call it before touching a unit, matching
-`attach_unit`/`hot_attach_unit`/`eject_unit`'s own precondition that the
-pipeline is already empty. There is no windowed-UI menu row or drag-and-drop
-path onto a `[copperhf]` unit -- a running unit's media only changes through
-`copperhf.attach`/`copperhf.eject` over the control protocol -- but a
-windowed session surfaces that CCP-initiated change with an on-screen notice
-the same way it does any other host-initiated media swap (see
-`docs/guide/ui.md`). A save state is therefore always captured with
-an empty copperhf pipeline, so resuming it reproduces an uninterrupted
-run's history byte-for-byte -- the same save-state contract every other
-board on this project holds to (`AGENTS.md`'s "Save states"), just with an
-explicit drain step to get there instead of nothing-in-flight-by
-construction. The state format version this landed at (`src/savestate.rs`'s
-own changelog names the exact number, since it has shifted at each
-upstream merge since) reflects this: `CopperhfBoard` gained a cached
-per-unit `total_sectors` field alongside its existing per-unit state,
-always serialized quiesced.
+`CopperhfBoard::quiesce` drains all in-flight work before a save or media
+change. `Emulator::save_state` and `save_state_bytes` call it before
+serialization; the `copperhf.attach` and `copperhf.eject` control methods
+call it before changing a unit. Snapshots therefore contain an empty work
+queue and the resulting guest-visible state, including cached unit sizes.
 
-`tests/copperhf_m5.rs` pins both properties end to end against a real AROS
-boot that drives dense doorbell traffic (the M3 RDSK/PART mounter walk
-plus the OFS Startup-Sequence's bootmark write): repeated boots of the
-identical scenario must produce byte-identical mid-boot save states and
-final screenshots, and a state saved mid-boot (deliberately inside the
-busy mounter/Startup-Sequence I/O window) must resume byte-identical to an
-uninterrupted run.
+Runtime media changes use the control protocol. There is no window menu or
+drag-and-drop target for copperhf units, though a windowed session displays
+an on-screen notice when CCP changes a unit.
+
+`tests/copperhf_m5.rs` checks ordered asynchronous I/O, repeated-boot
+save-state and screenshot equality, and resumption from a save made during
+boot-volume I/O.
 
 `Open` fails with `IOERR_OPENFAIL` unless the requested unit is below
 `CHF_UNITS` and its `CHF_UNIT_PRESENT` bit is set; on success it sets
@@ -274,72 +207,34 @@ uninterrupted run.
 `io_Error` to 0. `Close` decrements the open count and never expunges --
 this is a ROM-resident device, so `Expunge` unconditionally refuses
 (returns 0) regardless of open count. `AbortIO` always reports
-`IOERR_NOCMD`: by the time a client could call it, the synchronously
-executed request has either already completed or is a doorbell-write away
-from doing so, so there is never anything left to actually cancel.
+`IOERR_NOCMD`; cancellation is not implemented, so queued work continues
+to completion.
 
 The stub is V34-clean: no V36+ exec/expansion calls anywhere on this path,
 68000-only instructions, word-aligned structures throughout.
 
-## Milestone status
+(milestone-status)=
+## Autoboot and integration coverage
 
-- **M1** (committed): board, register protocol, `[copperhf]` config,
-  synchronous I/O. No boot ROM.
-- **M2** (committed): boot ROM with a working device stub, as described
-  above. A program that already knows the device's name can
-  `OpenDevice("copperhf.device", unit, ...)` and drive it.
-- **M3** (this page): the boot ROM's mounter (`guest/copperhf/mounter.c`):
-  a polled-I/O RDSK/PART walk building a `DeviceNode` +
-  `FileSysStartupMsg` + `DosEnvec` per partition, added via `AddBootNode`
-  (V36+) or the hand-built `eb_MountList` fallback (V34), plus FSHD/LSEG
-  loading into `FileSystem.resource` -- so attached units autoboot and
-  mount like `[ide]`/`[scsi]`/`[lide]` units do.
-- **M4** (this page): TD64/NSD/`HD_SCSICMD` command coverage and disk-change
-  handling, as described above. Hot attach/detach is also exposed over the
-  control protocol -- `copperhf.attach`/`copperhf.eject`
-  ([](../debugger/control)) -- for scripts and agents to swap a unit's media
-  at runtime the same way `TD_EJECT` does from the guest side.
-- **M5** (this page): asynchronous I/O on a worker thread, as described in
-  "Asynchronous I/O (M5)" above -- deterministic completion timing, a
-  bounded doorbell-to-worker channel, and quiesce-on-save/quiesce-on-hot-
-  mutate. The guest-visible protocol is unchanged from M4 (see the
-  `BeginIO`/INT2 note above).
-- **M6** (this page): the integration matrix, split across two test files
-  (`tests/README.md` has the full asset/gate rundown):
-  - `tests/copperhf_m6.rs` -- default-CI, bundled AROS, no local assets: a
-    hand-built RDB whose FSHD/LSEG chain carries a self-checking synthetic
-    fixture binary (`guest/copperhf-test/lsegfix`) proves
-    `guest/copperhf/mounter.c`'s FSHD/LSEG loader end to end (FileSystem.
-    resource entry, seglist walk, a called-and-verified relocation
-    self-test, and the mounted DeviceNode's patched fields) without
-    needing any licensed filesystem binary. This is the milestone's
-    stand-in for the FFS-from-LSEG axis in default CI. Building it did
-    exactly the job it exists to do: its first runs caught three real,
-    previously-unexercised `mounter.c` bugs (forward-referencing
-    relocations always failed because hunks were allocated lazily; an
-    even-length partition name left the FileSysStartupMsg odd-aligned and
-    address-faulted the 68000; `ADNF_STARTPROC`/`ConfigDev` were passed
-    for non-bootable partitions against the autodoc's documented
-    behaviour), all fixed at the site in `mounter.c`.
-  - `tests/copperhf_kickstarts.rs` -- `#[ignore]`d, real Kickstart 1.3/
-    3.1/3.2 ROMs: {RDB, RDB-less} x plain-OFS autoboot for each ROM (3.1/
-    3.2 verified structurally via the same bootmark trick as `tests/
-    copperhf_mounter.rs`; 1.3 has no ROM-resident `Echo`, so it is
-    verified by golden screenshot of the resulting CLI prompt instead --
-    genuinely exercising the V34 `AddDosNode`/`eb_MountList` fallback
-    path for the first time, which had never run before this milestone
-    since no earlier copperhf test booted Kickstart 1.3 from a copperhf
-    unit at all); an FFS-from-LSEG axis against Kickstart 3.1 using a real
-    `FastFileSystem` binary tagged DOS\3 (FFS+INTL is not ROM-resident on
-    3.1, unlike DOS\0/DOS\1, so this is the one dostype that actually
-    forces the LSEG path to run against real filesystem code); and a
-    deliberately narrow-scoped PFS3-DS axis that only proves a >4 GiB
-    LSEG-attached unit doesn't crash or hang the boot, not a full
-    format-and-mount (see that test's own header comment and `tests/
-    README.md` for the reasoning and the manual smoke-test alternative).
-    This machine has only `KICK31.ROM` locally, so the 3.1 OFS axes are
-    verified passing here; every other axis in this file is reviewed but
-    **locally unverified** -- only its skip-cleanly path has been run.
+`guest/copperhf/mounter.c` walks RDSK/PART blocks and creates a `DeviceNode`,
+`FileSysStartupMsg`, and `DosEnvec` for each partition. It uses `AddBootNode`
+on V36+ and the `eb_MountList` fallback on V34. FSHD/LSEG chains load
+filesystem code into `FileSystem.resource`, allowing attached units to
+mount and autoboot.
+
+The integration matrix includes:
+
+- `tests/copperhf_m6.rs`: bundled AROS and a synthetic LSEG fixture exercise
+  filesystem registration, relocation, partition-node construction, and
+  autoboot without external assets.
+- `tests/copperhf_kickstarts.rs`: ignored tests for Kickstart 1.3, 3.1, and
+  3.2, covering RDB and bare-OFS autoboot. Additional cases use a real
+  `FastFileSystem` binary for FFS-from-LSEG and a PFS3-DS binary for a
+  limited >4 GiB boot smoke test. The latter does not prove formatting or
+  mounting the full large partition.
+
+See `tests/README.md` for required assets and commands. A skipped test is
+not evidence that its configuration works.
 
 ## See also
 

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -503,169 +503,62 @@ once a machine is available. `timing-test/` remains the end-to-end regression
 for checking the combined CPU, cache, and chip-bus model rather than the
 source of the per-opcode constants.
 
-On the A1200 the 020 uses a 32-bit Alice chip-bus data path and a two-entry
-longword fetch latch. The 020's chip-bus cycle is modelled as 3
-CPU clocks, not the 68000's 4: after the granted colour-clock slot the access
-bills only the shorter remaining tail (one clock -- half a cck at the stock
-2-clock ratio, none at 14 MHz where the 3-clock cycle fits inside one slot).
-That is enough for a posted write. A chip-RAM read or custom-register read
-also waits one colour clock for the chipset's data-return phase, and a
-custom-register read waits one colour clock beyond that: chip RAM answers out of
-Agnus' DRAM controller with the row already open for the granted slot, while a
-register read has to cross to the addressed chip, be driven back onto the 16-bit
-chipset bus, and only then meet the CPU's data-return phase. A 68000 cannot see
-the difference -- its four-clock bus cycle is longer than either path -- but a
-14 MHz 020 samples early enough that the crossing costs a whole slot. This is
-what sets the rate of a VHPOSR/INTREQR polling loop, so it decides where
-chase-the-beam code lands relative to the copper: `timing-test` rows 16, 17 and
-21 fit 27% more iterations per frame without it. An AGA
-instruction-cache fill does the same for its first word; the second word from
-the already-latched 32-bit value is free. On OCS/ECS machines the 020 still
-talks to the 16-bit chip bus, so chip/slow/custom data reads likewise pay the
-return wait. The tail's fractional cck are carried so none are lost; the
-68000/010 keep the full 4-clock (2-cck) cycle
-(`Bus::cpu_short_bus_cycle`).
-
-This distinction is visible in SysInfo 4.4: treating Alice reads and cache
-fills like posted writes made the A1200 profile report 5.52x A600 chip speed
-and 1.61x A1200 CPU speed after the instruction-table update. Billing the
-data-return phase changes those figures to 3.55x and 1.10x respectively,
-without altering register-only timing-test rows.
-
-The real-A1200 column drove two further sub-cck mechanisms, both gated to the
-020+ short-cycle path (the 68000's four-clock cycle spans the whole port
-sequence, so it cannot see either).
-
-Chip writes are posted. The 020's bus unit runs decoupled from its execution
-unit: a chip write is accepted at the end of its 3-clock cycle and the
-transfer overlaps the following instructions, retiring into a later free chip
-slot. Copperline models this by crediting the transfer's clocks back against
-the instruction's charge (`take_cpu_bus_overlap_clocks`) and letting the
-pending write drain into the next free slot during subsequent beam
-advancement (`cpu_posted_write_debt`), at the port's 2-cck turnaround
-cadence. Only one bus cycle can be in flight, so a second chip access stalls
-until the pending write retires -- which is what paces a chip write+dbra loop
-to ~8 clocks per iteration on the real machine (`timing-test` rows 3, 10,
-12, 18) where a synchronous whole-slot bill gave 11-12. A DMA reader of the
-same address inside the drain window (at most two colour clocks) would see
-the write early; that race is unobservable in practice and accepted.
-
-Reads pay one further CPU clock synchronizing the returned data back into
-the CPU clock domain, accumulated into whole colour clocks
-(`bill_020_read_return_sync_clock`). The real chip-read loop measures 16.1
-clocks per iteration (row 2) where grant plus data-return bill 15; the old
-exact match on that row was the branch over-bill cancelling this missing
-clock. The same synchronizer clock on custom-register reads is what lands
-the copper-vs-CPU poll row (row 27) exactly on the real machine's beam
-position.
-
-The same column appeared to show 020 result forwarding -- the RAW-dependent
-MOVE pair of `timing-test` row 29 runs one clock per iteration faster than
-the independent pair of row 28 -- and m68k modelled it as such up to and
-including 0.5.0. **That model was wrong; it was removed upstream in m68k
-0.5.1, and remains absent from this tree's 0.12.1 dependency.** A second probe disk
-(`timing-test/fwdprobe.asm`) ran the same two
-loops at the opposite alignments on the same machine and reversed the
-ordering, which closes the 2x2: with the register dependency and the branch
-alignment separated, the dependency has no effect at all. What the pair rows
-actually measured is where the loop branch sits.
-
-Twenty-eight of the thirty cached loops across the two disks fit one rule to
-within a tick:
-
-```text
-clk/iter = 6 + 2 * (2-byte body instructions)
-             + 1 if the DBcc opcode word is longword-aligned
-```
-
-A cached taken `dbra` costs 7 clocks at `pc % 4 == 0` and 6 -- the manual's
-cache case -- at `pc % 4 == 2`. The loop *head* alignment varies freely
-within each refill class, so it is the branch's own alignment that decides
-and not the target's; the presumed cause is the longword granularity of 020
-instruction fetch, a branch straddling two longwords having already had the
-second fetched by the time it retires. Body instructions cost a flat two
-clocks whatever their shape (`.b`/`.w`/`.l` MOVE, MOVEA on either side,
-An-source MOVE, ADD, CMP, MOVEQ). Only `DBcc` was measured; `Bcc` and
-`BSR` are untested and should keep the flat refill until a probe covers them.
-
-The two loops that do not fit are `fwdprobe` rows 20/21, whose body carries a
-`NOP`: they measure 13.08 clocks where the rule says 13.01, while rows 22/23
-at the same body count and the same `dbra % 4 == 0` sit exactly on 13.01. A
-real `NOP` therefore costs nearer 2.07 clocks than 2 -- which is what a
-pipeline-synchronising instruction should look like. It is a 0.5% effect on
-one instruction measured on one couple, so it is recorded rather than
-modelled, and Copperline emits the rule value for both rows.
-
-Modelling the alignment rule reproduces 24 of the 26 `fwdprobe` rows exactly
-(the two `NOP` rows above being 0.5% low) and leaves the
-main disk's pure-CPU rows exact, but moves several of its chip-bus rows (the
-chip-read loop, the write-plus-poll composites, the copper-poll beam
-position) by a few percent: those loops' accesses re-phase against the
-chip-bus slot grid when the loop shortens by a clock, so their previous
-agreement was partly compensation for the branch over-bill.
-
 ### The chip-access phase
 
-`timing-test/rdprobe.asm` measured the chip side on the same machine, and its
-two no-access anchors reproduce the other disks exactly, so the column is
-trustworthy. It showed the CPU and the chip bus needed one clock timeline
-rather than two.
+On AGA machines, the 020+ CPU uses Alice's 32-bit chip-RAM path. One granted
+slot transfers a longword, and the two-entry fetch latch serves sequential
+opcode words from an already fetched longword without another bus access.
+OCS/ECS retain a 16-bit chip bus. The 68000/010 use their four-clock bus
+cycle; the 020+ path is selected by `Bus::cpu_short_bus_cycle`.
 
-**Every real loop containing a chip access runs a whole number of colour
-clocks** -- the chip-read loop 4.02, the chip-write loops 2.03 and 2.01, two
-reads 7.04, a read plus a posted write 5.05 -- while the two loops with no
-chip access sit on quarters (2.25, 2.00). An A1200 runs four CPU clocks per
-colour clock, so that is the CPU synchronising to the chip clock: a chip read
-cannot begin part way through a colour clock, and the wait absorbs whatever
-the rest of the loop left over. Reads carry the branch-alignment clock through
-into a whole extra colour clock (one read costs 4 cck at `dbra%4==2` and 5 at
-`%4==0`); posted writes do not, because the bus unit takes them behind the
-execution unit.
+For precise 020+ execution, the CPU's position is
+`emulated_cck * cpu_clocks_per_cck + Bus::cpu_chip_clock_phase`.
+Execution clocks accumulate in this shared phase and advance the beam when
+a whole colour clock is due (`Bus::charge_cpu_clocks_to_cck`). A chip-RAM
+read first waits out any partial colour clock
+(`Bus::sync_cpu_to_chip_clock`), then waits for a free bus slot. After the
+grant it pays one colour clock for data return and two further CPU clocks
+(`CPU_020_CHIP_READ_RETURN_CLOCKS`). Access time is credited against the
+instruction's own charge so it is not billed twice.
 
-Copperline used to model neither, and the second omission was the blocking
-one: two independent sub-colour-clock carries existed, the CPU's on
-`M68kMachine` where the bus could not see it at access time, and a dead one on
-`Bus`. Nothing made an access begin on a colour-clock boundary, so nothing
-quantised; and the per-instruction reconciliation
-`advance_cpu_internal_cycles(cpu_cck.saturating_sub(bus_cck))` could only add
-time, so an instruction whose accesses cost more colour clocks than its
-charged execution time -- routine for chip-bound 020 code -- had the surplus
-discarded. Together those turned a phase into a rate: the read loop had two
-stable orbits and returned 13.08 clocks per iteration on one disk and 17.04 on
-the other for identical code.
+The two-clock return cost comes from `timing-test/rdprobe.asm` on a stock
+A1200. The same chip-read loop measures 16 CPU clocks per iteration with a
+six-clock branch and 20 with a seven-clock branch. With four CPU clocks per
+colour clock, a read occupies ten clocks from the boundary it starts on;
+the next read's synchronization accounts for the difference between the two
+loop alignments. The probe and recorded hardware results live in
+`timing-test/`.
 
-The CPU's position is now `emulated_cck * cpu_clocks_per_cck +
-Bus::cpu_chip_clock_phase`. Execution clocks accumulate into that phase and
-turn into beam time a whole colour clock at a time
-(`Bus::charge_cpu_clocks_to_cck`); a chip read stalls out the remainder and
-resets the phase (`Bus::sync_cpu_to_chip_clock`); and every access the CPU
-waits for credits its own clocks back against the instruction charge, because
-the m68k timing table already allots the instruction the time for its memory
-reference. Nothing is reconciled afterwards and nothing is discarded. The
-per-iteration map on the phase is therefore the constant map for any loop
-containing a read, which is what makes the period independent of the phase the
-loop was entered with.
+Chip writes are posted. The bus unit accepts a write at the end of its
+three-clock cycle, credits those clocks against the instruction charge
+(`take_cpu_bus_overlap_clocks`), and retires the transfer into a later free
+slot (`cpu_posted_write_debt`). Only one transfer can be pending; the next
+chip access waits for it to retire. The port accepts transfers at a
+two-colour-clock cadence. Memory is currently updated before the deferred
+slot retires, so DMA can observe a posted write early; this is a modelling
+limitation.
 
-One derived constant remains: a chip read spends
-`CPU_020_CHIP_READ_RETURN_CLOCKS` = 2 CPU clocks returning data past the
-data-return colour clock. Rows 0 and 1 of the probe force it -- a read loop
-measures 16 clocks per iteration with a 6-clock branch and 20 with a 7-clock
-one, and since the period is a whole number of 4-clock colour clocks those
-pin the un-rounded cost at exactly 16, so a read occupies 10 clocks from the
-boundary it starts on.
+Custom-register reads use a separate return path: one colour clock for
+data return, another for crossing the chipset's 16-bit bus, and one CPU
+synchronizer clock. They are deliberately not aligned to the chip-RAM
+clock boundary. Hardware probes have not yet isolated this path as fully
+as chip RAM; the existing copper-poll beam-position test agrees with the
+current model, while chip-write-plus-poll composite rows remain about 9%
+low in the recorded comparison.
 
-This is gated to the 68020 and later (`cpu_short_bus_cycle`). The 68000 and
-68010 keep the two timelines and the reconciliation: their four-clock bus
-cycle is exactly two colour clocks and synchronous with the chip clock by
-construction, and their intra-instruction time is already placed correctly by
-the core's `sync` callback. The JIT batch path also keeps the older
-accounting, since it charges one lump per batch and would see a stale phase at
-every access after the first.
+The 68000/010 keep their existing instruction/bus reconciliation because
+their four-clock cycle spans two colour clocks at the stock rate. JIT
+batches also use the older accounting: a batch does not refresh the shared
+phase at every instruction, and is not the precise timing path.
 
-Still open: chip-write-plus-poll composite rows (16, 17, 21) read about 9%
-low, and custom-register accesses are deliberately left unsynchronised because
-the copper-poll beam row (27) is exact as they stand. Both want a probe that
-isolates custom-register timing the way `rdprobe` isolated chip RAM.
+The earlier result-forwarding interpretation of `timing-test` rows 28/29
+was removed from m68k. `fwdprobe.asm` reversed the apparent dependency
+advantage by moving the loop branches to the opposite alignments. The
+measured distinction is the taken `DBcc` opcode's alignment: seven clocks
+at `pc % 4 == 0`, six at `pc % 4 == 2`. Twenty-four of the 26 probe rows
+match this model exactly; the two rows containing `NOP` are about 0.5%
+low. These are measurements of particular loops on one stock A1200, not a
+claim that the full 020 pipeline is cycle-exact.
 
 ## MMU
 

--- a/docs/internals/mhi.md
+++ b/docs/internals/mhi.md
@@ -1,18 +1,12 @@
 # The MHI decoder board: mailbox register protocol
 
-This page is the **contract**, not an implementation note: it specifies the
-register-level protocol of Copperline's virtual MHI (Music Hardware
-Interface) MPEG audio decoder board, precisely enough that the host board
-(`src/mhi.rs`) and the guest library (`guest/mhi/`) can be implemented
-independently against it and interoperate. Where this document and either
-implementation disagree, this document wins -- fix the implementation, not
-the spec, unless the spec itself is being deliberately revised (see
-[Versioning](#mhi-versioning)).
+This chapter specifies the mailbox protocol shared by the host board
+(`src/mhi.rs`) and `mhi_copperline.library` (`guest/mhi/`). Protocol changes
+must follow the [versioning rules](#mhi-versioning).
 
-The protocol is deliberately **bus-agnostic**: every offset below is
-relative to the start of the board's autoconfigured window, and nothing in
-the register semantics depends on being read by Copperline specifically. See
-[Porting to another emulator](#porting-to-another-emulator) at the end.
+Offsets are relative to the board's autoconfigured window. The protocol
+can be implemented on another bus or emulator without changing register
+semantics; see [porting](#porting-to-another-emulator).
 
 MHI itself -- `MHIAllocDecoder`/`MHIQueueBuffer`/`MHIGetStatus`/etc., the
 Amiga-side API AmigaAMP and other players call -- is not this board's wire
@@ -77,8 +71,8 @@ implements degrades safely on old fields rather than reading garbage. See
 | `0x20`-`0xFFFF` | *reserved* | -- | -- | `0x0000` | -- |
 
 The window is 64 KiB (the smallest legal Zorro II size) even though only
-32 bytes of it currently decode to anything; the rest is headroom for
-future protocol versions (M3's seek support, a wider param space, etc.)
+32 bytes contain registers. The remaining space is reserved for future
+protocol versions
 without moving the board to a bigger window, which would change its
 autoconfig identity.
 
@@ -86,10 +80,9 @@ autoconfig identity.
 ### Capability/version registers
 
 - **`VERSION`** (`0x00`, RO) -- the register-protocol version this board
-  implements, currently `2` (bumped from `1` by M4 -- see
-  [Versioning](#mhi-versioning)'s worked example). A guest library reads this once at
-  `FindConfigDev` time and refuses to drive a board whose major protocol
-  it does not understand (see [Versioning](#mhi-versioning)).
+  implements: `2`. The guest library accepts version 1 or newer when
+  finding the board and checks `CAPS` for optional behavior. See
+  [Versioning](#mhi-versioning).
 - **`CAPS`** (`0x02`, RO) -- a bitmask of the MPEG formats and bitrate
   modes this board's decoder accepts. Bit layout:
 
@@ -104,30 +97,11 @@ autoconfig identity.
   | 6 | Param latches are applied to decoded PCM (see [Param latches](#param-latches)) |
   | 7-15 | reserved, read as 0 |
 
-  M1-M2 sets bits 0-5 (MPEG-1/2/2.5, Layer III, CBR, VBR) and no others --
-  Layer I/II are not implemented, so bits for them do not exist in this
-  version; a future version that adds them would need a `CAPS` bit for
-  each, which is exactly the kind of change that bumps `VERSION`. Bit 5's
-  own meaning was tightened in M3 (VBR entry at an arbitrary byte offset
-  is now hardened, not just "VBR decodes"; see
-  [Seek-entry hardening](#seek-entry-hardening)) without moving its value
-  or bumping `VERSION`: M1-M2 already accepted VBR as input and never
-  claimed seek support as a *board* feature (seeking was always the
-  player's job, done via `MHIStop`/reposition/`MHIQueueBuffer` -- MHI has
-  no seek call of its own), so M3 only proves and documents a stronger
-  guarantee about behavior the board's registers never described a limit
-  on in the first place -- not a change to any offset, width, access
-  rule, or bit meaning `VERSION` exists to gate. **M4** adds bit 6
-  (`VERSION` 2 -- see [Versioning](#mhi-versioning)), a genuine behavior
-  change unlike bit 5's rewording. This register is what the guest
-  library's `MHIQuery` handler consults for
-  `MHIQ_MPEG1`/`MHIQ_MPEG2`/`MHIQ_MPEG25`/`MHIQ_LAYER3`/
-  `MHIQ_VARIABLE_BITRATE` -- it is genuine hardware-reported capability,
-  unlike decoder identity (below). Bit 6 is what lets a single guest
-  library binary answer correctly against both an M1-M3 board (latches
-  exist but are inert) and an M4 board (latches are audible): the library
-  reads this bit at `FindConfigDev` time rather than assuming its own
-  build date implies the board's behavior.
+  Version 2 sets bits 0-6. Layer I/II are not implemented. Version 1
+  sets bits 0-5 and stores parameter values without applying them to audio.
+  The guest library checks bit 6 before advertising volume, panning, tone,
+  prefactor, and crossmix controls through `MHIQuery`; it does not infer
+  these capabilities from its own build version.
 
   Decoder identity strings (`MHIQ_DECODER_NAME`, `MHIQ_DECODER_VERSION`,
   `MHIQ_AUTHOR`, `MHIQ_CAPABILITIES`'s MIME-type string,
@@ -285,7 +259,7 @@ records:
   `MHIGetEmpty` -- the same idiom other in-tree boards use for
   free-running hardware counters. `CONTROL=STOP` resets it to `0`
   alongside `QUEUE_COUNT`; a guest observing a `STOP` (its own or another
-  client's, if the board is ever shared -- it isn't in M1-M2's single
+  client's, if the board is ever shared -- it uses a single
   `MHIAllocDecoder` model) must resynchronize its local counter to `0`
   rather than compute a delta across the reset.
 
@@ -330,15 +304,11 @@ regardless of how many parameters the guest library ends up exposing.
   guest library's own bookkeeping the only source of truth, which this
   avoids).
 
-  **M1-M3 scope**: writes latch the value and it reads back correctly;
-  nothing about decoded audio changes. **M4** (`VERSION` 2, `CAPS` bit 6)
-  connects these latches to the actual PCM path -- this is why the
-  register shape was fixed from M1: M4 changes what a latch *does*, never
-  where it lives or how it's addressed, so no guest library rebuild is
-  needed to keep talking to the register file, only to answer `MHIQuery`
-  correctly (see `CAPS` bit 6 above).
+  In version 1, writes only store the value. Version 2 applies the latches
+  to PCM and advertises that behavior through `CAPS` bit 6.
 
-#### M4: the DSP chain
+(m4-the-dsp-chain)=
+#### DSP chain
 
 Every latch is applied, every produced sample, in one fixed order --
 order is audible, so it is as much a part of the contract as the latch
@@ -550,8 +520,7 @@ buffers starting at that new position. From the board's side, a seek is
 indistinguishable from any other `STOP` followed by fresh descriptors --
 there is no seek-specific register or command, and none is needed.
 
-Two things this puts on the board, both true since M1-M2 and exercised
-explicitly by M3's test suite:
+The board must handle both parts of a seek:
 
 - **`STOP` resets decoder state, not just the queue** (see the `CONTROL`
   table above) -- otherwise the discarded pre-seek stream's bit reservoir
@@ -583,12 +552,6 @@ explicitly by M3's test suite:
   `mid_frame_entry_resyncs_to_the_next_real_frame` and
   `seek_entry_past_an_id3v2_tag_resyncs_correctly` in `src/mhi.rs` cover
   these cases directly.
-
-Nothing above is a new register, command, or protocol surface -- it is a
-guarantee about existing behavior (`STOP`'s semantics, the resync path's
-robustness) that M3 proved and documented rather than a M3-only feature a
-pre-M3 board would lack. See [CAPS](#capability-version-registers) for why
-this did not need a `VERSION` bump.
 
 **An incomplete trailing frame** (the queued bytes end mid-frame -- too few
 bytes for the decoder to tell whether they are even a valid sync, let alone
@@ -639,8 +602,8 @@ protocol, and the split is intentional, not an oversight:
 | `MHIQ_IS_HARDWARE`/`_IS_68K`/`_IS_PPC` | Guest library -- static answers (this is a real register-mailbox device the library talks to over the Zorro bus, so `MHIQ_IS_HARDWARE` answers true; it runs no 68k/PPC code of its own, so both processor queries answer false) |
 | MPEG version/layer/bitrate-mode support (`MHIQ_MPEG1`/`_MPEG2`/`_MPEG25`, `MHIQ_LAYER3`, `MHIQ_VARIABLE_BITRATE`) | `CAPS` register (`0x02`) -- genuinely board-reported, since a future board revision's decoder could differ |
 | `MHIQ_JOINT_STEREO` | Guest library -- fixed `MHIF_SUPPORTED`; decoding joint-stereo Layer III is inherent to any conforming decoder, not a distinct board capability worth its own `CAPS` bit |
-| Tone/volume/output query flags (`MHIQ_VOLUME_CONTROL`, `MHIQ_PANNING_CONTROL`, `MHIQ_BASS_CONTROL`, `MHIQ_TREBLE_CONTROL`, `MHIQ_MID_CONTROL`, `MHIQ_PREFACTOR_CONTROL`, `MHIQ_CROSSMIXING`, `MHIQ_5_BAND_EQ`, `MHIQ_10_BAND_EQ`) | Guest library -- keyed off `CAPS` bit 6 for the seven params this board's [param latch](#param-latches) table defines (indices `0`-`6`: volume, panning, bass, mid, treble, crossmixing, prefactor): `MHIF_UNSUPPORTED` against an M1-M3 board (bit 6 clear -- the latches exist and round-trip, but nothing applies them to decoded PCM, so answering `MHIF_SUPPORTED` would tell a client its `MHISetParam` calls are audible when they are not), `MHIF_SUPPORTED` against an M4-or-later board (bit 6 set). One guest library binary answers correctly either way -- see `CAPS`'s own bit-6 note above. The 5/10-band EQ stays `MHIF_UNSUPPORTED` regardless of bit 6, until a later `VERSION` adds `MHIP_MIDBASS`/`MHIP_MIDHIGH`/`MHIP_BAND1`-`MHIP_BAND10` equivalents at reserved indices `7`+ |
-| Decoder handle, client task pointer, signal mask (`MHIAllocDecoder`/`MHIFreeDecoder`) | Guest library only -- entirely a host-side (Amiga-side) bookkeeping concept; the board has no notion of "a handle" and, in this M1-M2 scope, serves exactly one client at a time |
+| Tone/volume/output query flags (`MHIQ_VOLUME_CONTROL`, `MHIQ_PANNING_CONTROL`, `MHIQ_BASS_CONTROL`, `MHIQ_TREBLE_CONTROL`, `MHIQ_MID_CONTROL`, `MHIQ_PREFACTOR_CONTROL`, `MHIQ_CROSSMIXING`, `MHIQ_5_BAND_EQ`, `MHIQ_10_BAND_EQ`) | Guest library -- keyed off `CAPS` bit 6 for the seven params this board's [param latch](#param-latches) table defines (indices `0`-`6`: volume, panning, bass, mid, treble, crossmixing, prefactor): `MHIF_UNSUPPORTED` against a version-1 board (bit 6 clear -- the latches exist and round-trip, but nothing applies them to decoded PCM, so answering `MHIF_SUPPORTED` would tell a client its `MHISetParam` calls are audible when they are not), `MHIF_SUPPORTED` when bit 6 is set (bit 6 set). One guest library binary answers correctly either way -- see `CAPS`'s own bit-6 note above. The 5/10-band EQ stays `MHIF_UNSUPPORTED` regardless of bit 6, until a later `VERSION` adds `MHIP_MIDBASS`/`MHIP_MIDHIGH`/`MHIP_BAND1`-`MHIP_BAND10` equivalents at reserved indices `7`+ |
+| Decoder handle, client task pointer, signal mask (`MHIAllocDecoder`/`MHIFreeDecoder`) | Guest library only -- entirely a host-side (Amiga-side) bookkeeping concept; the board has no notion of "a handle" and serves exactly one client at a time |
 | Transport (`MHIPlay`/`MHIStop`/`MHIPause`), status (`MHIGetStatus`), queueing (`MHIQueueBuffer`/`MHIGetEmpty`), params (`MHISetParam`) | Guest library translates 1:1 to/from this board's `CONTROL`/`STATUS`/descriptor-queue/`PARAM_*` registers |
 
 Keeping MHI's own vocabulary entirely out of the wire protocol is what
@@ -654,36 +617,18 @@ possible without also porting MHI-specific glue.
 (mhi-versioning)=
 ## Versioning
 
-`VERSION` (`0x00`) is the register-protocol's own version number, starting
-at **1** for the M1-M2 surface this document describes. This document is
-the contract: a change to any offset, width, access rule, bit meaning, or
-semantic described above is a protocol change and must bump `VERSION`,
-whether or not it happens to be backward compatible. A guest library
-should treat an unrecognized (higher-than-known) `VERSION` as "features
-beyond what I implement may exist at reserved offsets," not as an error,
-since new fields land at previously-reserved offsets (which any
-conforming board -- old or new -- already defines as inert) rather than by
-repurposing an existing offset's meaning. Repurposing an offset's meaning
-between versions is not permitted by this spec's own conventions; a
-protocol revision that needs to do that must move to a new offset and
-leave the old one reading its previous semantics (or a fixed sentinel) for
-compatibility, exactly like any other stable ABI.
+`VERSION` (`0x00`) is the register-protocol version; the current value is
+**2**. Changes to offsets, widths, access rules, bit meanings, or documented
+semantics require a version bump. Preserve existing register meanings and
+use reserved offsets for additions.
 
-**Worked example: `VERSION` 1 -> 2 (M4).** M4 makes the param latches
-(indices `0`-`6`, already defined and already readable/writable since
-M1) actually audible. No offset moves, no access rule changes, and every
-field that existed at `VERSION` 1 keeps exactly its `VERSION` 1 meaning
--- but the *documented semantic* of writing `PARAM_VALUE` changes (from
-"latched, otherwise inert" to "affects the next produced sample"), which
-this document's own rule above ("any... semantic described above is a
-protocol change") requires a bump for, independent of whether a guest
-built against `VERSION` 1 would even notice (it would: its own decoded
-audio starts changing when it writes params it always assumed were
-no-ops). `CAPS` gains bit 6 at a previously-reserved position (`6-15
-reserved` at `VERSION` 1 already defined that range as inert, so an old
-board and a new board agree on what an old guest sees there) -- exactly
-the "new fields land at previously-reserved offsets" case this section
-describes as not needing special-casing beyond the bump itself.
+The guest library requires at least version 1. It accepts newer versions
+and checks `CAPS` for optional features. A newer board must therefore
+remain compatible with the register operations older drivers use.
+
+Version 2 applies parameter latches 0-6 to decoded PCM and sets `CAPS` bit 6.
+Version 1 stores and reads back the same values but leaves the audio unchanged.
+Register locations and widths are identical in both versions.
 
 (porting-to-another-emulator)=
 ## Porting to another emulator
@@ -726,10 +671,8 @@ content above.
 - **Decoder**:
   [Symphonia](https://github.com/pdeljanov/Symphonia)'s pure-Rust
   MPEG audio decoder (`MpaDecoder`, MPL-2.0), with only its Layer III
-  feature enabled to match `CAPS`. Pure Rust is the point: the previous
-  decoder (`minimp3-sys`) compiled a vendored C minimp3 whose SIMD
-  detection broke the default build on MSVC ARM64 hosts (issue #474), and
-  it was the last C compile in the default feature set. `MpaDecoder` is
+  feature enabled to match `CAPS`. It requires no C decoder build.
+  `MpaDecoder` is
   packet-based, so `src/mhi.rs` carries its own packetizer that cuts the
   doorbell-fed byte queue into whole frames using the same ISO 11172-3
   header/length arithmetic Symphonia's parser applies; junk bytes, fake
@@ -750,40 +693,22 @@ content above.
   `Resampler` (`src/audio/resample.rs`, per-rate cached) pulls from that
   FIFO to the mixer's fixed rate, so the resampler's lookahead can never
   reorder when a descriptor completes or an interrupt raises.
-- **Savestates**: Symphonia keeps its cross-frame decoder state (Layer III
-  bit reservoir, IMDCT overlap, synthesis delay line) private, so the
-  board's `DecoderSnapshot` serializes a warmup history instead: the raw
-  bytes of the most recently submitted frames (a few KiB, bounded), which
-  a restore re-decodes into a fresh decoder with the output discarded.
-  The replay is exact because each piece of that state is a function of
-  the trailing few frames alone -- the reservoir holds at most the
-  trailing 2048 bytes of main data, and the overlap/synthesis state is
-  rewritten by each frame -- see the "Savestates" section of
-  `src/mhi.rs`'s module doc comment for the full argument. The board also
-  retains every not-yet-decoded byte of every queued descriptor and the
-  in-flight frame's un-played sample tail, so a save/restore cycle
-  reproduces an uninterrupted run's decoded output exactly -- the
-  savestate approach is re-decode of retained bitstream, not a snapshot
-  of decoded PCM. This is proven bit-for-bit at the struct level
-  in-process (`savestate_round_trip_reproduces_an_uninterrupted_runs_output`
-  in `src/mhi.rs`'s own tests). `tests/mhi.rs`'s end-to-end equivalent
-  (`mhi_m2_savestate_resume_matches_the_uninterrupted_tail`, a real
-  save-to-disk and reload across separate `copperline` process
-  invocations) finds the same holds to an excellent approximation but not
-  quite bit-exactly when the save lands mid-decode: a small, constant
-  correspondence-point offset (inherent to estimating which captured
-  sample lines up with the save instant from wall-clock arithmetic, not a
-  bug) plus a tiny residual around the guest's periodic re-reads of its
-  MP3 input buffer, not yet root-caused to a specific missing field --
-  see that test's long comment for the investigation.
-- **Savestate layout**: adding the `mhi_audio` ring to `Paula` and the
-  `BoardDevice::Mhi` variant bumped `savestate::STATE_VERSION` to **57**;
-  the decoder-snapshot reshape for the Symphonia move (issue #474) bumped
-  it again to **58**; M4's `ToneFilterBank` (bass/mid/treble biquad
-  coefficients and filter memory -- genuine machine state, the same
-  reasoning as the decoder's own warmup history) bumped it once more to
-  **59**.
-- **M4 DSP chain implementation**: `Biquad` is Direct Form II transposed,
+- **Savestates**: Symphonia keeps its cross-frame decoder state private.
+  `DecoderSnapshot` therefore stores a bounded history of encoded frames;
+  restoring a board replays them into a fresh decoder and discards the
+  warmup output. Queued descriptor bytes and the unplayed sample tail
+  are saved too. The in-process unit test
+  `savestate_round_trip_reproduces_an_uninterrupted_runs_output` verifies
+  exact output after restoration. The separate-process integration test
+  `mhi_m2_savestate_resume_matches_the_uninterrupted_tail` in `tests/mhi.rs`
+  uses an alignment window and a small error tolerance. It records a
+  remaining difference around guest input-buffer refills when restoring
+  mid-decode; that case is not established as bit-exact.
+- **Save-state layout**: decoder warmup history, tone-filter coefficients,
+  and filter memory are serialized machine state. Changes to their layout
+  require a `savestate::STATE_VERSION` bump, independently of the board's
+  register-protocol version.
+- **DSP chain implementation**: `Biquad` is Direct Form II transposed,
   reusing `src/chipset/paula.rs`'s `AnalogLedFilter`/`BiquadLowPass`
   structure and `process` shape rather than a second filter convention in
   the same codebase (see "Tone filters: bass/mid/treble" above for the RBJ
@@ -831,7 +756,7 @@ content above.
   fetched `test-assets/`, so it catches decoder-dependency drift or
   resampler/pacing regressions immediately rather than only when a
   developer happens to have local assets staged. The same two fixtures
-  back the M3 seek-entry tests (`stop_resets_decoder_state_so_a_reseek_
+  back the seek-entry tests (`stop_resets_decoder_state_so_a_reseek_
   matches_a_fresh_decode`, `mid_frame_entry_resyncs_to_the_next_real_frame`,
   `seek_entry_into_vbr_content_decodes_cleanly_after_a_settle_window`) --
   real encoded streams carry genuine cross-frame reservoir state that a

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -767,8 +767,8 @@ skips gamepad polling for port-2 input; gamepad mode disables keyboard
 joystick capture so the mapped keys take the normal Amiga keyboard path.
 (The old auto-detect mode has been removed; `"auto"` in a config parses
 as a backward-compatibility alias for gamepad.) Both sources ultimately
-call the same `InputState::set_joystick_port2`
-and `set_cd32_buttons_port2` helpers, so JOY1DAT, /FIR1, POT1Y/POTGOR, and
+call the port-indexed `InputState::set_joystick`
+and `set_cd32_buttons` helpers, so JOY1DAT, /FIR1, POT1Y/POTGOR, and
 the CD32 serial bits remain hardware-derived.
 
 Keyboard joystick emulation is deliberately a host input source, not a

--- a/docs/internals/savestate.md
+++ b/docs/internals/savestate.md
@@ -1,11 +1,9 @@
 # Save states (`savestate.rs`)
 
-A save state snapshots the whole emulated machine to a single file and
-restores it exactly. Because the core is deterministic
-([](architecture.md#determinism-and-the-host-boundary)), a restored run
-is byte-for-byte identical to one that was never interrupted -- the
-regression gate for the feature literally `cmp`s screenshots taken on
-either side of a save/restore cycle.
+A save state stores the emulated machine in a single file. With the same
+external media and repeatable inputs, restoring it reproduces the guest
+timeline. Host files, physical devices, and live services have separate
+[replay limits](#determinism-boundaries); they are not rolled back with RAM.
 
 User-facing behaviour (shortcuts, menu items, the `--save-state-after` /
 `--load-state` flags, and the operational caveats) is documented in the
@@ -15,10 +13,9 @@ This chapter is the implementation and format reference.
 
 ## Design
 
-The state is produced by `serde` derives on the live state structs
-themselves -- there is no hand-maintained parallel "snapshot" schema.
-`Bus` and everything it owns derive `Serialize`/`Deserialize`, as does
-the published `m68k` core with its `serde` feature enabled. `CpuCore`
+Most state uses `serde` derives on the live structs, including `Bus` and
+the published `m68k` core. Types with file handles, decoder internals, or
+feature-dependent board variants use custom serialization. `CpuCore`
 serializes architectural state, prefetch state, MMU state, and timing
 configuration; runtime-only decoded-op, FastMem, and trace-JIT caches are
 skipped and rebuilt after deserialization. New fields are picked up by the
@@ -31,13 +28,13 @@ What is captured:
 |---|---|
 | `CpuCore` | registers, SR flags, prefetch queue, pending interrupt/stop state, MMU/CACR state, cycle-timing configuration, `cpu_type` and address mask |
 | `MachineRuntimeState` | the `M68kMachine` fields outside the core: `last_cacr`, `sync_cck_on`, `cpu_clocks_per_cck`, `cpu_clock_carry` |
-| `icache` / `dcache` | the 020/030 cache models (`Option<Box<CpuCache>>`, `None` when the model has no such cache or it is opted out). A snapshot with `None` for a cache the running CPU has -- an older state, or one taken before the caches defaulted on -- re-establishes that cache cold on load (enable bits re-derived from the restored CACR) instead of dropping it |
+| `icache` / `dcache` | the CPU cache models (`Option<Box<CpuCache>>`, `None` when absent or opted out). If a compatible state lacks a cache that the restored CPU configuration requires, load creates it cold with enable bits derived from CACR |
 | `Bus` | chip/slow RAM, ROM and extended ROM, Zorro boards (including their RAM), both CIAs, RTC, Agnus/Copper/Denise/Paula/blitter state, floppy controller with in-memory disk images, Gayle IDE, A2091 SCSI, Akiko/CDTV with NVRAM, beam-event capture buffers, DMA pointers, interrupt latches, and the bus-arbitration counters |
 
 Deliberately excluded, with the mechanism in parentheses:
 
-- **Host sinks and taps**: Paula's `Box<dyn SerialSink>` /
-  `Box<dyn AudioSink>` and the bounded CCP serial-observation tap
+- **Host sinks and taps**: Paula's `Box<dyn SerialSink>`, `AudioMux`,
+  and the bounded CCP serial-observation tap
   (`#[serde(skip)]`; the sink defaults produce inert null devices). On load,
   `Bus::adopt_host_resources` moves the live sinks and tap from the old Bus
   onto the restored one, so output and an active subscription continue
@@ -68,11 +65,10 @@ is self-contained with respect to everything that was in memory, so
 loading one always rebuilds *its own* machine -- restoring the Bus and
 CPU restores the machine model along with them (the CPU bus adapter's
 address-mask copy is re-synced from the restored core's `address_mask`).
-A state loaded under a different config therefore does not corrupt
-emulation; it silently *becomes* the machine the state was taken on.
+A state loaded under a different config restores the saved machine model.
 
 To make that takeover visible and to keep host-side derived values in
-step, the header carries a `MachineDescriptor` (`config.rs`): the
+step, the header carries a `MachineDescriptor` (`config/mod.rs`): the
 machine "shape" -- CPU model, chip/fast/slow RAM sizes, chipset
 (OCS/ECS/AGA), video standard, and machine profile -- plus a fingerprint
 of the boot and extended ROM (`RomId` = byte length + CRC-32 via
@@ -106,25 +102,26 @@ images reopen by path and fail the load cleanly if absent (see below).
 
 ### File-backed images
 
-Two subsystems hold open `File` handles inside otherwise serializable
-state. Both get manual serde implementations through small shadow
-structs, and both **reopen the file during deserialization**, which
-turns a missing or moved image into a clean load-time error instead of a
-later I/O panic:
+Hard-drive and CD backends store enough metadata to reopen their backing
+files during deserialization. Missing or moved images cause a load-time error:
 
-- `HardDriveImage` (shared by Gayle IDE and A2091 SCSI) serializes as
+- `HardDriveImage` (shared by IDE, SCSI, and copperhf) serializes as
   `HardDriveImageState { path, memory, total_sectors, rdb_overlay,
-  overlay_write_warned, scsi_bus }`. A file-backed image stores
+  overlay_write_warned, scsi_bus, host_device }`. A file-backed image stores
   `memory: None` and reopens `path` read/write on load; an in-memory
   directory-built volume stores the whole image in `memory`, so its
   session-only writes survive the round trip. The synthesized-RDB
   overlay for bare hardfiles is embedded either way. Consequence: HDF
   *file contents* are not part of the state -- guest writes made after
   the snapshot are still visible after restoring.
-- `CdImage` serializes as `CdImageState { paths, tracks, extents,
-  total_sectors }` and reopens every image file read-only on load
-  (`CdImage` now keeps the per-file `paths` alongside its `files`
-  for exactly this purpose).
+- `CdImageState::Bin { sources, tracks, extents, total_sectors }` stores
+  the source descriptions needed to reopen BIN/WAVE/MP3, ISO, and NRG data.
+  `CdImageState::Chd { path }` stores the CHD path and rebuilds the CHD
+  backend on load. Both reopen media read-only.
+- A physical disk stores its identifier, fingerprint, and write-access
+  setting in `host_device`. Deserialization creates a pending device;
+  the host-disk reopen path then checks its identity and access rules.
+  It is never reopened as an ordinary file. Browser builds reject these states.
 
 Floppy images need no special handling: `FloppyImage` keeps its data
 in memory (`StandardAdf(Vec<u8>)` or per-track structures), so inserted
@@ -266,12 +263,9 @@ The regression checks cover serialization, failure recovery and replay:
 
 ## Reverse debugging (`timetravel.rs`)
 
-Reverse debugging is built directly on this determinism. Where `rr`
-records every nondeterministic syscall and signal to make replay
-reproducible, Copperline already has that for free, so going backwards is
-just *snapshot + replay*: keep a ring of recent machine states, and to
-reach an earlier point restore the nearest one at or before it and replay
-forward. The user-facing surfaces (headless `COPPERLINE_DBG_RWATCH`, the
+Reverse debugging keeps a ring of recent machine states. To reach an earlier
+point, it restores the nearest preceding snapshot and replays forward.
+The user-facing controls (headless `COPPERLINE_DBG_RWATCH`, the
 window's **&lt; Step** / **&lt; Run**) are documented in
 [](../debugger/reverse.md); this section is the model.
 
@@ -291,11 +285,9 @@ below one anchor.
 ### Position coordinate
 
 Reverse ops navigate by `Emulator::retired_instructions`, a monotonic
-count bumped per retired instruction in `execute_cpu_slice`. It lives
-**outside** the serialized state -- paired with each snapshot in the ring,
-not inside the blob -- so it costs nothing to capture and, importantly,
-**does not change the save-state shape**: reverse debugging needs no
-`STATE_VERSION` bump. A reverse step to position *P* restores the nearest
+count bumped per retired instruction in `execute_cpu_slice`. It is stored
+alongside each snapshot in the ring, outside the serialized machine blob.
+A reverse step to position *P* restores the nearest
 snapshot with `pos <= P` and single-steps to *P* through `run_one_step`,
 the exact per-instruction body the forward `step_real` loop uses (factored
 out so replay reproduces the forward run instruction-for-instruction,
@@ -313,18 +305,23 @@ logged actions as it reaches their positions. A floppy media change is
 logged as a marker that warns on replay rather than silently diverging (the
 inserted image is host-file state, not in the log).
 
+(determinism-boundaries)=
 ### Determinism boundaries
 
 The same host boundary as save states applies, plus the requirement that
 *time-dependent* inputs be pinned, since replay re-executes them:
 
-- The guest RTC (`rtc.rs`) reads host wall-clock time unless
-  `COPPERLINE_RTC_FIXED_SECS` is set; reverse mode warns when it is unset.
+- A fitted RTC reads host wall-clock time unless seeded with `--rtc-time`
+  or fixed with `COPPERLINE_RTC_FIXED_SECS`. The headless reverse-mode
+  warning checks only the environment override, so it can still appear
+  when `--rtc-time` already makes the clock deterministic.
 - Directory-backed (host-folder) filesystems stamp guest-visible host
   datestamps with no fixed-time override -- avoid for reverse replay.
 - HDF/CD images reopen by path and are externally mutable, so a guest disk
   write after a snapshot is not rolled back by restoring it; floppy
   contents are in-state and safe.
+- Physical media and live network, serial, MIDI, or sampler input cannot
+  be reproduced from the snapshot alone.
 
 ### Verification
 

--- a/docs/reference/custom-registers/000-BLTDDAT.md
+++ b/docs/reference/custom-registers/000-BLTDDAT.md
@@ -3,9 +3,8 @@ Offset: $000
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip BLTDDAT register.
+Blitter destination-data read address. Copperline does not expose a destination latch through this address.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+No destination bits are driven by the current model; a CPU read returns the custom-bus residue.

--- a/docs/reference/custom-registers/002-DMACONR.md
+++ b/docs/reference/custom-registers/002-DMACONR.md
@@ -3,9 +3,13 @@ Offset: $002
 Access: read
 Chipset: OCS/ECS/AGA
 
-Reports DMA enable state together with the blitter busy and zero-result flags.
+Reports DMA enable state and blitter status.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bit 14: BBUSY, blitter busy.
+- Bit 13: BZERO, all destination results in the current or last blit are zero.
+- Bit 10: BLTPRI, blitter priority over CPU chip-bus requests.
+- Bit 9: DMAEN, master DMA enable.
+- Bits 8-4: BPLEN, COPEN, BLTEN, SPREN, DSKEN.
+- Bits 3-0: AUD3EN through AUD0EN.

--- a/docs/reference/custom-registers/004-VPOSR.md
+++ b/docs/reference/custom-registers/004-VPOSR.md
@@ -3,9 +3,11 @@ Offset: $004
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip VPOSR register.
+Reads the vertical beam high bit, field flags, and Agnus identification.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bit 15: LOF, long-field flag.
+- Bits 14-8: Chipset identification.
+- Bit 7: LOL, long-line flag.
+- Bit 0: Vertical position bit 8; VHPOSR supplies bits 7-0.

--- a/docs/reference/custom-registers/006-VHPOSR.md
+++ b/docs/reference/custom-registers/006-VHPOSR.md
@@ -3,9 +3,11 @@ Offset: $006
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip VHPOSR register.
+Reads the beam position, or the latched light-pen position when enabled.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Vertical position bits 7-0.
+- Bits 7-0: Horizontal position in colour clocks.
 
+The live read is pipelined relative to the internal beam counter; VPOSR supplies the vertical high bit.

--- a/docs/reference/custom-registers/008-DSKDATR.md
+++ b/docs/reference/custom-registers/008-DSKDATR.md
@@ -3,9 +3,10 @@ Offset: $008
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip DSKDATR register.
+Reads a raw disk data word from the selected ready track.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Raw encoded track word.
 
+Copperline retains the last word when no ready track supplies a new value. DSKBYTR provides byte-ready and sync status.

--- a/docs/reference/custom-registers/00A-JOY0DAT.md
+++ b/docs/reference/custom-registers/00A-JOY0DAT.md
@@ -3,9 +3,11 @@ Offset: $00A
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip JOY0DAT register.
+Reads controller port 1's quadrature counters or digital joystick directions.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Y counter.
+- Bits 7-0: X counter.
 
+Joystick direction switches feed the quadrature inputs. Fire buttons are read through CIA-A and POTGOR, not this word.

--- a/docs/reference/custom-registers/00C-JOY1DAT.md
+++ b/docs/reference/custom-registers/00C-JOY1DAT.md
@@ -3,9 +3,11 @@ Offset: $00C
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip JOY1DAT register.
+Reads controller port 2's quadrature counters or digital joystick directions.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Y counter.
+- Bits 7-0: X counter.
 
+Joystick direction switches feed the quadrature inputs. Fire buttons are read through CIA-A and POTGOR, not this word.

--- a/docs/reference/custom-registers/00E-CLXDAT.md
+++ b/docs/reference/custom-registers/00E-CLXDAT.md
@@ -3,9 +3,13 @@ Offset: $00E
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip CLXDAT register.
+Reads and clears the accumulated sprite/playfield collision flags.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bit 15: Reads as 1 in Copperline.
+- Bits 14-9: Collisions between sprite pairs.
+- Bits 8-1: Sprite-pair collisions with either playfield.
+- Bit 0: Playfield 1/playfield 2 collision.
 
+CLXCON and CLXCON2 select participating planes and match values. Reading clears bits 14-0.

--- a/docs/reference/custom-registers/010-ADKCONR.md
+++ b/docs/reference/custom-registers/010-ADKCONR.md
@@ -3,9 +3,15 @@ Offset: $010
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip ADKCONR register.
+Reads the disk, serial-break, and audio-modulation control latches.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 14-13: Disk write precompensation selection.
+- Bit 12: MFMPREC, MFM precompensation mode.
+- Bit 11: UARTBRK, hold serial transmit low.
+- Bit 10: WORDSYNC, wait for DSKSYNC before disk read DMA.
+- Bit 9: MSBSYNC, disk byte-framing control.
+- Bit 8: FAST, disk bit-cell timing selection.
+- Bits 7-4: Audio period-modulation enables for channels 3-0.
+- Bits 3-0: Audio volume-modulation enables for channels 3-0.

--- a/docs/reference/custom-registers/012-POT0DAT.md
+++ b/docs/reference/custom-registers/012-POT0DAT.md
@@ -3,9 +3,11 @@ Offset: $012
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip POT0DAT register.
+Reads controller port 1's analogue measurement counters.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Y counter.
+- Bits 7-0: X counter.
 
+POTGO.START begins a measurement. Each input counter advances on horizontal sync until its pin reaches the charge threshold.

--- a/docs/reference/custom-registers/014-POT1DAT.md
+++ b/docs/reference/custom-registers/014-POT1DAT.md
@@ -3,9 +3,11 @@ Offset: $014
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip POT1DAT register.
+Reads controller port 2's analogue measurement counters.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Y counter.
+- Bits 7-0: X counter.
 
+POTGO.START begins a measurement. Each input counter advances on horizontal sync until its pin reaches the charge threshold.

--- a/docs/reference/custom-registers/016-POTGOR.md
+++ b/docs/reference/custom-registers/016-POTGOR.md
@@ -3,9 +3,11 @@ Offset: $016
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip POTGOR register.
+Reads potentiometer pin levels and output-enable latches.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15, 13, 11, 9: POTGO output-enable latches.
+- Bits 14, 12, 10, 8: Sensed levels of port 2 Y/X and port 1 Y/X.
 
+A pressed button can pull a pin low even when its output data bit is high.

--- a/docs/reference/custom-registers/018-SERDATR.md
+++ b/docs/reference/custom-registers/018-SERDATR.md
@@ -3,9 +3,15 @@ Offset: $018
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip SERDATR register.
+Reads serial receive data and transmit/receive status.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bit 15: OVRUN, receive overrun.
+- Bit 14: RBF, receive buffer full.
+- Bit 13: TBE, transmit buffer empty.
+- Bit 12: TSRE, transmit shift register empty.
+- Bit 11: RXD, synchronized receive-pin level.
+- Bits 9-0: Received data and stop bits.
 
+Acknowledge RBF through INTREQ; reading this register does not clear it.

--- a/docs/reference/custom-registers/01A-DSKBYTR.md
+++ b/docs/reference/custom-registers/01A-DSKBYTR.md
@@ -3,9 +3,12 @@ Offset: $01A
 Access: read
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip DSKBYTR register.
+Reads the latest disk byte and the disk DMA/sync flags.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bit 15: DSKBYT, a new byte is available; reading clears this flag.
+- Bit 14: DMAON.
+- Bit 13: DISKWRITE.
+- Bit 12: WORDEQUAL, the disk shifter matches DSKSYNC.
+- Bits 7-0: Latest disk byte.

--- a/docs/reference/custom-registers/01C-INTENAR.md
+++ b/docs/reference/custom-registers/01C-INTENAR.md
@@ -3,9 +3,19 @@ Offset: $01C
 Access: read
 Chipset: OCS/ECS/AGA
 
-Reports the enabled interrupt sources and master interrupt enable.
+Reads interrupt-source enables and the master enable.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bit 14: INTEN, master interrupt enable.
+- Bit 13: EXTER.
+- Bit 12: DSKSYNC.
+- Bit 11: RBF.
+- Bits 10-7: AUD3 through AUD0.
+- Bit 6: BLIT.
+- Bit 5: VERTB.
+- Bit 4: COPER.
+- Bit 3: PORTS.
+- Bit 2: SOFT.
+- Bit 1: DSKBLK.
+- Bit 0: TBE.

--- a/docs/reference/custom-registers/01E-INTREQR.md
+++ b/docs/reference/custom-registers/01E-INTREQR.md
@@ -3,9 +3,18 @@ Offset: $01E
 Access: read
 Chipset: OCS/ECS/AGA
 
-Reports pending interrupt requests.
+Reads pending interrupt requests without acknowledging them.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bit 13: EXTER.
+- Bit 12: DSKSYNC.
+- Bit 11: RBF.
+- Bits 10-7: AUD3 through AUD0.
+- Bit 6: BLIT.
+- Bit 5: VERTB.
+- Bit 4: COPER.
+- Bit 3: PORTS.
+- Bit 2: SOFT.
+- Bit 1: DSKBLK.
+- Bit 0: TBE.

--- a/docs/reference/custom-registers/020-DSKPTH.md
+++ b/docs/reference/custom-registers/020-DSKPTH.md
@@ -7,5 +7,8 @@ Sets the upper word of the DSK pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/024-DSKLEN.md
+++ b/docs/reference/custom-registers/024-DSKLEN.md
@@ -3,9 +3,12 @@ Offset: $024
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip DSKLEN register.
+Arms disk DMA, selects transfer direction, and sets the word count.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bit 15: DMAEN. Write the enabled value twice to start DMA; clearing this bit disarms it.
+- Bit 14: WRITE, 1 for disk writes and 0 for reads.
+- Bits 13-0: Transfer length in 16-bit words.
 
+DMACON must also enable master and disk DMA. ADKCON.WORDSYNC can defer reads until DSKSYNC matches.

--- a/docs/reference/custom-registers/026-DSKDAT.md
+++ b/docs/reference/custom-registers/026-DSKDAT.md
@@ -3,9 +3,8 @@ Offset: $026
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip DSKDAT register.
+Supplies a raw word to the disk write path.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 15-0: Encoded disk data; AmigaDOS sector encoding is the guest software's responsibility.

--- a/docs/reference/custom-registers/028-REFPTR.md
+++ b/docs/reference/custom-registers/028-REFPTR.md
@@ -3,9 +3,8 @@ Offset: $028
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip REFPTR register.
+Refresh pointer register.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+Copperline does not implement this register. No written bits affect the emulated machine.

--- a/docs/reference/custom-registers/02A-VPOSW.md
+++ b/docs/reference/custom-registers/02A-VPOSW.md
@@ -3,9 +3,11 @@ Offset: $02A
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip VPOSW register.
+Writes the long-field flag and high bit of the vertical beam counter.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bit 15: LOF.
+- Bit 0: Vertical position bit 8.
 
+Copperline retains the current low vertical byte and clamps the result to the configured field length.

--- a/docs/reference/custom-registers/02C-VHPOSW.md
+++ b/docs/reference/custom-registers/02C-VHPOSW.md
@@ -3,9 +3,9 @@ Offset: $02C
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip VHPOSW register.
+Writes the low vertical byte and horizontal beam position.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 15-8: Vertical position bits 7-0.
+- Bits 7-0: Horizontal position in colour clocks.

--- a/docs/reference/custom-registers/02E-COPCON.md
+++ b/docs/reference/custom-registers/02E-COPCON.md
@@ -3,9 +3,10 @@ Offset: $02E
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip COPCON register.
+Controls the Copper's access to low custom-register addresses.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bit 1: CDANG, permit Copper writes to the blitter register range.
 
+On OCS, clearing CDANG restricts writes to $080 and above; setting it lowers the boundary to $040. ECS/AGA extend the permitted range when CDANG is set.

--- a/docs/reference/custom-registers/030-SERDAT.md
+++ b/docs/reference/custom-registers/030-SERDAT.md
@@ -3,9 +3,11 @@ Offset: $030
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip SERDAT register.
+Queues a serial transmit word, including its stop bit.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 8-0: Data and first stop-bit position for the selected word length.
+- Bit 9: Stop bit for 9-bit mode.
 
+For 8-bit transmission, set bit 8 above the data byte. SERPER selects the bit period and 8/9-bit format.

--- a/docs/reference/custom-registers/032-SERPER.md
+++ b/docs/reference/custom-registers/032-SERPER.md
@@ -3,9 +3,11 @@ Offset: $032
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip SERPER register.
+Sets serial bit timing and word length.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bit 15: LONG, select 9 data bits instead of 8.
+- Bits 14-0: Bit period minus one, in Paula clocks.
 
+The bit rate is the Paula clock divided by the period plus one.

--- a/docs/reference/custom-registers/034-POTGO.md
+++ b/docs/reference/custom-registers/034-POTGO.md
@@ -3,9 +3,12 @@ Offset: $034
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip POTGO register.
+Controls the four potentiometer pins and starts analogue measurement.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15, 13, 11, 9: Output enables for port 2 Y/X and port 1 Y/X, respectively.
+- Bits 14, 12, 10, 8: Output data for those pins.
+- Bit 0: START, discharge the capacitors and begin a measurement.
 
+The pins also carry mouse buttons and the CD32 pad serial interface.

--- a/docs/reference/custom-registers/036-JOYTEST.md
+++ b/docs/reference/custom-registers/036-JOYTEST.md
@@ -3,9 +3,11 @@ Offset: $036
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip JOYTEST register.
+Loads both controller ports' quadrature counters for testing.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Y counter value.
+- Bits 7-0: X counter value.
 
+Copperline loads both bytes into both ports, regardless of the attached device.

--- a/docs/reference/custom-registers/038-STREQU.md
+++ b/docs/reference/custom-registers/038-STREQU.md
@@ -3,9 +3,8 @@ Offset: $038
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip STREQU register.
+Equalization-period sync strobe.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+No data bitfields: this is a strobe address. Copperline accepts writes without changing state; sync and blanking come from the beam model.

--- a/docs/reference/custom-registers/03A-STRVBL.md
+++ b/docs/reference/custom-registers/03A-STRVBL.md
@@ -3,9 +3,8 @@ Offset: $03A
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip STRVBL register.
+Vertical-blank sync strobe.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+No data bitfields: this is a strobe address. Copperline accepts writes without changing state; sync and blanking come from the beam model.

--- a/docs/reference/custom-registers/03C-STRHOR.md
+++ b/docs/reference/custom-registers/03C-STRHOR.md
@@ -3,9 +3,8 @@ Offset: $03C
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip STRHOR register.
+Horizontal sync strobe.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+No data bitfields: this is a strobe address. Copperline accepts writes without changing state; sync and blanking come from the beam model.

--- a/docs/reference/custom-registers/03E-STRLONG.md
+++ b/docs/reference/custom-registers/03E-STRLONG.md
@@ -3,9 +3,8 @@ Offset: $03E
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip STRLONG register.
+Long-line sync strobe.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+No data bitfields: this is a strobe address. Copperline accepts writes without changing state; sync and blanking come from the beam model.

--- a/docs/reference/custom-registers/040-BLTCON0.md
+++ b/docs/reference/custom-registers/040-BLTCON0.md
@@ -3,9 +3,10 @@ Offset: $040
 Access: write
 Chipset: OCS/ECS/AGA
 
-Selects blitter source channels, shifts source A, and supplies the minterm.
+Selects source A shift, DMA channels, and the blitter minterm.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 15-12: ASH, source A shift (0-15).
+- Bits 11-8: USEA, USEB, USEC, USED, respectively.
+- Bits 7-0: LF, the eight-entry truth table for the A/B/C Boolean operation.

--- a/docs/reference/custom-registers/042-BLTCON1.md
+++ b/docs/reference/custom-registers/042-BLTCON1.md
@@ -3,9 +3,15 @@ Offset: $042
 Access: write
 Chipset: OCS/ECS/AGA
 
-Selects blitter line or area mode and source B shift and descending controls.
+Selects area or line mode, source B shift, fill, and direction.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-12: BSH, source B shift or line-texture position.
+- Bit 7: DOFF, suppress destination writes (ECS/AGA).
+- Bit 6: SIGN, line error-term sign.
+- Bits 4-2: EFE/IFE/FCI in area mode; SUD/SUL/AUL direction controls in line mode.
+- Bit 1: DESC in area mode; SING in line mode.
+- Bit 0: LINE, select line mode.
 
+Bits 11-8 and bit 5 are unused. Fill applies to descending area blits.

--- a/docs/reference/custom-registers/044-BLTAFWM.md
+++ b/docs/reference/custom-registers/044-BLTAFWM.md
@@ -3,9 +3,8 @@ Offset: $044
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip BLTAFWM register.
+Masks source A on the first word of each blitter row.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 15-0: AND mask applied before source A shifting; a cleared bit suppresses the corresponding input bit.

--- a/docs/reference/custom-registers/046-BLTALWM.md
+++ b/docs/reference/custom-registers/046-BLTALWM.md
@@ -3,9 +3,8 @@ Offset: $046
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip BLTALWM register.
+Masks source A on the last word of each blitter row.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 15-0: AND mask applied before source A shifting; a cleared bit suppresses the corresponding input bit.

--- a/docs/reference/custom-registers/048-BLTCPTH.md
+++ b/docs/reference/custom-registers/048-BLTCPTH.md
@@ -7,5 +7,8 @@ Sets the upper word of the BLTC pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/04C-BLTBPTH.md
+++ b/docs/reference/custom-registers/04C-BLTBPTH.md
@@ -7,5 +7,8 @@ Sets the upper word of the BLTB pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/050-BLTAPTH.md
+++ b/docs/reference/custom-registers/050-BLTAPTH.md
@@ -7,5 +7,8 @@ Sets the upper word of the BLTA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/054-BLTDPTH.md
+++ b/docs/reference/custom-registers/054-BLTDPTH.md
@@ -7,5 +7,8 @@ Sets the upper word of the BLTD pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/05A-BLTCON0L.md
+++ b/docs/reference/custom-registers/05A-BLTCON0L.md
@@ -3,9 +3,9 @@ Offset: $05A
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip BLTCON0L register.
+Updates the blitter minterm without changing source shift or channel enables.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 7-0: BLTCON0.LF Boolean truth table.
+- Bits 15-8: Ignored.

--- a/docs/reference/custom-registers/05C-BLTSIZV.md
+++ b/docs/reference/custom-registers/05C-BLTSIZV.md
@@ -3,9 +3,11 @@ Offset: $05C
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip BLTSIZV register.
+Latches the extended blitter height for a later BLTSIZH start.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 14-0: Height in rows; zero means 32768.
+- Bit 15: Ignored.
 
+Writing this register alone does not start a blit.

--- a/docs/reference/custom-registers/05E-BLTSIZH.md
+++ b/docs/reference/custom-registers/05E-BLTSIZH.md
@@ -3,9 +3,9 @@ Offset: $05E
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip BLTSIZH register.
+Starts an ECS/AGA blit using the height in BLTSIZV.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 10-0: Width in 16-bit words; zero means 2048.
+- Bits 15-11: Ignored.

--- a/docs/reference/custom-registers/060-BLTCMOD.md
+++ b/docs/reference/custom-registers/060-BLTCMOD.md
@@ -3,9 +3,10 @@ Offset: $060
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip BLTCMOD register.
+Sets the signed row-end address adjustment for blitter channel C.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-1: Signed byte displacement; bit 0 is ignored for word alignment.
 
+Area mode adds the modulo after each row, or subtracts it in descending mode. Line mode uses the blitter modulos for its address/error updates.

--- a/docs/reference/custom-registers/062-BLTBMOD.md
+++ b/docs/reference/custom-registers/062-BLTBMOD.md
@@ -3,9 +3,10 @@ Offset: $062
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip BLTBMOD register.
+Sets the signed row-end address adjustment for blitter channel B.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-1: Signed byte displacement; bit 0 is ignored for word alignment.
 
+Area mode adds the modulo after each row, or subtracts it in descending mode. Line mode uses the blitter modulos for its address/error updates.

--- a/docs/reference/custom-registers/064-BLTAMOD.md
+++ b/docs/reference/custom-registers/064-BLTAMOD.md
@@ -3,9 +3,10 @@ Offset: $064
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip BLTAMOD register.
+Sets the signed row-end address adjustment for blitter channel A.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-1: Signed byte displacement; bit 0 is ignored for word alignment.
 
+Area mode adds the modulo after each row, or subtracts it in descending mode. Line mode uses the blitter modulos for its address/error updates.

--- a/docs/reference/custom-registers/066-BLTDMOD.md
+++ b/docs/reference/custom-registers/066-BLTDMOD.md
@@ -3,9 +3,10 @@ Offset: $066
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip BLTDMOD register.
+Sets the signed row-end address adjustment for blitter channel D.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-1: Signed byte displacement; bit 0 is ignored for word alignment.
 
+Area mode adds the modulo after each row, or subtracts it in descending mode. Line mode uses the blitter modulos for its address/error updates.

--- a/docs/reference/custom-registers/070-BLTCDAT.md
+++ b/docs/reference/custom-registers/070-BLTCDAT.md
@@ -3,9 +3,10 @@ Offset: $070
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip BLTCDAT register.
+Holds the source C word used by the blitter.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Source data.
 
+When the channel's DMA is disabled, software can supply its data through this latch.

--- a/docs/reference/custom-registers/072-BLTBDAT.md
+++ b/docs/reference/custom-registers/072-BLTBDAT.md
@@ -3,9 +3,10 @@ Offset: $072
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip BLTBDAT register.
+Holds the source B word used by the blitter.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Source data.
 
+When the channel's DMA is disabled, software can supply its data through this latch.

--- a/docs/reference/custom-registers/072-BLTBDAT.md
+++ b/docs/reference/custom-registers/072-BLTBDAT.md
@@ -9,4 +9,7 @@ Holds the source B word used by the blitter.
 
 - Bits 15-0: Source data.
 
-When the channel's DMA is disabled, software can supply its data through this latch.
+A write immediately runs the B barrel shifter using the current BLTCON1
+BSH and DESC values. Area blits with USEB clear consume this shifted hold
+word; changing BSH before starting the blit does not shift it again.
+Line mode uses BLTBDAT as its texture and applies the live BSH value.

--- a/docs/reference/custom-registers/074-BLTADAT.md
+++ b/docs/reference/custom-registers/074-BLTADAT.md
@@ -3,9 +3,10 @@ Offset: $074
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip BLTADAT register.
+Holds the source A word used by the blitter.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Source data.
 
+When the channel's DMA is disabled, software can supply its data through this latch.

--- a/docs/reference/custom-registers/078-SPRHDAT.md
+++ b/docs/reference/custom-registers/078-SPRHDAT.md
@@ -3,8 +3,10 @@ Offset: $078
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip SPRHDAT register.
+Latches the ECS UHRES sprite identifier/data word.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Stored word.
+
+The latch is available to debugger inspection, but UHRES display/DMA is not emulated.

--- a/docs/reference/custom-registers/07A-BPLHDAT.md
+++ b/docs/reference/custom-registers/07A-BPLHDAT.md
@@ -3,8 +3,8 @@ Offset: $07A
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip BPLHDAT register.
+UHRES bitplane identifier/data register.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+Copperline does not implement this register. No written bits affect the emulated machine.

--- a/docs/reference/custom-registers/07C-DENISEID.md
+++ b/docs/reference/custom-registers/07C-DENISEID.md
@@ -3,8 +3,10 @@ Offset: $07C
 Access: read
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip DENISEID register.
+Identifies ECS Denise or AGA Lisa.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- ECS Denise reads $FFFC.
+- AGA Lisa reads $00F8.
+- OCS has no register here; Copperline returns $FFFF as a detection workaround instead of the floating-bus residue.

--- a/docs/reference/custom-registers/07E-DSKSYNC.md
+++ b/docs/reference/custom-registers/07E-DSKSYNC.md
@@ -3,9 +3,10 @@ Offset: $07E
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip DSKSYNC register.
+Sets the disk shifter's sync comparison word.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Raw sync word, commonly $4489 for AmigaDOS tracks.
 
+Matches set the DSKSYNC interrupt request; ADKCON.WORDSYNC also uses the comparison to start read DMA.

--- a/docs/reference/custom-registers/080-COP1LCH.md
+++ b/docs/reference/custom-registers/080-COP1LCH.md
@@ -7,5 +7,8 @@ Sets the upper word of the COP1 pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/084-COP2LCH.md
+++ b/docs/reference/custom-registers/084-COP2LCH.md
@@ -7,5 +7,8 @@ Sets the upper word of the COP2 pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/088-COPJMP1.md
+++ b/docs/reference/custom-registers/088-COPJMP1.md
@@ -3,9 +3,8 @@ Offset: $088
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip COPJMP1 register.
+Restarts the Copper from COP1LC.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+No data bitfields: accessing the address fires the strobe. Copperline handles CPU reads as well as writes; a read returns the undriven bus value.

--- a/docs/reference/custom-registers/08A-COPJMP2.md
+++ b/docs/reference/custom-registers/08A-COPJMP2.md
@@ -3,9 +3,8 @@ Offset: $08A
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip COPJMP2 register.
+Restarts the Copper from COP2LC.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+No data bitfields: accessing the address fires the strobe. Copperline handles CPU reads as well as writes; a read returns the undriven bus value.

--- a/docs/reference/custom-registers/08C-COPINS.md
+++ b/docs/reference/custom-registers/08C-COPINS.md
@@ -3,9 +3,8 @@ Offset: $08C
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip COPINS register.
+Copper instruction register address.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+Copperline does not implement this register. No written bits affect the emulated machine.

--- a/docs/reference/custom-registers/08E-DIWSTRT.md
+++ b/docs/reference/custom-registers/08E-DIWSTRT.md
@@ -3,9 +3,11 @@ Offset: $08E
 Access: write
 Chipset: OCS/ECS/AGA
 
-Sets the display window start position.
+Sets the display-window start position.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Vertical position low byte.
+- Bits 7-0: Horizontal position low byte.
 
+OCS supplies implicit high bits. ECS/AGA can override them with DIWHIGH, which must be written after DIWSTRT/DIWSTOP.

--- a/docs/reference/custom-registers/090-DIWSTOP.md
+++ b/docs/reference/custom-registers/090-DIWSTOP.md
@@ -3,9 +3,11 @@ Offset: $090
 Access: write
 Chipset: OCS/ECS/AGA
 
-Sets the display window stop position.
+Sets the display-window stop position.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Vertical position low byte.
+- Bits 7-0: Horizontal position low byte.
 
+OCS supplies implicit high bits. ECS/AGA can override them with DIWHIGH, which must be written after DIWSTRT/DIWSTOP.

--- a/docs/reference/custom-registers/092-DDFSTRT.md
+++ b/docs/reference/custom-registers/092-DDFSTRT.md
@@ -3,9 +3,12 @@ Offset: $092
 Access: write
 Chipset: OCS/ECS/AGA
 
-Sets the first colour clock at which bitplane DMA fetches.
+Sets the horizontal bitplane-fetch start comparison.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 7-2: OCS horizontal comparison in colour clocks.
+- Bit 1: Additional ECS/AGA comparison precision.
+- Bit 0: Ignored.
 
+The sequencer's state, DMA enables, and fetch width determine the actual transfers; DDFSTOP does not cut off a fetch group already in progress.

--- a/docs/reference/custom-registers/094-DDFSTOP.md
+++ b/docs/reference/custom-registers/094-DDFSTOP.md
@@ -3,9 +3,12 @@ Offset: $094
 Access: write
 Chipset: OCS/ECS/AGA
 
-Sets the last colour clock at which bitplane DMA fetches.
+Sets the horizontal bitplane-fetch stop comparison.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 7-2: OCS horizontal comparison in colour clocks.
+- Bit 1: Additional ECS/AGA comparison precision.
+- Bit 0: Ignored.
 
+The sequencer's state, DMA enables, and fetch width determine the actual transfers; DDFSTOP does not cut off a fetch group already in progress.

--- a/docs/reference/custom-registers/096-DMACON.md
+++ b/docs/reference/custom-registers/096-DMACON.md
@@ -3,10 +3,14 @@ Offset: $096
 Access: write
 Chipset: OCS/ECS/AGA
 
-Sets or clears DMA enable bits using bit 15 as the set/clear selector.
+Sets or clears the DMA enables and blitter priority.
 
 ## Bitfields
 
-- Bit 15: SET/CLR selector.
-- Bits 14-0: Register-specific enable or request flags.
+- Bit 15: SET/CLR; 1 sets the selected bits, 0 clears them.
+- Bit 10: BLTPRI, blitter priority over CPU chip-bus requests.
+- Bit 9: DMAEN, master DMA enable.
+- Bits 8-4: BPLEN, COPEN, BLTEN, SPREN, DSKEN.
+- Bits 3-0: AUD3EN through AUD0EN.
 
+Bits 14-13 are status in DMACONR and cannot be written here.

--- a/docs/reference/custom-registers/098-CLXCON.md
+++ b/docs/reference/custom-registers/098-CLXCON.md
@@ -3,9 +3,12 @@ Offset: $098
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip CLXCON register.
+Selects sprite participation and bitplane matches for collision detection.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-12: Include odd sprites 7, 5, 3, and 1 in their respective pairs.
+- Bits 11-6: Enable bitplanes 6-1 for comparison.
+- Bits 5-0: Required match values for bitplanes 6-1.
 
+On AGA, writing CLXCON also clears CLXCON2.

--- a/docs/reference/custom-registers/09A-INTENA.md
+++ b/docs/reference/custom-registers/09A-INTENA.md
@@ -3,10 +3,20 @@ Offset: $09A
 Access: write
 Chipset: OCS/ECS/AGA
 
-Sets or clears interrupt enable bits using bit 15 as the set/clear selector.
+Sets or clears interrupt-source enables and the master enable.
 
 ## Bitfields
 
-- Bit 15: SET/CLR selector.
-- Bits 14-0: Register-specific enable or request flags.
-
+- Bit 15: SET/CLR; 1 sets selected bits, 0 clears them.
+- Bit 14: INTEN, master interrupt enable.
+- Bit 13: EXTER.
+- Bit 12: DSKSYNC.
+- Bit 11: RBF.
+- Bits 10-7: AUD3 through AUD0.
+- Bit 6: BLIT.
+- Bit 5: VERTB.
+- Bit 4: COPER.
+- Bit 3: PORTS.
+- Bit 2: SOFT.
+- Bit 1: DSKBLK.
+- Bit 0: TBE.

--- a/docs/reference/custom-registers/09C-INTREQ.md
+++ b/docs/reference/custom-registers/09C-INTREQ.md
@@ -3,10 +3,19 @@ Offset: $09C
 Access: write
 Chipset: OCS/ECS/AGA
 
-Sets or clears interrupt requests using bit 15 as the set/clear selector.
+Sets or clears pending interrupt requests.
 
 ## Bitfields
 
-- Bit 15: SET/CLR selector.
-- Bits 14-0: Register-specific enable or request flags.
-
+- Bit 15: SET/CLR; 1 sets selected bits, 0 clears them.
+- Bit 13: EXTER.
+- Bit 12: DSKSYNC.
+- Bit 11: RBF.
+- Bits 10-7: AUD3 through AUD0.
+- Bit 6: BLIT.
+- Bit 5: VERTB.
+- Bit 4: COPER.
+- Bit 3: PORTS.
+- Bit 2: SOFT.
+- Bit 1: DSKBLK.
+- Bit 0: TBE.

--- a/docs/reference/custom-registers/09E-ADKCON.md
+++ b/docs/reference/custom-registers/09E-ADKCON.md
@@ -3,10 +3,16 @@ Offset: $09E
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip ADKCON register.
+Sets or clears disk, serial-break, and audio-modulation controls.
 
 ## Bitfields
 
-- Bit 15: SET/CLR selector.
-- Bits 14-0: Register-specific enable or request flags.
-
+- Bit 15: SET/CLR; 1 sets selected bits, 0 clears them.
+- Bits 14-13: Disk write precompensation selection.
+- Bit 12: MFMPREC, MFM precompensation mode.
+- Bit 11: UARTBRK, hold serial transmit low.
+- Bit 10: WORDSYNC, wait for DSKSYNC before disk read DMA.
+- Bit 9: MSBSYNC, disk byte-framing control.
+- Bit 8: FAST, disk bit-cell timing selection.
+- Bits 7-4: Audio period-modulation enables for channels 3-0.
+- Bits 3-0: Audio volume-modulation enables for channels 3-0.

--- a/docs/reference/custom-registers/0A0-AUD0LCH.md
+++ b/docs/reference/custom-registers/0A0-AUD0LCH.md
@@ -7,5 +7,8 @@ Sets the upper word of audio channel 0's sample pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/0A4-AUD0LEN.md
+++ b/docs/reference/custom-registers/0A4-AUD0LEN.md
@@ -3,9 +3,8 @@ Offset: $0A4
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls audio channel 0's sample length.
+Sets audio channel 0's DMA block length.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 15-0: Length in 16-bit words, two 8-bit samples per word. Zero represents 65536 words.

--- a/docs/reference/custom-registers/0A6-AUD0PER.md
+++ b/docs/reference/custom-registers/0A6-AUD0PER.md
@@ -3,9 +3,10 @@ Offset: $0A6
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls audio channel 0's playback period.
+Sets audio channel 0's sample playback period.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Period in Paula clocks per 8-bit sample.
 
+DMA supplies two samples per word; a shorter period increases playback rate.

--- a/docs/reference/custom-registers/0A8-AUD0VOL.md
+++ b/docs/reference/custom-registers/0A8-AUD0VOL.md
@@ -3,9 +3,12 @@ Offset: $0A8
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls audio channel 0's output volume.
+Sets audio channel 0's volume latch.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 5-0: Volume from 0 to 63.
+- Bit 6: Select maximum volume (64), regardless of bits 5-0.
+- Bits 15-7: Ignored.
 
+The live volume reloads at the next output-word boundary.

--- a/docs/reference/custom-registers/0B0-AUD1LCH.md
+++ b/docs/reference/custom-registers/0B0-AUD1LCH.md
@@ -7,5 +7,8 @@ Sets the upper word of audio channel 1's sample pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/0B4-AUD1LEN.md
+++ b/docs/reference/custom-registers/0B4-AUD1LEN.md
@@ -3,9 +3,8 @@ Offset: $0B4
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls audio channel 1's sample length.
+Sets audio channel 1's DMA block length.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 15-0: Length in 16-bit words, two 8-bit samples per word. Zero represents 65536 words.

--- a/docs/reference/custom-registers/0B6-AUD1PER.md
+++ b/docs/reference/custom-registers/0B6-AUD1PER.md
@@ -3,9 +3,10 @@ Offset: $0B6
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls audio channel 1's playback period.
+Sets audio channel 1's sample playback period.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Period in Paula clocks per 8-bit sample.
 
+DMA supplies two samples per word; a shorter period increases playback rate.

--- a/docs/reference/custom-registers/0B8-AUD1VOL.md
+++ b/docs/reference/custom-registers/0B8-AUD1VOL.md
@@ -3,9 +3,12 @@ Offset: $0B8
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls audio channel 1's output volume.
+Sets audio channel 1's volume latch.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 5-0: Volume from 0 to 63.
+- Bit 6: Select maximum volume (64), regardless of bits 5-0.
+- Bits 15-7: Ignored.
 
+The live volume reloads at the next output-word boundary.

--- a/docs/reference/custom-registers/0C0-AUD2LCH.md
+++ b/docs/reference/custom-registers/0C0-AUD2LCH.md
@@ -7,5 +7,8 @@ Sets the upper word of audio channel 2's sample pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/0C4-AUD2LEN.md
+++ b/docs/reference/custom-registers/0C4-AUD2LEN.md
@@ -3,9 +3,8 @@ Offset: $0C4
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls audio channel 2's sample length.
+Sets audio channel 2's DMA block length.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 15-0: Length in 16-bit words, two 8-bit samples per word. Zero represents 65536 words.

--- a/docs/reference/custom-registers/0C6-AUD2PER.md
+++ b/docs/reference/custom-registers/0C6-AUD2PER.md
@@ -3,9 +3,10 @@ Offset: $0C6
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls audio channel 2's playback period.
+Sets audio channel 2's sample playback period.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Period in Paula clocks per 8-bit sample.
 
+DMA supplies two samples per word; a shorter period increases playback rate.

--- a/docs/reference/custom-registers/0C8-AUD2VOL.md
+++ b/docs/reference/custom-registers/0C8-AUD2VOL.md
@@ -3,9 +3,12 @@ Offset: $0C8
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls audio channel 2's output volume.
+Sets audio channel 2's volume latch.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 5-0: Volume from 0 to 63.
+- Bit 6: Select maximum volume (64), regardless of bits 5-0.
+- Bits 15-7: Ignored.
 
+The live volume reloads at the next output-word boundary.

--- a/docs/reference/custom-registers/0D0-AUD3LCH.md
+++ b/docs/reference/custom-registers/0D0-AUD3LCH.md
@@ -7,5 +7,8 @@ Sets the upper word of audio channel 3's sample pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/0D4-AUD3LEN.md
+++ b/docs/reference/custom-registers/0D4-AUD3LEN.md
@@ -3,9 +3,8 @@ Offset: $0D4
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls audio channel 3's sample length.
+Sets audio channel 3's DMA block length.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 15-0: Length in 16-bit words, two 8-bit samples per word. Zero represents 65536 words.

--- a/docs/reference/custom-registers/0D6-AUD3PER.md
+++ b/docs/reference/custom-registers/0D6-AUD3PER.md
@@ -3,9 +3,10 @@ Offset: $0D6
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls audio channel 3's playback period.
+Sets audio channel 3's sample playback period.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Period in Paula clocks per 8-bit sample.
 
+DMA supplies two samples per word; a shorter period increases playback rate.

--- a/docs/reference/custom-registers/0D8-AUD3VOL.md
+++ b/docs/reference/custom-registers/0D8-AUD3VOL.md
@@ -3,9 +3,12 @@ Offset: $0D8
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls audio channel 3's output volume.
+Sets audio channel 3's volume latch.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 5-0: Volume from 0 to 63.
+- Bit 6: Select maximum volume (64), regardless of bits 5-0.
+- Bits 15-7: Ignored.
 
+The live volume reloads at the next output-word boundary.

--- a/docs/reference/custom-registers/0E0-BPL1PTH.md
+++ b/docs/reference/custom-registers/0E0-BPL1PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of bitplane 1's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/0E4-BPL2PTH.md
+++ b/docs/reference/custom-registers/0E4-BPL2PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of bitplane 2's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/0E8-BPL3PTH.md
+++ b/docs/reference/custom-registers/0E8-BPL3PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of bitplane 3's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/0EC-BPL4PTH.md
+++ b/docs/reference/custom-registers/0EC-BPL4PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of bitplane 4's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/0F0-BPL5PTH.md
+++ b/docs/reference/custom-registers/0F0-BPL5PTH.md
@@ -7,4 +7,7 @@ Sets the upper word of bitplane 5's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.

--- a/docs/reference/custom-registers/0F4-BPL6PTH.md
+++ b/docs/reference/custom-registers/0F4-BPL6PTH.md
@@ -7,4 +7,7 @@ Sets the upper word of bitplane 6's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.

--- a/docs/reference/custom-registers/0F8-BPL7PTH.md
+++ b/docs/reference/custom-registers/0F8-BPL7PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of bitplane 7's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/0FC-BPL8PTH.md
+++ b/docs/reference/custom-registers/0FC-BPL8PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of bitplane 8's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/100-BPLCON0.md
+++ b/docs/reference/custom-registers/100-BPLCON0.md
@@ -3,11 +3,20 @@ Offset: $100
 Access: write
 Chipset: OCS/ECS/AGA
 
-Selects display resolution, bitplane count, HAM, dual-playfield, and lace modes.
+Selects resolution, bitplane count, HAM, dual playfields, and beam controls.
 
 ## Bitfields
 
-- Bits 14-12 and bit 4: Bitplane count.
-- Bits 11-9: HAM, dual playfield, and colour enable.
-- Bits 6 and 3-0: Resolution and display controls.
-
+- Bit 15: HIRES.
+- Bits 14-12: BPU2-0, bitplane count; AGA adds BPU3 at bit 4.
+- Bit 11: HAM.
+- Bit 10: DPF, dual playfields.
+- Bit 9: COLOR, colour output enable.
+- Bit 8: GAUD, genlock audio control.
+- Bit 7: UHRES (not emulated).
+- Bit 6: SHRES (ECS/AGA).
+- Bit 5: BYPASS (AGA).
+- Bit 3: LPEN, light-pen latch enable.
+- Bit 2: LACE, interlace.
+- Bit 1: ERSY, external resynchronization.
+- Bit 0: ECSENA, enable extended Denise controls.

--- a/docs/reference/custom-registers/102-BPLCON1.md
+++ b/docs/reference/custom-registers/102-BPLCON1.md
@@ -3,9 +3,11 @@ Offset: $102
 Access: write
 Chipset: OCS/ECS/AGA
 
-Sets horizontal scroll values for the odd and even bitplane groups.
+Sets horizontal scroll for odd and even bitplane groups.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 3-0: PF1 scroll, odd bitplanes.
+- Bits 7-4: PF2 scroll, even bitplanes.
+- AGA bits 11-10 and 15-14: Upper PF1/PF2 delay bits.
+- AGA bits 9-8 and 13-12: Fine PF1/PF2 delay bits in superhires-pixel units.

--- a/docs/reference/custom-registers/104-BPLCON2.md
+++ b/docs/reference/custom-registers/104-BPLCON2.md
@@ -3,9 +3,17 @@ Offset: $104
 Access: write
 Chipset: OCS/ECS/AGA
 
-Sets playfield and sprite priority relationships.
+Sets playfield/sprite priorities and extended colour controls.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 2-0: PF1 priority relative to sprite pairs.
+- Bits 5-3: PF2 priority relative to sprite pairs.
+- Bit 6: PF2PRI, place playfield 2 above playfield 1.
+- Bit 7: SOGEN, genlock control.
+- Bit 8: RDRAM, AGA palette readback.
+- Bit 9: KILLEHB, disable extra-half-brite decoding.
+- Bits 10-11: ZDCTEN/ZDBPEN, genlock transparency enables.
+- Bits 14-12: ZDBPSEL, genlock bitplane selection.
 
+Extended controls depend on the fitted Denise/Lisa revision; bit 15 is unused.

--- a/docs/reference/custom-registers/104-BPLCON2.md
+++ b/docs/reference/custom-registers/104-BPLCON2.md
@@ -13,7 +13,8 @@ Sets playfield/sprite priorities and extended colour controls.
 - Bit 7: SOGEN, genlock control.
 - Bit 8: RDRAM, AGA palette readback.
 - Bit 9: KILLEHB, disable extra-half-brite decoding.
-- Bits 10-11: ZDCTEN/ZDBPEN, genlock transparency enables.
+- Bit 10: ZDCTEN, genlock colour-transparency enable.
+- Bit 11: ZDBPEN, genlock bitplane-transparency enable.
 - Bits 14-12: ZDBPSEL, genlock bitplane selection.
 
 Extended controls depend on the fitted Denise/Lisa revision; bit 15 is unused.

--- a/docs/reference/custom-registers/106-BPLCON3.md
+++ b/docs/reference/custom-registers/106-BPLCON3.md
@@ -3,9 +3,18 @@ Offset: $106
 Access: write
 Chipset: ECS/AGA
 
-Controls ECS/AGA display, palette-bank, and border behaviour.
+Controls ECS/AGA borders, sprite resolution, and AGA palette addressing.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-13: BANK, AGA palette bank (0-7).
+- Bits 12-10: PF2OF, AGA playfield 2 palette offset.
+- Bit 9: LOCT, AGA low colour-nibble selection.
+- Bits 7-6: SPRES, sprite resolution (default/lores/hires/superhires).
+- Bit 5: BRDRBLNK, blank border.
+- Bit 4: BRDNTRAN, opaque border for genlock.
+- Bit 2: ZDCLKEN, genlock clock output.
+- Bit 1: BRDRSPRT, sprites in the border.
+- Bit 0: EXTBLKEN, external blanking control.
 
+Bits 8 and 3 are unused. ECS implements only the extended Denise subset; AGA adds the palette and sprite controls.

--- a/docs/reference/custom-registers/108-BPL1MOD.md
+++ b/docs/reference/custom-registers/108-BPL1MOD.md
@@ -3,9 +3,9 @@ Offset: $108
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip BPL1MOD register.
+Sets the row-end DMA pointer adjustment for the odd-numbered bitplanes.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 15-1: Signed byte displacement added after a fetched row.
+- Bit 0: Ignored for word alignment.

--- a/docs/reference/custom-registers/10A-BPL2MOD.md
+++ b/docs/reference/custom-registers/10A-BPL2MOD.md
@@ -3,9 +3,9 @@ Offset: $10A
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls or reports the custom-chip BPL2MOD register.
+Sets the row-end DMA pointer adjustment for the even-numbered bitplanes.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 15-1: Signed byte displacement added after a fetched row.
+- Bit 0: Ignored for word alignment.

--- a/docs/reference/custom-registers/10C-BPLCON4.md
+++ b/docs/reference/custom-registers/10C-BPLCON4.md
@@ -3,9 +3,10 @@ Offset: $10C
 Access: write
 Chipset: AGA
 
-Selects AGA bitplane and sprite palette banks.
+Applies the AGA bitplane colour XOR mask and sprite palette bases.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 15-8: BPLAM, XOR mask for bitplane colour indices.
+- Bits 7-4: ESPRM, palette-base nibble for even sprites.
+- Bits 3-0: OSPRM, palette-base nibble for odd sprites.

--- a/docs/reference/custom-registers/10E-CLXCON2.md
+++ b/docs/reference/custom-registers/10E-CLXCON2.md
@@ -3,9 +3,11 @@ Offset: $10E
 Access: write
 Chipset: AGA
 
-Controls or reports the custom-chip CLXCON2 register.
+Extends AGA collision matching to bitplanes 7 and 8.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 7-6: Enable bitplanes 8 and 7.
+- Bits 1-0: Required match values for bitplanes 8 and 7.
 
+CLXCON writes reset this latch.

--- a/docs/reference/custom-registers/110-BPL1DAT.md
+++ b/docs/reference/custom-registers/110-BPL1DAT.md
@@ -3,9 +3,10 @@ Offset: $110
 Access: write
 Chipset: OCS/ECS/AGA
 
-Holds the fetched display data word for bitplane 1.
+Holds display data for bitplane 1.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Planar pixel data, most-significant bit first.
 
+A BPL1DAT write strobes the bitplane output load; writes to the other BPLxDAT latches do not trigger that load by themselves.

--- a/docs/reference/custom-registers/112-BPL2DAT.md
+++ b/docs/reference/custom-registers/112-BPL2DAT.md
@@ -3,9 +3,10 @@ Offset: $112
 Access: write
 Chipset: OCS/ECS/AGA
 
-Holds the fetched display data word for bitplane 2.
+Holds display data for bitplane 2.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Planar pixel data, most-significant bit first.
 
+A BPL1DAT write strobes the bitplane output load; writes to the other BPLxDAT latches do not trigger that load by themselves.

--- a/docs/reference/custom-registers/114-BPL3DAT.md
+++ b/docs/reference/custom-registers/114-BPL3DAT.md
@@ -3,9 +3,10 @@ Offset: $114
 Access: write
 Chipset: OCS/ECS/AGA
 
-Holds the fetched display data word for bitplane 3.
+Holds display data for bitplane 3.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Planar pixel data, most-significant bit first.
 
+A BPL1DAT write strobes the bitplane output load; writes to the other BPLxDAT latches do not trigger that load by themselves.

--- a/docs/reference/custom-registers/116-BPL4DAT.md
+++ b/docs/reference/custom-registers/116-BPL4DAT.md
@@ -3,9 +3,10 @@ Offset: $116
 Access: write
 Chipset: OCS/ECS/AGA
 
-Holds the fetched display data word for bitplane 4.
+Holds display data for bitplane 4.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Planar pixel data, most-significant bit first.
 
+A BPL1DAT write strobes the bitplane output load; writes to the other BPLxDAT latches do not trigger that load by themselves.

--- a/docs/reference/custom-registers/118-BPL5DAT.md
+++ b/docs/reference/custom-registers/118-BPL5DAT.md
@@ -3,8 +3,10 @@ Offset: $118
 Access: write
 Chipset: OCS/ECS/AGA
 
-Holds the fetched display data word for bitplane 5.
+Holds display data for bitplane 5.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Planar pixel data, most-significant bit first.
+
+A BPL1DAT write strobes the bitplane output load; writes to the other BPLxDAT latches do not trigger that load by themselves.

--- a/docs/reference/custom-registers/11A-BPL6DAT.md
+++ b/docs/reference/custom-registers/11A-BPL6DAT.md
@@ -3,8 +3,10 @@ Offset: $11A
 Access: write
 Chipset: OCS/ECS/AGA
 
-Holds the fetched display data word for bitplane 6.
+Holds display data for bitplane 6.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Planar pixel data, most-significant bit first.
+
+A BPL1DAT write strobes the bitplane output load; writes to the other BPLxDAT latches do not trigger that load by themselves.

--- a/docs/reference/custom-registers/11C-BPL7DAT.md
+++ b/docs/reference/custom-registers/11C-BPL7DAT.md
@@ -3,9 +3,10 @@ Offset: $11C
 Access: write
 Chipset: AGA
 
-Holds the fetched display data word for bitplane 7.
+Holds display data for bitplane 7.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Planar pixel data, most-significant bit first.
 
+A BPL1DAT write strobes the bitplane output load; writes to the other BPLxDAT latches do not trigger that load by themselves.

--- a/docs/reference/custom-registers/11E-BPL8DAT.md
+++ b/docs/reference/custom-registers/11E-BPL8DAT.md
@@ -3,9 +3,10 @@ Offset: $11E
 Access: write
 Chipset: AGA
 
-Holds the fetched display data word for bitplane 8.
+Holds display data for bitplane 8.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Planar pixel data, most-significant bit first.
 
+A BPL1DAT write strobes the bitplane output load; writes to the other BPLxDAT latches do not trigger that load by themselves.

--- a/docs/reference/custom-registers/120-SPR0PTH.md
+++ b/docs/reference/custom-registers/120-SPR0PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of sprite 0's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/124-SPR1PTH.md
+++ b/docs/reference/custom-registers/124-SPR1PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of sprite 1's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/128-SPR2PTH.md
+++ b/docs/reference/custom-registers/128-SPR2PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of sprite 2's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/12C-SPR3PTH.md
+++ b/docs/reference/custom-registers/12C-SPR3PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of sprite 3's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/130-SPR4PTH.md
+++ b/docs/reference/custom-registers/130-SPR4PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of sprite 4's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/134-SPR5PTH.md
+++ b/docs/reference/custom-registers/134-SPR5PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of sprite 5's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/138-SPR6PTH.md
+++ b/docs/reference/custom-registers/138-SPR6PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of sprite 6's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/13C-SPR7PTH.md
+++ b/docs/reference/custom-registers/13C-SPR7PTH.md
@@ -7,5 +7,8 @@ Sets the upper word of sprite 7's DMA pointer.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
+- Bits 4-0: Chip-RAM address bits 20-16.
+- Bits 15-5: Ignored.
+
+The usable address range also depends on the fitted Agnus and chip RAM.
 

--- a/docs/reference/custom-registers/140-SPR0POS.md
+++ b/docs/reference/custom-registers/140-SPR0POS.md
@@ -3,9 +3,11 @@ Offset: $140
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 0's start position.
+Sets sprite 0's vertical start and horizontal position.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Vertical start bits 7-0.
+- Bits 7-0: Horizontal position bits 8-1.
 
+SPRxCTL supplies the extra position bits.

--- a/docs/reference/custom-registers/142-SPR0CTL.md
+++ b/docs/reference/custom-registers/142-SPR0CTL.md
@@ -3,9 +3,17 @@ Offset: $142
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 0's stop position and mode.
+Sets sprite 0's vertical stop, attachment, and extra position bits.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+Copperline decodes these fields:
 
+- Bits 15-8: Vertical stop bits 7-0.
+- Bit 7: Attach this sprite pair for 16-colour output (set on the odd sprite).
+- Bit 4: Horizontal subpixel position when BPLCON0.SHRES is set.
+- Bit 2: Vertical start bit 8.
+- Bit 1: Vertical stop bit 8.
+- Bit 0: Horizontal position bit 0.
+
+A control write disarms the sprite until new data arms it.

--- a/docs/reference/custom-registers/144-SPR0DATA.md
+++ b/docs/reference/custom-registers/144-SPR0DATA.md
@@ -3,9 +3,10 @@ Offset: $144
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 0's first data plane.
+Holds sprite 0's low pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/146-SPR0DATB.md
+++ b/docs/reference/custom-registers/146-SPR0DATB.md
@@ -3,9 +3,10 @@ Offset: $146
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 0's second data plane.
+Holds sprite 0's high pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/148-SPR1POS.md
+++ b/docs/reference/custom-registers/148-SPR1POS.md
@@ -3,9 +3,11 @@ Offset: $148
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 1's start position.
+Sets sprite 1's vertical start and horizontal position.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Vertical start bits 7-0.
+- Bits 7-0: Horizontal position bits 8-1.
 
+SPRxCTL supplies the extra position bits.

--- a/docs/reference/custom-registers/14A-SPR1CTL.md
+++ b/docs/reference/custom-registers/14A-SPR1CTL.md
@@ -3,9 +3,17 @@ Offset: $14A
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 1's stop position and mode.
+Sets sprite 1's vertical stop, attachment, and extra position bits.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+Copperline decodes these fields:
 
+- Bits 15-8: Vertical stop bits 7-0.
+- Bit 7: Attach this sprite pair for 16-colour output (set on the odd sprite).
+- Bit 4: Horizontal subpixel position when BPLCON0.SHRES is set.
+- Bit 2: Vertical start bit 8.
+- Bit 1: Vertical stop bit 8.
+- Bit 0: Horizontal position bit 0.
+
+A control write disarms the sprite until new data arms it.

--- a/docs/reference/custom-registers/14C-SPR1DATA.md
+++ b/docs/reference/custom-registers/14C-SPR1DATA.md
@@ -3,9 +3,10 @@ Offset: $14C
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 1's first data plane.
+Holds sprite 1's low pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/14E-SPR1DATB.md
+++ b/docs/reference/custom-registers/14E-SPR1DATB.md
@@ -3,9 +3,10 @@ Offset: $14E
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 1's second data plane.
+Holds sprite 1's high pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/150-SPR2POS.md
+++ b/docs/reference/custom-registers/150-SPR2POS.md
@@ -3,9 +3,11 @@ Offset: $150
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 2's start position.
+Sets sprite 2's vertical start and horizontal position.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Vertical start bits 7-0.
+- Bits 7-0: Horizontal position bits 8-1.
 
+SPRxCTL supplies the extra position bits.

--- a/docs/reference/custom-registers/152-SPR2CTL.md
+++ b/docs/reference/custom-registers/152-SPR2CTL.md
@@ -3,9 +3,17 @@ Offset: $152
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 2's stop position and mode.
+Sets sprite 2's vertical stop, attachment, and extra position bits.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+Copperline decodes these fields:
 
+- Bits 15-8: Vertical stop bits 7-0.
+- Bit 7: Attach this sprite pair for 16-colour output (set on the odd sprite).
+- Bit 4: Horizontal subpixel position when BPLCON0.SHRES is set.
+- Bit 2: Vertical start bit 8.
+- Bit 1: Vertical stop bit 8.
+- Bit 0: Horizontal position bit 0.
+
+A control write disarms the sprite until new data arms it.

--- a/docs/reference/custom-registers/154-SPR2DATA.md
+++ b/docs/reference/custom-registers/154-SPR2DATA.md
@@ -3,9 +3,10 @@ Offset: $154
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 2's first data plane.
+Holds sprite 2's low pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/156-SPR2DATB.md
+++ b/docs/reference/custom-registers/156-SPR2DATB.md
@@ -3,9 +3,10 @@ Offset: $156
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 2's second data plane.
+Holds sprite 2's high pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/158-SPR3POS.md
+++ b/docs/reference/custom-registers/158-SPR3POS.md
@@ -3,9 +3,11 @@ Offset: $158
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 3's start position.
+Sets sprite 3's vertical start and horizontal position.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Vertical start bits 7-0.
+- Bits 7-0: Horizontal position bits 8-1.
 
+SPRxCTL supplies the extra position bits.

--- a/docs/reference/custom-registers/15A-SPR3CTL.md
+++ b/docs/reference/custom-registers/15A-SPR3CTL.md
@@ -3,9 +3,17 @@ Offset: $15A
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 3's stop position and mode.
+Sets sprite 3's vertical stop, attachment, and extra position bits.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+Copperline decodes these fields:
 
+- Bits 15-8: Vertical stop bits 7-0.
+- Bit 7: Attach this sprite pair for 16-colour output (set on the odd sprite).
+- Bit 4: Horizontal subpixel position when BPLCON0.SHRES is set.
+- Bit 2: Vertical start bit 8.
+- Bit 1: Vertical stop bit 8.
+- Bit 0: Horizontal position bit 0.
+
+A control write disarms the sprite until new data arms it.

--- a/docs/reference/custom-registers/15C-SPR3DATA.md
+++ b/docs/reference/custom-registers/15C-SPR3DATA.md
@@ -3,9 +3,10 @@ Offset: $15C
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 3's first data plane.
+Holds sprite 3's low pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/15E-SPR3DATB.md
+++ b/docs/reference/custom-registers/15E-SPR3DATB.md
@@ -3,9 +3,10 @@ Offset: $15E
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 3's second data plane.
+Holds sprite 3's high pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/160-SPR4POS.md
+++ b/docs/reference/custom-registers/160-SPR4POS.md
@@ -3,9 +3,11 @@ Offset: $160
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 4's start position.
+Sets sprite 4's vertical start and horizontal position.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Vertical start bits 7-0.
+- Bits 7-0: Horizontal position bits 8-1.
 
+SPRxCTL supplies the extra position bits.

--- a/docs/reference/custom-registers/162-SPR4CTL.md
+++ b/docs/reference/custom-registers/162-SPR4CTL.md
@@ -3,9 +3,17 @@ Offset: $162
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 4's stop position and mode.
+Sets sprite 4's vertical stop, attachment, and extra position bits.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+Copperline decodes these fields:
 
+- Bits 15-8: Vertical stop bits 7-0.
+- Bit 7: Attach this sprite pair for 16-colour output (set on the odd sprite).
+- Bit 4: Horizontal subpixel position when BPLCON0.SHRES is set.
+- Bit 2: Vertical start bit 8.
+- Bit 1: Vertical stop bit 8.
+- Bit 0: Horizontal position bit 0.
+
+A control write disarms the sprite until new data arms it.

--- a/docs/reference/custom-registers/164-SPR4DATA.md
+++ b/docs/reference/custom-registers/164-SPR4DATA.md
@@ -3,9 +3,10 @@ Offset: $164
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 4's first data plane.
+Holds sprite 4's low pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/166-SPR4DATB.md
+++ b/docs/reference/custom-registers/166-SPR4DATB.md
@@ -3,9 +3,10 @@ Offset: $166
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 4's second data plane.
+Holds sprite 4's high pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/168-SPR5POS.md
+++ b/docs/reference/custom-registers/168-SPR5POS.md
@@ -3,9 +3,11 @@ Offset: $168
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 5's start position.
+Sets sprite 5's vertical start and horizontal position.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Vertical start bits 7-0.
+- Bits 7-0: Horizontal position bits 8-1.
 
+SPRxCTL supplies the extra position bits.

--- a/docs/reference/custom-registers/16A-SPR5CTL.md
+++ b/docs/reference/custom-registers/16A-SPR5CTL.md
@@ -3,9 +3,17 @@ Offset: $16A
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 5's stop position and mode.
+Sets sprite 5's vertical stop, attachment, and extra position bits.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+Copperline decodes these fields:
 
+- Bits 15-8: Vertical stop bits 7-0.
+- Bit 7: Attach this sprite pair for 16-colour output (set on the odd sprite).
+- Bit 4: Horizontal subpixel position when BPLCON0.SHRES is set.
+- Bit 2: Vertical start bit 8.
+- Bit 1: Vertical stop bit 8.
+- Bit 0: Horizontal position bit 0.
+
+A control write disarms the sprite until new data arms it.

--- a/docs/reference/custom-registers/16C-SPR5DATA.md
+++ b/docs/reference/custom-registers/16C-SPR5DATA.md
@@ -3,9 +3,10 @@ Offset: $16C
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 5's first data plane.
+Holds sprite 5's low pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/16E-SPR5DATB.md
+++ b/docs/reference/custom-registers/16E-SPR5DATB.md
@@ -3,9 +3,10 @@ Offset: $16E
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 5's second data plane.
+Holds sprite 5's high pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/170-SPR6POS.md
+++ b/docs/reference/custom-registers/170-SPR6POS.md
@@ -3,9 +3,11 @@ Offset: $170
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 6's start position.
+Sets sprite 6's vertical start and horizontal position.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Vertical start bits 7-0.
+- Bits 7-0: Horizontal position bits 8-1.
 
+SPRxCTL supplies the extra position bits.

--- a/docs/reference/custom-registers/172-SPR6CTL.md
+++ b/docs/reference/custom-registers/172-SPR6CTL.md
@@ -3,9 +3,17 @@ Offset: $172
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 6's stop position and mode.
+Sets sprite 6's vertical stop, attachment, and extra position bits.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+Copperline decodes these fields:
 
+- Bits 15-8: Vertical stop bits 7-0.
+- Bit 7: Attach this sprite pair for 16-colour output (set on the odd sprite).
+- Bit 4: Horizontal subpixel position when BPLCON0.SHRES is set.
+- Bit 2: Vertical start bit 8.
+- Bit 1: Vertical stop bit 8.
+- Bit 0: Horizontal position bit 0.
+
+A control write disarms the sprite until new data arms it.

--- a/docs/reference/custom-registers/174-SPR6DATA.md
+++ b/docs/reference/custom-registers/174-SPR6DATA.md
@@ -3,9 +3,10 @@ Offset: $174
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 6's first data plane.
+Holds sprite 6's low pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/176-SPR6DATB.md
+++ b/docs/reference/custom-registers/176-SPR6DATB.md
@@ -3,9 +3,10 @@ Offset: $176
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 6's second data plane.
+Holds sprite 6's high pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/178-SPR7POS.md
+++ b/docs/reference/custom-registers/178-SPR7POS.md
@@ -3,9 +3,11 @@ Offset: $178
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 7's start position.
+Sets sprite 7's vertical start and horizontal position.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-8: Vertical start bits 7-0.
+- Bits 7-0: Horizontal position bits 8-1.
 
+SPRxCTL supplies the extra position bits.

--- a/docs/reference/custom-registers/17A-SPR7CTL.md
+++ b/docs/reference/custom-registers/17A-SPR7CTL.md
@@ -3,9 +3,17 @@ Offset: $17A
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 7's stop position and mode.
+Sets sprite 7's vertical stop, attachment, and extra position bits.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+Copperline decodes these fields:
 
+- Bits 15-8: Vertical stop bits 7-0.
+- Bit 7: Attach this sprite pair for 16-colour output (set on the odd sprite).
+- Bit 4: Horizontal subpixel position when BPLCON0.SHRES is set.
+- Bit 2: Vertical start bit 8.
+- Bit 1: Vertical stop bit 8.
+- Bit 0: Horizontal position bit 0.
+
+A control write disarms the sprite until new data arms it.

--- a/docs/reference/custom-registers/17C-SPR7DATA.md
+++ b/docs/reference/custom-registers/17C-SPR7DATA.md
@@ -3,9 +3,10 @@ Offset: $17C
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 7's first data plane.
+Holds sprite 7's low pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/17E-SPR7DATB.md
+++ b/docs/reference/custom-registers/17E-SPR7DATB.md
@@ -3,9 +3,10 @@ Offset: $17E
 Access: write
 Chipset: OCS/ECS/AGA
 
-Controls sprite 7's second data plane.
+Holds sprite 7's high pixel bitplane.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 15-0: Sixteen planar pixels, most-significant bit first.
 
+Matching DATA/DATB bits form a two-bit pixel; zero is transparent. A DATA write arms the sprite, while DATB updates its other plane.

--- a/docs/reference/custom-registers/180-COLOR00.md
+++ b/docs/reference/custom-registers/180-COLOR00.md
@@ -7,7 +7,11 @@ Sets colour register 0; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/182-COLOR01.md
+++ b/docs/reference/custom-registers/182-COLOR01.md
@@ -7,7 +7,11 @@ Sets colour register 1; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/184-COLOR02.md
+++ b/docs/reference/custom-registers/184-COLOR02.md
@@ -7,7 +7,11 @@ Sets colour register 2; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/186-COLOR03.md
+++ b/docs/reference/custom-registers/186-COLOR03.md
@@ -7,7 +7,11 @@ Sets colour register 3; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/188-COLOR04.md
+++ b/docs/reference/custom-registers/188-COLOR04.md
@@ -7,7 +7,11 @@ Sets colour register 4; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/18A-COLOR05.md
+++ b/docs/reference/custom-registers/18A-COLOR05.md
@@ -7,7 +7,11 @@ Sets colour register 5; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/18C-COLOR06.md
+++ b/docs/reference/custom-registers/18C-COLOR06.md
@@ -7,7 +7,11 @@ Sets colour register 6; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/18E-COLOR07.md
+++ b/docs/reference/custom-registers/18E-COLOR07.md
@@ -7,7 +7,11 @@ Sets colour register 7; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/190-COLOR08.md
+++ b/docs/reference/custom-registers/190-COLOR08.md
@@ -7,7 +7,11 @@ Sets colour register 8; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/192-COLOR09.md
+++ b/docs/reference/custom-registers/192-COLOR09.md
@@ -7,7 +7,11 @@ Sets colour register 9; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/194-COLOR10.md
+++ b/docs/reference/custom-registers/194-COLOR10.md
@@ -7,7 +7,11 @@ Sets colour register 10; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/196-COLOR11.md
+++ b/docs/reference/custom-registers/196-COLOR11.md
@@ -7,7 +7,11 @@ Sets colour register 11; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/198-COLOR12.md
+++ b/docs/reference/custom-registers/198-COLOR12.md
@@ -7,7 +7,11 @@ Sets colour register 12; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/19A-COLOR13.md
+++ b/docs/reference/custom-registers/19A-COLOR13.md
@@ -7,7 +7,11 @@ Sets colour register 13; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/19C-COLOR14.md
+++ b/docs/reference/custom-registers/19C-COLOR14.md
@@ -7,7 +7,11 @@ Sets colour register 14; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/19E-COLOR15.md
+++ b/docs/reference/custom-registers/19E-COLOR15.md
@@ -7,7 +7,11 @@ Sets colour register 15; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1A0-COLOR16.md
+++ b/docs/reference/custom-registers/1A0-COLOR16.md
@@ -7,7 +7,11 @@ Sets colour register 16; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1A2-COLOR17.md
+++ b/docs/reference/custom-registers/1A2-COLOR17.md
@@ -7,7 +7,11 @@ Sets colour register 17; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1A4-COLOR18.md
+++ b/docs/reference/custom-registers/1A4-COLOR18.md
@@ -7,7 +7,11 @@ Sets colour register 18; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1A6-COLOR19.md
+++ b/docs/reference/custom-registers/1A6-COLOR19.md
@@ -7,7 +7,11 @@ Sets colour register 19; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1A8-COLOR20.md
+++ b/docs/reference/custom-registers/1A8-COLOR20.md
@@ -7,7 +7,11 @@ Sets colour register 20; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1AA-COLOR21.md
+++ b/docs/reference/custom-registers/1AA-COLOR21.md
@@ -7,7 +7,11 @@ Sets colour register 21; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1AC-COLOR22.md
+++ b/docs/reference/custom-registers/1AC-COLOR22.md
@@ -7,7 +7,11 @@ Sets colour register 22; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1AE-COLOR23.md
+++ b/docs/reference/custom-registers/1AE-COLOR23.md
@@ -7,7 +7,11 @@ Sets colour register 23; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1B0-COLOR24.md
+++ b/docs/reference/custom-registers/1B0-COLOR24.md
@@ -7,7 +7,11 @@ Sets colour register 24; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1B2-COLOR25.md
+++ b/docs/reference/custom-registers/1B2-COLOR25.md
@@ -7,7 +7,11 @@ Sets colour register 25; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1B4-COLOR26.md
+++ b/docs/reference/custom-registers/1B4-COLOR26.md
@@ -7,7 +7,11 @@ Sets colour register 26; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1B6-COLOR27.md
+++ b/docs/reference/custom-registers/1B6-COLOR27.md
@@ -7,7 +7,11 @@ Sets colour register 27; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1B8-COLOR28.md
+++ b/docs/reference/custom-registers/1B8-COLOR28.md
@@ -7,7 +7,11 @@ Sets colour register 28; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1BA-COLOR29.md
+++ b/docs/reference/custom-registers/1BA-COLOR29.md
@@ -7,7 +7,11 @@ Sets colour register 29; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1BC-COLOR30.md
+++ b/docs/reference/custom-registers/1BC-COLOR30.md
@@ -7,7 +7,11 @@ Sets colour register 30; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1BE-COLOR31.md
+++ b/docs/reference/custom-registers/1BE-COLOR31.md
@@ -7,7 +7,11 @@ Sets colour register 31; AGA uses BPLCON3 banking and nibble selection.
 
 ## Bitfields
 
+- Bit 15: Genlock transparency bit (T).
 - Bits 11-8: Red nibble.
 - Bits 7-4: Green nibble.
 - Bits 3-0: Blue nibble.
 
+On AGA, `BPLCON3.BANK` selects the 32-entry palette bank and LOCT selects the
+high or low component nibbles. Setting `BPLCON2.RDRAM` makes this address a
+palette read port; writes are ignored until RDRAM is cleared.

--- a/docs/reference/custom-registers/1C0-HTOTAL.md
+++ b/docs/reference/custom-registers/1C0-HTOTAL.md
@@ -3,9 +3,11 @@ Offset: $1C0
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip HTOTAL register.
+Sets the last horizontal colour-clock position of a programmable line.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 8-0: Horizontal position in colour clocks.
+- Bits 15-9: Ignored.
 
+BEAMCON0 selects whether programmable timing is used.

--- a/docs/reference/custom-registers/1C2-HSSTOP.md
+++ b/docs/reference/custom-registers/1C2-HSSTOP.md
@@ -10,4 +10,7 @@ Sets the programmable horizontal sync stop.
 - Bits 8-0: Horizontal position in colour clocks.
 - Bits 15-9: Ignored.
 
-BEAMCON0 selects whether programmable timing is used.
+With BEAMCON0 VARBEAMEN and VARHSYEN set, Copperline uses the HSSTRT/HSSTOP
+window for display presentation and horizontal-sync trace events. The
+window must satisfy HSSTRT < HSSTOP <= HTOTAL. These latches do not set
+line length; HTOTAL does that.

--- a/docs/reference/custom-registers/1C2-HSSTOP.md
+++ b/docs/reference/custom-registers/1C2-HSSTOP.md
@@ -3,9 +3,11 @@ Offset: $1C2
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip HSSTOP register.
+Sets the programmable horizontal sync stop.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 8-0: Horizontal position in colour clocks.
+- Bits 15-9: Ignored.
 
+BEAMCON0 selects whether programmable timing is used.

--- a/docs/reference/custom-registers/1C4-HBSTRT.md
+++ b/docs/reference/custom-registers/1C4-HBSTRT.md
@@ -3,9 +3,11 @@ Offset: $1C4
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip HBSTRT register.
+Sets the programmable horizontal blanking start.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 8-0: Horizontal position in colour clocks.
+- Bits 15-9: Ignored.
 
+BEAMCON0 selects whether programmable timing is used.

--- a/docs/reference/custom-registers/1C6-HBSTOP.md
+++ b/docs/reference/custom-registers/1C6-HBSTOP.md
@@ -3,9 +3,11 @@ Offset: $1C6
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip HBSTOP register.
+Sets the programmable horizontal blanking stop.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 8-0: Horizontal position in colour clocks.
+- Bits 15-9: Ignored.
 
+BEAMCON0 selects whether programmable timing is used.

--- a/docs/reference/custom-registers/1C8-VTOTAL.md
+++ b/docs/reference/custom-registers/1C8-VTOTAL.md
@@ -3,9 +3,11 @@ Offset: $1C8
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip VTOTAL register.
+Sets the last vertical line number of a programmable field.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 10-0: Vertical line number.
+- Bits 15-11: Ignored.
 
+BEAMCON0 selects whether programmable timing is used.

--- a/docs/reference/custom-registers/1CA-VSSTOP.md
+++ b/docs/reference/custom-registers/1CA-VSSTOP.md
@@ -10,4 +10,7 @@ Sets the programmable vertical sync stop.
 - Bits 10-0: Vertical line number.
 - Bits 15-11: Ignored.
 
-BEAMCON0 selects whether programmable timing is used.
+With BEAMCON0 VARBEAMEN and VARVSYEN set, Copperline uses the VSSTRT/VSSTOP
+window for display presentation and vertical-sync trace state. The
+window must satisfy VSSTRT < VSSTOP <= VTOTAL. These latches do not set
+field length; VTOTAL does that.

--- a/docs/reference/custom-registers/1CA-VSSTOP.md
+++ b/docs/reference/custom-registers/1CA-VSSTOP.md
@@ -3,9 +3,11 @@ Offset: $1CA
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip VSSTOP register.
+Sets the programmable vertical sync stop.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 10-0: Vertical line number.
+- Bits 15-11: Ignored.
 
+BEAMCON0 selects whether programmable timing is used.

--- a/docs/reference/custom-registers/1CC-VBSTRT.md
+++ b/docs/reference/custom-registers/1CC-VBSTRT.md
@@ -3,9 +3,11 @@ Offset: $1CC
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip VBSTRT register.
+Sets the programmable vertical blanking start.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 10-0: Vertical line number.
+- Bits 15-11: Ignored.
 
+BEAMCON0 selects whether programmable timing is used.

--- a/docs/reference/custom-registers/1CE-VBSTOP.md
+++ b/docs/reference/custom-registers/1CE-VBSTOP.md
@@ -3,9 +3,11 @@ Offset: $1CE
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip VBSTOP register.
+Sets the programmable vertical blanking stop.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 10-0: Vertical line number.
+- Bits 15-11: Ignored.
 
+BEAMCON0 selects whether programmable timing is used.

--- a/docs/reference/custom-registers/1D0-SPRHSTRT.md
+++ b/docs/reference/custom-registers/1D0-SPRHSTRT.md
@@ -3,9 +3,8 @@ Offset: $1D0
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip SPRHSTRT register.
+UHRES sprite horizontal start register.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+Copperline does not implement this register. No written bits affect the emulated machine.

--- a/docs/reference/custom-registers/1D2-SPRHSTOP.md
+++ b/docs/reference/custom-registers/1D2-SPRHSTOP.md
@@ -3,9 +3,8 @@ Offset: $1D2
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip SPRHSTOP register.
+UHRES sprite horizontal stop register.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+Copperline does not implement this register. No written bits affect the emulated machine.

--- a/docs/reference/custom-registers/1D4-BPLHSTRT.md
+++ b/docs/reference/custom-registers/1D4-BPLHSTRT.md
@@ -3,9 +3,8 @@ Offset: $1D4
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip BPLHSTRT register.
+UHRES bitplane horizontal start register.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+Copperline does not implement this register. No written bits affect the emulated machine.

--- a/docs/reference/custom-registers/1D6-BPLHSTOP.md
+++ b/docs/reference/custom-registers/1D6-BPLHSTOP.md
@@ -3,9 +3,8 @@ Offset: $1D6
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip BPLHSTOP register.
+UHRES bitplane horizontal stop register.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+Copperline does not implement this register. No written bits affect the emulated machine.

--- a/docs/reference/custom-registers/1D8-HHPOSW.md
+++ b/docs/reference/custom-registers/1D8-HHPOSW.md
@@ -3,9 +3,10 @@ Offset: $1D8
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip HHPOSW register.
+Writes the UHRES horizontal-position latch.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 8-0: Horizontal-position value.
 
+Copperline stores HHPOSW and returns it through HHPOSR; the UHRES counter does not advance.

--- a/docs/reference/custom-registers/1DA-HHPOSR.md
+++ b/docs/reference/custom-registers/1DA-HHPOSR.md
@@ -3,9 +3,10 @@ Offset: $1DA
 Access: read
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip HHPOSR register.
+Reads the UHRES horizontal-position latch.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 8-0: Horizontal-position value.
 
+Copperline stores HHPOSW and returns it through HHPOSR; the UHRES counter does not advance.

--- a/docs/reference/custom-registers/1DC-BEAMCON0.md
+++ b/docs/reference/custom-registers/1DC-BEAMCON0.md
@@ -3,9 +3,20 @@ Offset: $1DC
 Access: write
 Chipset: ECS/AGA
 
-Selects programmable beam timing, sync polarity, and PAL or NTSC behaviour.
+Selects fixed or programmable beam timing and sync/blanking controls.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bit 14: HARDDIS.
+- Bit 13: LPENDIS.
+- Bit 12: VARVBEN.
+- Bit 11: LOLDIS.
+- Bit 10: CSCBEN.
+- Bit 9: VARVSYEN.
+- Bit 8: VARHSYEN.
+- Bit 7: VARBEAMEN, use programmable beam totals.
+- Bit 6: DUAL (UHRES dual mode is not emulated).
+- Bit 5: PAL, select PAL rather than NTSC timing.
+- Bit 3: BLANKEN.
 
+Copperline models beam, blanking, and light-pen controls. External genlock/sync output is not a physical host signal.

--- a/docs/reference/custom-registers/1DC-BEAMCON0.md
+++ b/docs/reference/custom-registers/1DC-BEAMCON0.md
@@ -17,6 +17,13 @@ Selects fixed or programmable beam timing and sync/blanking controls.
 - Bit 7: VARBEAMEN, use programmable beam totals.
 - Bit 6: DUAL (UHRES dual mode is not emulated).
 - Bit 5: PAL, select PAL rather than NTSC timing.
+- Bit 4: VARCSYEN, programmable composite-sync output enable.
 - Bit 3: BLANKEN.
+- Bit 2: CSYTRUE, composite-sync pin polarity.
+- Bit 1: VSYTRUE, vertical-sync pin polarity.
+- Bit 0: HSYTRUE, horizontal-sync pin polarity.
 
-Copperline models beam, blanking, and light-pen controls. External genlock/sync output is not a physical host signal.
+Copperline models beam, blanking, and light-pen controls. With VARBEAMEN set,
+VARHSYEN and VARVSYEN enable sync windows used by display presentation and
+beam traces. Composite-sync routing and sync-pin polarities are latched;
+physical sync/genlock output is not emulated.

--- a/docs/reference/custom-registers/1DE-HSSTRT.md
+++ b/docs/reference/custom-registers/1DE-HSSTRT.md
@@ -10,4 +10,7 @@ Sets the programmable horizontal sync start.
 - Bits 8-0: Horizontal position in colour clocks.
 - Bits 15-9: Ignored.
 
-BEAMCON0 selects whether programmable timing is used.
+With BEAMCON0 VARBEAMEN and VARHSYEN set, Copperline uses the HSSTRT/HSSTOP
+window for display presentation and horizontal-sync trace events. The
+window must satisfy HSSTRT < HSSTOP <= HTOTAL. These latches do not set
+line length; HTOTAL does that.

--- a/docs/reference/custom-registers/1DE-HSSTRT.md
+++ b/docs/reference/custom-registers/1DE-HSSTRT.md
@@ -3,9 +3,11 @@ Offset: $1DE
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip HSSTRT register.
+Sets the programmable horizontal sync start.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 8-0: Horizontal position in colour clocks.
+- Bits 15-9: Ignored.
 
+BEAMCON0 selects whether programmable timing is used.

--- a/docs/reference/custom-registers/1E0-VSSTRT.md
+++ b/docs/reference/custom-registers/1E0-VSSTRT.md
@@ -3,9 +3,11 @@ Offset: $1E0
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip VSSTRT register.
+Sets the programmable vertical sync start.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 10-0: Vertical line number.
+- Bits 15-11: Ignored.
 
+BEAMCON0 selects whether programmable timing is used.

--- a/docs/reference/custom-registers/1E0-VSSTRT.md
+++ b/docs/reference/custom-registers/1E0-VSSTRT.md
@@ -10,4 +10,7 @@ Sets the programmable vertical sync start.
 - Bits 10-0: Vertical line number.
 - Bits 15-11: Ignored.
 
-BEAMCON0 selects whether programmable timing is used.
+With BEAMCON0 VARBEAMEN and VARVSYEN set, Copperline uses the VSSTRT/VSSTOP
+window for display presentation and vertical-sync trace state. The
+window must satisfy VSSTRT < VSSTOP <= VTOTAL. These latches do not set
+field length; VTOTAL does that.

--- a/docs/reference/custom-registers/1E2-HCENTER.md
+++ b/docs/reference/custom-registers/1E2-HCENTER.md
@@ -3,11 +3,12 @@ Offset: $1E2
 Access: write
 Chipset: ECS/AGA
 
-Sets the half-line sync position used for interlaced timing.
+Latches the half-line sync position for interlaced timing.
 
 ## Bitfields
 
 - Bits 8-0: Horizontal position in colour clocks.
 - Bits 15-9: Ignored.
 
-BEAMCON0 selects whether programmable timing is used.
+Copperline stores this value for debugger inspection and byte-write
+reconstruction. It does not currently apply HCENTER to sync timing.

--- a/docs/reference/custom-registers/1E2-HCENTER.md
+++ b/docs/reference/custom-registers/1E2-HCENTER.md
@@ -3,9 +3,11 @@ Offset: $1E2
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip HCENTER register.
+Sets the half-line sync position used for interlaced timing.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 8-0: Horizontal position in colour clocks.
+- Bits 15-9: Ignored.
 
+BEAMCON0 selects whether programmable timing is used.

--- a/docs/reference/custom-registers/1E4-DIWHIGH.md
+++ b/docs/reference/custom-registers/1E4-DIWHIGH.md
@@ -3,9 +3,13 @@ Offset: $1E4
 Access: write
 Chipset: ECS/AGA
 
-Controls or reports the custom-chip DIWHIGH register.
+Supplies extended display-window position bits on ECS/AGA.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
+- Bits 2-0: Vertical start bits 10-8.
+- Bit 5: Horizontal start bit 8.
+- Bits 10-8: Vertical stop bits 10-8.
+- Bit 13: Horizontal stop bit 8.
 
+These are the fields Copperline decodes. Write DIWHIGH after DIWSTRT/DIWSTOP; either of those later writes restores implicit high-bit decoding.

--- a/docs/reference/custom-registers/1E6-BPLHMOD.md
+++ b/docs/reference/custom-registers/1E6-BPLHMOD.md
@@ -3,9 +3,8 @@ Offset: $1E6
 Access: write
 Chipset: AGA
 
-Controls or reports the custom-chip BPLHMOD register.
+UHRES bitplane modulo register.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+Copperline does not implement this register. No written bits affect the emulated machine.

--- a/docs/reference/custom-registers/1E8-SPRHPTH.md
+++ b/docs/reference/custom-registers/1E8-SPRHPTH.md
@@ -3,9 +3,8 @@ Offset: $1E8
 Access: write
 Chipset: AGA
 
-Sets the upper word of the SPRH pointer.
+UHRES sprite pointer high word.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
-
+Copperline does not implement this register. No written bits affect the emulated machine.

--- a/docs/reference/custom-registers/1EA-SPRHPTL.md
+++ b/docs/reference/custom-registers/1EA-SPRHPTL.md
@@ -3,9 +3,8 @@ Offset: $1EA
 Access: write
 Chipset: AGA
 
-Sets the lower word of the SPRH pointer.
+UHRES sprite pointer low word.
 
 ## Bitfields
 
-- Bits 15-0: Lower pointer word; bit 0 is ignored for word-aligned DMA.
-
+Copperline does not implement this register. No written bits affect the emulated machine.

--- a/docs/reference/custom-registers/1EC-BPLHPTH.md
+++ b/docs/reference/custom-registers/1EC-BPLHPTH.md
@@ -3,9 +3,8 @@ Offset: $1EC
 Access: write
 Chipset: AGA
 
-Sets the upper word of the BPLH pointer.
+UHRES bitplane pointer high word.
 
 ## Bitfields
 
-- Bits 15-0: Upper pointer word.
-
+Copperline does not implement this register. No written bits affect the emulated machine.

--- a/docs/reference/custom-registers/1EE-BPLHPTL.md
+++ b/docs/reference/custom-registers/1EE-BPLHPTL.md
@@ -3,9 +3,8 @@ Offset: $1EE
 Access: write
 Chipset: AGA
 
-Sets the lower word of the BPLH pointer.
+UHRES bitplane pointer low word.
 
 ## Bitfields
 
-- Bits 15-0: Lower pointer word; bit 0 is ignored for word-aligned DMA.
-
+Copperline does not implement this register. No written bits affect the emulated machine.

--- a/docs/reference/custom-registers/1FC-FMODE.md
+++ b/docs/reference/custom-registers/1FC-FMODE.md
@@ -3,9 +3,12 @@ Offset: $1FC
 Access: write
 Chipset: AGA
 
-Selects AGA bitplane and sprite fetch widths and scan-doubling modes.
+Selects AGA DMA fetch widths and scan doubling.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+- Bits 1-0: Bitplane fetch width; 0 = 16 bits, 1 or 2 = 32 bits, 3 = 64 bits.
+- Bits 3-2: Sprite fetch width, using the same encoding.
+- Bit 14: BSCAN2, bitplane scan doubling.
+- Bit 15: SSCAN2, sprite scan doubling.
+- Bits 13-4: Ignored.

--- a/docs/reference/custom-registers/1FE-NO-OP.md
+++ b/docs/reference/custom-registers/1FE-NO-OP.md
@@ -7,5 +7,4 @@ Accepts a write without changing custom-chip state.
 
 ## Bitfields
 
-- Bits 15-0: Register value; the summary identifies the field's role.
-
+No data bitfields. All written bits are ignored.

--- a/docs/reference/custom-registers/index.md
+++ b/docs/reference/custom-registers/index.md
@@ -1,8 +1,15 @@
 # Custom chip registers
 
-These ASCII Markdown pages are the source used by Copperline's IO Map, debugger console, control protocol, DAP adapter, and VS Code register tree. Offsets are relative to `$DFF000`. Access descriptions refer to the CPU-visible register direction; Copperline can still show the internal latch behind write-only registers.
+These ASCII Markdown pages supply Copperline's IO Map, debugger console,
+control protocol, DAP adapter, and VS Code register tree. Offsets are relative
+to `$DFF000`. Access descriptions give the usual CPU-visible direction;
+individual pages describe exceptions such as AGA palette readback. Debugger
+inspection can also show internal latches behind write-only registers.
 
-The field names and chipset availability follow the Amiga Hardware Reference Manual terminology.
+Field names follow Amiga Hardware Reference Manual terminology. The pages
+also describe Copperline's implementation limits, including registers that
+are only latched or have no effect. They are a programming reference for
+the emulator, not a complete specification of external chip signals.
 
 | Offset | Register | Access | Chipset |
 |---:|---|---|---|

--- a/src/chipset/agnus.rs
+++ b/src/chipset/agnus.rs
@@ -19,10 +19,10 @@ pub const NTSC_LONG_COLORCLOCKS_PER_LINE: u32 = 228;
 pub const DMACON_BPLEN: u16 = 1 << 8;
 pub const DMACON_DMAEN: u16 = 1 << 9;
 // BEAMCON0 ($DFF1DC) control bits (ECS Agnus). PAL, VARBEAMEN, LOLDIS,
-// HARDDIS, DUAL, LPENDIS, VARVBEN, and BLANKEN are interpreted; the
-// sync-shape bits (VARHSYEN/VARVSYEN/VARCSYEN/CSCBEN and the xSYTRUE
-// polarities) affect monitor sync pulses only, which the emulated display
-// always locks to, so they are decoded for completeness.
+// HARDDIS, DUAL, LPENDIS, VARVBEN, and BLANKEN are interpreted.
+// VARHSYEN/VARVSYEN select sync windows used by display presentation and
+// beam traces. Composite-sync routing (VARCSYEN/CSCBEN) and the xSYTRUE
+// pin polarities are latched without physical host output.
 #[allow(dead_code)]
 pub const BEAMCON0_BLANKEN: u16 = 1 << 3;
 pub const BEAMCON0_PAL: u16 = 1 << 5;
@@ -1285,8 +1285,8 @@ impl Agnus {
     // ECS programmable sync/blank latches and the UHRES sprite identifier.
     // Writes are gated on ECS Agnus. The blank windows are interpreted (see
     // programmable_vertical_blank / programmable_horizontal_blank); the sync
-    // position latches are stored for readback only. Horizontal positions
-    // are 9-bit (& 0x01FF, like HTOTAL); vertical line counts are 11-bit
+    // windows feed presentation and beam traces. HCENTER is only latched.
+    // Horizontal positions are 9-bit (& 0x01FF, like HTOTAL); line counts are 11-bit
     // (& 0x07FF). The getters back the byte-write reconstruction latch.
     pub fn hsstrt(&self) -> u16 {
         self.hsstrt


### PR DESCRIPTION
The manual contained stale build and CLI examples, outdated descriptions of save states and CPU timing, and 137 placeholder custom-register descriptions. Refresh the README, guides, debugger documentation, and internals against the current implementation, and trim repeated prose and obsolete development history.

The register reference now describes bitfields, access side effects, AGA palette readback, and implementation limits. These pages also supply the debugger, CCP, and DAP help. Correct stale source comments about sync-window handling; emulation behavior is unchanged. Corrected examples cover ROM sizes and checksums, configuration precedence, WebAssembly builds, reverse-debugger commands, and capture scheduling.

Validation:

- Strict MyST HTML/link checks and PDF export; spot-checked rendered pages. Remaining PDF template warnings also reproduce on the unchanged baseline.
- `cargo test --profile ci --locked --lib custom`: 25 passed.
- `cargo clippy --profile ci --locked --all-targets` and `cargo fmt --all --check`.
- Repeated 30-second headless boots and save-state resumption produced identical screenshots; both screenshot/frame-dump exit orders matched the documentation.
- Live CCP inspection verified generated help for all 187 exposed registers.
