### PR TITLE
Add browser rollback netplay over WebRTC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,8 +477,8 @@ jobs:
     # Guards the portability split behind the browser build (see
     # docs/guide/browser.md): the core must keep compiling without the
     # desktop frontend, and the web crate must keep compiling for
-    # wasm32-unknown-unknown. Cheap check-only job, so plain ubuntu is fine
-    # (no GPU or audio stack is reached without the `frontend` feature).
+    # wasm32-unknown-unknown, including paired rollback on a release bundle.
+    # No GPU or audio stack is reached without the `frontend` feature.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -489,6 +489,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            . -> target
+            crates/copperline-web -> target
       - name: Core without the desktop frontend
         run: cargo check --no-default-features --locked
       - name: Save-state fixture across optional features
@@ -507,6 +510,15 @@ jobs:
         # step never reaches it.
         working-directory: crates/copperline-web
         run: cargo fmt --check
+      - name: Browser rollback netplay on the release WASM bundle
+        working-directory: crates/copperline-web
+        run: |
+          version="$(sed -n 's/^wasm-bindgen = "=\(.*\)"$/\1/p' Cargo.toml)"
+          test -n "$version"
+          cargo install wasm-bindgen-cli --version "$version" --locked
+          RUSTFLAGS="-C target-feature=+simd128" cargo build --release --target wasm32-unknown-unknown --locked
+          wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/copperline_web.wasm
+          node ../../tools/check-web-netplay.mjs pkg
       - name: Browser page controller tests
         working-directory: crates/copperline-web/www
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,6 +505,9 @@ jobs:
       - name: Web crate (wasm32-unknown-unknown)
         working-directory: crates/copperline-web
         run: cargo check --target wasm32-unknown-unknown --locked
+      - name: Web wrapper unit tests
+        working-directory: crates/copperline-web
+        run: cargo test --locked
       - name: Web crate formatting
         # The web crate is a standalone workspace, so the root Formatting
         # step never reaches it.

--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -9,7 +9,7 @@ name: Browser demo
 # The page shell (try/index.html) is hand-written in the website repository
 # and left alone. This workflow replaces the parts that must change together
 # with the emulator: the wasm-bindgen bundle (try/pkg), the JS glue that
-# drives the WebEmu API (try/try.js, try/render-stride.js,
+# drives the WebEmu API (try/try.js, try/netplay.js, try/render-stride.js,
 # try/serial-telnet.js, try/audio-worklet.js, sourced from
 # crates/copperline-web/www), and the AROS ROMs (try/aros).
 #
@@ -125,6 +125,7 @@ jobs:
           console.log('bundle loads:', emu.machine_summary());
           SMOKE
           node pkg-smoke.mjs
+          node ../../tools/check-web-netplay.mjs pkg
           rm pkg-smoke.mjs pkg-smoke-glue.mjs
       - name: Check out the website repository
         uses: actions/checkout@v7
@@ -143,6 +144,7 @@ jobs:
              crates/copperline-web/pkg/copperline_web_bg.wasm site/try/pkg/
           cp crates/copperline-web/www/try.js \
              crates/copperline-web/www/render-stride.js \
+             crates/copperline-web/www/netplay.js \
              crates/copperline-web/www/serial-telnet.js \
              crates/copperline-web/www/audio-worklet.js site/try/
           cp assets/aros/aros-amiga-m68k-rom.bin \

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The manual is published at [copperline.dev/docs](https://copperline.dev/docs/) a
 - [WHDLoad Support](docs/guide/whdload.md) - Direct WHDLoad package loading
 - [Direct Executable Launching](docs/guide/run.md) - Running cross-compiled Amiga binaries
 - [Floppy Hardware Bridge](docs/guide/fluxbridge.md) - Real floppy drives via Greaseweazle
-- [Rollback Netplay](docs/guide/netplay.md) - GUI or CLI setup for direct two-player sessions with input prediction and rollback
+- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions through desktop GUI/CLI or browser WebRTC, with input prediction and rollback
 - [Headless Mode](docs/guide/headless.md) - Scripted runs and screenshot/frame dumps
 - [Debugging](docs/debugger/window.md) - In-window, headless, and GDB debugging
 - [VS Code](docs/debugger/vscode.md) - Setup and illustrated source debugging; [Bartman with Copperline](docs/debugger/vscode-bartman.md) covers fork installation and visual profiling

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The manual is published at [copperline.dev/docs](https://copperline.dev/docs/) a
 - [WHDLoad Support](docs/guide/whdload.md) - Direct WHDLoad package loading
 - [Direct Executable Launching](docs/guide/run.md) - Running cross-compiled Amiga binaries
 - [Floppy Hardware Bridge](docs/guide/fluxbridge.md) - Real floppy drives via Greaseweazle
-- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions through desktop GUI/CLI or browser WebRTC, with input prediction and rollback
+- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions through desktop GUI/CLI or browser WebRTC, with input prediction, rollback and matching-machine checks
 - [Headless Mode](docs/guide/headless.md) - Scripted runs and screenshot/frame dumps
 - [Debugging](docs/debugger/window.md) - In-window, headless, and GDB debugging
 - [VS Code](docs/debugger/vscode.md) - Setup and illustrated source debugging; [Bartman with Copperline](docs/debugger/vscode-bartman.md) covers fork installation and visual profiling

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -885,7 +885,8 @@ impl WebEmu {
         }
     }
 
-    /// Forward an Amiga raw key transition straight to the keyboard MCU.
+    /// Forward an Amiga raw key transition to the keyboard MCU, or update the
+    /// held keys sampled by the rollback timeline during netplay.
     /// The page's on-screen keyboard draws Amiga keys, so its keys already
     /// are rawkeys and a `KeyboardEvent.code` round trip would be a lossy
     /// detour: $2B, the key beside Return on an ISO Amiga keyboard, has no
@@ -983,11 +984,8 @@ impl WebEmu {
             // The page's primary controller always arrives on port 2; the
             // connection assigns it to this peer's negotiated Amiga port.
             if port == 2 {
-                self.netplay_input.buttons = (self.netplay_input.buttons & !0x3f)
-                    | [up, down, left, right, fire, button2]
-                        .into_iter()
-                        .enumerate()
-                        .fold(0, |bits, (bit, on)| bits | (u16::from(on) << bit));
+                self.netplay_input
+                    .set_joystick([up, down, left, right, fire, button2]);
             }
             return;
         }
@@ -1016,11 +1014,8 @@ impl WebEmu {
     ) {
         if self.netplay.is_some() {
             if port == 2 {
-                self.netplay_input.buttons = (self.netplay_input.buttons & 0x3f)
-                    | [play, rwd, ffw, green, yellow]
-                        .into_iter()
-                        .enumerate()
-                        .fold(0, |bits, (bit, on)| bits | (u16::from(on) << (bit + 6)));
+                self.netplay_input
+                    .set_cd32_buttons([play, rwd, ffw, green, yellow]);
             }
             return;
         }
@@ -1036,16 +1031,15 @@ impl WebEmu {
     /// page whose gamepad goes away restores the mouse on port 1 with
     /// `set_port_device(1, "mouse")` rather than leaving a stuck stick.
     /// Unknown names are ignored.
-    pub fn set_port_device(&mut self, port: u8, device: &str) {
-        if self.netplay.is_some() {
-            return;
-        }
+    pub fn set_port_device(&mut self, port: u8, device: &str) -> Result<(), JsValue> {
+        self.require_local_session()?;
         if let Some(device) = PortDevice::parse(device) {
             self.emu
                 .bus_mut()
                 .input
                 .set_port_device(port_index(port), device);
         }
+        Ok(())
     }
 
     /// Port-2 joystick state. Superseded by `set_joystick_port`, kept
@@ -1571,33 +1565,36 @@ impl WebEmu {
     /// Enable or mute the synthesized floppy drive sounds (motor hum,
     /// head-step clicks, read hiss). On by default, like the desktop's
     /// `[audio] floppy_sounds` knob.
-    pub fn set_floppy_sounds(&mut self, enabled: bool) {
+    pub fn set_floppy_sounds(&mut self, enabled: bool) -> Result<(), JsValue> {
+        self.require_local_session()?;
         self.emu
             .bus_mut()
             .paula
             .drive_sounds_mut()
             .set_enabled(enabled);
+        Ok(())
     }
 
     /// Drive-sound level, 0-100, relative to Paula's output (the desktop's
     /// `[audio] floppy_sounds_volume`).
-    pub fn set_floppy_sounds_volume(&mut self, percent: u8) {
+    pub fn set_floppy_sounds_volume(&mut self, percent: u8) -> Result<(), JsValue> {
+        self.require_local_session()?;
         self.emu
             .bus_mut()
             .paula
             .drive_sounds_mut()
             .set_volume_percent(percent);
+        Ok(())
     }
 
     /// Emulated floppy drive speed (the desktop's `[floppy] speed`): a
     /// data-rate percentage of 100/200/400/800, or 0 for turbo, where disk
     /// DMA transfers complete almost instantly. Other values fall back to
     /// 100. Applies immediately; drive mechanics stay at real speed.
-    pub fn set_floppy_speed(&mut self, percent: u16) {
-        if self.netplay.is_some() {
-            return;
-        }
+    pub fn set_floppy_speed(&mut self, percent: u16) -> Result<(), JsValue> {
+        self.require_local_session()?;
         self.emu.bus_mut().floppy.set_speed_percent(percent);
+        Ok(())
     }
 
     /// Current floppy drive speed value (percentage, or 0 for turbo).

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -29,6 +29,8 @@ use copperline::video::deinterlace::Deinterlacer;
 use copperline::video::{bitplane, present_common, FB_WIDTH, MAX_CANVAS_PIXELS};
 use wasm_bindgen::prelude::*;
 
+mod netplay;
+
 #[wasm_bindgen(start)]
 pub fn start() {
     console_error_panic_hook::set_once();
@@ -203,6 +205,13 @@ const MAX_CATCHUP_SECONDS: f64 = 0.1;
 
 #[wasm_bindgen]
 pub struct WebEmu {
+    netplay: Option<copperline::netplay::Connection<copperline::netplay::PacketQueue>>,
+    netplay_input: copperline::netplay::Input,
+    // Netplay keeps Paula's serialized output gain fixed; the browser applies
+    // this local preference when draining its host audio buffer instead.
+    netplay_volume: u8,
+    netplay_eligible: bool,
+    config: Config,
     emu: Emulator,
     audio: Rc<RefCell<Vec<f32>>>,
     fb: Vec<u32>,
@@ -348,6 +357,11 @@ impl WebEmu {
         let (serial_sink, serial) = ChannelSerialSink::pair();
         emu.bus_mut().paula.serial = Box::new(serial_sink);
         Ok(WebEmu {
+            netplay: None,
+            netplay_input: Default::default(),
+            netplay_volume: 100,
+            netplay_eligible: true,
+            config: cfg,
             emu,
             audio,
             fb: vec![0u32; MAX_CANVAS_PIXELS],
@@ -467,6 +481,7 @@ impl WebEmu {
     /// cold-reset, as if the chips had been swapped and the machine power
     /// cycled. 256 KiB Kickstart 1.x images are mirrored up automatically.
     pub fn load_rom(&mut self, rom: Vec<u8>, ext: Option<Vec<u8>>) -> Result<(), JsValue> {
+        self.require_local_session()?;
         self.emu.reload_rom(rom, ext).map_err(js_err)?;
         self.anchor = None;
         self.deferred_fields = 0;
@@ -494,6 +509,10 @@ impl WebEmu {
     }
 
     fn run_paced(&mut self, now_ms: f64, max_frames: u32, render: bool) -> Result<u32, JsValue> {
+        if self.netplay.is_some() {
+            return self.run_netplay(now_ms, max_frames, render);
+        }
+        self.netplay_eligible = false;
         self.last_run_core_ms = 0.0;
         self.last_run_render_ms = 0.0;
         let (anchor_wall, anchor_emu) = *self
@@ -547,7 +566,9 @@ impl WebEmu {
             return;
         }
         let visible_start_vpos = self.emu.bus().frame_visible_start_vpos();
-        let field_content = if self.deinterlacer.phosphor() == 0.0 {
+        let field_content = if self.netplay.is_some() {
+            bitplane::render_display_only_with_content(self.emu.bus(), &mut self.fb)
+        } else if self.deinterlacer.phosphor() == 0.0 {
             // A frame identical to the previous render needs no pipeline at
             // all: the present buffer already shows it, and the detector
             // carries the frame's CLXDAT so collisions still accumulate.
@@ -836,7 +857,14 @@ impl WebEmu {
     /// frame is 882 stereo frames. The page transfers the returned buffer to
     /// the AudioWorklet.
     pub fn take_audio(&mut self) -> Vec<f32> {
-        std::mem::take(&mut *self.audio.borrow_mut())
+        let mut audio = std::mem::take(&mut *self.audio.borrow_mut());
+        if self.netplay.is_some() && self.netplay_volume != 100 {
+            let gain = f32::from(self.netplay_volume) / 100.0;
+            for sample in &mut audio {
+                *sample *= gain;
+            }
+        }
+        audio
     }
 
     /// Queued audio frames not yet drained (diagnostics).
@@ -850,7 +878,7 @@ impl WebEmu {
     pub fn key_event(&mut self, code: &str, pressed: bool) -> bool {
         match w3c_code_to_amiga_rawkey(code) {
             Some(rawkey) => {
-                self.emu.bus_mut().enqueue_key_event(rawkey, pressed);
+                self.key_raw(rawkey, pressed);
                 true
             }
             None => false,
@@ -864,6 +892,10 @@ impl WebEmu {
     /// positional code a browser reports on every host layout, and the
     /// reverse table would have to be duplicated in the page glue.
     pub fn key_raw(&mut self, rawkey: u8, pressed: bool) {
+        if self.netplay.is_some() {
+            self.netplay_input.set_key(rawkey & 0x7f, pressed);
+            return;
+        }
         self.emu.bus_mut().enqueue_key_event(rawkey & 0x7F, pressed);
     }
 
@@ -878,6 +910,9 @@ impl WebEmu {
     /// Relative mouse motion in emulated hi-res pixels (pointer-lock
     /// movementX/Y, or scaled cursor deltas when unlocked).
     pub fn mouse_delta(&mut self, dx: f64, dy: f64) {
+        if self.netplay.is_some() {
+            return;
+        }
         if !dx.is_finite() || !dy.is_finite() {
             return;
         }
@@ -915,6 +950,9 @@ impl WebEmu {
 
     /// Mouse buttons: 0 = left, 1 = middle, 2 = right (MouseEvent.button).
     pub fn mouse_button(&mut self, button: u8, pressed: bool) {
+        if self.netplay.is_some() {
+            return;
+        }
         let input = &mut self.emu.bus_mut().input;
         match button {
             0 => input.set_mouse_button(0, 0, pressed),
@@ -941,6 +979,19 @@ impl WebEmu {
         fire: bool,
         button2: bool,
     ) {
+        if self.netplay.is_some() {
+            // The page's primary controller always arrives on port 2; the
+            // connection assigns it to this peer's negotiated Amiga port.
+            if port == 2 {
+                self.netplay_input.buttons = (self.netplay_input.buttons & !0x3f)
+                    | [up, down, left, right, fire, button2]
+                        .into_iter()
+                        .enumerate()
+                        .fold(0, |bits, (bit, on)| bits | (u16::from(on) << bit));
+            }
+            return;
+        }
+
         self.emu.bus_mut().input.set_joystick(
             port_index(port),
             up,
@@ -963,6 +1014,17 @@ impl WebEmu {
         green: bool,
         yellow: bool,
     ) {
+        if self.netplay.is_some() {
+            if port == 2 {
+                self.netplay_input.buttons = (self.netplay_input.buttons & 0x3f)
+                    | [play, rwd, ffw, green, yellow]
+                        .into_iter()
+                        .enumerate()
+                        .fold(0, |bits, (bit, on)| bits | (u16::from(on) << (bit + 6)));
+            }
+            return;
+        }
+
         self.emu
             .bus_mut()
             .input
@@ -975,6 +1037,9 @@ impl WebEmu {
     /// `set_port_device(1, "mouse")` rather than leaving a stuck stick.
     /// Unknown names are ignored.
     pub fn set_port_device(&mut self, port: u8, device: &str) {
+        if self.netplay.is_some() {
+            return;
+        }
         if let Some(device) = PortDevice::parse(device) {
             self.emu
                 .bus_mut()
@@ -1015,6 +1080,7 @@ impl WebEmu {
     /// recognised by signature rather than by name. Always write-protected;
     /// use `insert_floppy_writable` when the page will offer an export.
     pub fn insert_floppy(&mut self, drive: u8, bytes: Vec<u8>, name: &str) -> Result<(), JsValue> {
+        self.require_local_session()?;
         self.emu
             .bus_mut()
             .floppy
@@ -1033,6 +1099,7 @@ impl WebEmu {
         bytes: Vec<u8>,
         name: &str,
     ) -> Result<(), JsValue> {
+        self.require_local_session()?;
         self.emu
             .bus_mut()
             .floppy
@@ -1043,6 +1110,7 @@ impl WebEmu {
     /// Snapshot DFn's current image bytes. Standard disks export as ADF and
     /// track images as UAE extended ADF; compressed inputs export decoded.
     pub fn export_floppy(&self, drive: u8) -> Result<Vec<u8>, JsValue> {
+        self.require_local_session()?;
         self.emu
             .bus()
             .floppy
@@ -1051,6 +1119,7 @@ impl WebEmu {
     }
 
     pub fn eject_floppy(&mut self, drive: u8) -> Result<(), JsValue> {
+        self.require_local_session()?;
         self.emu
             .bus_mut()
             .floppy
@@ -1116,6 +1185,9 @@ impl WebEmu {
     /// at the emulated baud rate, so pace large transfers with
     /// `serial_input_backlog` instead of pushing megabytes at once.
     pub fn serial_send(&mut self, bytes: Vec<u8>) {
+        if self.netplay.is_some() {
+            return;
+        }
         self.serial.push_input(&bytes);
     }
 
@@ -1154,6 +1226,9 @@ impl WebEmu {
     /// with `true` when the socket opens and `false` when it closes; a page
     /// that never calls it leaves the guest seeing a modem with no call up.
     pub fn serial_set_carrier(&mut self, connected: bool) {
+        if self.netplay.is_some() {
+            return;
+        }
         self.serial.set_carrier(connected);
     }
 
@@ -1167,6 +1242,7 @@ impl WebEmu {
     // before serializing -- src/copperhf.rs's module doc -- so the core
     // emulator method takes &mut self as of M5.)
     pub fn save_state(&mut self) -> Result<Vec<u8>, JsValue> {
+        self.require_local_session()?;
         self.emu.save_state_bytes().map_err(js_err)
     }
 
@@ -1180,7 +1256,9 @@ impl WebEmu {
     /// the machine): a page that keeps its own volume, drive-sound or floppy
     /// speed choices should re-apply them after a load.
     pub fn load_state(&mut self, blob: &[u8]) -> Result<(), JsValue> {
+        self.require_local_session()?;
         self.emu.load_state_bytes(blob).map_err(js_err)?;
+        self.netplay_eligible = false;
         // A desktop state can name writable host files. The browser has no
         // such paths, so adopt every restored image into serialized memory
         // before the guest gets another chance to write it.
@@ -1211,6 +1289,7 @@ impl WebEmu {
 
     /// Cold reset (power cycle), keeping the fitted ROM and inserted disks.
     pub fn reset(&mut self) -> Result<(), JsValue> {
+        self.require_local_session()?;
         self.emu.power_on_reset().map_err(js_err)?;
         self.anchor = None;
         self.deferred_fields = 0;
@@ -1475,7 +1554,11 @@ impl WebEmu {
     }
 
     pub fn set_volume_percent(&mut self, percent: u8) {
-        self.emu.bus_mut().set_output_volume_percent(percent);
+        if self.netplay.is_some() {
+            self.netplay_volume = percent.min(100);
+        } else {
+            self.emu.bus_mut().set_output_volume_percent(percent);
+        }
     }
 
     /// Average the left and right channels into both outputs (the desktop's
@@ -1511,6 +1594,9 @@ impl WebEmu {
     /// DMA transfers complete almost instantly. Other values fall back to
     /// 100. Applies immediately; drive mechanics stay at real speed.
     pub fn set_floppy_speed(&mut self, percent: u16) {
+        if self.netplay.is_some() {
+            return;
+        }
         self.emu.bus_mut().floppy.set_speed_percent(percent);
     }
 

--- a/crates/copperline-web/src/netplay.rs
+++ b/crates/copperline-web/src/netplay.rs
@@ -32,7 +32,7 @@ impl WebEmu {
         self.require_local_session()?;
         if !self.netplay_eligible || self.emu.bus().emulated_cck() != 0 {
             return Err(JsValue::from_str(
-                "Netplay needs a fresh machine; load ROM and disks before starting",
+                "Netplay needs a fresh machine; create a new WebEmu and load ROM and disks before starting",
             ));
         }
         let settings = Settings {
@@ -50,25 +50,18 @@ impl WebEmu {
                 ))
             }
         };
-        let mut cfg = self.config.clone();
-        cfg.serial.mode = copperline::config::SerialMode::Off;
-        copperline::netplay::prepare_config(&mut cfg).map_err(js_err)?;
-        self.netplay_volume = self.emu.bus().output_volume_percent();
-        self.emu.bus_mut().set_output_volume_percent(100);
-        self.emu.bus_mut().rtc.set_seed(Some(946684800), false);
-        self.emu.bus_mut().paula.serial = Box::new(copperline::serial::NullSerialSink);
-        for port in 0..2 {
-            self.emu.bus_mut().input.set_port_device(port, device);
-        }
-        self.mouse_pending = (0, 0);
-        self.mouse_remainder = (0.0, 0.0);
-        self.netplay_input = Default::default();
-        self.netplay = Some(
-            Connection::with_transport(settings, PacketQueue::default(), &mut self.emu, &cfg)
-                .map_err(js_err)?,
-        );
-        self.anchor = None;
-        Ok(())
+        self.start_netplay_inner(settings, device).map_err(js_err)
+    }
+
+    /// [protocol version, maximum packet bytes, header bytes, input record bytes].
+    pub fn netplay_packet_layout() -> Vec<u32> {
+        use copperline::netplay::{INPUT_RECORD, MAX_PACKET, PACKET_HEADER, PROTOCOL_VERSION};
+        vec![
+            u32::from(PROTOCOL_VERSION),
+            MAX_PACKET as u32,
+            PACKET_HEADER as u32,
+            INPUT_RECORD as u32,
+        ]
     }
 
     pub fn netplay_receive(&mut self, packet: &[u8]) -> Result<(), JsValue> {
@@ -112,10 +105,51 @@ impl WebEmu {
 }
 
 impl WebEmu {
+    fn start_netplay_inner(
+        &mut self,
+        settings: Settings,
+        device: PortDevice,
+    ) -> anyhow::Result<()> {
+        let mut cfg = self.config.clone();
+        cfg.serial.mode = copperline::config::SerialMode::Off;
+        copperline::netplay::prepare_config(&mut cfg)?;
+        let checkpoint = self.emu.netplay_snapshot()?;
+        let volume = self.emu.bus().output_volume_percent();
+        let serial = std::mem::replace(
+            &mut self.emu.bus_mut().paula.serial,
+            Box::new(copperline::serial::NullSerialSink),
+        );
+        self.emu.bus_mut().set_output_volume_percent(100);
+        self.emu
+            .bus_mut()
+            .rtc
+            .set_seed(Some(copperline::netplay::RTC_SEED), false);
+        for port in 0..2 {
+            self.emu.bus_mut().input.set_port_device(port, device);
+        }
+        let connection =
+            Connection::with_transport(settings, PacketQueue::default(), &mut self.emu, &cfg);
+        match connection {
+            Ok(connection) => self.netplay = Some(connection),
+            Err(error) => {
+                let restored = self.emu.netplay_restore(&checkpoint);
+                self.emu.bus_mut().paula.serial = serial;
+                restored?;
+                return Err(error);
+            }
+        }
+        self.netplay_volume = volume;
+        self.mouse_pending = (0, 0);
+        self.mouse_remainder = (0.0, 0.0);
+        self.netplay_input = Default::default();
+        self.anchor = None;
+        Ok(())
+    }
+
     pub(super) fn require_local_session(&self) -> Result<(), JsValue> {
         if self.netplay.is_some() {
             Err(JsValue::from_str(
-                "Unavailable during netplay; disconnect first",
+                "Unavailable during netplay; free this instance and create a new WebEmu",
             ))
         } else {
             Ok(())
@@ -180,5 +214,86 @@ impl WebEmu {
                 .max(u32::from(corrected));
         }
         Ok(stepped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings(player: usize) -> Settings {
+        Settings {
+            player,
+            session: [42; 16],
+            input_delay: 0,
+            rollback_frames: 8,
+        }
+    }
+
+    #[test]
+    fn failed_startup_restores_machine_and_host_state() -> anyhow::Result<()> {
+        let mut web = WebEmu::new(Some("A500".into()), Some("PAL".into()), Some(1.0)).unwrap();
+        web.insert_floppy(0, vec![0; 901_120], "original.adf")
+            .unwrap();
+        web.set_volume_percent(37);
+        web.serial_set_carrier(true);
+        web.mouse_delta(12.5, -3.25);
+        web.anchor = Some((123.0, 0.0));
+        // This is a runtime rejection after preparation, not argument validation.
+        web.emu.enable_time_travel(8, 1);
+        let before = web.emu.netplay_snapshot()?;
+        let lines = web.emu.bus().paula.serial.control_lines();
+        assert!(web
+            .start_netplay_inner(settings(0), PortDevice::Cd32Pad)
+            .unwrap_err()
+            .to_string()
+            .contains("reverse history"));
+        assert!(
+            web.emu.netplay_snapshot()? == before,
+            "startup changed the machine"
+        );
+        assert_eq!(web.emu.bus().paula.serial.control_lines(), lines);
+        assert_eq!(web.mouse_pending, (12, -3));
+        assert_eq!(web.mouse_remainder, (0.5, -0.25));
+        assert_eq!(web.anchor, Some((123.0, 0.0)));
+        assert!(web.netplay.is_none());
+        web.emu.disable_time_travel();
+        web.start_netplay_inner(settings(0), PortDevice::Cd32Pad)?;
+        Ok(())
+    }
+
+    #[test]
+    fn netplay_routes_each_controller_button_and_keyboard_and_scales_local_audio(
+    ) -> anyhow::Result<()> {
+        for player in 0..2 {
+            let mut web = WebEmu::new(None, None, Some(0.0)).unwrap();
+            web.start_netplay_inner(settings(player), PortDevice::Cd32Pad)?;
+            for bit in 0..11 {
+                let on = |i| i == bit;
+                web.set_joystick_port2(on(0), on(1), on(2), on(3), on(4), on(5));
+                web.set_cd32_buttons_port2(on(6), on(7), on(8), on(9), on(10));
+                assert_eq!(web.netplay_input.buttons, 1 << bit);
+                // The secondary page controller cannot overwrite the primary.
+                web.set_joystick_port(1, false, false, false, false, false, false);
+                web.set_cd32_buttons_port(1, false, false, false, false, false);
+                assert_eq!(web.netplay_input.buttons, 1 << bit);
+            }
+            assert!(web.key_event("Space", true));
+            web.key_raw(0x20, true);
+            assert_eq!(web.netplay_input.keys[8], 1);
+            assert_eq!(web.netplay_input.keys[4], 1);
+            web.key_raw(0x20, false);
+            assert_eq!(web.netplay_input.keys[4], 0);
+            web.netplay_release_input();
+            assert_eq!(web.netplay_input, Default::default());
+            for volume in [0, 35, 100] {
+                web.set_volume_percent(volume);
+                web.audio.borrow_mut().extend([1.0, -0.5]);
+                let gain = f32::from(volume) / 100.0;
+                assert_eq!(web.take_audio(), vec![gain, -0.5 * gain]);
+                assert_eq!(web.emu.bus().output_volume_percent(), 100);
+            }
+        }
+        Ok(())
     }
 }

--- a/crates/copperline-web/src/netplay.rs
+++ b/crates/copperline-web/src/netplay.rs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Browser ownership of the shared rollback timeline; JavaScript owns WebRTC.
+
+use super::*;
+use copperline::netplay::{Connection, PacketQueue, Settings};
+
+fn integer(value: f64, min: u8, max: u8, name: &str) -> Result<u8, JsValue> {
+    if !value.is_finite()
+        || value.fract() != 0.0
+        || !(f64::from(min)..=f64::from(max)).contains(&value)
+    {
+        return Err(JsValue::from_str(&format!(
+            "{name} must be an integer from {min} to {max}"
+        )));
+    }
+    Ok(value as u8)
+}
+
+#[wasm_bindgen]
+impl WebEmu {
+    /// Call after loading ROM/disks into a fresh WebEmu, before any run/state load.
+    /// Connection codes and data-channel setup are handled by the page.
+    pub fn start_netplay(
+        &mut self,
+        player: f64,
+        code: &str,
+        delay: f64,
+        window: f64,
+        controller: &str,
+    ) -> Result<(), JsValue> {
+        self.require_local_session()?;
+        if !self.netplay_eligible || self.emu.bus().emulated_cck() != 0 {
+            return Err(JsValue::from_str(
+                "Netplay needs a fresh machine; load ROM and disks before starting",
+            ));
+        }
+        let settings = Settings {
+            player: usize::from(integer(player, 1, 2, "player")? - 1),
+            session: copperline::netplay::parse_session_id(code).map_err(js_err)?,
+            input_delay: integer(delay, 0, 6, "input delay")?,
+            rollback_frames: integer(window, 1, 12, "rollback window")?,
+        };
+        let device = match controller {
+            "joystick" => PortDevice::Joystick,
+            "cd32" => PortDevice::Cd32Pad,
+            _ => {
+                return Err(JsValue::from_str(
+                    "Netplay controller must be joystick or cd32",
+                ))
+            }
+        };
+        let mut cfg = self.config.clone();
+        cfg.serial.mode = copperline::config::SerialMode::Off;
+        copperline::netplay::prepare_config(&mut cfg).map_err(js_err)?;
+        self.netplay_volume = self.emu.bus().output_volume_percent();
+        self.emu.bus_mut().set_output_volume_percent(100);
+        self.emu.bus_mut().rtc.set_seed(Some(946684800), false);
+        self.emu.bus_mut().paula.serial = Box::new(copperline::serial::NullSerialSink);
+        for port in 0..2 {
+            self.emu.bus_mut().input.set_port_device(port, device);
+        }
+        self.mouse_pending = (0, 0);
+        self.mouse_remainder = (0.0, 0.0);
+        self.netplay_input = Default::default();
+        self.netplay = Some(
+            Connection::with_transport(settings, PacketQueue::default(), &mut self.emu, &cfg)
+                .map_err(js_err)?,
+        );
+        self.anchor = None;
+        Ok(())
+    }
+
+    pub fn netplay_receive(&mut self, packet: &[u8]) -> Result<(), JsValue> {
+        self.netplay
+            .as_mut()
+            .ok_or_else(|| JsValue::from_str("No netplay session"))?
+            .transport_mut()
+            .push(packet)
+            .map_err(js_err)
+    }
+
+    /// Empty means there is no outgoing packet. Drain after every run call.
+    pub fn netplay_take_packet(&mut self) -> Vec<u8> {
+        self.netplay
+            .as_mut()
+            .and_then(|peer| peer.transport_mut().pop())
+            .unwrap_or_default()
+    }
+
+    /// [connected, frame, confirmed, acknowledged, rollbacks, replayed, checked].
+    /// Counters are exact JavaScript numbers for any practical session duration.
+    pub fn netplay_status(&self) -> Vec<f64> {
+        self.netplay.as_ref().map_or_else(Vec::new, |peer| {
+            let s = peer.status();
+            vec![
+                u8::from(s.connected) as f64,
+                s.frame as f64,
+                s.confirmed_frame as f64,
+                s.acknowledged_frame as f64,
+                s.rollbacks as f64,
+                s.replayed_frames as f64,
+                s.checked_frame as f64,
+            ]
+        })
+    }
+
+    /// Release this peer's held keys/controller without touching the guest directly.
+    pub fn netplay_release_input(&mut self) {
+        self.netplay_input = Default::default();
+    }
+}
+
+impl WebEmu {
+    pub(super) fn require_local_session(&self) -> Result<(), JsValue> {
+        if self.netplay.is_some() {
+            Err(JsValue::from_str(
+                "Unavailable during netplay; disconnect first",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(super) fn run_netplay(
+        &mut self,
+        now_ms: f64,
+        max_frames: u32,
+        render: bool,
+    ) -> Result<u32, JsValue> {
+        if !now_ms.is_finite() {
+            return Err(JsValue::from_str("Netplay clock must be finite"));
+        }
+        self.last_run_core_ms = 0.0;
+        self.last_run_render_ms = 0.0;
+        let started = Instant::now();
+        let peer = self.netplay.as_mut().unwrap();
+        let before = peer.status();
+        peer.step(&mut self.emu, self.netplay_input, false)
+            .map_err(js_err)?;
+        if !before.connected {
+            self.anchor = None;
+        }
+        let (wall, emulated) = *self
+            .anchor
+            .get_or_insert((now_ms, self.emu.bus().emulated_seconds()));
+        let target = emulated + (now_ms - wall) / 1000.0;
+        let mut stepped = 0;
+        while self.emu.bus().emulated_seconds() < target && stepped < max_frames.min(8) {
+            if !peer
+                .step(&mut self.emu, self.netplay_input, true)
+                .map_err(js_err)?
+            {
+                self.anchor = Some((now_ms, self.emu.bus().emulated_seconds()));
+                break;
+            }
+            stepped += 1;
+        }
+        let corrected = peer.status().rollbacks != before.rollbacks;
+        if corrected {
+            self.last_rendered_frame = None;
+            self.deinterlacer.reset_history();
+            self.reset_presentation_latches();
+        }
+        self.last_run_core_ms = started.elapsed().as_secs_f64() * 1000.0;
+        if target - self.emu.bus().emulated_seconds() > MAX_CATCHUP_SECONDS {
+            self.anchor = Some((now_ms, self.emu.bus().emulated_seconds()));
+        }
+        if render && (stepped > 0 || corrected || self.deferred_fields > 0) {
+            let render_started = Instant::now();
+            self.render_completed_frame_elapsed(
+                self.deferred_fields.saturating_add(stepped).max(1),
+            );
+            self.deferred_fields = 0;
+            self.last_run_render_ms = render_started.elapsed().as_secs_f64() * 1000.0;
+        } else if !render {
+            self.deferred_fields = self
+                .deferred_fields
+                .saturating_add(stepped)
+                .max(u32::from(corrected));
+        }
+        Ok(stepped)
+    }
+}

--- a/crates/copperline-web/www/netplay.js
+++ b/crates/copperline-web/www/netplay.js
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Signaling is copy/paste; only bounded input packets use the data channel.
+const CODE_LIMIT = 96 * 1024;
+const PACKET_LIMIT = 943;
+const QUEUE_LIMIT = 64;
+const CHANNEL = 'copperline-netplay-v1';
+
+export function validateSettings(value) {
+  if (!value || !/^[0-9a-f]{32}$/i.test(value.session ?? '') ||
+      !Number.isInteger(value.delay) || value.delay < 0 || value.delay > 6 ||
+      !Number.isInteger(value.window) || value.window < 1 || value.window > 12 ||
+      !['joystick', 'cd32'].includes(value.controller)) {
+    throw new Error('Invalid netplay settings in connection code');
+  }
+  return { session: value.session.toLowerCase(), delay: value.delay,
+    window: value.window, controller: value.controller };
+}
+
+export function encodeCode(description, settings) {
+  const code = 'CLNP1.' + btoa(JSON.stringify({ description, settings: validateSettings(settings) }));
+  if (code.length > CODE_LIMIT) throw new Error('Connection code is too large');
+  return code;
+}
+
+export function decodeCode(code, type) {
+  code = code.trim();
+  if (code.length > CODE_LIMIT || !code.startsWith('CLNP1.')) {
+    throw new Error('Paste a Copperline connection code');
+  }
+  let value;
+  try { value = JSON.parse(atob(code.slice(6))); }
+  catch { throw new Error('Connection code is incomplete or damaged'); }
+  const description = value?.description;
+  if (description?.type !== type || typeof description.sdp !== 'string' ||
+      !description.sdp.startsWith('v=0\r\n') || description.sdp.length > CODE_LIMIT) {
+    throw new Error(`Expected an ${type} connection code`);
+  }
+  return { description: { type, sdp: description.sdp }, settings: validateSettings(value.settings) };
+}
+
+export function newSettings(delay, window, controller) {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  return validateSettings({ session: [...bytes].map(b => b.toString(16).padStart(2, '0')).join(''),
+    delay, window, controller });
+}
+
+export class RtcLink {
+  constructor({ iceServers = [], onOpen = () => {}, onClose = () => {},
+    PeerConnection = globalThis.RTCPeerConnection } = {}) {
+    if (!PeerConnection) throw new Error('This browser does not support WebRTC data channels');
+    this.pc = new PeerConnection({ iceServers });
+    this.channel = null;
+    this.settings = null;
+    this.incoming = [];
+    this.closed = false;
+    this.opened = false;
+    this.onOpen = onOpen;
+    this.onClose = onClose;
+    this.timer = null;
+    this.cancelGather = null;
+    this.pc.ondatachannel = event => this.attach(event.channel);
+    this.pc.onconnectionstatechange = () => {
+      if (['failed', 'closed'].includes(this.pc.connectionState)) {
+        this.close('Peer connection ended. Check the network and start a new session.');
+      }
+    };
+  }
+
+  attach(channel) {
+    if (this.closed || this.channel || channel.label !== CHANNEL ||
+        channel.ordered || channel.maxRetransmits !== 0) {
+      channel.close();
+      this.close('Unexpected netplay data channel');
+      return;
+    }
+    this.channel = channel;
+    channel.binaryType = 'arraybuffer';
+    channel.onmessage = event => {
+      if (this.closed) return;
+      if (!(event.data instanceof ArrayBuffer) || event.data.byteLength > PACKET_LIMIT) {
+        this.close('Invalid netplay packet');
+        return;
+      }
+      // Browser timer throttling can batch valid retransmissions. Keep the
+      // newest packets, which repeat every unacknowledged input, as UDP does.
+      if (this.incoming.length === QUEUE_LIMIT) this.incoming.shift();
+      this.incoming.push(new Uint8Array(event.data));
+    };
+    channel.onopen = () => {
+      if (this.closed || this.opened) return;
+      this.opened = true;
+      clearTimeout(this.timer);
+      Promise.resolve().then(() => this.closed ? undefined : this.onOpen(this))
+        .catch(error => this.close(String(error.message ?? error)));
+    };
+    channel.onclose = () => this.close('Peer disconnected');
+    channel.onerror = () => this.close('Netplay data channel failed');
+  }
+
+  async gather(description) {
+    if (this.closed) throw new Error('Connection cancelled');
+    await this.pc.setLocalDescription(description);
+    if (this.closed) throw new Error('Connection cancelled');
+    if (this.pc.iceGatheringState !== 'complete') {
+      await new Promise((resolve, reject) => {
+        let timer;
+        const finish = error => {
+          clearTimeout(timer);
+          this.pc.removeEventListener('icegatheringstatechange', changed);
+          this.cancelGather = null;
+          error ? reject(error) : resolve();
+        };
+        const changed = () => {
+          if (this.pc.iceGatheringState === 'complete') finish();
+        };
+        this.cancelGather = () => finish(new Error('Connection cancelled'));
+        this.pc.addEventListener('icegatheringstatechange', changed);
+        timer = setTimeout(() => finish(new Error('Network address discovery timed out; check the STUN server')), 15000);
+        changed();
+      });
+    }
+    if (this.closed) throw new Error('Connection cancelled');
+    return encodeCode(this.pc.localDescription, this.settings);
+  }
+
+  async offer(settings) {
+    this.settings = validateSettings(settings);
+    this.attach(this.pc.createDataChannel(CHANNEL, { ordered: false, maxRetransmits: 0 }));
+    return this.gather(await this.pc.createOffer());
+  }
+
+  async answer(code) {
+    const { description, settings } = decodeCode(code, 'offer');
+    this.settings = settings;
+    await this.pc.setRemoteDescription(description);
+    if (this.closed) throw new Error('Connection cancelled');
+    return this.gather(await this.pc.createAnswer());
+  }
+
+  async accept(code) {
+    const { description, settings } = decodeCode(code, 'answer');
+    if (JSON.stringify(settings) !== JSON.stringify(this.settings)) {
+      throw new Error('Answer belongs to a different netplay session');
+    }
+    await this.pc.setRemoteDescription(description);
+    if (this.closed) throw new Error('Connection cancelled');
+    if (!this.opened) {
+      clearTimeout(this.timer);
+      this.timer = setTimeout(() => this.close('Peer connection timed out; try a LAN or VPN'), 60000);
+    }
+  }
+
+  receive(emu) {
+    for (const packet of this.incoming.splice(0)) emu.netplay_receive(packet);
+  }
+
+  send(emu) {
+    if (this.closed || this.channel?.readyState !== 'open') return;
+    for (let count = 0; count < QUEUE_LIMIT && this.channel.bufferedAmount < PACKET_LIMIT * QUEUE_LIMIT; count++) {
+      const packet = emu.netplay_take_packet();
+      if (!packet.length) break;
+      this.channel.send(packet);
+    }
+  }
+
+  close(reason = 'Disconnected. Start a new session to play again.') {
+    if (this.closed) return;
+    this.closed = true;
+    clearTimeout(this.timer);
+    this.cancelGather?.();
+    this.incoming.length = 0;
+    this.pc.ondatachannel = this.pc.onconnectionstatechange = null;
+    if (this.channel) {
+      this.channel.onopen = this.channel.onmessage = this.channel.onclose = this.channel.onerror = null;
+      this.channel.close();
+    }
+    this.pc.close();
+    this.onClose(reason, this);
+  }
+}
+
+// The panel inserts itself into old static page shells, as the other controls do.
+export function mountNetplayPanel(parent, { prepare, start, stop }) {
+  const style = document.createElement('style');
+  style.textContent = `
+    #netplay-panel { font-size: .8rem; line-height: 1.4; color: var(--ink-mute, #bbc0ca); }
+    #netplay-panel summary { cursor: pointer; font-weight: 600; color: var(--ink, #eee); }
+    #netplay-panel p { margin: .6rem 0; }
+    #netplay-panel label { display: block; margin-top: .6rem; }
+    #netplay-panel input, #netplay-panel textarea, #netplay-panel select {
+      display: block; box-sizing: border-box; width: 100%; margin-top: .2rem;
+      border: 1px solid var(--line, #454b57); border-radius: 6px; padding: .35rem;
+      background: rgba(10, 13, 22, .6); color: var(--ink, #eee); font: inherit;
+    }
+    #netplay-panel textarea { resize: vertical; font-family: ui-monospace, monospace; font-size: .7rem; }
+    #netplay-panel .btn { margin-top: .4rem; width: 100%; justify-content: center; font-size: .8rem; padding: .35rem .5rem; }
+    #netplay-panel :disabled { opacity: .45; cursor: default; }
+    #netplay-panel #netplay-status { overflow-wrap: anywhere; color: var(--ink, #eee); }
+  `;
+  document.head.appendChild(style);
+  const root = document.createElement('details');
+  root.id = 'netplay-panel';
+  root.className = 'try-side-section';
+  root.innerHTML = `<summary>Netplay</summary>
+    <p>Two browsers, matching ROMs and disks. Host is player 1; Join is player 2.</p>
+    <label>Input delay <select id="netplay-delay">${[0,1,2,3,4,5,6].map(n => `<option ${n === 2 ? 'selected' : ''}>${n}</option>`).join('')}</select></label>
+    <label>Rollback limit <select id="netplay-window">${Array.from({length:12}, (_, i) => `<option ${i === 7 ? 'selected' : ''}>${i + 1}</option>`).join('')}</select></label>
+    <label>Controllers <select id="netplay-controller"><option value="joystick">Joystick</option><option value="cd32">CD32 pad</option></select></label>
+    <label>STUN server <input id="netplay-stun" value="stun:stun.l.google.com:19302" spellcheck="false"></label>
+    <p>STUN helps find a route over the internet. Leave it blank for LAN-only setup. Some networks need a VPN.</p>
+    <button id="netplay-host" type="button">Host game</button>
+    <label>Code from the other player <textarea id="netplay-remote" rows="3" spellcheck="false"></textarea></label>
+    <button id="netplay-join" type="button">Join offer</button>
+    <button id="netplay-accept" type="button" disabled>Connect answer</button>
+    <label>Your connection code <textarea id="netplay-local" rows="3" readonly spellcheck="false"></textarea></label>
+    <button id="netplay-copy" type="button" disabled>Copy code</button>
+    <button id="netplay-disconnect" type="button" disabled>Disconnect</button>
+    <p id="netplay-status" role="status">Load matching ROMs and disks, then host or join.</p>`;
+  for (const button of root.querySelectorAll('button')) button.className = 'btn btn--ghost';
+  root.addEventListener('keydown', event => event.stopPropagation());
+  root.addEventListener('keyup', event => event.stopPropagation());
+  parent.insertBefore(root, parent.querySelector('.try-side-section'));
+  const field = name => root.querySelector(`#netplay-${name}`);
+  let link = null;
+  const status = text => { field('status').textContent = text; };
+  const controls = () => {
+    const active = !!link;
+    for (const name of ['host', 'join', 'delay', 'window', 'controller', 'stun']) field(name).disabled = active;
+    field('disconnect').disabled = !active;
+    field('copy').disabled = !field('local').value;
+    if (!active) field('accept').disabled = true;
+  };
+  async function begin(host) {
+    if (link) return;
+    let current;
+    try {
+      const remote = field('remote').value;
+      const settings = host ? newSettings(Number(field('delay').value), Number(field('window').value), field('controller').value)
+        : decodeCode(remote, 'offer').settings;
+      const stun = field('stun').value.trim();
+      if (stun && !/^stuns?:[^\s]+$/i.test(stun)) throw new Error('STUN server must start with stun: or stuns:');
+      current = new RtcLink({ iceServers: stun ? [{ urls: stun }] : [],
+        onOpen: async peer => {
+          if (link !== peer) return;
+          status('Connected. Checking the initial machines…');
+          await start(peer, settings, host ? 1 : 2);
+        },
+        onClose: (reason, peer) => {
+          if (link !== peer) return;
+          link = null;
+          field('local').value = '';
+          controls();
+          stop(reason);
+          status(reason);
+        },
+      });
+      link = current;
+      field('local').value = '';
+      controls();
+      status('Preparing a fresh session and gathering network addresses…');
+      await prepare(current);
+      if (link !== current) return;
+      const code = host ? await current.offer(settings) : await current.answer(remote);
+      if (link !== current) return;
+      field('local').value = code;
+      field('copy').disabled = false;
+      field('accept').disabled = !host;
+      status(host ? 'Send your offer code. Paste the reply and click Connect answer.' : 'Send your answer code back to the host. Keep this page open.');
+    } catch (error) {
+      if (current && link === current) current.close(String(error.message ?? error));
+      else if (!current) status(String(error.message ?? error));
+    }
+  }
+  field('host').addEventListener('click', () => begin(true));
+  field('join').addEventListener('click', () => begin(false));
+  field('accept').addEventListener('click', async () => {
+    const current = link;
+    if (!current) return;
+    field('accept').disabled = true;
+    try {
+      await current.accept(field('remote').value);
+      if (link !== current) return;
+      field('accept').disabled = true;
+      if (!current.opened) status('Connecting to the other player…');
+    } catch (error) {
+      if (link !== current) return;
+      field('accept').disabled = current.opened;
+      status(String(error.message ?? error));
+    }
+  });
+  field('copy').addEventListener('click', async () => {
+    try { await navigator.clipboard.writeText(field('local').value); status('Connection code copied'); }
+    catch { field('local').focus(); field('local').select(); status('Copy the selected connection code'); }
+  });
+  field('disconnect').addEventListener('click', () => link?.close());
+  window.addEventListener('pagehide', () => link?.close());
+  return { get link() { return link; }, status, root };
+}

--- a/crates/copperline-web/www/netplay.js
+++ b/crates/copperline-web/www/netplay.js
@@ -2,7 +2,7 @@
 
 // Signaling is copy/paste; only bounded input packets use the data channel.
 const CODE_LIMIT = 96 * 1024;
-const PACKET_LIMIT = 943;
+export const PACKET_LIMIT = 943;
 const QUEUE_LIMIT = 64;
 const CHANNEL = 'copperline-netplay-v1';
 
@@ -71,7 +71,7 @@ export class RtcLink {
     if (this.closed || this.channel || channel.label !== CHANNEL ||
         channel.ordered || channel.maxRetransmits !== 0) {
       channel.close();
-      this.close('Unexpected netplay data channel');
+      this.close(`Unexpected netplay data channel: label=${channel.label}, ordered=${channel.ordered}, maxRetransmits=${channel.maxRetransmits}`);
       return;
     }
     this.channel = channel;
@@ -83,7 +83,7 @@ export class RtcLink {
         return;
       }
       // Browser timer throttling can batch valid retransmissions. Keep the
-      // newest packets, which repeat every unacknowledged input, as UDP does.
+      // newest packets, which repeat every unacknowledged input.
       if (this.incoming.length === QUEUE_LIMIT) this.incoming.shift();
       this.incoming.push(new Uint8Array(event.data));
     };
@@ -92,10 +92,13 @@ export class RtcLink {
       this.opened = true;
       clearTimeout(this.timer);
       Promise.resolve().then(() => this.closed ? undefined : this.onOpen(this))
-        .catch(error => this.close(String(error.message ?? error)));
+        .catch(error => { console.error('Netplay startup failed', error); this.close(String(error.message ?? error)); });
     };
     channel.onclose = () => this.close('Peer disconnected');
-    channel.onerror = () => this.close('Netplay data channel failed');
+    channel.onerror = event => {
+      console.error('Netplay data channel failed', event.error ?? event);
+      this.close(`Netplay data channel failed${event.error?.message ? ': ' + event.error.message : ''}`);
+    };
   }
 
   async gather(description) {
@@ -169,6 +172,13 @@ export class RtcLink {
     this.closed = true;
     clearTimeout(this.timer);
     this.cancelGather?.();
+    // Let the owner poll final queued packets for the core's failure reason
+    // before freeing the machine. A remote close can follow its hello packet.
+    try { this.onClose(reason, this); }
+    finally { this.dispose(); }
+  }
+
+  dispose() {
     this.incoming.length = 0;
     this.pc.ondatachannel = this.pc.onconnectionstatechange = null;
     if (this.channel) {
@@ -176,7 +186,6 @@ export class RtcLink {
       this.channel.close();
     }
     this.pc.close();
-    this.onClose(reason, this);
   }
 }
 
@@ -243,7 +252,7 @@ export function mountNetplayPanel(parent, { prepare, start, stop }) {
       current = new RtcLink({ iceServers: stun ? [{ urls: stun }] : [],
         onOpen: async peer => {
           if (link !== peer) return;
-          status('Connected. Checking the initial machines…');
+          status('Connected. Checking the initial machines...');
           await start(peer, settings, host ? 1 : 2);
         },
         onClose: (reason, peer) => {
@@ -251,14 +260,13 @@ export function mountNetplayPanel(parent, { prepare, start, stop }) {
           link = null;
           field('local').value = '';
           controls();
-          stop(reason);
-          status(reason);
+          status(stop(reason, peer) ?? reason);
         },
       });
       link = current;
       field('local').value = '';
       controls();
-      status('Preparing a fresh session and gathering network addresses…');
+      status('Preparing a fresh session and gathering network addresses...');
       await prepare(current);
       if (link !== current) return;
       const code = host ? await current.offer(settings) : await current.answer(remote);
@@ -266,7 +274,7 @@ export function mountNetplayPanel(parent, { prepare, start, stop }) {
       field('local').value = code;
       field('copy').disabled = false;
       field('accept').disabled = !host;
-      status(host ? 'Send your offer code. Paste the reply and click Connect answer.' : 'Send your answer code back to the host. Keep this page open.');
+      status(host ? 'Send your offer code. Paste the reply and click Connect answer.' : 'Send your answer code back to the host. Keep this page open, or Disconnect to cancel.');
     } catch (error) {
       if (current && link === current) current.close(String(error.message ?? error));
       else if (!current) status(String(error.message ?? error));
@@ -282,7 +290,7 @@ export function mountNetplayPanel(parent, { prepare, start, stop }) {
       await current.accept(field('remote').value);
       if (link !== current) return;
       field('accept').disabled = true;
-      if (!current.opened) status('Connecting to the other player…');
+      if (!current.opened) status('Connecting to the other player...');
     } catch (error) {
       if (link !== current) return;
       field('accept').disabled = current.opened;

--- a/crates/copperline-web/www/netplay.test.js
+++ b/crates/copperline-web/www/netplay.test.js
@@ -104,3 +104,40 @@ test('duplicate or incompatible channels close without running the emulator', ()
   assert.equal(link.closed, true);
   assert.equal(opened, 0);
 });
+
+test('data-channel open runs once, remote close drains queued input before cleanup', async () => {
+  let opens = 0;
+  let closed;
+  const link = new RtcLink({ PeerConnection: Peer, onOpen: () => opens++,
+    onClose: (reason, peer) => {
+      const received = [];
+      peer.receive({ netplay_receive: packet => received.push(...packet) });
+      closed = { reason, received };
+    } });
+  const channel = new Channel('copperline-netplay-v1', { ordered: false, maxRetransmits: 0 });
+  link.pc.ondatachannel({ channel });
+  channel.onopen();
+  channel.onopen();
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(opens, 1);
+  channel.onmessage({ data: new Uint8Array([7, 8]).buffer });
+  channel.onclose();
+  assert.deepEqual(closed, { reason: 'Peer disconnected', received: [7, 8] });
+  assert.equal(link.closed, true);
+  assert.equal(channel.onopen, null);
+  assert.equal(link.pc.ondatachannel, null);
+  assert.equal(link.incoming.length, 0);
+});
+
+test('connection-state failure closes once and an open queued before cancellation stays cancelled', async () => {
+  let opens = 0, closes = 0;
+  const link = new RtcLink({ PeerConnection: Peer, onOpen: () => opens++, onClose: () => closes++ });
+  await link.offer(settings);
+  link.channel.onopen();
+  link.pc.connectionState = 'failed';
+  link.pc.onconnectionstatechange();
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(opens, 0);
+  assert.equal(closes, 1);
+  assert.equal(link.channel.readyState, 'closed');
+});

--- a/crates/copperline-web/www/netplay.test.js
+++ b/crates/copperline-web/www/netplay.test.js
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { RtcLink, decodeCode, encodeCode, newSettings, validateSettings } from './netplay.js';
+
+const settings = { session: '0123456789abcdef0123456789abcdef', delay: 2, window: 8, controller: 'joystick' };
+const description = type => ({ type, sdp: 'v=0\r\ns=-\r\n' });
+
+class Channel {
+  constructor(label, options) { Object.assign(this, { label, ...options, bufferedAmount: 0, readyState: 'connecting', sent: [] }); }
+  send(packet) { this.sent.push(packet); }
+  close() { this.readyState = 'closed'; }
+}
+class Peer extends EventTarget {
+  constructor() { super(); this.iceGatheringState = 'complete'; this.connectionState = 'new'; }
+  createDataChannel(label, options) { return new Channel(label, options); }
+  async createOffer() { return description('offer'); }
+  async createAnswer() { return description('answer'); }
+  async setLocalDescription(value) { this.localDescription = value; }
+  async setRemoteDescription(value) { this.remoteDescription = value; }
+  close() { this.connectionState = 'closed'; }
+}
+
+test('connection codes round-trip only valid settings and the expected description type', () => {
+  const code = encodeCode(description('offer'), settings);
+  assert.deepEqual(decodeCode(code, 'offer'), { description: description('offer'), settings });
+  assert.throws(() => decodeCode(code, 'answer'), /Expected/);
+  for (const bad of ['', 'CLNP1.!', 'CLNP1.' + 'A'.repeat(100000)]) assert.throws(() => decodeCode(bad, 'offer'));
+  for (const key of ['delay', 'window']) {
+    for (const value of [-1, 1.5, 257, NaN, Infinity, '2']) assert.throws(() => validateSettings({ ...settings, [key]: value }));
+  }
+  assert.throws(() => validateSettings({ ...settings, controller: 'mouse' }));
+  assert.throws(() => validateSettings({ ...settings, session: 'bad' }));
+  assert.notEqual(newSettings(0, 1, 'cd32').session, newSettings(0, 1, 'cd32').session);
+});
+
+test('host accepts only its answer and negotiates an unordered channel without retransmission', async () => {
+  const host = new RtcLink({ PeerConnection: Peer });
+  const join = new RtcLink({ PeerConnection: Peer });
+  try {
+    const offer = await host.offer(settings);
+    const answer = await join.answer(offer);
+    await assert.rejects(host.accept(encodeCode(description('answer'), { ...settings, delay: 3 })), /different/);
+    assert.equal(host.pc.remoteDescription, undefined);
+    await host.accept(answer);
+    assert.equal(host.channel.ordered, false);
+    assert.equal(host.channel.maxRetransmits, 0);
+    assert.equal(host.channel.binaryType, 'arraybuffer');
+    assert.deepEqual(join.settings, settings);
+  } finally { host.close(); join.close(); }
+});
+
+test('cancelling ICE gathering rejects the pending offer and closes only once', async () => {
+  let closed = 0;
+  const link = new RtcLink({ PeerConnection: Peer, onClose: () => closed++ });
+  link.pc.iceGatheringState = 'gathering';
+  const offer = link.offer(settings);
+  await new Promise(resolve => setImmediate(resolve));
+  link.close();
+  link.close();
+  await assert.rejects(offer, /cancelled/);
+  assert.equal(closed, 1);
+  assert.equal(link.pc.connectionState, 'closed');
+});
+
+test('a delayed offer cannot resurrect a cancelled link', async () => {
+  const link = new RtcLink({ PeerConnection: Peer });
+  let finish;
+  link.pc.createOffer = () => new Promise(resolve => { finish = resolve; });
+  const offer = link.offer(settings);
+  link.close();
+  finish(description('offer'));
+  await assert.rejects(offer, /cancelled/);
+  assert.equal(link.pc.localDescription, undefined);
+});
+
+test('packet queues bound throttled-browser bursts and respect send backpressure', async () => {
+  const link = new RtcLink({ PeerConnection: Peer });
+  await link.offer(settings);
+  const channel = link.channel;
+  channel.readyState = 'open';
+  for (let i = 0; i < 100; i++) channel.onmessage({ data: new Uint8Array([i]).buffer });
+  const received = [];
+  link.receive({ netplay_receive: bytes => received.push(bytes[0]) });
+  assert.equal(received.length, 64);
+  assert.equal(received[0], 36);
+  assert.equal(received.at(-1), 99);
+  let drained = 0;
+  const emu = { netplay_take_packet: () => ++drained < 3 ? new Uint8Array([1]) : new Uint8Array() };
+  channel.bufferedAmount = 943 * 64;
+  link.send(emu);
+  assert.equal(drained, 0);
+  channel.bufferedAmount = 0;
+  link.send(emu);
+  assert.equal(channel.sent.length, 2);
+  channel.onmessage({ data: new ArrayBuffer(944) });
+  assert.equal(link.closed, true);
+});
+
+test('duplicate or incompatible channels close without running the emulator', () => {
+  let opened = 0;
+  const link = new RtcLink({ PeerConnection: Peer, onOpen: () => opened++ });
+  link.attach(new Channel('copperline-netplay-v1', { ordered: true, maxRetransmits: null }));
+  assert.equal(link.closed, true);
+  assert.equal(opened, 0);
+});

--- a/crates/copperline-web/www/package.json
+++ b/crates/copperline-web/www/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --check try.js && node --test render-stride.test.js"
+    "test": "node --check try.js && node --test *.test.js"
   }
 }

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -117,7 +117,7 @@ const netplayDisabled = new Map();
 const NETPLAY_LOCKED_IDS = ['boot', 'machine', 'video', 'reset', 'pause', 'savestate',
   'loadstate', 'quicksave', 'quickload', 'savedstates', 'kick', 'kickurl', 'kicklist',
   'df0', 'df1', 'df0url', 'df0list', 'eject', 'eject1', 'blank-df0', 'blank-df1',
-  'download-df0', 'download-df1', 'writable-floppies', 'floppy-speed',
+  'download-df0', 'download-df1', 'writable-floppies', 'floppy-speed', 'floppy-sounds',
   'serial-connect', 'serial-url', 'serial-raw'];
 
 function syncNetplayControls() {
@@ -1191,6 +1191,7 @@ function stepMachine(nowMs, deferRender) {
     if (stepped > 0) presentDirty = true;
   } catch (e) {
     if (netplayBusy()) {
+      console.error('Netplay stopped', e);
       netplayPanel.link.close(`Netplay stopped: ${e.message ?? e}`);
       return false;
     }
@@ -1852,7 +1853,7 @@ const padAssignments = new Map(); // gamepad index -> Amiga port (2 first)
 // reads exactly like a two-button stick -- so any source that can produce
 // the extras (a gamepad, or the keyboard's cd32 mapping) fits one.
 function fitCd32Pad(port) {
-  emu?.set_port_device(port, 'cd32');
+  if (!netplayBusy()) emu?.set_port_device(port, 'cd32');
 }
 
 function padPressed(pad, index) {
@@ -1892,7 +1893,7 @@ function refreshPadAssignments(pads) {
       // a pad leaving it puts the mouse back; port 2 keeps the pad fitting
       // (idle, and indistinguishable from a joystick to anything that is
       // not driving the CD32 serial protocol).
-      if (port === 1 && emu) {
+      if (port === 1 && emu && !netplayBusy()) {
         emu.set_port_device(1, 'mouse');
         releasedPort1 = true;
       }
@@ -7569,6 +7570,10 @@ if (typeof WebEmu.prototype.start_netplay === 'function') {
         if (!await boot({ link, settings, player, snapshot })) return;
         if (netplayPanel.link !== link) return;
         netplayMachineReady = true;
+        // Send our initial fingerprint before consuming the peer's. Both
+        // machines can then report a mismatch even if one closes first.
+        emu.run_hidden(performance.now(), 0);
+        link.send(emu);
         setJoyMode(hasTouch ? 'touch' : settings.controller === 'cd32' ? 'cd32' : 'keys');
         let lastStatus = 0;
         netplayTimer = setInterval(() => {
@@ -7582,13 +7587,22 @@ if (typeof WebEmu.prototype.start_netplay === 'function') {
               const [connected, frame, confirmed, , rollbacks, , checked] = emu.netplay_status();
               netplayPanel.status(connected
                 ? `Player ${player}: frame ${frame}, confirmed ${confirmed}, ${rollbacks} rollbacks, checked ${checked}`
-                : 'Waiting for a matching machine…');
+                : 'Waiting for a matching machine...');
               lastStatus = performance.now();
             }
-          } catch (error) { link.close(`Netplay stopped: ${error.message ?? error}`); }
+          } catch (error) { console.error('Netplay stopped', error); link.close(`Netplay stopped: ${error.message ?? error}`); }
         }, 50);
       },
-      stop: reason => {
+      stop: (reason, link) => {
+        if (netplayMachineReady && emu) {
+          try {
+            link.receive(emu);
+            emu.run_hidden(performance.now(), 0);
+          } catch (error) {
+            console.error('Netplay stopped', error);
+            reason = `Netplay stopped: ${error.message ?? error}`;
+          }
+        }
         clearInterval(netplayTimer);
         netplayTimer = null;
         if (netplayPreparing) {
@@ -7611,6 +7625,7 @@ if (typeof WebEmu.prototype.start_netplay === 'function') {
         setPauseLabel();
         syncWakeLock();
         setLoadStatus(reason);
+        return reason;
       },
     },
   );

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -6,7 +6,7 @@
 // (the click also unlocks the AudioContext), then runs one
 // requestAnimationFrame loop: step the core to the wall clock, blit the
 // presentation buffer to the canvas, and post the frame's audio to the
-// worklet. Everything is served from this site - no external requests.
+// worklet. Netplay optionally contacts the selected STUN server and its peer.
 
 import init, { WebEmu } from './pkg/copperline_web.js';
 import {
@@ -16,6 +16,7 @@ import {
   updateRenderStrideState,
 } from './render-stride.js';
 import { TelnetSession } from './serial-telnet.js';
+import { mountNetplayPanel } from './netplay.js';
 
 const $ = (id) => document.getElementById(id);
 let canvas = $('screen');
@@ -106,6 +107,57 @@ let queuedMs = 0;
 let lastAudioReportMs = 0;
 let running = false;
 let paused = false;
+let netplayPanel = null;
+let netplayPreparing = null;
+let netplayMachineReady = false;
+let netplayTimer = null;
+let machineGeneration = 0;
+const netplayBusy = () => !!netplayPanel?.link;
+const netplayDisabled = new Map();
+const NETPLAY_LOCKED_IDS = ['boot', 'machine', 'video', 'reset', 'pause', 'savestate',
+  'loadstate', 'quicksave', 'quickload', 'savedstates', 'kick', 'kickurl', 'kicklist',
+  'df0', 'df1', 'df0url', 'df0list', 'eject', 'eject1', 'blank-df0', 'blank-df1',
+  'download-df0', 'download-df1', 'writable-floppies', 'floppy-speed',
+  'serial-connect', 'serial-url', 'serial-raw'];
+
+function syncNetplayControls() {
+  for (const id of NETPLAY_LOCKED_IDS) {
+    const element = $(id);
+    if (!element) continue;
+    if (netplayBusy()) {
+      if (!netplayDisabled.has(element)) netplayDisabled.set(element, element.disabled);
+      element.disabled = true;
+    } else if (netplayDisabled.has(element)) {
+      element.disabled = netplayDisabled.get(element);
+      netplayDisabled.delete(element);
+    }
+  }
+}
+
+function requireLocalPage() {
+  if (netplayBusy()) throw new Error('Disconnect netplay before changing the machine or media');
+}
+
+function releaseNetplayInput() {
+  if (!netplayBusy()) return;
+  for (const key of Object.keys(joyHeld)) joyHeld[key] = false;
+  hostKeyQueue.length = 0;
+  resetTouchState();
+  emu?.netplay_release_input?.();
+}
+window.addEventListener('blur', releaseNetplayInput);
+for (const type of ['click', 'change', 'drop']) {
+  document.addEventListener(type, event => {
+    if (!netplayBusy()) return;
+    const locked = event.target.closest?.(NETPLAY_LOCKED_IDS.map(id => `#${id}`).join(','));
+    if (locked || type === 'drop') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      netplayPanel.status('Disconnect before changing the machine or media.');
+    }
+  }, true);
+}
+
 let framesThisSecond = 0;
 // Diagnostic split of the fps figure. fps counts frames *stepped*; a blit
 // shows only the newest of them, so "shown" (blits that had a fresh
@@ -232,6 +284,7 @@ const diskNames = Array(4).fill(null); // page's view, for reports and captions
 const lastDisks = Array(4).fill(null); // last uploaded { bytes, name, writable }
 
 function refreshBootButton() {
+  if (netplayBusy()) { syncNetplayControls(); return; }
   bootBtn.disabled = !(wasm && bootRom);
   bootBtn.textContent = bootRom && bootRom.label !== 'AROS' ? 'Boot Kickstart' : 'Boot AROS';
   // The save-state controls follow the same milestones (the module is
@@ -254,6 +307,7 @@ let romChosenExplicitly = false;
 // A ROM that fits is remembered in the browser (IndexedDB), so the next
 // visit boots it without the picker; see the saved-states panel to forget.
 function fitRom(bytes, label) {
+  requireLocalPage();
   if (emu) emu.load_rom(bytes, undefined);
   bootRom = { rom: bytes, ext: null, label };
   romChosenExplicitly = true;
@@ -349,6 +403,7 @@ async function forgetStoredRom() {
 // Route disk bytes from any source (picker, URL, drop): insert into a
 // running machine, or stash them for the boot button to insert after boot.
 function insertDisk(bytes, name, drive = 0, writable = writableFloppyToggle.checked) {
+  requireLocalPage();
   if (drive < 0 || drive >= PAGE_FLOPPY_DRIVES) {
     throw new Error(`DF${drive} is not fitted`);
   }
@@ -787,7 +842,14 @@ async function buildAudioStack(suspendForPause) {
 
 // --- boot ----------------------------------------------------------------
 
-async function boot() {
+async function boot(request = null) {
+  // A DOM click passes its event; only the netplay controller supplies a link.
+  if (!request?.link) request = null;
+  if (netplayBusy() && !request) return;
+  if (request && request.link !== netplayPanel?.link) return;
+  const generation = ++machineGeneration;
+  const snapshot = request?.snapshot;
+  let freshMachine = null;
   bootBtn.disabled = true;
   try {
     // Fit the ROM into a fresh machine before anything else: a bad image
@@ -802,13 +864,20 @@ async function boot() {
     // video argument picks PAL/NTSC the same way; a bundle older than both
     // ignores the extra arguments.
     const machine = new WebEmu(
-      machineModel ?? undefined,
-      videoStandard ?? undefined,
+      (snapshot?.model ?? machineModel) ?? undefined,
+      (snapshot?.video ?? videoStandard) ?? undefined,
       PAGE_FLOPPY_DRIVES,
     );
-    if (bootRom) machine.load_rom(bootRom.rom, bootRom.ext ?? undefined);
+    freshMachine = machine;
+    const rom = snapshot?.rom ?? bootRom;
+    if (rom) machine.load_rom(rom.rom, rom.ext ?? undefined);
 
     await buildAudioStack(false);
+    if (generation !== machineGeneration) {
+      freshMachine.free();
+      freshMachine = null;
+      return false;
+    }
     presentDirty = false;
     lastPresentationRevision = null;
     coreMsThisSecond = 0;
@@ -820,14 +889,14 @@ async function boot() {
     // A fresh machine boots with empty drives: each holds its pending disk or
     // nothing, never a name left over from before the reboot.
     for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
-      const disk = pendingDisks[drive];
+      const disk = (snapshot?.disks ?? pendingDisks)[drive];
       if (disk) {
         if (disk.writable) machine.insert_floppy_writable(drive, disk.bytes, disk.name);
         else machine.insert_floppy(drive, disk.bytes, disk.name);
       }
     }
     for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
-      diskNames[drive] = pendingDisks[drive]?.name ?? null;
+      diskNames[drive] = (snapshot?.disks ?? pendingDisks)[drive]?.name ?? null;
     }
     pendingDisks.fill(null);
     machine.set_volume_percent(Number($('vol').value));
@@ -842,7 +911,13 @@ async function boot() {
     machine.set_autocrop?.(autocropOn);
     machine.set_deinterlace?.(deinterlaceEnabled);
     machine.set_phosphor?.(phosphorPersistence);
+    if (request) {
+      const settings = request.settings;
+      machine.start_netplay(request.player, settings.session, settings.delay, settings.window, settings.controller);
+    }
+    emu?.free();
     emu = machine;
+    freshMachine = null;
     window.__emu = emu; // for debugging/automation
     serialApplyCarrier(); // a socket opened before (or across) this boot
     lastFddTrack = null; // a new machine starts the track latch over
@@ -885,8 +960,13 @@ async function boot() {
     // is a machine to type into: raised at page load it would cover half
     // the boot overlay with nothing behind it to receive the keys.
     if (HAS_KEY_RAW && storedPref(KB_OPEN_STORAGE_KEY) === 'on') openKeyboard();
+    syncNetplayControls();
     requestAnimationFrame(tick);
+    return true;
   } catch (e) {
+    freshMachine?.free();
+    if (generation !== machineGeneration) return false;
+    if (request) throw e;
     setLoadStatus(`boot failed: ${e.message ?? e}`);
     bootBtn.disabled = false;
     showBugLink(true);
@@ -1090,8 +1170,10 @@ function stepMachine(nowMs, deferRender) {
   try {
     const max = maxFramesForQueue();
     const stepStart = performance.now();
+    if (netplayMachineReady) netplayPanel.link.receive(emu);
     const deferred = deferRender && typeof emu.run_hidden === 'function';
     const stepped = deferred ? emu.run_hidden(nowMs, max) : emu.run(nowMs, max);
+    if (netplayMachineReady) netplayPanel.link.send(emu);
     const stepElapsed = performance.now() - stepStart;
     updateRenderStrideController(nowMs, stepElapsed, stepped, !deferred);
     if (
@@ -1108,6 +1190,10 @@ function stepMachine(nowMs, deferRender) {
     framesThisSecond += stepped;
     if (stepped > 0) presentDirty = true;
   } catch (e) {
+    if (netplayBusy()) {
+      netplayPanel.link.close(`Netplay stopped: ${e.message ?? e}`);
+      return false;
+    }
     running = false;
     setLoadStatus(`emulator error: ${e.message ?? e}`);
     overlay.style.display = '';
@@ -1269,6 +1355,7 @@ document.addEventListener('visibilitychange', () => {
   // it when a still-running machine comes back into view.
   syncWakeLock();
   if (document.hidden) {
+    releaseNetplayInput();
     // No stack, nothing to suspend. The show path takes no such guard:
     // recoverAudio must run for a running machine whose stack is gone
     // (a rebuild that failed mid-flight), or it could never come back.
@@ -1681,6 +1768,10 @@ function orPortState(a, b) {
 // switched away from the mouse.
 function applyJoystick() {
   if (!emu) return;
+  if (netplayBusy() && (document.hidden || !document.hasFocus())) {
+    emu.netplay_release_input?.();
+    return;
+  }
   const port2 = orPortState(orPortState(keyboardPortState(), touchPortState()), padPort[2]);
   emu.set_joystick_port(2, port2.up, port2.down, port2.left, port2.right, port2.fire, port2.button2);
   emu.set_cd32_buttons_port(2, port2.play, port2.rwd, port2.ffw, port2.green, port2.yellow);
@@ -1839,6 +1930,10 @@ function pumpGamepads() {
 // The mouse is only worth mentioning when a pad actually vacated port 1,
 // which is the only case where the pointer was displaced.
 function updatePadStatus(releasedPort1) {
+  if (netplayBusy()) {
+    setLoadStatus('Netplay: your first gamepad drives your assigned player port');
+    return;
+  }
   const where = [...padAssignments.values()]
     .sort()
     .map((port) => `port ${port}`)
@@ -1950,7 +2045,7 @@ const cssToEmu = () => {
 canvas.addEventListener('mousedown', (e) => {
   if (!emu || !running) return;
   e.preventDefault();
-  if (document.pointerLockElement !== canvas && e.button === 0) {
+  if (!netplayBusy() && document.pointerLockElement !== canvas && e.button === 0) {
     canvas.requestPointerLock?.();
   }
   emu.mouse_button(e.button, true);
@@ -2353,6 +2448,7 @@ const downloadFloppyButtons = Array.from(
 );
 
 function updateFloppyImageControls() {
+  if (netplayBusy()) { syncNetplayControls(); return; }
   for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
     const button = downloadFloppyButtons[drive];
     if (!button) continue;
@@ -3534,8 +3630,21 @@ function hostCharKey(ch) {
 // frame loop feeds them in at a rate a keyboard could plausibly send.
 const hostKeyQueue = [];
 const HOST_KEYS_PER_FRAME = 2;
+let netplayHostKeyFrame = 0;
 
 function pumpHostKeys() {
+  if (netplayMachineReady) {
+    const [connected, frame] = emu.netplay_status();
+    if (!connected || document.hidden || !document.hasFocus() || frame < netplayHostKeyFrame) return;
+    if (hostKeyQueue.length) {
+      const [raw, pressed] = hostKeyQueue.shift();
+      kbdSend(raw, pressed);
+      // A stalled frame may already have sampled its input. Hold through the
+      // next frame too so a queued tap cannot collapse to an all-released state.
+      netplayHostKeyFrame = frame + 2;
+    }
+    return;
+  }
   for (let i = 0; i < HOST_KEYS_PER_FRAME && hostKeyQueue.length; i++) {
     const [raw, pressed] = hostKeyQueue.shift();
     kbdSend(raw, pressed);
@@ -3817,6 +3926,7 @@ function setPauseLabel() {
 }
 
 function setPaused(next) {
+  if (netplayBusy()) return;
   if (!emu || !running || next === paused) return;
   paused = next;
   // Paused wall time must not count toward the controller's sustained
@@ -4054,6 +4164,7 @@ function describeState(info) {
 // needs a running machine, loading only needs the wasm module (it boots one
 // on demand), and quick load additionally needs something in the slot.
 function updateStateButtons() {
+  if (netplayBusy()) { syncNetplayControls(); return; }
   const live = Boolean(emu && running);
   if (saveStateBtn) saveStateBtn.disabled = !live;
   if (quickSaveBtn) quickSaveBtn.disabled = !live;
@@ -4075,13 +4186,14 @@ function updateStateButtons() {
 // then fails can put the page back rather than strand the visitor on a
 // machine they never asked to start.
 async function machineForStateLoad() {
+  if (netplayBusy()) return { ready: false, booted: false };
   if (emu && running) return { ready: true, booted: false };
   if (!wasm) {
     setLoadStatus('the emulator is still loading');
     return { ready: false, booted: false };
   }
-  await boot();
-  return { ready: Boolean(emu && running), booted: true };
+  const booted = Boolean(await boot());
+  return { ready: booted && !netplayBusy() && Boolean(emu && running), booted };
 }
 
 // Undo a boot that only happened to receive a state which then would not
@@ -4089,6 +4201,7 @@ async function machineForStateLoad() {
 // does nothing at all - so the page returns to its pre-boot screen with
 // the failure still on the status line.
 function unbootAfterFailedStateLoad() {
+  if (netplayBusy()) return;
   const failure = loadStatus.textContent;
   emu = null;
   window.__emu = null;
@@ -4106,6 +4219,7 @@ function unbootAfterFailedStateLoad() {
 // machine untouched when a blob does not parse, so a bad file costs the
 // visitor nothing but the message.
 function restoreState(bytes, source) {
+  if (netplayBusy()) return false;
   try {
     emu.load_state(bytes);
   } catch (e) {
@@ -7419,5 +7533,86 @@ async function startup() {
     await Promise.all([loaded, ...fetches]);
     if (!bootBtn.disabled && !emu) boot();
   }
+}
+if (typeof WebEmu.prototype.start_netplay === 'function') {
+  netplayPanel = mountNetplayPanel(
+    $('reset').closest('.try-side-section')?.parentElement ?? shell.parentElement,
+    {
+      prepare: async link => {
+        if (!wasm || !bootRom) throw new Error('Load a ROM before setting up netplay');
+        keepUploadedDisksForRebuild();
+        const disks = pendingDisks.slice();
+        for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
+          if (diskNames[drive] && !disks[drive]) throw new Error(`Load the DF${drive} image again before netplay`);
+        }
+        netplayPreparing = { link, rom: bootRom, model: machineModel, video: videoStandard, disks };
+        machineGeneration++;
+        netplayHostKeyFrame = 0;
+        if (statesPanelOpen) toggleStatesPanel();
+        running = false;
+        paused = false;
+        netplayMachineReady = false;
+        document.exitPointerLock?.();
+        forgetVirtualKeys();
+        emu?.free();
+        emu = null;
+        window.__emu = null;
+        serialDisconnect('Serial disabled during netplay');
+        syncNetplayControls();
+        overlay.style.display = '';
+        setLoadStatus('Netplay setup: emulation starts when the peer connects');
+        await buildAudioStack(false);
+      },
+      start: async (link, settings, player) => {
+        const snapshot = netplayPreparing;
+        if (snapshot?.link !== link || netplayPanel.link !== link) return;
+        if (!await boot({ link, settings, player, snapshot })) return;
+        if (netplayPanel.link !== link) return;
+        netplayMachineReady = true;
+        setJoyMode(hasTouch ? 'touch' : settings.controller === 'cd32' ? 'cd32' : 'keys');
+        let lastStatus = 0;
+        netplayTimer = setInterval(() => {
+          if (!netplayMachineReady || netplayPanel.link !== link || !emu) return;
+          try {
+            // Continue acknowledging packets while a hidden page stops painting.
+            link.receive(emu);
+            emu.run_hidden(performance.now(), 0);
+            link.send(emu);
+            if (performance.now() - lastStatus > 1000) {
+              const [connected, frame, confirmed, , rollbacks, , checked] = emu.netplay_status();
+              netplayPanel.status(connected
+                ? `Player ${player}: frame ${frame}, confirmed ${confirmed}, ${rollbacks} rollbacks, checked ${checked}`
+                : 'Waiting for a matching machine…');
+              lastStatus = performance.now();
+            }
+          } catch (error) { link.close(`Netplay stopped: ${error.message ?? error}`); }
+        }, 50);
+      },
+      stop: reason => {
+        clearInterval(netplayTimer);
+        netplayTimer = null;
+        if (netplayPreparing) {
+          machineGeneration++;
+          running = false;
+          paused = false;
+          netplayMachineReady = false;
+          forgetVirtualKeys();
+          emu?.free();
+          emu = null;
+          window.__emu = null;
+          netplayPreparing.disks.forEach((disk, drive) => { pendingDisks[drive] = disk; });
+          netplayPreparing = null;
+          audioCtx?.suspend().catch(() => {});
+          overlay.style.display = '';
+        }
+        syncNetplayControls();
+        refreshBootButton();
+        updateFloppyImageControls();
+        setPauseLabel();
+        syncWakeLock();
+        setLoadStatus(reason);
+      },
+    },
+  );
 }
 startup();

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -213,15 +213,19 @@ Create and load a fresh `WebEmu` for each connection. After WebRTC opens, call
 `run` or `run_hidden` call. `player` is 1 or 2; `session` is a shared 32-digit hex
 ID; delay is an integer from 0 to 6, window from 1 to 12, and controller is
 `"joystick"` or `"cd32"`. Both ports use that controller. A machine that has run
-or loaded a save state is ineligible. The guest clock starts at 2000-01-01 UTC.
+or loaded a save state is ineligible. A fitted RTC is seeded to 2000-01-01 UTC;
+this does not add a clock to models without one. Failed startup restores the
+machine and leaves it available for local use or another startup attempt.
 
 `RtcLink` in `www/netplay.js` provides `offer(settings)`, `answer(offerCode)` and
 `accept(answerCode)`. Its `onOpen` callback is the point to construct the machine
 and call `start_netplay`. Its `onClose` callback must stop the page's loops and
-free the machine. Call `link.receive(emu)` before `run`/`run_hidden`, then
+free the machine. Immediately after startup, call `run_hidden(now, 0)` and
+`link.send(emu)` once to send the initial fingerprint. Then call `link.receive(emu)` before `run`/`run_hidden`, then
 `link.send(emu)` afterwards, including polls that advance zero frames. Polls with
 zero frames process handshakes, corrections and retransmissions. The ordinary
-render and audio-drain APIs still apply.
+render and audio-drain APIs still apply. On close, drain queued packets and
+poll once more before freeing the machine, to surface a pending mismatch error.
 
 For another transport, pass each complete received packet to
 `netplay_receive(Uint8Array)`, and drain `netplay_take_packet()` until it returns
@@ -237,7 +241,13 @@ During netplay, the port-2 joystick/CD32 methods collect the local player's
 controller even when that player owns Amiga port 1; port-1 calls are ignored.
 This preserves the page's first-gamepad mapping.
 
-Machine/media/state operations fail while a session exists; mouse and serial
+`WebEmu.netplay_packet_layout()` returns `[protocol, maxBytes, headerBytes,
+inputBytes]` for glue compatibility checks. Floppy sound enablement and level
+must match before startup; their setters fail during a session. Output volume
+and mono/stereo presentation remain local.
+
+Machine/media/state operations, including controller fitting and floppy speed,
+fail while a session exists; mouse and serial
 input are ignored. A protocol error stays latched. Free the instance and start
 fresh after any disconnect or error; there is no operation to resume it locally.
 

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -67,6 +67,20 @@ The web build uses the same `.clstate` file format as the desktop version:
   for instant resumption across page reloads.
 - **Saved states panel:** Manage named state slots in browser storage.
 
+### Rollback netplay
+
+**Controls → Netplay** connects two browsers using WebRTC. The host sends an offer
+code, the joining player sends an answer, and the host connects that answer.
+Both pages start fresh machines with matching ROMs, disks and hardware settings.
+Each player controls one Amiga port; late input is predicted and corrected by
+rollback. See [browser netplay setup](netplay.md#browser-netplay) for the steps,
+controller mapping, STUN settings and restrictions.
+
+Netplay requires WebRTC data channels as well as WebAssembly. It works on a
+static site without a signaling server. A desktop UDP peer cannot join a browser
+session. Save states, media changes, serial connections and pause are unavailable
+until disconnect.
+
 ## Architecture
 
 The browser implementation consists of the following components:
@@ -82,6 +96,9 @@ The browser implementation consists of the following components:
   HTML5 `<canvas>` via `putImageData` or WebGL2 textures with custom CRT fragment shaders.
 - **Audio pipeline:** Stereo 44.1 kHz float samples are transferred directly to an
   `AudioWorklet` processor for low-latency playback.
+- **Netplay:** The Rust core owns the shared rollback timeline and bounded packet
+  queues. `www/netplay.js` handles connection codes and the WebRTC data channel;
+  `try.js` owns the session lifecycle and locks controls that change the machine.
 
 ## Building the WebAssembly package locally
 
@@ -108,6 +125,11 @@ wasm-bindgen --target web --out-dir pkg \
 
 The compiled JavaScript loader (`copperline_web.js`) and WebAssembly binary
 (`copperline_web_bg.wasm`) are output to the `pkg/` directory.
+
+From the repository root, `node tools/check-web-netplay.mjs` exercises this release
+bundle with two emulators, packet loss/reordering, input changes and different
+presentation settings. Run `npm test --prefix crates/copperline-web/www` for the
+page controller tests. These checks need no display, network or external ROMs.
 
 ## Embedding with the WebEmu API
 
@@ -183,6 +205,41 @@ requestAnimationFrame(renderLoop);
   containing the source sub-rect, destination rect, and integer scale multipliers (`0, 0` for
   smooth scaling). Returns an empty array until the first frame is presented. Used by `try.js`
   when integer scaling or autocrop is enabled without a monitor bezel.
+
+### Embedding netplay
+
+Create and load a fresh `WebEmu` for each connection. After WebRTC opens, call
+`start_netplay(player, session, delay, window, controller)` before the first
+`run` or `run_hidden` call. `player` is 1 or 2; `session` is a shared 32-digit hex
+ID; delay is an integer from 0 to 6, window from 1 to 12, and controller is
+`"joystick"` or `"cd32"`. Both ports use that controller. A machine that has run
+or loaded a save state is ineligible. The guest clock starts at 2000-01-01 UTC.
+
+`RtcLink` in `www/netplay.js` provides `offer(settings)`, `answer(offerCode)` and
+`accept(answerCode)`. Its `onOpen` callback is the point to construct the machine
+and call `start_netplay`. Its `onClose` callback must stop the page's loops and
+free the machine. Call `link.receive(emu)` before `run`/`run_hidden`, then
+`link.send(emu)` afterwards, including polls that advance zero frames. Polls with
+zero frames process handshakes, corrections and retransmissions. The ordinary
+render and audio-drain APIs still apply.
+
+For another transport, pass each complete received packet to
+`netplay_receive(Uint8Array)`, and drain `netplay_take_packet()` until it returns
+an empty array. Preserve packet boundaries; do not interpret packets as text.
+The supported browser transport uses an unordered data channel with
+`maxRetransmits: 0`; Copperline performs input retransmission itself.
+
+`netplay_status()` returns `[connected, frame, confirmed, acknowledged, rollbacks,
+replayed, checked]`, with `connected` represented by 0 or 1. It returns an empty
+array outside netplay. `netplay_release_input()` clears this peer's held input;
+call it when the page loses focus. Existing key methods collect local input.
+During netplay, the port-2 joystick/CD32 methods collect the local player's
+controller even when that player owns Amiga port 1; port-1 calls are ignored.
+This preserves the page's first-gamepad mapping.
+
+Machine/media/state operations fail while a session exists; mouse and serial
+input are ignored. A protocol error stays latched. Free the instance and start
+fresh after any disconnect or error; there is no operation to resume it locally.
 
 ### HTML element hooks in `try.js`
 

--- a/docs/guide/netplay.md
+++ b/docs/guide/netplay.md
@@ -17,7 +17,7 @@ mixed operating systems and browser engines have not yet been qualified.
 ## Set up in the browser
 
 On the [browser page](browser.md), open **Controls → Netplay**. Load the same ROM
-and disks, and choose the same model, video standard, floppy speed and writable
+and disks, and choose the same model, video standard, floppy speed, floppy sounds and writable
 disk setting on both pages. Setup starts a fresh machine, replacing any running
 local session.
 
@@ -33,8 +33,8 @@ local session.
 
 Host owns Amiga port 1; Join owns port 2. On each page, the usual first gamepad,
 keyboard joystick or touch controls drive that player's port. The keyboard
-joystick mode is enabled on connection; cycle **Joystick** off to type ordinary
-Amiga keys. Both keyboards contribute to the shared keyboard. Mouse input is
+joystick mode is enabled on desktop browsers; touch devices start with touch
+controls. Cycle **Joystick** off to type ordinary Amiga keys. Both keyboards contribute to the shared keyboard. Mouse input is
 disabled. The desktop F11/F12 netplay shortcuts do not apply to the browser.
 
 The default STUN server helps WebRTC discover an internet route. Leave the field
@@ -47,8 +47,9 @@ snapshots are not sent to the peer. WebRTC encrypts the data channel.
 
 Keep both pages open. A suspended tab can stall its peer and eventually time out;
 background execution depends on browser and device restrictions. Machine, media,
-serial, pause and save-state controls are locked from setup until disconnect.
-Display and volume choices remain local. **Disconnect** cancels setup or stops
+serial, floppy sound, pause and save-state controls are locked from setup until disconnect.
+Display and main output volume choices remain local. Floppy sound enablement
+and level are part of the machine fingerprint and must match. **Disconnect** cancels setup or stops
 play, discards session disk writes, and restores the selected cold-boot media.
 Either player can host or join again with new codes. The browser does not resume
 the abandoned network timeline as local play.

--- a/docs/guide/netplay.md
+++ b/docs/guide/netplay.md
@@ -1,16 +1,57 @@
 # Rollback netplay
 
-Copperline can run a two-player floppy game across two native desktop instances.
+Copperline can run a two-player floppy game across two desktop instances or two browsers.
 Each peer emulates the whole Amiga and owns one controller port. Both players
 see their own input after a small configurable delay. Copperline predicts late
 remote input, then restores and replays frames when that prediction was wrong.
 This follows the approach described by [GGPO](https://github.com/pond3r/ggpo);
 it uses Copperline's own Rust implementation and wire protocol.
 
-This first version connects directly to a known peer. There is no lobby, relay,
-NAT traversal, spectator mode, reconnect, or browser support. Use the same
-Copperline build on both machines. Cross-platform peer combinations have not
-yet been qualified.
+Sessions connect directly to a known peer. Desktop builds use UDP; browsers use
+WebRTC with copy/paste connection codes and optional STUN address discovery.
+There is no lobby, relay, spectator mode or reconnect. Browser and desktop peers
+cannot connect to each other. Use the same Copperline build on both machines;
+mixed operating systems and browser engines have not yet been qualified.
+
+(browser-netplay)=
+## Set up in the browser
+
+On the [browser page](browser.md), open **Controls → Netplay**. Load the same ROM
+and disks, and choose the same model, video standard, floppy speed and writable
+disk setting on both pages. Setup starts a fresh machine, replacing any running
+local session.
+
+1. The host chooses **Input delay**, **Rollback limit** and **Controllers**, then
+   clicks **Host game**. Send **Your connection code** to the other player.
+2. The other player pastes it into **Code from the other player** and clicks
+   **Join offer**. Send the resulting answer code back to the host. The offer
+   supplies the controller and delay/window settings for both peers.
+3. The host pastes the answer into **Code from the other player** and clicks
+   **Connect answer**. Both pages cold-boot after checking that their initial
+   machines match. The panel reports confirmed frames, rollbacks and the latest
+   checked frame.
+
+Host owns Amiga port 1; Join owns port 2. On each page, the usual first gamepad,
+keyboard joystick or touch controls drive that player's port. The keyboard
+joystick mode is enabled on connection; cycle **Joystick** off to type ordinary
+Amiga keys. Both keyboards contribute to the shared keyboard. Mouse input is
+disabled. The desktop F11/F12 netplay shortcuts do not apply to the browser.
+
+The default STUN server helps WebRTC discover an internet route. Leave the field
+blank on both pages for LAN-only address discovery, or enter another `stun:` URL.
+Some NATs and firewalls still prevent a direct connection; use a shared LAN or
+VPN in that case. There is no TURN relay configuration in this panel.
+Connection codes contain WebRTC network addresses and session details; exchange
+them privately with the person you intend to play with. ROMs, disks and machine
+snapshots are not sent to the peer. WebRTC encrypts the data channel.
+
+Keep both pages open. A suspended tab can stall its peer and eventually time out;
+background execution depends on browser and device restrictions. Machine, media,
+serial, pause and save-state controls are locked from setup until disconnect.
+Display and volume choices remain local. **Disconnect** cancels setup or stops
+play, discards session disk writes, and restores the selected cold-boot media.
+Either player can host or join again with new codes. The browser does not resume
+the abandoned network timeline as local play.
 
 ## Set up in the GUI
 
@@ -123,8 +164,10 @@ with a memory-budget error.
 Unacknowledged inputs are retransmitted, so loss, duplication, and reordering do
 not by themselves lose button transitions. Confirmed machine states are checked
 every 60 frames. A mismatch stops the session with the affected frame number.
-Connection setup times out after 60 seconds; an established connection stops
-after 10 seconds without a valid peer packet.
+The machine handshake times out after 60 seconds; an established connection stops
+after 10 seconds without a valid peer packet. Browser code exchange precedes the
+handshake: gathering addresses has a 15-second limit, and connecting an accepted
+answer has a 60-second limit. Waiting for a player to paste a code has no timer.
 
 Audio plays once on the initial execution of a frame. Replayed frames are silent.
 A sound already played from an incorrect prediction cannot be taken back, so

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -1,6 +1,6 @@
-# Netplay implementation plan and architecture
+# Netplay architecture
 
-The implementation follows four steps:
+The implementation follows five steps:
 
 1. Establish a deterministic session boundary. Validate the machine's host
    dependencies, adopt floppy contents into memory, normalize disk path metadata,
@@ -14,10 +14,12 @@ The implementation follows four steps:
 4. Integrate both native frontend loops. Route all machine input through the
    timeline, prevent unilateral machine changes, discard stale rendered frames
    after rollback, and document supported workflows and limitations.
+5. Reuse that timeline and wire protocol in WASM. Separate packet transport from
+   the session, bridge bounded queues to WebRTC, and add browser Host/Join setup.
 
 These steps are implemented in `src/netplay/`, `Emulator::step_netplay_frame`,
 and `src/video/window/app_netplay.rs`. The feature uses native Rust and does not
-link the GGPO SDK. Matchmaking, relay/NAT traversal, spectators, reconnect, shared
+link the GGPO SDK. Matchmaking, relays, spectators, reconnect, shared
 media operations, and transactional host filesystems remain separate work.
 
 ## Frame ownership
@@ -82,8 +84,9 @@ The initial fingerprint hashes Copperline's display build version and the entire
 normalized initial machine snapshot, including ROM and in-memory floppy data.
 It does not fingerprint uncommitted source modifications: development peers must
 build the same source. No executable, ROM, disk image, or serialized guest state
-is received from a peer. An ID separates sessions; this protocol supplies neither
-cryptographic peer authentication nor encryption.
+is received from a peer. An ID separates sessions; the packet format supplies
+neither cryptographic peer authentication nor encryption. Browser WebRTC adds
+transport encryption; native UDP needs a VPN for that protection.
 
 Every datagram repeats the session fingerprint and settings. Peers announce
 whether they have seen a matching peer; emulation starts after receiving that
@@ -96,6 +99,47 @@ unrelated endpoints, and unrelated session IDs are discarded. Conflicting input,
 impossible acknowledgements, and data beyond the bounded future horizon stop the
 session. Errors stay latched so callers cannot accidentally continue a failed
 session as local play.
+
+## Browser transport and lifecycle
+
+`Connection<T: Transport>` owns the handshake, rollback and timeout logic.
+`Session` remains the native alias for `Connection<UdpTransport>`; `Options`
+contains its UDP endpoints. Transport-independent `Settings` contains the player,
+session ID, input delay and prediction limit. Timers use `timebase::Instant` on
+both targets. Neither target serializes transport or wall-clock state.
+
+The web wrapper owns `Connection<PacketQueue>`. Each direction holds at most
+64 packets of at most 943 bytes. Incoming bursts evict the oldest datagram, relying
+on subsequent retransmissions; a full outgoing queue reports backpressure.
+`netplay.js` also bounds its receive queue and stops draining Rust's send queue
+when the channel's buffered amount reaches 64 maximum-size packets.
+
+The page exchanges a versioned offer and answer by copy/paste, including the
+SDP and host-selected settings. It waits for ICE gathering to complete before
+creating either code; no signaling service or trickled candidates are needed.
+The optional STUN server supplies address discovery, with no TURN relay UI.
+The [WebRTC data channel](https://www.w3.org/TR/webrtc/) is unordered and uses
+zero SCTP retransmissions, since the shared Copperline protocol already repeats
+unacknowledged inputs. Browser and native transports have no interoperability
+adapter. Codes are bounded and checked before passing SDP to WebRTC.
+
+Host/Join freezes the chosen cold-boot media and frees any local emulator.
+On channel open, the wrapper builds a fresh machine, fixes the RTC seed,
+disables serial and sets both digital controllers before fingerprinting it.
+JS numeric settings enter Rust as `f64` and are checked for finiteness, integer
+values and range before narrowing. Setup operations carry their connection
+identity across awaits so cancellation cannot publish a late machine or code.
+Disconnect and runtime failures stop all session loops and free the emulator;
+the chosen pre-session media remains available for another cold boot.
+
+Netplay calls use the shared precise frame stepper, with browser pacing capped
+at eight frames per call. Zero-frame polls can reconcile and acknowledge input
+while painting is suspended. Corrections invalidate field history and cropping
+latches. Browser netplay renders through `render_display_only_with_content` so
+different paint cadences cannot write collision bits into checkpoint state.
+Paula's output gain is serialized in ordinary save states, so browser netplay
+fixes it at 100% and applies the page's volume when draining the host audio buffer.
+This avoids a save-state format change and keeps volume local across replay.
 
 ## Configuration screen
 
@@ -140,7 +184,23 @@ The regression suite covers:
 - CLI combinations, GUI field/edit/navigation coverage, and frontend input/mutation
   routing. Two GUI-configured peers must connect, confirm matching states, return
   to setup and successfully rebind for another cold boot.
+- Browser packet queue bounds, signaling validation, data-channel options,
+  cancellation and backpressure. The release WASM smoke runs paired A500/PAL and
+  A1200/NTSC machines through 120 confirmed/checksummed frames under loss,
+  duplication, reordering and asymmetric pauses. Different volume, overscan and
+  painting cadence must preserve checkpoints and produce identical final pixels.
 
 Run the focused tests with `cargo test --profile ci --locked netplay`; UDP tests
 need permission to bind loopback sockets. No external ROM or disk assets are
 required for the regression suite.
+
+After building the release web bundle, run `node tools/check-web-netplay.mjs` and
+`npm test --prefix crates/copperline-web/www`. CI runs both. The browser publishing
+workflow also checks the optimized bundle before copying `netplay.js` alongside
+the other page modules. For a served local page, the optional Playwright check
+`node tools/check-web-netplay-browser.mjs http://127.0.0.1:8000/` exercises actual
+Host/Join, cancellation, reconnect by cold boot, locked controls and mismatch
+rejection in two Chromium contexts. It also verifies that a device-keyboard tap
+appears as a held key and subsequent release in transmitted input frames.
+`CHROME_PATH` selects an installed Chrome;
+`PLAYWRIGHT_MODULE` can point to a local Playwright module.

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -18,7 +18,8 @@ The implementation follows five steps:
    the session, bridge bounded queues to WebRTC, and add browser Host/Join setup.
 
 These steps are implemented in `src/netplay/`, `Emulator::step_netplay_frame`,
-and `src/video/window/app_netplay.rs`. The feature uses native Rust and does not
+`src/video/window/app_netplay.rs`, `crates/copperline-web/src/netplay.rs` and
+`crates/copperline-web/www/netplay.js`. The feature uses native Rust and does not
 link the GGPO SDK. Matchmaking, relays, spectators, reconnect, shared
 media operations, and transactional host filesystems remain separate work.
 
@@ -141,6 +142,13 @@ Paula's output gain is serialized in ordinary save states, so browser netplay
 fixes it at 100% and applies the page's volume when draining the host audio buffer.
 This avoids a save-state format change and keeps volume local across replay.
 
+Browser startup keeps a local rollback checkpoint and the original serial sink
+until connection construction succeeds. Failure restores both before returning
+an error. Floppy sound settings remain serialized because they also control the
+sound generator timeline; browser setters and UI controls lock them during a
+session. The wire decoder reports incompatible protocol/save-state versions for
+the recognized session immediately, while unrelated traffic remains ignored.
+
 ## Configuration screen
 
 `LauncherState::netplay` holds a `NetplaySetup` beside the machine setup. It uses
@@ -195,8 +203,9 @@ need permission to bind loopback sockets. No external ROM or disk assets are
 required for the regression suite.
 
 After building the release web bundle, run `node tools/check-web-netplay.mjs` and
-`npm test --prefix crates/copperline-web/www`. CI runs both. The browser publishing
-workflow also checks the optimized bundle before copying `netplay.js` alongside
+`npm test --prefix crates/copperline-web/www`. CI also runs the native web wrapper
+unit tests, including failed startup, input routing and audio gain checks. The
+browser publishing workflow also checks the optimized bundle before copying `netplay.js` alongside
 the other page modules. For a served local page, the optional Playwright check
 `node tools/check-web-netplay-browser.mjs http://127.0.0.1:8000/` exercises actual
 Host/Join, cancellation, reconnect by cold boot, locked controls and mismatch

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -5459,7 +5459,6 @@ impl Bus {
         Ok(())
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn rollback_state(&self) -> RollbackState {
         RollbackState {
             data_bus: self.data_bus,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1471,13 +1471,11 @@ impl M68kMachine {
         Ok(())
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn write_rollback_state<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
         serialize_component(w, &self.bus.bus.rollback_state(), "rollback latches")?;
         self.write_state(w)
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn apply_rollback_state<R: std::io::Read>(&mut self, r: &mut R) -> Result<()> {
         let runtime = deserialize_component(r, "rollback latches")?;
         self.apply_state_inner(r, Some(runtime))

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1468,13 +1468,17 @@ impl Emulator {
         self.snapshot_blob()
     }
 
-    pub(crate) fn netplay_snapshot(&self) -> Result<Vec<u8>> {
+    /// Capture a same-process rollback checkpoint, including CPU pipeline state.
+    /// Valid only for this build; never accept checkpoints from a remote peer.
+    pub fn netplay_snapshot(&self) -> Result<Vec<u8>> {
         let mut bytes = Vec::new();
         self.machine.write_rollback_state(&mut bytes)?;
         Ok(bytes)
     }
 
-    pub(crate) fn netplay_restore(&mut self, blob: &[u8]) -> Result<()> {
+    /// Restore a local checkpoint from [`Self::netplay_snapshot`], preserving
+    /// live host resources and resetting the real-time stepping quantum.
+    pub fn netplay_restore(&mut self, blob: &[u8]) -> Result<()> {
         self.machine
             .apply_rollback_state(&mut std::io::Cursor::new(blob))?;
         self.reset_realtime_quantum();

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -1468,14 +1468,12 @@ impl Emulator {
         self.snapshot_blob()
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn netplay_snapshot(&self) -> Result<Vec<u8>> {
         let mut bytes = Vec::new();
         self.machine.write_rollback_state(&mut bytes)?;
         Ok(bytes)
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn netplay_restore(&mut self, blob: &[u8]) -> Result<()> {
         self.machine
             .apply_rollback_state(&mut std::io::Cursor::new(blob))?;
@@ -2324,7 +2322,6 @@ impl Emulator {
     /// Advance to the next hardware video frame for netplay. The normal
     /// frontend quantum is a CPU budget and can end within a raster frame;
     /// network inputs need a boundary defined entirely by the guest hardware.
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn step_netplay_frame(&mut self, replay: bool) -> Result<()> {
         self.real_pacing_budget_mode = RealPacingBudgetMode::M68kCycles;
         self.reset_realtime_quantum();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,6 @@ pub mod modem;
 #[cfg(feature = "mt32")]
 pub mod mt32;
 pub mod net;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod netplay;
 pub mod package;
 pub mod parallel;

--- a/src/netplay/mod.rs
+++ b/src/netplay/mod.rs
@@ -5,15 +5,20 @@
 mod rollback;
 #[cfg(test)]
 mod tests;
+mod transport;
 mod wire;
+#[cfg(not(target_arch = "wasm32"))]
+use transport::UdpTransport;
+pub use transport::{PacketQueue, Transport};
 
 use crate::emulator::Emulator;
+use crate::timebase::{Duration, Instant};
 use anyhow::{ensure, Context, Result};
 use rollback::{Machine, Rollback};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
-use std::net::{SocketAddr, UdpSocket};
-use std::time::{Duration, Instant};
+#[cfg(not(target_arch = "wasm32"))]
+use std::net::SocketAddr;
 
 /// A held digital controller and Amiga keyboard, sampled once per frame.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -52,7 +57,33 @@ pub fn parse_session_id(code: &str) -> Result<[u8; 16]> {
     Ok(session)
 }
 
+/// Negotiated timeline settings, shared by every transport.
+#[derive(Clone, Debug)]
+pub struct Settings {
+    /// Zero-based controller port owned by this peer.
+    pub player: usize,
+    pub session: [u8; 16],
+    pub input_delay: u8,
+    pub rollback_frames: u8,
+}
+
+impl Settings {
+    pub fn validate(&self) -> Result<()> {
+        ensure!(self.player < 2, "netplay player must be 1 or 2");
+        ensure!(
+            self.input_delay <= 6,
+            "netplay input delay must be 0..6 frames"
+        );
+        ensure!(
+            (1..=12).contains(&self.rollback_frames),
+            "netplay rollback window must be 1..12 frames"
+        );
+        Ok(())
+    }
+}
+
 /// Both peers specify each other's reachable UDP address and the same session ID.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone, Debug)]
 pub struct Options {
     pub bind: SocketAddr,
@@ -64,17 +95,18 @@ pub struct Options {
     pub rollback_frames: u8,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Options {
+    fn settings(&self) -> Settings {
+        Settings {
+            player: self.player,
+            session: self.session,
+            input_delay: self.input_delay,
+            rollback_frames: self.rollback_frames,
+        }
+    }
     pub fn validate(&self) -> Result<()> {
-        ensure!(self.player < 2, "netplay player must be 1 or 2");
-        ensure!(
-            self.input_delay <= 6,
-            "netplay input delay must be 0..6 frames"
-        );
-        ensure!(
-            (1..=12).contains(&self.rollback_frames),
-            "netplay rollback window must be 1..12 frames"
-        );
+        self.settings().validate()?;
         ensure!(
             self.bind.is_ipv4() == self.peer.is_ipv4(),
             "netplay addresses must use the same IP family"
@@ -140,9 +172,12 @@ pub fn prepare_config(cfg: &mut crate::config::Config) -> Result<()> {
 }
 
 /// A session is serviced on the emulation thread; socket I/O never blocks it.
-pub struct Session {
-    socket: UdpSocket,
-    options: Options,
+#[cfg(not(target_arch = "wasm32"))]
+pub type Session = Connection<UdpTransport>;
+
+pub struct Connection<T: Transport> {
+    transport: T,
+    settings: Settings,
     identity: [u8; 32],
     rollback: Rollback,
     seen_peer: bool,
@@ -176,14 +211,33 @@ impl Status {
     }
 }
 
-impl Session {
+#[cfg(not(target_arch = "wasm32"))]
+impl Connection<UdpTransport> {
     pub fn new(options: Options, emu: &mut Emulator, cfg: &crate::config::Config) -> Result<Self> {
+        options.validate()?;
+        let settings = options.settings();
+        let transport = UdpTransport::new(options)?;
+        Self::with_transport(settings, transport, emu, cfg)
+    }
+
+    pub fn options(&self) -> &Options {
+        &self.transport.options
+    }
+}
+
+impl<T: Transport> Connection<T> {
+    pub fn with_transport(
+        settings: Settings,
+        transport: T,
+        emu: &mut Emulator,
+        cfg: &crate::config::Config,
+    ) -> Result<Self> {
         validate_config(cfg)?;
         ensure!(
             emu.bus().emulated_cck() == 0,
             "netplay must start before the machine runs"
         );
-        options.validate()?;
+        settings.validate()?;
         // Paths are host metadata; normalize only after adopting the complete
         // images into memory so replay cannot reopen or overwrite local files.
         emu.bus_mut().floppy.prepare_netplay_images();
@@ -204,18 +258,14 @@ impl Session {
         identity_hash.update(env!("COPPERLINE_DISPLAY_VERSION").as_bytes());
         identity_hash.update(emu.netplay_snapshot()?);
         let identity = identity_hash.finalize().into();
-        let socket = UdpSocket::bind(options.bind).context("binding netplay UDP socket")?;
-        socket.set_nonblocking(true)?;
-        log::info!(
-            "netplay: listening on {}, peer {}, player {}; waiting for matching machine",
-            socket.local_addr()?,
-            options.peer,
-            options.player + 1
+        let rollback = Rollback::new(
+            settings.player,
+            settings.input_delay,
+            settings.rollback_frames,
         );
-        let rollback = Rollback::new(options.player, options.input_delay, options.rollback_frames);
         Ok(Self {
-            socket,
-            options,
+            transport,
+            settings,
             identity,
             rollback,
             seen_peer: false,
@@ -229,12 +279,12 @@ impl Session {
         })
     }
 
-    pub fn options(&self) -> &Options {
-        &self.options
+    pub fn transport_mut(&mut self) -> &mut T {
+        &mut self.transport
     }
 
     pub fn player(&self) -> usize {
-        self.options.player
+        self.settings.player
     }
 
     pub fn status(&self) -> Status {
@@ -266,18 +316,15 @@ impl Session {
         // A finite receive budget keeps window input responsive under a burst.
         let mut buffer = [0; wire::MAX_PACKET + 1];
         for _ in 0..64 {
-            match self.socket.recv_from(&mut buffer) {
-                Ok((len, source)) => {
-                    if source != self.options.peer {
-                        continue;
-                    }
-                    let Some(packet) = wire::Packet::decode(&buffer[..len]) else {
+            match self.transport.receive(&mut buffer) {
+                Ok(Some(len)) => {
+                    let Some(packet) = buffer.get(..len).and_then(wire::Packet::decode) else {
                         continue;
                     };
-                    if packet.session != self.options.session {
+                    if packet.session != self.settings.session {
                         continue;
                     }
-                    ensure!(packet.player == 1 - self.options.player && packet.delay == self.options.input_delay && packet.window == self.options.rollback_frames,
+                    ensure!(packet.player == 1 - self.settings.player && packet.delay == self.settings.input_delay && packet.window == self.settings.rollback_frames,
                         "netplay settings differ: use opposite players and identical delay/rollback values");
                     ensure!(packet.identity == self.identity, "netplay initial machine mismatch: use the same build, ROM, disks and deterministic machine settings");
                     self.seen_peer = true;
@@ -297,7 +344,7 @@ impl Session {
                     if let Some((frame, hash)) = packet.checksum {
                         ensure!(
                             frame
-                                <= self.rollback.current + u64::from(self.options.input_delay) + 1,
+                                <= self.rollback.current + u64::from(self.settings.input_delay) + 1,
                             "netplay checksum is too far in the future"
                         );
                         if frame > self.last_checked {
@@ -305,7 +352,7 @@ impl Session {
                         }
                     }
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                Ok(None) => break,
                 Err(e) => return Err(e).context("receiving netplay input"),
             }
         }
@@ -358,12 +405,12 @@ impl Session {
                 .is_none_or(|last| now.duration_since(last) >= Duration::from_millis(10))
         {
             let packet = wire::Packet {
-                session: self.options.session,
+                session: self.settings.session,
                 identity: self.identity,
                 player: self.player(),
                 ready: self.seen_peer,
-                delay: self.options.input_delay,
-                window: self.options.rollback_frames,
+                delay: self.settings.input_delay,
+                window: self.settings.rollback_frames,
                 ack: self.rollback.received,
                 inputs: self
                     .rollback
@@ -374,17 +421,19 @@ impl Session {
                 checksum: self.rollback.hashes.last_key_value().map(|(&f, &h)| (f, h)),
             }
             .encode();
-            match self.socket.send_to(&packet, self.options.peer) {
-                Ok(_) => self.last_sent = Some(now),
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
-                Err(e) => return Err(e).context("sending netplay input"),
+            if self
+                .transport
+                .send(&packet)
+                .context("sending netplay input")?
+            {
+                self.last_sent = Some(now);
             }
         }
         Ok(())
     }
 }
 
-impl Drop for Session {
+impl<T: Transport> Drop for Connection<T> {
     fn drop(&mut self) {
         let status = self.status();
         log::info!(

--- a/src/netplay/mod.rs
+++ b/src/netplay/mod.rs
@@ -10,6 +10,10 @@ mod wire;
 #[cfg(not(target_arch = "wasm32"))]
 use transport::UdpTransport;
 pub use transport::{PacketQueue, Transport};
+/// Fixed wire layout, also exposed to browser glue for compatibility checks.
+pub use wire::{HEADER as PACKET_HEADER, INPUT_RECORD, MAX_PACKET, VERSION as PROTOCOL_VERSION};
+/// Default seed for a fitted clock in deterministic netplay sessions.
+pub const RTC_SEED: u64 = 946684800;
 
 use crate::emulator::Emulator;
 use crate::timebase::{Duration, Instant};
@@ -29,6 +33,24 @@ pub struct Input {
 }
 
 impl Input {
+    pub const BUTTONS: u16 = 0x7ff;
+
+    /// Direction switches, red/fire and blue/second button, in wire order.
+    pub fn set_joystick(&mut self, held: [bool; 6]) {
+        self.buttons = (self.buttons & !0x3f) | Self::pack_buttons(held);
+    }
+
+    /// Play, rewind, forward, green and yellow, in wire order.
+    pub fn set_cd32_buttons(&mut self, held: [bool; 5]) {
+        self.buttons = (self.buttons & 0x3f) | (Self::pack_buttons(held) << 6);
+    }
+
+    fn pack_buttons<const N: usize>(held: [bool; N]) -> u16 {
+        held.into_iter()
+            .enumerate()
+            .fold(0, |bits, (bit, on)| bits | (u16::from(on) << bit))
+    }
+
     pub fn set_key(&mut self, key: u8, pressed: bool) {
         if key >= 128 {
             return;
@@ -165,7 +187,7 @@ pub fn validate_config(cfg: &crate::config::Config) -> Result<()> {
 pub fn prepare_config(cfg: &mut crate::config::Config) -> Result<()> {
     validate_config(cfg)?;
     if cfg.rtc_present && cfg.rtc_seed_unix.is_none() {
-        cfg.rtc_seed_unix = Some(946684800);
+        cfg.rtc_seed_unix = Some(RTC_SEED);
         log::info!("netplay: guest clock starts at 2000-01-01 00:00:00 UTC");
     }
     Ok(())
@@ -318,7 +340,11 @@ impl<T: Transport> Connection<T> {
         for _ in 0..64 {
             match self.transport.receive(&mut buffer) {
                 Ok(Some(len)) => {
-                    let Some(packet) = buffer.get(..len).and_then(wire::Packet::decode) else {
+                    let Some(bytes) = buffer.get(..len) else {
+                        continue;
+                    };
+                    wire::Packet::check_version(bytes, &self.settings.session)?;
+                    let Some(packet) = wire::Packet::decode(bytes) else {
                         continue;
                     };
                     if packet.session != self.settings.session {
@@ -326,7 +352,7 @@ impl<T: Transport> Connection<T> {
                     }
                     ensure!(packet.player == 1 - self.settings.player && packet.delay == self.settings.input_delay && packet.window == self.settings.rollback_frames,
                         "netplay settings differ: use opposite players and identical delay/rollback values");
-                    ensure!(packet.identity == self.identity, "netplay initial machine mismatch: use the same build, ROM, disks and deterministic machine settings");
+                    ensure!(packet.identity == self.identity, "netplay initial machine mismatch: use the same build, ROM, disks, floppy sounds and deterministic machine settings");
                     self.seen_peer = true;
                     if packet.ready && !self.connected {
                         self.connected = true;
@@ -357,7 +383,7 @@ impl<T: Transport> Connection<T> {
             }
         }
         ensure!(
-            input.buttons & !0x7ff == 0,
+            input.buttons & !Input::BUTTONS == 0,
             "invalid local netplay controller input"
         );
         let now = Instant::now();

--- a/src/netplay/tests.rs
+++ b/src/netplay/tests.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::*;
+use std::net::UdpSocket;
 
 #[derive(Default)]
 struct ToyMachine {
@@ -147,6 +148,31 @@ fn invalid_input_and_ack_are_rejected() -> Result<()> {
     assert!(rb.receive(0, input(999, 1)).is_err());
     assert!(rb.receive(u64::MAX, Input::default()).is_err());
     assert!(rb.acknowledge(100).is_err());
+    Ok(())
+}
+
+#[test]
+fn browser_packet_queues_bound_bursts_and_preserve_recent_retransmissions() -> Result<()> {
+    let mut queue = PacketQueue::default();
+    for byte in 0..100 {
+        queue.push(&[byte])?;
+    }
+    let mut buffer = [0; wire::MAX_PACKET + 1];
+    for expected in 36..100 {
+        assert_eq!(queue.receive(&mut buffer)?, Some(1));
+        assert_eq!(buffer[0], expected);
+    }
+    assert_eq!(queue.receive(&mut buffer)?, None);
+    assert!(queue.push(&vec![0; wire::MAX_PACKET + 1]).is_err());
+    assert!(queue.send(&vec![0; wire::MAX_PACKET + 1]).is_err());
+    queue.push(&[1, 2])?;
+    assert!(queue.receive(&mut [0]).is_err());
+    for _ in 0..64 {
+        assert!(queue.send(&[1, 2])?);
+    }
+    assert!(!queue.send(&[3])?);
+    assert_eq!(queue.pop(), Some(vec![1, 2]));
+    assert!(queue.send(&[3])?);
     Ok(())
 }
 
@@ -313,8 +339,8 @@ fn udp_pair_with_delay(delay: u8, window: u8) -> Result<()> {
         Session::new(session_options(1)?, &mut machines[1], &safe_config()?)?,
     ];
     let destinations = [
-        sessions[0].socket.local_addr()?,
-        sessions[1].socket.local_addr()?,
+        sessions[0].transport.socket.local_addr()?,
+        sessions[1].transport.socket.local_addr()?,
     ];
     let mut queued = Vec::<(u64, usize, Vec<u8>)>::new();
     let mut packets = 0u64;
@@ -384,7 +410,7 @@ fn mismatch_desync_and_disconnect_stop_the_session() -> Result<()> {
         inputs: vec![],
         checksum: None,
     };
-    peer.send_to(&packet.encode(), session.socket.local_addr()?)?;
+    peer.send_to(&packet.encode(), session.transport.socket.local_addr()?)?;
     assert!(poll_error(&mut session, &mut emu)
         .to_string()
         .contains("mismatch"));
@@ -400,7 +426,7 @@ fn mismatch_desync_and_disconnect_stop_the_session() -> Result<()> {
     session.rollback.received = 60;
     session.rollback.hashes.insert(60, [1; 32]);
     packet.checksum = Some((60, [2; 32]));
-    peer.send_to(&packet.encode(), session.socket.local_addr()?)?;
+    peer.send_to(&packet.encode(), session.transport.socket.local_addr()?)?;
     assert!(poll_error(&mut session, &mut emu)
         .to_string()
         .contains("desynchronized"));
@@ -451,7 +477,7 @@ fn capture_waits_for_the_peer_to_acknowledge_retransmitted_local_input() -> Resu
     let mut emu = emulator()?;
     let mut session = Session::new(options(peer.local_addr()?, 0), &mut emu, &safe_config()?)?;
     let mut packet = wire::Packet {
-        session: session.options.session,
+        session: session.settings.session,
         identity: session.identity,
         player: 1,
         ready: true,
@@ -461,7 +487,7 @@ fn capture_waits_for_the_peer_to_acknowledge_retransmitted_local_input() -> Resu
         inputs: vec![(0, input(0, 1))],
         checksum: None,
     };
-    peer.send_to(&packet.encode(), session.socket.local_addr()?)?;
+    peer.send_to(&packet.encode(), session.transport.socket.local_addr()?)?;
     for _ in 0..100 {
         if session.step(&mut emu, input(0, 0), true)? {
             break;
@@ -492,7 +518,7 @@ fn capture_waits_for_the_peer_to_acknowledge_retransmitted_local_input() -> Resu
     );
     assert!(!session.status().ready_to_capture());
     packet.ack = 1;
-    peer.send_to(&packet.encode(), session.socket.local_addr()?)?;
+    peer.send_to(&packet.encode(), session.transport.socket.local_addr()?)?;
     for _ in 0..100 {
         session.step(&mut emu, Input::default(), false)?;
         if session.status().ready_to_capture() {

--- a/src/netplay/tests.rs
+++ b/src/netplay/tests.rs
@@ -551,3 +551,123 @@ fn netplay_snapshot_preserves_the_completed_frame_and_runtime_latches() -> Resul
     assert_eq!(emu.netplay_snapshot()?, before);
     Ok(())
 }
+
+#[test]
+fn queued_peers_confirm_input_driven_machine_state() -> Result<()> {
+    let mut machines = [emulator()?, emulator()?];
+    let settings = |player| Settings {
+        player,
+        session: [42; 16],
+        input_delay: 0,
+        rollback_frames: 8,
+    };
+    let mut peers = [
+        Connection::with_transport(
+            settings(0),
+            PacketQueue::default(),
+            &mut machines[0],
+            &safe_config()?,
+        )?,
+        Connection::with_transport(
+            settings(1),
+            PacketQueue::default(),
+            &mut machines[1],
+            &safe_config()?,
+        )?,
+    ];
+    let inputs = [
+        Input {
+            buttons: 1 | 16,
+            ..Default::default()
+        },
+        Input {
+            buttons: 2 | 32,
+            ..Default::default()
+        },
+    ];
+    for _ in 0..200 {
+        for player in 0..2 {
+            let advance = peers[player].status().frame < 60;
+            peers[player].step(&mut machines[player], inputs[player], advance)?;
+            while let Some(packet) = peers[player].transport_mut().pop() {
+                peers[1 - player].transport_mut().push(&packet)?;
+            }
+        }
+        if peers.iter().all(|p| p.status().checked_frame == 60) {
+            break;
+        }
+    }
+    for peer in &peers {
+        assert_eq!(peer.status().checked_frame, 60);
+    }
+    // An independent uninterrupted machine proves that equal hashes did not
+    // result from both transport adapters silently dropping the same input.
+    let mut baseline = emulator()?;
+    for _ in 0..60 {
+        EmulatedMachine(&mut baseline).frame(inputs, [0; 16], false)?;
+    }
+    for machine in &machines {
+        assert_eq!(machine.netplay_snapshot()?, baseline.netplay_snapshot()?);
+        assert!(machine.bus().input.ports[0].up);
+        assert!(machine.bus().input.ports[0].fire);
+        assert!(machine.bus().input.ports[1].down);
+        assert!(machine.bus().input.ports[1].button2);
+    }
+    Ok(())
+}
+
+#[test]
+fn recognized_session_reports_incompatible_build_but_ignores_other_sessions() -> Result<()> {
+    for offset in [4, 6] {
+        let mut machine = emulator()?;
+        let mut peer = Connection::with_transport(
+            Settings {
+                player: 0,
+                session: [42; 16],
+                input_delay: 0,
+                rollback_frames: 8,
+            },
+            PacketQueue::default(),
+            &mut machine,
+            &safe_config()?,
+        )?;
+        peer.step(&mut machine, Input::default(), false)?;
+        let mut packet = peer.transport_mut().pop().unwrap();
+        packet[offset] ^= 1;
+        packet[10] ^= 1;
+        peer.transport_mut().push(&packet)?;
+        peer.step(&mut machine, Input::default(), false)?;
+        packet[10] ^= 1;
+        peer.transport_mut().push(&packet)?;
+        assert!(peer
+            .step(&mut machine, Input::default(), false)
+            .unwrap_err()
+            .to_string()
+            .contains("incompatible build"));
+    }
+    Ok(())
+}
+
+#[test]
+fn udp_transport_discards_foreign_source_and_keeps_expected_peer() -> Result<()> {
+    let expected = UdpSocket::bind("127.0.0.1:0")?;
+    let foreign = UdpSocket::bind("127.0.0.1:0")?;
+    let mut transport = UdpTransport::new(options(expected.local_addr()?, 0))?;
+    foreign.send_to(&[1], transport.socket.local_addr()?)?;
+    let mut bytes = [0; 8];
+    let receive = |transport: &mut UdpTransport, bytes: &mut [u8]| -> Result<Option<usize>> {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            if let Some(len) = transport.receive(bytes)? {
+                return Ok(Some(len));
+            }
+            ensure!(Instant::now() < deadline, "loopback packet did not arrive");
+            std::thread::yield_now();
+        }
+    };
+    assert_eq!(receive(&mut transport, &mut bytes)?, Some(0));
+    expected.send_to(&[2, 3], transport.socket.local_addr()?)?;
+    assert_eq!(receive(&mut transport, &mut bytes)?, Some(2));
+    assert_eq!(&bytes[..2], &[2, 3]);
+    Ok(())
+}

--- a/src/netplay/transport.rs
+++ b/src/netplay/transport.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Nonblocking packet adapters. Reliability belongs to the shared protocol.
+
+use super::wire::MAX_PACKET;
+use anyhow::{ensure, Result};
+use std::collections::VecDeque;
+
+pub trait Transport {
+    /// Read one complete packet without blocking. None means the queue is empty;
+    /// a returned length must fit the supplied buffer.
+    fn receive(&mut self, buffer: &mut [u8]) -> Result<Option<usize>>;
+    /// False means the transport is temporarily unable to accept this packet.
+    fn send(&mut self, packet: &[u8]) -> Result<bool>;
+}
+
+/// The browser feeds incoming data-channel packets and drains outgoing packets.
+/// Both queues are bounded independently of how often JavaScript services them.
+#[derive(Default)]
+pub struct PacketQueue {
+    incoming: VecDeque<Vec<u8>>,
+    outgoing: VecDeque<Vec<u8>>,
+}
+
+impl PacketQueue {
+    pub fn push(&mut self, packet: &[u8]) -> Result<()> {
+        ensure!(packet.len() <= MAX_PACKET, "netplay packet is too large");
+        if self.incoming.len() == 64 {
+            self.incoming.pop_front();
+        }
+        self.incoming.push_back(packet.to_vec());
+        Ok(())
+    }
+
+    pub fn pop(&mut self) -> Option<Vec<u8>> {
+        self.outgoing.pop_front()
+    }
+}
+
+impl Transport for PacketQueue {
+    fn receive(&mut self, buffer: &mut [u8]) -> Result<Option<usize>> {
+        let Some(packet) = self.incoming.pop_front() else {
+            return Ok(None);
+        };
+        ensure!(
+            packet.len() <= buffer.len(),
+            "netplay receive buffer is too small"
+        );
+        buffer[..packet.len()].copy_from_slice(&packet);
+        Ok(Some(packet.len()))
+    }
+
+    fn send(&mut self, packet: &[u8]) -> Result<bool> {
+        ensure!(packet.len() <= MAX_PACKET, "netplay packet is too large");
+        if self.outgoing.len() == 64 {
+            return Ok(false);
+        }
+        self.outgoing.push_back(packet.to_vec());
+        Ok(true)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub struct UdpTransport {
+    pub(super) socket: std::net::UdpSocket,
+    pub(super) options: super::Options,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl UdpTransport {
+    pub(super) fn new(options: super::Options) -> Result<Self> {
+        use anyhow::Context;
+        let socket =
+            std::net::UdpSocket::bind(options.bind).context("binding netplay UDP socket")?;
+        socket.set_nonblocking(true)?;
+        log::info!(
+            "netplay: listening on {}, peer {}, player {}; waiting for matching machine",
+            socket.local_addr()?,
+            options.peer,
+            options.player + 1
+        );
+        Ok(Self { socket, options })
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Transport for UdpTransport {
+    fn receive(&mut self, buffer: &mut [u8]) -> Result<Option<usize>> {
+        match self.socket.recv_from(buffer) {
+            Ok((len, source)) => Ok(Some(if source == self.options.peer { len } else { 0 })),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn send(&mut self, packet: &[u8]) -> Result<bool> {
+        match self.socket.send_to(packet, self.options.peer) {
+            Ok(_) => Ok(true),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(false),
+            Err(e) => Err(e.into()),
+        }
+    }
+}

--- a/src/netplay/transport.rs
+++ b/src/netplay/transport.rs
@@ -8,7 +8,8 @@ use std::collections::VecDeque;
 
 pub trait Transport {
     /// Read one complete packet without blocking. None means the queue is empty;
-    /// a returned length must fit the supplied buffer.
+    /// a returned length must fit the supplied buffer. Some(0) means a packet
+    /// was consumed and discarded (for example, a foreign UDP source).
     fn receive(&mut self, buffer: &mut [u8]) -> Result<Option<usize>>;
     /// False means the transport is temporarily unable to accept this packet.
     fn send(&mut self, packet: &[u8]) -> Result<bool>;

--- a/src/netplay/wire.rs
+++ b/src/netplay/wire.rs
@@ -6,10 +6,11 @@
 use super::Input;
 
 const MAGIC: &[u8; 4] = b"CLNP";
-const VERSION: u16 = 1;
-const MAX_INPUTS: usize = 32;
-const HEADER: usize = 4 + 2 + 4 + 16 + 32 + 4 + 8 + 8 + 32 + 1;
-pub(super) const MAX_PACKET: usize = HEADER + MAX_INPUTS * 26;
+pub const VERSION: u16 = 1;
+pub const MAX_INPUTS: usize = 32;
+pub const HEADER: usize = 4 + 2 + 4 + 16 + 32 + 4 + 8 + 8 + 32 + 1;
+pub const INPUT_RECORD: usize = 8 + 2 + 16;
+pub const MAX_PACKET: usize = HEADER + MAX_INPUTS * INPUT_RECORD;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct Packet {
@@ -53,6 +54,19 @@ impl Packet {
         out
     }
 
+    // The magic and session prefix are stable across protocol versions. Only
+    // diagnose a recognized session; unrelated datagrams remain ignorable.
+    pub fn check_version(bytes: &[u8], session: &[u8; 16]) -> anyhow::Result<()> {
+        if bytes.len() >= 26 && &bytes[..4] == MAGIC && &bytes[10..26] == session {
+            anyhow::ensure!(
+                bytes[4..6] == VERSION.to_le_bytes()
+                    && bytes[6..10] == crate::savestate::STATE_VERSION.to_le_bytes(),
+                "netplay incompatible build: protocol or save-state version differs; use the same Copperline build"
+            );
+        }
+        Ok(())
+    }
+
     pub fn decode(mut bytes: &[u8]) -> Option<Self> {
         if bytes.len() < HEADER || bytes.len() > MAX_PACKET {
             return None;
@@ -81,14 +95,16 @@ impl Packet {
             return None;
         }
         let [count] = take(&mut bytes)?;
-        if usize::from(count) > MAX_INPUTS || bytes.len() != usize::from(count) * 26 {
+        if usize::from(count) > MAX_INPUTS || bytes.len() != usize::from(count) * INPUT_RECORD {
             return None;
         }
         let mut inputs = Vec::with_capacity(usize::from(count));
         for _ in 0..count {
             let number = u64::from_le_bytes(take(&mut bytes)?);
             let buttons = u16::from_le_bytes(take(&mut bytes)?);
-            if buttons & !0x7ff != 0 || inputs.last().is_some_and(|(prev, _)| *prev >= number) {
+            if buttons & !Input::BUTTONS != 0
+                || inputs.last().is_some_and(|(prev, _)| *prev >= number)
+            {
                 return None;
             }
             inputs.push((

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -4519,6 +4519,11 @@ pub fn render_reusing_previous(
 /// re-render of the same frame (a layer-isolation toggle while paused)
 /// cannot perturb the machine.
 pub fn render_display_only(bus: &Bus, fb: &mut [u32]) {
+    let _ = render_display_only_with_content(bus, fb);
+}
+
+/// Presentation-only render with its active content envelope for browser cropping.
+pub fn render_display_only_with_content(bus: &Bus, fb: &mut [u32]) -> Option<ContentRect> {
     thread_local! {
         static RENDER_INPUT_SCRATCH: std::cell::RefCell<Option<RenderInput>> =
             const { std::cell::RefCell::new(None) };
@@ -4529,15 +4534,16 @@ pub fn render_display_only(bus: &Bus, fb: &mut [u32]) {
             Some(input) => input.refill_from_bus(bus),
             None => *scratch = Some(RenderInput::from_bus(bus)),
         }
-        {
+        let content = {
             let input = scratch.as_ref().expect("scratch render input present");
-            let _ = render_from_input(input, fb);
-        }
+            render_from_input(input, fb).content_rect
+        };
         scratch
             .as_mut()
             .expect("scratch render input present")
             .release_shared_frame_data();
-    });
+        content
+    })
 }
 
 /// Side-effect-free display render with final Denise/Lisa output provenance.

--- a/tools/check-web-netplay-browser.mjs
+++ b/tools/check-web-netplay-browser.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Serve the browser page with its release bundle, then pass its loopback URL.
+// Requires Playwright. PLAYWRIGHT_MODULE and CHROME_PATH may select local tools.
+import assert from 'node:assert/strict';
+import { mkdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const url = new URL(process.argv[2] ?? 'http://127.0.0.1:8000/');
+assert.ok(['127.0.0.1', 'localhost', '[::1]'].includes(url.hostname), 'Use a local test page');
+const output = resolve(process.argv[3] ?? '/tmp/copperline-web-netplay-browser');
+await mkdir(output, { recursive: true });
+const module = process.env.PLAYWRIGHT_MODULE;
+const { chromium } = await import(module ? pathToFileURL(resolve(module)).href : 'playwright');
+const browser = await chromium.launch({ executablePath: process.env.CHROME_PATH,
+  args: ['--autoplay-policy=no-user-gesture-required', '--disable-background-timer-throttling',
+    '--disable-renderer-backgrounding', '--disable-backgrounding-occluded-windows'] });
+const errors = [];
+try {
+  const pages = [];
+  for (let player = 0; player < 2; player++) {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 1000 },
+      hasTouch: player === 0, serviceWorkers: 'block' });
+    // Tests exchange LAN candidates only and do not contact analytics or STUN.
+    await context.route('**/*', route => {
+      const target = new URL(route.request().url());
+      return target.origin === url.origin ? route.continue() : route.abort();
+    });
+    const page = await context.newPage();
+    page.on('pageerror', error => errors.push(error.message));
+    await page.goto(url.href);
+    await page.locator('#boot:enabled').waitFor({ timeout: 30000 });
+    await page.locator('#netplay-panel summary').click();
+    await page.locator('#netplay-stun').fill('');
+    pages.push(page);
+  }
+  const [host, guest] = pages;
+  // Hold a local boot at its audio await, enter/cancel netplay, then let the
+  // obsolete boot complete. It must not resurrect a local machine after setup.
+  await host.evaluate(async () => {
+    const probe = new AudioContext();
+    const proto = Object.getPrototypeOf(probe.audioWorklet);
+    const addModule = proto.addModule;
+    let first = true;
+    proto.addModule = async function (...args) {
+      if (!first) return addModule.apply(this, args);
+      first = false;
+      window.__testAudioWaiting = true;
+      await new Promise(resolve => { window.__releaseTestAudio = resolve; });
+      try { return await addModule.apply(this, args); }
+      finally { window.__testAudioDone = true; proto.addModule = addModule; }
+    };
+    await probe.close();
+  });
+  await host.locator('#boot').click();
+  await host.waitForFunction(() => window.__testAudioWaiting);
+  await host.locator('#netplay-host').click();
+  await host.locator('#netplay-disconnect').click();
+  await host.evaluate(() => window.__releaseTestAudio());
+  await host.waitForFunction(() => window.__testAudioDone);
+  await host.waitForFunction(() => !window.__emu && !document.querySelector('#boot').disabled);
+  await host.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+  assert.equal(await host.evaluate(() => window.__emu == null), true, 'cancelled local boot must stay stopped');
+  async function connect() {
+    await host.locator('#netplay-host').click();
+    await host.waitForFunction(() => document.querySelector('#netplay-local').value.startsWith('CLNP1.'));
+    await guest.locator('#netplay-remote').fill(await host.locator('#netplay-local').inputValue());
+    await guest.locator('#netplay-join').click();
+    await guest.waitForFunction(() => document.querySelector('#netplay-local').value.startsWith('CLNP1.'));
+    await host.locator('#netplay-remote').fill(await guest.locator('#netplay-local').inputValue());
+    await host.locator('#netplay-accept').click();
+  }
+  // Cancel a gathered offer and prove the setup can be used again.
+  await host.locator('#netplay-host').click();
+  await host.waitForFunction(() => document.querySelector('#netplay-local').value.startsWith('CLNP1.'));
+  await host.locator('#netplay-disconnect').click();
+  assert.equal(await host.locator('#boot').isEnabled(), true);
+  await connect();
+  await Promise.all(pages.map(page => page.waitForFunction(() => window.__emu?.netplay_status()[6] >= 120,
+    null, { timeout: 90000 })));
+  await host.bringToFront();
+  await host.evaluate(() => {
+    const emu = window.__emu;
+    const take = emu.netplay_take_packet.bind(emu);
+    window.__testKeyFrames = [];
+    emu.netplay_take_packet = () => {
+      const packet = take();
+      // Protocol v1: 111-byte header, then 26-byte input records. Check the
+      // emitted held-key states, not merely the UI's keydown/up callbacks.
+      const view = new DataView(packet.buffer, packet.byteOffset, packet.byteLength);
+      for (let offset = 111; offset + 26 <= packet.length; offset += 26) {
+        window.__testKeyFrames.push([Number(view.getBigUint64(offset, true)),
+          !!(packet[offset + 10 + (0x20 >> 3)] & (1 << (0x20 & 7)))]);
+      }
+      return packet;
+    };
+  });
+  await host.locator('#devkeyboard').click();
+  await host.getByLabel('Type into the Amiga').evaluate(field =>
+    field.dispatchEvent(new InputEvent('beforeinput', { inputType: 'insertText', data: 'a', bubbles: true, cancelable: true })));
+  await host.waitForFunction(() => {
+    const frames = window.__testKeyFrames;
+    const down = frames.find(([frame, pressed]) => pressed);
+    return down && frames.some(([frame, pressed]) => !pressed && frame > down[0]);
+  }).catch(async error => {
+    console.error(await host.evaluate(() => ({ frames: window.__testKeyFrames,
+      focused: document.hasFocus(), active: document.activeElement?.getAttribute('aria-label'),
+      status: document.querySelector('#netplay-status').textContent })));
+    throw error;
+  });
+  await host.locator('#devkeyboard').click();
+  for (const [player, page] of pages.entries()) {
+    for (const id of ['boot', 'machine', 'video', 'reset', 'pause', 'df0', 'df1', 'floppy-speed']) {
+      assert.equal(await page.locator(`#${id}`).isDisabled(), true, `${id} must stay locked`);
+    }
+    const status = await page.evaluate(() => [...window.__emu.netplay_status()]);
+    console.log(`Browser player ${player + 1}: ${JSON.stringify(status)}`);
+  }
+  await host.locator('#netplay-panel').screenshot({ path: `${output}/netplay-desktop.png` });
+  await host.locator('#netplay-disconnect').click();
+  await Promise.all(pages.map(page => page.waitForFunction(() => !window.__emu && !document.querySelector('#netplay-host').disabled)));
+  await connect();
+  await Promise.all(pages.map(page => page.waitForFunction(() => window.__emu?.netplay_status()[6] >= 60,
+    null, { timeout: 60000 })));
+  await guest.locator('#netplay-disconnect').click();
+  await Promise.all(pages.map(page => page.locator('#netplay-host:enabled').waitFor()));
+  // A different hardware setup must stop both sides instead of running locally.
+  await guest.locator('#video').selectOption('NTSC');
+  await connect();
+  await Promise.all(pages.map(page => page.waitForFunction(() =>
+    !window.__emu && !document.querySelector('#netplay-host').disabled,
+  null, { timeout: 30000 })));
+  const messages = await Promise.all(pages.map(page => page.locator('#netplay-status').textContent()));
+  console.log(`Mismatched machines: ${messages.join('; ')}`);
+  assert.ok(messages.some(message => /mismatch|different/i.test(message)), messages.join('; '));
+  await host.setViewportSize({ width: 390, height: 844 });
+  await host.locator('#sidebar-toggle').click();
+  await host.locator('#netplay-panel').screenshot({ path: `${output}/netplay-mobile.png` });
+  assert.deepEqual(errors, []);
+  console.log('Host/Join, cancellation, restart, control locking, mismatch rejection and browser rendering passed');
+} finally { await browser.close(); }

--- a/tools/check-web-netplay-browser.mjs
+++ b/tools/check-web-netplay-browser.mjs
@@ -83,13 +83,15 @@ try {
   await host.evaluate(() => {
     const emu = window.__emu;
     const take = emu.netplay_take_packet.bind(emu);
+    const [protocol, , headerBytes, inputBytes] = emu.constructor.netplay_packet_layout();
+    if (protocol !== 1 || headerBytes !== 111 || inputBytes !== 26) throw new Error('Packet decoder layout changed');
     window.__testKeyFrames = [];
     emu.netplay_take_packet = () => {
       const packet = take();
       // Protocol v1: 111-byte header, then 26-byte input records. Check the
       // emitted held-key states, not merely the UI's keydown/up callbacks.
       const view = new DataView(packet.buffer, packet.byteOffset, packet.byteLength);
-      for (let offset = 111; offset + 26 <= packet.length; offset += 26) {
+      for (let offset = headerBytes; offset + inputBytes <= packet.length; offset += inputBytes) {
         window.__testKeyFrames.push([Number(view.getBigUint64(offset, true)),
           !!(packet[offset + 10 + (0x20 >> 3)] & (1 << (0x20 & 7)))]);
       }
@@ -111,7 +113,7 @@ try {
   });
   await host.locator('#devkeyboard').click();
   for (const [player, page] of pages.entries()) {
-    for (const id of ['boot', 'machine', 'video', 'reset', 'pause', 'df0', 'df1', 'floppy-speed']) {
+    for (const id of ['boot', 'machine', 'video', 'reset', 'pause', 'df0', 'df1', 'floppy-speed', 'floppy-sounds']) {
       assert.equal(await page.locator(`#${id}`).isDisabled(), true, `${id} must stay locked`);
     }
     const status = await page.evaluate(() => [...window.__emu.netplay_status()]);
@@ -133,7 +135,7 @@ try {
   null, { timeout: 30000 })));
   const messages = await Promise.all(pages.map(page => page.locator('#netplay-status').textContent()));
   console.log(`Mismatched machines: ${messages.join('; ')}`);
-  assert.ok(messages.some(message => /mismatch|different/i.test(message)), messages.join('; '));
+  assert.ok(messages.every(message => /mismatch|different/i.test(message)), messages.join('; '));
   await host.setViewportSize({ width: 390, height: 844 });
   await host.locator('#sidebar-toggle').click();
   await host.locator('#netplay-panel').screenshot({ path: `${output}/netplay-mobile.png` });

--- a/tools/check-web-netplay.mjs
+++ b/tools/check-web-netplay.mjs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Exercise the release wasm-bindgen bundle; no sockets or display are needed.
 import assert from 'node:assert/strict';
+import { PACKET_LIMIT } from '../crates/copperline-web/www/netplay.js';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -21,6 +22,11 @@ function fresh(model = 'A500', video = 'PAL') {
   return emu;
 }
 
+const [protocol, packetLimit, headerBytes, inputBytes] = WebEmu.netplay_packet_layout();
+assert.equal(protocol, 1);
+assert.equal(packetLimit, PACKET_LIMIT, 'Rust and WebRTC packet limits must match');
+assert.equal(headerBytes, 111);
+assert.equal(inputBytes, 26);
 const validation = fresh();
 try {
   for (const player of [-1, 0, 3, 1.5, 257, NaN, Infinity]) {
@@ -34,10 +40,13 @@ try {
   }
   assert.throws(() => validation.start_netplay(1, 'bad', 2, 8, 'joystick'));
   assert.throws(() => validation.start_netplay(1, code, 2, 8, 'mouse'));
+  const saved = validation.save_state();
   validation.start_netplay(1, code, 2, 8, 'joystick');
   for (const mutate of [() => validation.reset(), () => validation.save_state(),
     () => validation.load_rom(rom, ext), () => validation.insert_floppy(0, new Uint8Array(901120), 'blank.adf'),
-    () => validation.eject_floppy(0), () => validation.load_state(new Uint8Array())]) assert.throws(mutate);
+    () => validation.eject_floppy(0), () => validation.load_state(saved),
+    () => validation.set_floppy_sounds(false), () => validation.set_floppy_sounds_volume(12),
+    () => validation.set_port_device(1, 'mouse'), () => validation.set_floppy_speed(400)]) assert.throws(mutate);
   assert.throws(() => validation.start_netplay(1, code, 2, 8, 'joystick'));
 } finally { validation.free(); }
 const warm = fresh();
@@ -56,6 +65,7 @@ for (const [model, video, delay, window] of [['A500', 'PAL', 0, 8], ['A500', 'PA
     });
     let queued = [];
     let packets = 0;
+    let checkedSoundGuard = false;
     for (let tick = 0; tick < 1800; tick++) {
       for (let player = 0; player < 2; player++) {
         const emu = peers[player];
@@ -76,17 +86,36 @@ for (const [model, video, delay, window] of [['A500', 'PAL', 0, 8], ['A500', 'PA
         for (;;) {
           const bytes = emu.netplay_take_packet();
           if (!bytes.length) break;
+          assert.ok(bytes.length <= packetLimit);
+          // Inspect the sampled input, independently of peer checksum equality.
+          const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+          for (let offset = headerBytes; offset < bytes.length; offset += inputBytes) {
+            const sampled = Number(view.getBigUint64(offset, true)) - delay;
+            if (sampled < 0) continue;
+            const expected = (sampled % 9 < 3 ? 1 : 0) | (sampled % 7 < 3 ? 16 : 0)
+              | (sampled % 5 < 2 ? 64 : 0) | (sampled % 7 < 2 ? 128 : 0)
+              | (sampled % 11 < 3 ? 256 : 0) | (sampled % 13 < 4 ? 512 : 0)
+              | (sampled % 17 < 3 ? 1024 : 0);
+            assert.equal(view.getUint16(offset + 8, true), expected, 'controller routing');
+            assert.equal(bytes[offset + 10 + 8], sampled % 13 < 4 ? 1 : 0, 'Space key routing');
+          }
           packets++;
           if (packets % 7 === 0) continue;
           queued.push({ due: tick + packets % 5, target: 1 - player, bytes });
           if (packets % 11 === 0) queued.push({ due: tick + packets % 5 + 2, target: 1 - player, bytes });
         }
       }
+      if (!checkedSoundGuard && peers[0].netplay_status()[6] >= 60) {
+        assert.throws(() => peers[0].set_floppy_sounds(false), /Unavailable during netplay/);
+        assert.throws(() => peers[0].set_floppy_sounds_volume(12), /Unavailable during netplay/);
+        checkedSoundGuard = true;
+      }
       const ready = queued.filter(packet => packet.due <= tick);
       queued = queued.filter(packet => packet.due > tick);
       for (const packet of ready) peers[packet.target].netplay_receive(packet.bytes);
       if (peers.every(emu => { const s = emu.netplay_status(); return s[1] === 120 && s[2] === 120 && s[3] >= 120 && s[6] === 120; })) break;
     }
+    assert.ok(checkedSoundGuard);
     for (const emu of peers) {
       const status = emu.netplay_status();
       assert.equal(status[1], 120);
@@ -103,3 +132,20 @@ for (const [model, video, delay, window] of [['A500', 'PAL', 0, 8], ['A500', 'PA
   } finally { peers.forEach(emu => emu.free()); }
 }
 console.log('WASM netplay numeric boundaries, session guards, packet loss/reordering and presentation isolation passed');
+
+for (const configure of [emu => emu.set_floppy_sounds(false), emu => emu.set_floppy_sounds_volume(12)]) {
+  const peers = [fresh(), fresh()];
+  try {
+    configure(peers[1]);
+    peers.forEach((emu, player) => {
+      emu.start_netplay(player + 1, code, 2, 8, 'joystick');
+      emu.run_hidden(0, 0);
+    });
+    const packets = peers.map(emu => emu.netplay_take_packet());
+    peers.forEach((emu, player) => {
+      emu.netplay_receive(packets[1 - player]);
+      assert.throws(() => emu.run_hidden(1, 0), /initial machine mismatch/);
+    });
+  } finally { peers.forEach(emu => emu.free()); }
+}
+console.log('Floppy sound mismatches rejected on both peers');

--- a/tools/check-web-netplay.mjs
+++ b/tools/check-web-netplay.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Exercise the release wasm-bindgen bundle; no sockets or display are needed.
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const pkg = resolve(process.argv[2] ?? resolve(root, 'crates/copperline-web/pkg'));
+const glue = await readFile(`${pkg}/copperline_web.js`, 'utf8');
+const { default: init, WebEmu } = await import(`data:text/javascript;base64,${Buffer.from(glue).toString('base64')}`);
+const wasm = await init({ module_or_path: await readFile(`${pkg}/copperline_web_bg.wasm`) });
+const rom = new Uint8Array(await readFile(resolve(root, 'assets/aros/aros-amiga-m68k-rom.bin')));
+const ext = new Uint8Array(await readFile(resolve(root, 'assets/aros/aros-amiga-m68k-ext.bin')));
+const code = '0123456789abcdef0123456789abcdef';
+
+function fresh(model = 'A500', video = 'PAL') {
+  const emu = new WebEmu(model, video, 2);
+  emu.load_rom(rom, ext);
+  return emu;
+}
+
+const validation = fresh();
+try {
+  for (const player of [-1, 0, 3, 1.5, 257, NaN, Infinity]) {
+    assert.throws(() => validation.start_netplay(player, code, 2, 8, 'joystick'));
+  }
+  for (const delay of [-1, 7, 1.5, 257, NaN, Infinity]) {
+    assert.throws(() => validation.start_netplay(1, code, delay, 8, 'joystick'));
+  }
+  for (const window of [-1, 0, 13, 1.5, 257, NaN, Infinity]) {
+    assert.throws(() => validation.start_netplay(1, code, 2, window, 'joystick'));
+  }
+  assert.throws(() => validation.start_netplay(1, 'bad', 2, 8, 'joystick'));
+  assert.throws(() => validation.start_netplay(1, code, 2, 8, 'mouse'));
+  validation.start_netplay(1, code, 2, 8, 'joystick');
+  for (const mutate of [() => validation.reset(), () => validation.save_state(),
+    () => validation.load_rom(rom, ext), () => validation.insert_floppy(0, new Uint8Array(901120), 'blank.adf'),
+    () => validation.eject_floppy(0), () => validation.load_state(new Uint8Array())]) assert.throws(mutate);
+  assert.throws(() => validation.start_netplay(1, code, 2, 8, 'joystick'));
+} finally { validation.free(); }
+const warm = fresh();
+try {
+  warm.run(0, 0);
+  assert.throws(() => warm.start_netplay(1, code, 2, 8, 'joystick'));
+} finally { warm.free(); }
+
+for (const [model, video, delay, window] of [['A500', 'PAL', 0, 8], ['A500', 'PAL', 2, 8], ['A1200', 'NTSC', 6, 1]]) {
+  const peers = [fresh(model, video), fresh(model, video)];
+  try {
+    peers.forEach((emu, player) => {
+      emu.insert_floppy(0, new Uint8Array(901120), player ? 'other/path.adf' : 'disk.adf');
+      emu.set_volume_percent(player ? 40 : 100);
+      emu.start_netplay(player + 1, code, delay, window, 'cd32');
+    });
+    let queued = [];
+    let packets = 0;
+    for (let tick = 0; tick < 1800; tick++) {
+      for (let player = 0; player < 2; player++) {
+        const emu = peers[player];
+        const frame = emu.netplay_status()[1];
+        emu.set_joystick_port(2, frame % 9 < 3, false, false, false, frame % 7 < 3, false);
+        emu.set_cd32_buttons_port(2, frame % 5 < 2, frame % 7 < 2, frame % 11 < 3, frame % 13 < 4, frame % 17 < 3);
+        emu.key_event('Space', frame % 13 < 4);
+        const advance = frame < 120 && (player !== 0 || tick % 90 < 30 || tick % 90 >= 42);
+        // Deliberately different rendering cadence, display settings and audio
+        // levels: host presentation must not enter machine checkpoint hashes.
+        if (player === 1) {
+          emu.set_volume_percent(35);
+          if (tick % 9 === 0) emu.set_overscan(tick % 18 ? 'tv' : 'full');
+        }
+        if (player === 1 && tick % 3) emu.run_hidden(tick * 20, advance ? 1 : 0);
+        else emu.run(tick * 20, advance ? 1 : 0);
+        emu.take_audio();
+        for (;;) {
+          const bytes = emu.netplay_take_packet();
+          if (!bytes.length) break;
+          packets++;
+          if (packets % 7 === 0) continue;
+          queued.push({ due: tick + packets % 5, target: 1 - player, bytes });
+          if (packets % 11 === 0) queued.push({ due: tick + packets % 5 + 2, target: 1 - player, bytes });
+        }
+      }
+      const ready = queued.filter(packet => packet.due <= tick);
+      queued = queued.filter(packet => packet.due > tick);
+      for (const packet of ready) peers[packet.target].netplay_receive(packet.bytes);
+      if (peers.every(emu => { const s = emu.netplay_status(); return s[1] === 120 && s[2] === 120 && s[3] >= 120 && s[6] === 120; })) break;
+    }
+    for (const emu of peers) {
+      const status = emu.netplay_status();
+      assert.equal(status[1], 120);
+      assert.equal(status[2], 120);
+      assert.equal(status[6], 120);
+      if (delay === 0) assert.ok(status[4] > 0, 'late inputs must exercise rollback');
+      emu.set_overscan('tv');
+      emu.run(40000, 0);
+    }
+    const pixels = peers.map(emu => Buffer.from(new Uint8Array(wasm.memory.buffer,
+      emu.present_ptr(), emu.present_width() * emu.present_rows() * 4)));
+    assert.deepEqual(pixels[0], pixels[1]);
+    console.log(`${model}/${video} delay=${delay} window=${window}: 120 confirmed/checksummed frames; identical render`);
+  } finally { peers.forEach(emu => emu.free()); }
+}
+console.log('WASM netplay numeric boundaries, session guards, packet loss/reordering and presentation isolation passed');


### PR DESCRIPTION
Browser users can now start two-player rollback sessions through **Controls → Netplay**. The host shares a WebRTC offer code, the joining player returns an answer, and both pages cold-boot after their initial machines match. Each player owns one Amiga controller port; keyboard input is shared.

Reuse the existing rollback engine and wire protocol through bounded packet transports, retaining native UDP support. Browser setup supports optional STUN discovery, cancellation and fresh-session restart. Machine/media/state and floppy sound controls stay locked during setup and play, while rendering and main output volume remain local. Floppy sound settings must match. Disconnect discards the network timeline and session disk writes.

Failed startup restores the original machine. Recognized peers with incompatible builds fail immediately, and closing a browser connection drains queued diagnostics before freeing the machine. CI checks Rust/JavaScript packet-layout agreement and rejects mid-session floppy sound changes.

This connects browser peers to each other. Native/browser interoperability and TURN relays are outside this change. Update the setup/API/internals documentation and run the optimized WASM peer smoke in CI and the browser publishing workflow.

Validation:

- 3,627 native Rust unit tests and six web wrapper tests passed, including 24 netplay regressions, failed-start restoration, input routing and audio gain.
- Strict all-target/all-feature Clippy, WASM Clippy, formatting, ten page controller tests and workflow lint passed.
- Optimized A500/PAL and A1200/NTSC WASM peers confirmed matching checkpoints and final pixels under loss, reordering, duplication and asymmetric pauses, with different volume/render settings.
- Two Chromium contexts passed Host/Join, cancellation during a pending boot, restart, locked controls, initial-machine mismatch diagnostics on both peers and transmitted device-keyboard taps.
- Rebuilt native UDP peers completed 1,500 frames with identical PNG captures.
- Strict MyST site build passed using Node 24.
