### PR TITLE
Add browser netplay invitations, QR sharing and relay support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,23 @@ jobs:
         working-directory: crates/copperline-web/www
         run: npm test
 
+  netplay-service:
+    name: Browser netplay room service
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: services/netplay/package-lock.json
+      - run: npm ci
+        working-directory: services/netplay
+      - run: npm test
+        working-directory: services/netplay
+      - run: npx wrangler deploy --env="" --dry-run
+        working-directory: services/netplay
+
   player:
     name: Publisher-kit player crate
     # Guards the feature combination the player builds against (frontend +

--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -9,8 +9,8 @@ name: Browser demo
 # The page shell (try/index.html) is hand-written in the website repository
 # and left alone. This workflow replaces the parts that must change together
 # with the emulator: the wasm-bindgen bundle (try/pkg), the JS glue that
-# drives the WebEmu API (try/try.js, try/netplay.js, try/render-stride.js,
-# try/serial-telnet.js, try/audio-worklet.js, sourced from
+# drives the WebEmu API (try/try.js, the netplay modules and QR license,
+# try/render-stride.js, try/serial-telnet.js, try/audio-worklet.js, sourced from
 # crates/copperline-web/www), and the AROS ROMs (try/aros).
 #
 # Pushing to the website repository needs the SITE_DEPLOY_KEY secret: the
@@ -145,6 +145,10 @@ jobs:
           cp crates/copperline-web/www/try.js \
              crates/copperline-web/www/render-stride.js \
              crates/copperline-web/www/netplay.js \
+             crates/copperline-web/www/netplay-room.js \
+             crates/copperline-web/www/netplay-diagnostics.js \
+             crates/copperline-web/www/netplay-qr.js \
+             crates/copperline-web/www/netplay-qr.LICENSE \
              crates/copperline-web/www/serial-telnet.js \
              crates/copperline-web/www/audio-worklet.js site/try/
           cp assets/aros/aros-amiga-m68k-rom.bin \

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The manual is published at [copperline.dev/docs](https://copperline.dev/docs/) a
 - [WHDLoad Support](docs/guide/whdload.md) - Direct WHDLoad package loading
 - [Direct Executable Launching](docs/guide/run.md) - Running cross-compiled Amiga binaries
 - [Floppy Hardware Bridge](docs/guide/fluxbridge.md) - Real floppy drives via Greaseweazle
-- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions through desktop GUI/CLI or browser WebRTC, with input prediction, rollback and matching-machine checks
+- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions through desktop GUI/CLI or browser WebRTC with invitation links, QR sharing and relay fallback, plus input prediction, rollback and matching-machine checks
 - [Headless Mode](docs/guide/headless.md) - Scripted runs and screenshot/frame dumps
 - [Debugging](docs/debugger/window.md) - In-window, headless, and GDB debugging
 - [VS Code](docs/debugger/vscode.md) - Setup and illustrated source debugging; [Bartman with Copperline](docs/debugger/vscode-bartman.md) covers fork installation and visual profiling

--- a/crates/copperline-web/www/netplay-diagnostics.js
+++ b/crates/copperline-web/www/netplay-diagnostics.js
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Export only enumerated states and numeric counters. SDP, candidate addresses,
+// invitation/session tokens, TURN credentials and arbitrary error text stay out.
+const states = new Set(['new', 'checking', 'connected', 'completed', 'disconnected', 'failed', 'closed',
+  'gathering', 'complete', 'stable', 'have-local-offer', 'have-remote-offer', 'have-local-pranswer',
+  'have-remote-pranswer', 'connecting', 'open', 'closing', 'waiting', 'in-progress', 'succeeded', 'frozen']);
+const types = new Set(['host', 'srflx', 'prflx', 'relay']);
+const state = value => states.has(value) ? value : 'unknown';
+const number = value => typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+const candidateType = value => types.has(value) ? value : 'unknown';
+
+export function candidateCounts(sdp = '') {
+  const counts = { host: 0, srflx: 0, prflx: 0, relay: 0 };
+  for (const line of sdp.split('\n')) {
+    if (!line.startsWith('a=candidate:')) continue;
+    const type = /\btyp (host|srflx|prflx|relay)\b/.exec(line)?.[1];
+    if (type) counts[type]++;
+  }
+  return counts;
+}
+
+export function summarizeStats(stats) {
+  const values = [...stats.values()];
+  const transport = values.find(value => value.type === 'transport');
+  const pair = stats.get(transport?.selectedCandidatePairId)
+    ?? values.find(value => value.type === 'candidate-pair' && value.nominated && value.state === 'succeeded');
+  const local = stats.get(pair?.localCandidateId);
+  const remote = stats.get(pair?.remoteCandidateId);
+  return {
+    dtls: state(transport?.dtlsState),
+    selectedPair: pair ? {
+      state: state(pair.state), local: candidateType(local?.candidateType), remote: candidateType(remote?.candidateType),
+      protocol: ['udp', 'tcp'].includes(local?.protocol) ? local.protocol : 'unknown',
+      roundTripSeconds: number(pair.currentRoundTripTime),
+      bytesSent: number(pair.bytesSent), bytesReceived: number(pair.bytesReceived),
+    } : null,
+    pairs: values.filter(value => value.type === 'candidate-pair').slice(0, 32).map(value => ({
+      state: state(value.state), nominated: value.nominated === true,
+      requestsSent: number(value.requestsSent), responsesReceived: number(value.responsesReceived),
+    })),
+  };
+}
+
+export class NetplayDiagnostics {
+  constructor() {
+    this.started = performance.now();
+    this.events = [];
+    this.connection = null;
+    this.stats = null;
+    this.pending = Promise.resolve();
+    this.iceErrors = [];
+    this.sample = 0;
+  }
+
+  record(event, pc) {
+    this.connection = {
+      peer: state(pc.connectionState), ice: state(pc.iceConnectionState),
+      gathering: state(pc.iceGatheringState), signaling: state(pc.signalingState),
+      localCandidates: candidateCounts(pc.localDescription?.sdp),
+      remoteCandidates: candidateCounts(pc.remoteDescription?.sdp),
+    };
+    // Call sites supply fixed event names. Do not accept arbitrary reason strings.
+    const kinds = ['created', 'peer-state', 'ice-state', 'gathering-state', 'signaling-state',
+      'data-open', 'data-close', 'data-error', 'ice-error', 'stopped', 'copy'];
+    if (kinds.includes(event)) this.events.push({ event, elapsedMs: Math.round(performance.now() - this.started),
+      peer: this.connection.peer, ice: this.connection.ice });
+    if (this.events.length > 40) this.events.shift();
+  }
+
+  capture(pc) {
+    if (typeof pc.getStats !== 'function' || pc.connectionState === 'closed') return this.pending;
+    // Invoke before dispose closes the connection; retain the last useful stats
+    // if the browser rejects a final sample during teardown.
+    const sample = ++this.sample;
+    try {
+      this.pending = Promise.resolve(pc.getStats()).then(stats => {
+        if (sample === this.sample) this.stats = summarizeStats(stats);
+      }).catch(() => {});
+    } catch { /* Some browsers throw synchronously during teardown. */ }
+    return this.pending;
+  }
+
+  iceError(code) {
+    if (Number.isInteger(code) && code >= 0 && code <= 999 && this.iceErrors.length < 8) this.iceErrors.push(code);
+  }
+
+  async report(pc, channel) {
+    if (pc.connectionState !== 'closed') { this.record('copy', pc); await this.capture(pc); }
+    await this.pending;
+    return {
+      format: 'copperline-netplay-diagnostics-v1',
+      browser: typeof navigator === 'undefined' ? 'test' : navigator.userAgent.slice(0, 256),
+      secureContext: globalThis.isSecureContext === true,
+      connection: this.connection,
+      channel: channel ? { state: state(channel.readyState), ordered: channel.ordered === true,
+        maxRetransmits: number(channel.maxRetransmits), bufferedAmount: number(channel.bufferedAmount) } : null,
+      stats: this.stats, iceErrorCodes: this.iceErrors.slice(), events: this.events.slice(),
+    };
+  }
+}
+
+export function connectionFailure(pc) {
+  const ice = state(pc.iceConnectionState);
+  const peer = state(pc.connectionState);
+  const stage = ice === 'failed' ? 'Network route discovery failed (ICE)'
+    : ['connected', 'completed'].includes(ice) ? 'The network route opened, but the peer transport ended'
+    : 'The peer connection ended during setup';
+  return `${stage}. ICE: ${ice}; connection: ${peer}. Copy diagnostics for a connection report.`;
+}

--- a/crates/copperline-web/www/netplay-diagnostics.test.js
+++ b/crates/copperline-web/www/netplay-diagnostics.test.js
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { NetplayDiagnostics, connectionFailure } from './netplay-diagnostics.js';
+test('diagnostics retain route and DTLS evidence after teardown without network addresses or credentials', async () => {
+  const secret = 'never-export-this';
+  const stats = new Map([
+    ['t', { type: 'transport', selectedCandidatePairId: 'p', dtlsState: 'failed', tlsVersion: secret }],
+    ['p', { type: 'candidate-pair', state: 'succeeded', nominated: true, localCandidateId: 'l', remoteCandidateId: 'r', currentRoundTripTime: 0.02, bytesSent: 12 }],
+    ['l', { type: 'local-candidate', candidateType: 'relay', protocol: 'udp', address: secret, url: secret, usernameFragment: secret }],
+    ['r', { type: 'remote-candidate', candidateType: 'host', address: secret }],
+  ]);
+  const pc = { connectionState: 'failed', iceConnectionState: 'connected', iceGatheringState: 'complete', signalingState: 'stable',
+    localDescription: { sdp: `a=candidate:${secret} 1 udp 1 ${secret} 10 typ relay\r\na=ice-pwd:${secret}` },
+    getStats: async () => stats };
+  const diagnostics = new NetplayDiagnostics();
+  diagnostics.record('peer-state', pc);
+  diagnostics.iceError(701);
+  diagnostics.iceError(secret);
+  await diagnostics.capture(pc);
+  pc.connectionState = 'closed';
+  const report = await diagnostics.report(pc, null);
+  assert.equal(report.connection.peer, 'failed');
+  assert.equal(report.connection.localCandidates.relay, 1);
+  assert.equal(report.stats.dtls, 'failed');
+  assert.equal(report.stats.selectedPair.local, 'relay');
+  assert.deepEqual(report.iceErrorCodes, [701]);
+  assert.ok(!JSON.stringify(report).includes(secret));
+  assert.match(connectionFailure(pc), /network route opened/);
+  pc.connectionState = 'failed'; pc.iceConnectionState = 'failed';
+  assert.match(connectionFailure(pc), /discovery failed/);
+  pc.getStats = () => { throw new Error(secret); };
+  await diagnostics.capture(pc);
+  assert.equal(diagnostics.stats.dtls, 'failed');
+});

--- a/crates/copperline-web/www/netplay-qr.LICENSE
+++ b/crates/copperline-web/www/netplay-qr.LICENSE
@@ -1,0 +1,24 @@
+qrcode-generator 2.0.4, dist/qrcode.mjs (unmodified).
+Source: https://github.com/kazuhikoarase/qrcode-generator
+
+MIT License
+
+Copyright (c) 2009 Kazuhiko Arase
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/copperline-web/www/netplay-qr.js
+++ b/crates/copperline-web/www/netplay-qr.js
@@ -1,0 +1,2237 @@
+//---------------------------------------------------------------------
+//
+// QR Code Generator for JavaScript
+//
+// Copyright (c) 2009 Kazuhiko Arase
+//
+// URL: http://www.d-project.com/
+//
+// Licensed under the MIT license:
+//  http://www.opensource.org/licenses/mit-license.php
+//
+// The word 'QR Code' is registered trademark of
+// DENSO WAVE INCORPORATED
+//  http://www.denso-wave.com/qrcode/faqpatent-e.html
+//
+//---------------------------------------------------------------------
+
+//---------------------------------------------------------------------
+// qrcode
+//---------------------------------------------------------------------
+
+/**
+ * qrcode
+ * @param typeNumber 1 to 40
+ * @param errorCorrectionLevel 'L','M','Q','H'
+ */
+export const qrcode = function(typeNumber, errorCorrectionLevel) {
+
+  const PAD0 = 0xEC;
+  const PAD1 = 0x11;
+
+  let _typeNumber = typeNumber;
+  const _errorCorrectionLevel = QRErrorCorrectionLevel[errorCorrectionLevel];
+  let _modules = null;
+  let _moduleCount = 0;
+  let _dataCache = null;
+  const _dataList = [];
+
+  const _this = {};
+
+  const makeImpl = function(test, maskPattern) {
+
+    _moduleCount = _typeNumber * 4 + 17;
+    _modules = function(moduleCount) {
+      const modules = new Array(moduleCount);
+      for (let row = 0; row < moduleCount; row += 1) {
+        modules[row] = new Array(moduleCount);
+        for (let col = 0; col < moduleCount; col += 1) {
+          modules[row][col] = null;
+        }
+      }
+      return modules;
+    }(_moduleCount);
+
+    setupPositionProbePattern(0, 0);
+    setupPositionProbePattern(_moduleCount - 7, 0);
+    setupPositionProbePattern(0, _moduleCount - 7);
+    setupPositionAdjustPattern();
+    setupTimingPattern();
+    setupTypeInfo(test, maskPattern);
+
+    if (_typeNumber >= 7) {
+      setupTypeNumber(test);
+    }
+
+    if (_dataCache == null) {
+      _dataCache = createData(_typeNumber, _errorCorrectionLevel, _dataList);
+    }
+
+    mapData(_dataCache, maskPattern);
+  };
+
+  const setupPositionProbePattern = function(row, col) {
+
+    for (let r = -1; r <= 7; r += 1) {
+
+      if (row + r <= -1 || _moduleCount <= row + r) continue;
+
+      for (let c = -1; c <= 7; c += 1) {
+
+        if (col + c <= -1 || _moduleCount <= col + c) continue;
+
+        if ( (0 <= r && r <= 6 && (c == 0 || c == 6) )
+            || (0 <= c && c <= 6 && (r == 0 || r == 6) )
+            || (2 <= r && r <= 4 && 2 <= c && c <= 4) ) {
+          _modules[row + r][col + c] = true;
+        } else {
+          _modules[row + r][col + c] = false;
+        }
+      }
+    }
+  };
+
+  const getBestMaskPattern = function() {
+
+    let minLostPoint = 0;
+    let pattern = 0;
+
+    for (let i = 0; i < 8; i += 1) {
+
+      makeImpl(true, i);
+
+      const lostPoint = QRUtil.getLostPoint(_this);
+
+      if (i == 0 || minLostPoint > lostPoint) {
+        minLostPoint = lostPoint;
+        pattern = i;
+      }
+    }
+
+    return pattern;
+  };
+
+  const setupTimingPattern = function() {
+
+    for (let r = 8; r < _moduleCount - 8; r += 1) {
+      if (_modules[r][6] != null) {
+        continue;
+      }
+      _modules[r][6] = (r % 2 == 0);
+    }
+
+    for (let c = 8; c < _moduleCount - 8; c += 1) {
+      if (_modules[6][c] != null) {
+        continue;
+      }
+      _modules[6][c] = (c % 2 == 0);
+    }
+  };
+
+  const setupPositionAdjustPattern = function() {
+
+    const pos = QRUtil.getPatternPosition(_typeNumber);
+
+    for (let i = 0; i < pos.length; i += 1) {
+
+      for (let j = 0; j < pos.length; j += 1) {
+
+        const row = pos[i];
+        const col = pos[j];
+
+        if (_modules[row][col] != null) {
+          continue;
+        }
+
+        for (let r = -2; r <= 2; r += 1) {
+
+          for (let c = -2; c <= 2; c += 1) {
+
+            if (r == -2 || r == 2 || c == -2 || c == 2
+                || (r == 0 && c == 0) ) {
+              _modules[row + r][col + c] = true;
+            } else {
+              _modules[row + r][col + c] = false;
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const setupTypeNumber = function(test) {
+
+    const bits = QRUtil.getBCHTypeNumber(_typeNumber);
+
+    for (let i = 0; i < 18; i += 1) {
+      const mod = (!test && ( (bits >> i) & 1) == 1);
+      _modules[Math.floor(i / 3)][i % 3 + _moduleCount - 8 - 3] = mod;
+    }
+
+    for (let i = 0; i < 18; i += 1) {
+      const mod = (!test && ( (bits >> i) & 1) == 1);
+      _modules[i % 3 + _moduleCount - 8 - 3][Math.floor(i / 3)] = mod;
+    }
+  };
+
+  const setupTypeInfo = function(test, maskPattern) {
+
+    const data = (_errorCorrectionLevel << 3) | maskPattern;
+    const bits = QRUtil.getBCHTypeInfo(data);
+
+    // vertical
+    for (let i = 0; i < 15; i += 1) {
+
+      const mod = (!test && ( (bits >> i) & 1) == 1);
+
+      if (i < 6) {
+        _modules[i][8] = mod;
+      } else if (i < 8) {
+        _modules[i + 1][8] = mod;
+      } else {
+        _modules[_moduleCount - 15 + i][8] = mod;
+      }
+    }
+
+    // horizontal
+    for (let i = 0; i < 15; i += 1) {
+
+      const mod = (!test && ( (bits >> i) & 1) == 1);
+
+      if (i < 8) {
+        _modules[8][_moduleCount - i - 1] = mod;
+      } else if (i < 9) {
+        _modules[8][15 - i - 1 + 1] = mod;
+      } else {
+        _modules[8][15 - i - 1] = mod;
+      }
+    }
+
+    // fixed module
+    _modules[_moduleCount - 8][8] = (!test);
+  };
+
+  const mapData = function(data, maskPattern) {
+
+    let inc = -1;
+    let row = _moduleCount - 1;
+    let bitIndex = 7;
+    let byteIndex = 0;
+    const maskFunc = QRUtil.getMaskFunction(maskPattern);
+
+    for (let col = _moduleCount - 1; col > 0; col -= 2) {
+
+      if (col == 6) col -= 1;
+
+      while (true) {
+
+        for (let c = 0; c < 2; c += 1) {
+
+          if (_modules[row][col - c] == null) {
+
+            let dark = false;
+
+            if (byteIndex < data.length) {
+              dark = ( ( (data[byteIndex] >>> bitIndex) & 1) == 1);
+            }
+
+            const mask = maskFunc(row, col - c);
+
+            if (mask) {
+              dark = !dark;
+            }
+
+            _modules[row][col - c] = dark;
+            bitIndex -= 1;
+
+            if (bitIndex == -1) {
+              byteIndex += 1;
+              bitIndex = 7;
+            }
+          }
+        }
+
+        row += inc;
+
+        if (row < 0 || _moduleCount <= row) {
+          row -= inc;
+          inc = -inc;
+          break;
+        }
+      }
+    }
+  };
+
+  const createBytes = function(buffer, rsBlocks) {
+
+    let offset = 0;
+
+    let maxDcCount = 0;
+    let maxEcCount = 0;
+
+    const dcdata = new Array(rsBlocks.length);
+    const ecdata = new Array(rsBlocks.length);
+
+    for (let r = 0; r < rsBlocks.length; r += 1) {
+
+      const dcCount = rsBlocks[r].dataCount;
+      const ecCount = rsBlocks[r].totalCount - dcCount;
+
+      maxDcCount = Math.max(maxDcCount, dcCount);
+      maxEcCount = Math.max(maxEcCount, ecCount);
+
+      dcdata[r] = new Array(dcCount);
+
+      for (let i = 0; i < dcdata[r].length; i += 1) {
+        dcdata[r][i] = 0xff & buffer.getBuffer()[i + offset];
+      }
+      offset += dcCount;
+
+      const rsPoly = QRUtil.getErrorCorrectPolynomial(ecCount);
+      const rawPoly = qrPolynomial(dcdata[r], rsPoly.getLength() - 1);
+
+      const modPoly = rawPoly.mod(rsPoly);
+      ecdata[r] = new Array(rsPoly.getLength() - 1);
+      for (let i = 0; i < ecdata[r].length; i += 1) {
+        const modIndex = i + modPoly.getLength() - ecdata[r].length;
+        ecdata[r][i] = (modIndex >= 0)? modPoly.getAt(modIndex) : 0;
+      }
+    }
+
+    let totalCodeCount = 0;
+    for (let i = 0; i < rsBlocks.length; i += 1) {
+      totalCodeCount += rsBlocks[i].totalCount;
+    }
+
+    const data = new Array(totalCodeCount);
+    let index = 0;
+
+    for (let i = 0; i < maxDcCount; i += 1) {
+      for (let r = 0; r < rsBlocks.length; r += 1) {
+        if (i < dcdata[r].length) {
+          data[index] = dcdata[r][i];
+          index += 1;
+        }
+      }
+    }
+
+    for (let i = 0; i < maxEcCount; i += 1) {
+      for (let r = 0; r < rsBlocks.length; r += 1) {
+        if (i < ecdata[r].length) {
+          data[index] = ecdata[r][i];
+          index += 1;
+        }
+      }
+    }
+
+    return data;
+  };
+
+  const createData = function(typeNumber, errorCorrectionLevel, dataList) {
+
+    const rsBlocks = QRRSBlock.getRSBlocks(typeNumber, errorCorrectionLevel);
+
+    const buffer = qrBitBuffer();
+
+    for (let i = 0; i < dataList.length; i += 1) {
+      const data = dataList[i];
+      buffer.put(data.getMode(), 4);
+      buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+      data.write(buffer);
+    }
+
+    // calc num max data.
+    let totalDataCount = 0;
+    for (let i = 0; i < rsBlocks.length; i += 1) {
+      totalDataCount += rsBlocks[i].dataCount;
+    }
+
+    if (buffer.getLengthInBits() > totalDataCount * 8) {
+      throw 'code length overflow. ('
+        + buffer.getLengthInBits()
+        + '>'
+        + totalDataCount * 8
+        + ')';
+    }
+
+    // end code
+    if (buffer.getLengthInBits() + 4 <= totalDataCount * 8) {
+      buffer.put(0, 4);
+    }
+
+    // padding
+    while (buffer.getLengthInBits() % 8 != 0) {
+      buffer.putBit(false);
+    }
+
+    // padding
+    while (true) {
+
+      if (buffer.getLengthInBits() >= totalDataCount * 8) {
+        break;
+      }
+      buffer.put(PAD0, 8);
+
+      if (buffer.getLengthInBits() >= totalDataCount * 8) {
+        break;
+      }
+      buffer.put(PAD1, 8);
+    }
+
+    return createBytes(buffer, rsBlocks);
+  };
+
+  _this.addData = function(data, mode) {
+
+    mode = mode || 'Byte';
+
+    let newData = null;
+
+    switch(mode) {
+    case 'Numeric' :
+      newData = qrNumber(data);
+      break;
+    case 'Alphanumeric' :
+      newData = qrAlphaNum(data);
+      break;
+    case 'Byte' :
+      newData = qr8BitByte(data);
+      break;
+    case 'Kanji' :
+      newData = qrKanji(data);
+      break;
+    default :
+      throw 'mode:' + mode;
+    }
+
+    _dataList.push(newData);
+    _dataCache = null;
+  };
+
+  _this.isDark = function(row, col) {
+    if (row < 0 || _moduleCount <= row || col < 0 || _moduleCount <= col) {
+      throw row + ',' + col;
+    }
+    return _modules[row][col];
+  };
+
+  _this.getModuleCount = function() {
+    return _moduleCount;
+  };
+
+  _this.make = function() {
+    if (_typeNumber < 1) {
+      let typeNumber = 1;
+
+      for (; typeNumber < 40; typeNumber++) {
+        const rsBlocks = QRRSBlock.getRSBlocks(typeNumber, _errorCorrectionLevel);
+        const buffer = qrBitBuffer();
+
+        for (let i = 0; i < _dataList.length; i++) {
+          const data = _dataList[i];
+          buffer.put(data.getMode(), 4);
+          buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+          data.write(buffer);
+        }
+
+        let totalDataCount = 0;
+        for (let i = 0; i < rsBlocks.length; i++) {
+          totalDataCount += rsBlocks[i].dataCount;
+        }
+
+        if (buffer.getLengthInBits() <= totalDataCount * 8) {
+          break;
+        }
+      }
+
+      _typeNumber = typeNumber;
+    }
+
+    makeImpl(false, getBestMaskPattern() );
+  };
+
+  _this.createTableTag = function(cellSize, margin) {
+
+    cellSize = cellSize || 2;
+    margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+    let qrHtml = '';
+
+    qrHtml += '<table style="';
+    qrHtml += ' border-width: 0px; border-style: none;';
+    qrHtml += ' border-collapse: collapse;';
+    qrHtml += ' padding: 0px; margin: ' + margin + 'px;';
+    qrHtml += '">';
+    qrHtml += '<tbody>';
+
+    for (let r = 0; r < _this.getModuleCount(); r += 1) {
+
+      qrHtml += '<tr>';
+
+      for (let c = 0; c < _this.getModuleCount(); c += 1) {
+        qrHtml += '<td style="';
+        qrHtml += ' border-width: 0px; border-style: none;';
+        qrHtml += ' border-collapse: collapse;';
+        qrHtml += ' padding: 0px; margin: 0px;';
+        qrHtml += ' width: ' + cellSize + 'px;';
+        qrHtml += ' height: ' + cellSize + 'px;';
+        qrHtml += ' background-color: ';
+        qrHtml += _this.isDark(r, c)? '#000000' : '#ffffff';
+        qrHtml += ';';
+        qrHtml += '"/>';
+      }
+
+      qrHtml += '</tr>';
+    }
+
+    qrHtml += '</tbody>';
+    qrHtml += '</table>';
+
+    return qrHtml;
+  };
+
+  _this.createSvgTag = function(cellSize, margin, alt, title) {
+
+    let opts = {};
+    if (typeof arguments[0] == 'object') {
+      // Called by options.
+      opts = arguments[0];
+      // overwrite cellSize and margin.
+      cellSize = opts.cellSize;
+      margin = opts.margin;
+      alt = opts.alt;
+      title = opts.title;
+    }
+
+    cellSize = cellSize || 2;
+    margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+    // Compose alt property surrogate
+    alt = (typeof alt === 'string') ? {text: alt} : alt || {};
+    alt.text = alt.text || null;
+    alt.id = (alt.text) ? alt.id || 'qrcode-description' : null;
+
+    // Compose title property surrogate
+    title = (typeof title === 'string') ? {text: title} : title || {};
+    title.text = title.text || null;
+    title.id = (title.text) ? title.id || 'qrcode-title' : null;
+
+    const size = _this.getModuleCount() * cellSize + margin * 2;
+    let c, mc, r, mr, qrSvg='', rect;
+
+    rect = 'l' + cellSize + ',0 0,' + cellSize +
+      ' -' + cellSize + ',0 0,-' + cellSize + 'z ';
+
+    qrSvg += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"';
+    qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
+    qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
+    qrSvg += ' preserveAspectRatio="xMinYMin meet"';
+    qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
+        escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
+    qrSvg += '>';
+    qrSvg += (title.text) ? '<title id="' + escapeXml(title.id) + '">' +
+        escapeXml(title.text) + '</title>' : '';
+    qrSvg += (alt.text) ? '<description id="' + escapeXml(alt.id) + '">' +
+        escapeXml(alt.text) + '</description>' : '';
+    qrSvg += '<rect width="100%" height="100%" fill="white" cx="0" cy="0"/>';
+    qrSvg += '<path d="';
+
+    for (r = 0; r < _this.getModuleCount(); r += 1) {
+      mr = r * cellSize + margin;
+      for (c = 0; c < _this.getModuleCount(); c += 1) {
+        if (_this.isDark(r, c) ) {
+          mc = c*cellSize+margin;
+          qrSvg += 'M' + mc + ',' + mr + rect;
+        }
+      }
+    }
+
+    qrSvg += '" stroke="transparent" fill="black"/>';
+    qrSvg += '</svg>';
+
+    return qrSvg;
+  };
+
+  _this.createDataURL = function(cellSize, margin) {
+
+    cellSize = cellSize || 2;
+    margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+    const size = _this.getModuleCount() * cellSize + margin * 2;
+    const min = margin;
+    const max = size - margin;
+
+    return createDataURL(size, size, function(x, y) {
+      if (min <= x && x < max && min <= y && y < max) {
+        const c = Math.floor( (x - min) / cellSize);
+        const r = Math.floor( (y - min) / cellSize);
+        return _this.isDark(r, c)? 0 : 1;
+      } else {
+        return 1;
+      }
+    } );
+  };
+
+  _this.createImgTag = function(cellSize, margin, alt) {
+
+    cellSize = cellSize || 2;
+    margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+    const size = _this.getModuleCount() * cellSize + margin * 2;
+
+    let img = '';
+    img += '<img';
+    img += '\u0020src="';
+    img += _this.createDataURL(cellSize, margin);
+    img += '"';
+    img += '\u0020width="';
+    img += size;
+    img += '"';
+    img += '\u0020height="';
+    img += size;
+    img += '"';
+    if (alt) {
+      img += '\u0020alt="';
+      img += escapeXml(alt);
+      img += '"';
+    }
+    img += '/>';
+
+    return img;
+  };
+
+  const escapeXml = function(s) {
+    let escaped = '';
+    for (let i = 0; i < s.length; i += 1) {
+      const c = s.charAt(i);
+      switch(c) {
+      case '<': escaped += '&lt;'; break;
+      case '>': escaped += '&gt;'; break;
+      case '&': escaped += '&amp;'; break;
+      case '"': escaped += '&quot;'; break;
+      default : escaped += c; break;
+      }
+    }
+    return escaped;
+  };
+
+  const _createHalfASCII = function(margin) {
+    const cellSize = 1;
+    margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+    const size = _this.getModuleCount() * cellSize + margin * 2;
+    const min = margin;
+    const max = size - margin;
+
+    let y, x, r1, r2, p;
+
+    const blocks = {
+      '██': '█',
+      '█ ': '▀',
+      ' █': '▄',
+      '  ': ' '
+    };
+
+    const blocksLastLineNoMargin = {
+      '██': '▀',
+      '█ ': '▀',
+      ' █': ' ',
+      '  ': ' '
+    };
+
+    let ascii = '';
+    for (y = 0; y < size; y += 2) {
+      r1 = Math.floor((y - min) / cellSize);
+      r2 = Math.floor((y + 1 - min) / cellSize);
+      for (x = 0; x < size; x += 1) {
+        p = '█';
+
+        if (min <= x && x < max && min <= y && y < max && _this.isDark(r1, Math.floor((x - min) / cellSize))) {
+          p = ' ';
+        }
+
+        if (min <= x && x < max && min <= y+1 && y+1 < max && _this.isDark(r2, Math.floor((x - min) / cellSize))) {
+          p += ' ';
+        }
+        else {
+          p += '█';
+        }
+
+        // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+        ascii += (margin < 1 && y+1 >= max) ? blocksLastLineNoMargin[p] : blocks[p];
+      }
+
+      ascii += '\n';
+    }
+
+    if (size % 2 && margin > 0) {
+      return ascii.substring(0, ascii.length - size - 1) + Array(size+1).join('▀');
+    }
+
+    return ascii.substring(0, ascii.length-1);
+  };
+
+  _this.createASCII = function(cellSize, margin) {
+    cellSize = cellSize || 1;
+
+    if (cellSize < 2) {
+      return _createHalfASCII(margin);
+    }
+
+    cellSize -= 1;
+    margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+    const size = _this.getModuleCount() * cellSize + margin * 2;
+    const min = margin;
+    const max = size - margin;
+
+    let y, x, r, p;
+
+    const white = Array(cellSize+1).join('██');
+    const black = Array(cellSize+1).join('  ');
+
+    let ascii = '';
+    let line = '';
+    for (y = 0; y < size; y += 1) {
+      r = Math.floor( (y - min) / cellSize);
+      line = '';
+      for (x = 0; x < size; x += 1) {
+        p = 1;
+
+        if (min <= x && x < max && min <= y && y < max && _this.isDark(r, Math.floor((x - min) / cellSize))) {
+          p = 0;
+        }
+
+        // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+        line += p ? white : black;
+      }
+
+      for (r = 0; r < cellSize; r += 1) {
+        ascii += line + '\n';
+      }
+    }
+
+    return ascii.substring(0, ascii.length-1);
+  };
+
+  _this.renderTo2dContext = function(context, cellSize) {
+    cellSize = cellSize || 2;
+    const length = _this.getModuleCount();
+    for (let row = 0; row < length; row++) {
+      for (let col = 0; col < length; col++) {
+        context.fillStyle = _this.isDark(row, col) ? 'black' : 'white';
+        context.fillRect(col * cellSize, row * cellSize, cellSize, cellSize);
+      }
+    }
+  }
+
+  return _this;
+};
+
+//---------------------------------------------------------------------
+// qrcode.stringToBytes
+//---------------------------------------------------------------------
+
+qrcode.stringToBytes = function(s) {
+  const bytes = [];
+  for (let i = 0; i < s.length; i += 1) {
+    const c = s.charCodeAt(i);
+    bytes.push(c & 0xff);
+  }
+  return bytes;
+};
+
+//---------------------------------------------------------------------
+// qrcode.createStringToBytes
+//---------------------------------------------------------------------
+
+/**
+ * @param unicodeData base64 string of byte array.
+ * [16bit Unicode],[16bit Bytes], ...
+ * @param numChars
+ */
+qrcode.createStringToBytes = function(unicodeData, numChars) {
+
+  // create conversion map.
+
+  const unicodeMap = function() {
+
+    const bin = base64DecodeInputStream(unicodeData);
+    const read = function() {
+      const b = bin.read();
+      if (b == -1) throw 'eof';
+      return b;
+    };
+
+    let count = 0;
+    const unicodeMap = {};
+    while (true) {
+      const b0 = bin.read();
+      if (b0 == -1) break;
+      const b1 = read();
+      const b2 = read();
+      const b3 = read();
+      const k = String.fromCharCode( (b0 << 8) | b1);
+      const v = (b2 << 8) | b3;
+      unicodeMap[k] = v;
+      count += 1;
+    }
+    if (count != numChars) {
+      throw count + ' != ' + numChars;
+    }
+
+    return unicodeMap;
+  }();
+
+  const unknownChar = '?'.charCodeAt(0);
+
+  return function(s) {
+    const bytes = [];
+    for (let i = 0; i < s.length; i += 1) {
+      const c = s.charCodeAt(i);
+      if (c < 128) {
+        bytes.push(c);
+      } else {
+        const b = unicodeMap[s.charAt(i)];
+        if (typeof b == 'number') {
+          if ( (b & 0xff) == b) {
+            // 1byte
+            bytes.push(b);
+          } else {
+            // 2bytes
+            bytes.push(b >>> 8);
+            bytes.push(b & 0xff);
+          }
+        } else {
+          bytes.push(unknownChar);
+        }
+      }
+    }
+    return bytes;
+  };
+};
+
+//---------------------------------------------------------------------
+// QRMode
+//---------------------------------------------------------------------
+
+const QRMode = {
+  MODE_NUMBER :    1 << 0,
+  MODE_ALPHA_NUM : 1 << 1,
+  MODE_8BIT_BYTE : 1 << 2,
+  MODE_KANJI :     1 << 3
+};
+
+//---------------------------------------------------------------------
+// QRErrorCorrectionLevel
+//---------------------------------------------------------------------
+
+const QRErrorCorrectionLevel = {
+  L : 1,
+  M : 0,
+  Q : 3,
+  H : 2
+};
+
+//---------------------------------------------------------------------
+// QRMaskPattern
+//---------------------------------------------------------------------
+
+const QRMaskPattern = {
+  PATTERN000 : 0,
+  PATTERN001 : 1,
+  PATTERN010 : 2,
+  PATTERN011 : 3,
+  PATTERN100 : 4,
+  PATTERN101 : 5,
+  PATTERN110 : 6,
+  PATTERN111 : 7
+};
+
+//---------------------------------------------------------------------
+// QRUtil
+//---------------------------------------------------------------------
+
+const QRUtil = function() {
+
+  const PATTERN_POSITION_TABLE = [
+    [],
+    [6, 18],
+    [6, 22],
+    [6, 26],
+    [6, 30],
+    [6, 34],
+    [6, 22, 38],
+    [6, 24, 42],
+    [6, 26, 46],
+    [6, 28, 50],
+    [6, 30, 54],
+    [6, 32, 58],
+    [6, 34, 62],
+    [6, 26, 46, 66],
+    [6, 26, 48, 70],
+    [6, 26, 50, 74],
+    [6, 30, 54, 78],
+    [6, 30, 56, 82],
+    [6, 30, 58, 86],
+    [6, 34, 62, 90],
+    [6, 28, 50, 72, 94],
+    [6, 26, 50, 74, 98],
+    [6, 30, 54, 78, 102],
+    [6, 28, 54, 80, 106],
+    [6, 32, 58, 84, 110],
+    [6, 30, 58, 86, 114],
+    [6, 34, 62, 90, 118],
+    [6, 26, 50, 74, 98, 122],
+    [6, 30, 54, 78, 102, 126],
+    [6, 26, 52, 78, 104, 130],
+    [6, 30, 56, 82, 108, 134],
+    [6, 34, 60, 86, 112, 138],
+    [6, 30, 58, 86, 114, 142],
+    [6, 34, 62, 90, 118, 146],
+    [6, 30, 54, 78, 102, 126, 150],
+    [6, 24, 50, 76, 102, 128, 154],
+    [6, 28, 54, 80, 106, 132, 158],
+    [6, 32, 58, 84, 110, 136, 162],
+    [6, 26, 54, 82, 110, 138, 166],
+    [6, 30, 58, 86, 114, 142, 170]
+  ];
+  const G15 = (1 << 10) | (1 << 8) | (1 << 5) | (1 << 4) | (1 << 2) | (1 << 1) | (1 << 0);
+  const G18 = (1 << 12) | (1 << 11) | (1 << 10) | (1 << 9) | (1 << 8) | (1 << 5) | (1 << 2) | (1 << 0);
+  const G15_MASK = (1 << 14) | (1 << 12) | (1 << 10) | (1 << 4) | (1 << 1);
+
+  const _this = {};
+
+  const getBCHDigit = function(data) {
+    let digit = 0;
+    while (data != 0) {
+      digit += 1;
+      data >>>= 1;
+    }
+    return digit;
+  };
+
+  _this.getBCHTypeInfo = function(data) {
+    let d = data << 10;
+    while (getBCHDigit(d) - getBCHDigit(G15) >= 0) {
+      d ^= (G15 << (getBCHDigit(d) - getBCHDigit(G15) ) );
+    }
+    return ( (data << 10) | d) ^ G15_MASK;
+  };
+
+  _this.getBCHTypeNumber = function(data) {
+    let d = data << 12;
+    while (getBCHDigit(d) - getBCHDigit(G18) >= 0) {
+      d ^= (G18 << (getBCHDigit(d) - getBCHDigit(G18) ) );
+    }
+    return (data << 12) | d;
+  };
+
+  _this.getPatternPosition = function(typeNumber) {
+    return PATTERN_POSITION_TABLE[typeNumber - 1];
+  };
+
+  _this.getMaskFunction = function(maskPattern) {
+
+    switch (maskPattern) {
+
+    case QRMaskPattern.PATTERN000 :
+      return function(i, j) { return (i + j) % 2 == 0; };
+    case QRMaskPattern.PATTERN001 :
+      return function(i, j) { return i % 2 == 0; };
+    case QRMaskPattern.PATTERN010 :
+      return function(i, j) { return j % 3 == 0; };
+    case QRMaskPattern.PATTERN011 :
+      return function(i, j) { return (i + j) % 3 == 0; };
+    case QRMaskPattern.PATTERN100 :
+      return function(i, j) { return (Math.floor(i / 2) + Math.floor(j / 3) ) % 2 == 0; };
+    case QRMaskPattern.PATTERN101 :
+      return function(i, j) { return (i * j) % 2 + (i * j) % 3 == 0; };
+    case QRMaskPattern.PATTERN110 :
+      return function(i, j) { return ( (i * j) % 2 + (i * j) % 3) % 2 == 0; };
+    case QRMaskPattern.PATTERN111 :
+      return function(i, j) { return ( (i * j) % 3 + (i + j) % 2) % 2 == 0; };
+
+    default :
+      throw 'bad maskPattern:' + maskPattern;
+    }
+  };
+
+  _this.getErrorCorrectPolynomial = function(errorCorrectLength) {
+    let a = qrPolynomial([1], 0);
+    for (let i = 0; i < errorCorrectLength; i += 1) {
+      a = a.multiply(qrPolynomial([1, QRMath.gexp(i)], 0) );
+    }
+    return a;
+  };
+
+  _this.getLengthInBits = function(mode, type) {
+
+    if (1 <= type && type < 10) {
+
+      // 1 - 9
+
+      switch(mode) {
+      case QRMode.MODE_NUMBER    : return 10;
+      case QRMode.MODE_ALPHA_NUM : return 9;
+      case QRMode.MODE_8BIT_BYTE : return 8;
+      case QRMode.MODE_KANJI     : return 8;
+      default :
+        throw 'mode:' + mode;
+      }
+
+    } else if (type < 27) {
+
+      // 10 - 26
+
+      switch(mode) {
+      case QRMode.MODE_NUMBER    : return 12;
+      case QRMode.MODE_ALPHA_NUM : return 11;
+      case QRMode.MODE_8BIT_BYTE : return 16;
+      case QRMode.MODE_KANJI     : return 10;
+      default :
+        throw 'mode:' + mode;
+      }
+
+    } else if (type < 41) {
+
+      // 27 - 40
+
+      switch(mode) {
+      case QRMode.MODE_NUMBER    : return 14;
+      case QRMode.MODE_ALPHA_NUM : return 13;
+      case QRMode.MODE_8BIT_BYTE : return 16;
+      case QRMode.MODE_KANJI     : return 12;
+      default :
+        throw 'mode:' + mode;
+      }
+
+    } else {
+      throw 'type:' + type;
+    }
+  };
+
+  _this.getLostPoint = function(qrcode) {
+
+    const moduleCount = qrcode.getModuleCount();
+
+    let lostPoint = 0;
+
+    // LEVEL1
+
+    for (let row = 0; row < moduleCount; row += 1) {
+      for (let col = 0; col < moduleCount; col += 1) {
+
+        let sameCount = 0;
+        const dark = qrcode.isDark(row, col);
+
+        for (let r = -1; r <= 1; r += 1) {
+
+          if (row + r < 0 || moduleCount <= row + r) {
+            continue;
+          }
+
+          for (let c = -1; c <= 1; c += 1) {
+
+            if (col + c < 0 || moduleCount <= col + c) {
+              continue;
+            }
+
+            if (r == 0 && c == 0) {
+              continue;
+            }
+
+            if (dark == qrcode.isDark(row + r, col + c) ) {
+              sameCount += 1;
+            }
+          }
+        }
+
+        if (sameCount > 5) {
+          lostPoint += (3 + sameCount - 5);
+        }
+      }
+    };
+
+    // LEVEL2
+
+    for (let row = 0; row < moduleCount - 1; row += 1) {
+      for (let col = 0; col < moduleCount - 1; col += 1) {
+        let count = 0;
+        if (qrcode.isDark(row, col) ) count += 1;
+        if (qrcode.isDark(row + 1, col) ) count += 1;
+        if (qrcode.isDark(row, col + 1) ) count += 1;
+        if (qrcode.isDark(row + 1, col + 1) ) count += 1;
+        if (count == 0 || count == 4) {
+          lostPoint += 3;
+        }
+      }
+    }
+
+    // LEVEL3
+
+    for (let row = 0; row < moduleCount; row += 1) {
+      for (let col = 0; col < moduleCount - 6; col += 1) {
+        if (qrcode.isDark(row, col)
+            && !qrcode.isDark(row, col + 1)
+            &&  qrcode.isDark(row, col + 2)
+            &&  qrcode.isDark(row, col + 3)
+            &&  qrcode.isDark(row, col + 4)
+            && !qrcode.isDark(row, col + 5)
+            &&  qrcode.isDark(row, col + 6) ) {
+          lostPoint += 40;
+        }
+      }
+    }
+
+    for (let col = 0; col < moduleCount; col += 1) {
+      for (let row = 0; row < moduleCount - 6; row += 1) {
+        if (qrcode.isDark(row, col)
+            && !qrcode.isDark(row + 1, col)
+            &&  qrcode.isDark(row + 2, col)
+            &&  qrcode.isDark(row + 3, col)
+            &&  qrcode.isDark(row + 4, col)
+            && !qrcode.isDark(row + 5, col)
+            &&  qrcode.isDark(row + 6, col) ) {
+          lostPoint += 40;
+        }
+      }
+    }
+
+    // LEVEL4
+
+    let darkCount = 0;
+
+    for (let col = 0; col < moduleCount; col += 1) {
+      for (let row = 0; row < moduleCount; row += 1) {
+        if (qrcode.isDark(row, col) ) {
+          darkCount += 1;
+        }
+      }
+    }
+
+    const ratio = Math.abs(100 * darkCount / moduleCount / moduleCount - 50) / 5;
+    lostPoint += ratio * 10;
+
+    return lostPoint;
+  };
+
+  return _this;
+}();
+
+//---------------------------------------------------------------------
+// QRMath
+//---------------------------------------------------------------------
+
+const QRMath = function() {
+
+  const EXP_TABLE = new Array(256);
+  const LOG_TABLE = new Array(256);
+
+  // initialize tables
+  for (let i = 0; i < 8; i += 1) {
+    EXP_TABLE[i] = 1 << i;
+  }
+  for (let i = 8; i < 256; i += 1) {
+    EXP_TABLE[i] = EXP_TABLE[i - 4]
+      ^ EXP_TABLE[i - 5]
+      ^ EXP_TABLE[i - 6]
+      ^ EXP_TABLE[i - 8];
+  }
+  for (let i = 0; i < 255; i += 1) {
+    LOG_TABLE[EXP_TABLE[i] ] = i;
+  }
+
+  const _this = {};
+
+  _this.glog = function(n) {
+
+    if (n < 1) {
+      throw 'glog(' + n + ')';
+    }
+
+    return LOG_TABLE[n];
+  };
+
+  _this.gexp = function(n) {
+
+    while (n < 0) {
+      n += 255;
+    }
+
+    while (n >= 256) {
+      n -= 255;
+    }
+
+    return EXP_TABLE[n];
+  };
+
+  return _this;
+}();
+
+//---------------------------------------------------------------------
+// qrPolynomial
+//---------------------------------------------------------------------
+
+const qrPolynomial = function(num, shift) {
+
+  if (typeof num.length == 'undefined') {
+    throw num.length + '/' + shift;
+  }
+
+  const _num = function() {
+    let offset = 0;
+    while (offset < num.length && num[offset] == 0) {
+      offset += 1;
+    }
+    const _num = new Array(num.length - offset + shift);
+    for (let i = 0; i < num.length - offset; i += 1) {
+      _num[i] = num[i + offset];
+    }
+    return _num;
+  }();
+
+  const _this = {};
+
+  _this.getAt = function(index) {
+    return _num[index];
+  };
+
+  _this.getLength = function() {
+    return _num.length;
+  };
+
+  _this.multiply = function(e) {
+
+    const num = new Array(_this.getLength() + e.getLength() - 1);
+
+    for (let i = 0; i < _this.getLength(); i += 1) {
+      for (let j = 0; j < e.getLength(); j += 1) {
+        num[i + j] ^= QRMath.gexp(QRMath.glog(_this.getAt(i) ) + QRMath.glog(e.getAt(j) ) );
+      }
+    }
+
+    return qrPolynomial(num, 0);
+  };
+
+  _this.mod = function(e) {
+
+    if (_this.getLength() - e.getLength() < 0) {
+      return _this;
+    }
+
+    const ratio = QRMath.glog(_this.getAt(0) ) - QRMath.glog(e.getAt(0) );
+
+    const num = new Array(_this.getLength() );
+    for (let i = 0; i < _this.getLength(); i += 1) {
+      num[i] = _this.getAt(i);
+    }
+
+    for (let i = 0; i < e.getLength(); i += 1) {
+      num[i] ^= QRMath.gexp(QRMath.glog(e.getAt(i) ) + ratio);
+    }
+
+    // recursive call
+    return qrPolynomial(num, 0).mod(e);
+  };
+
+  return _this;
+};
+
+//---------------------------------------------------------------------
+// QRRSBlock
+//---------------------------------------------------------------------
+
+const QRRSBlock = function() {
+
+  const RS_BLOCK_TABLE = [
+
+    // L
+    // M
+    // Q
+    // H
+
+    // 1
+    [1, 26, 19],
+    [1, 26, 16],
+    [1, 26, 13],
+    [1, 26, 9],
+
+    // 2
+    [1, 44, 34],
+    [1, 44, 28],
+    [1, 44, 22],
+    [1, 44, 16],
+
+    // 3
+    [1, 70, 55],
+    [1, 70, 44],
+    [2, 35, 17],
+    [2, 35, 13],
+
+    // 4
+    [1, 100, 80],
+    [2, 50, 32],
+    [2, 50, 24],
+    [4, 25, 9],
+
+    // 5
+    [1, 134, 108],
+    [2, 67, 43],
+    [2, 33, 15, 2, 34, 16],
+    [2, 33, 11, 2, 34, 12],
+
+    // 6
+    [2, 86, 68],
+    [4, 43, 27],
+    [4, 43, 19],
+    [4, 43, 15],
+
+    // 7
+    [2, 98, 78],
+    [4, 49, 31],
+    [2, 32, 14, 4, 33, 15],
+    [4, 39, 13, 1, 40, 14],
+
+    // 8
+    [2, 121, 97],
+    [2, 60, 38, 2, 61, 39],
+    [4, 40, 18, 2, 41, 19],
+    [4, 40, 14, 2, 41, 15],
+
+    // 9
+    [2, 146, 116],
+    [3, 58, 36, 2, 59, 37],
+    [4, 36, 16, 4, 37, 17],
+    [4, 36, 12, 4, 37, 13],
+
+    // 10
+    [2, 86, 68, 2, 87, 69],
+    [4, 69, 43, 1, 70, 44],
+    [6, 43, 19, 2, 44, 20],
+    [6, 43, 15, 2, 44, 16],
+
+    // 11
+    [4, 101, 81],
+    [1, 80, 50, 4, 81, 51],
+    [4, 50, 22, 4, 51, 23],
+    [3, 36, 12, 8, 37, 13],
+
+    // 12
+    [2, 116, 92, 2, 117, 93],
+    [6, 58, 36, 2, 59, 37],
+    [4, 46, 20, 6, 47, 21],
+    [7, 42, 14, 4, 43, 15],
+
+    // 13
+    [4, 133, 107],
+    [8, 59, 37, 1, 60, 38],
+    [8, 44, 20, 4, 45, 21],
+    [12, 33, 11, 4, 34, 12],
+
+    // 14
+    [3, 145, 115, 1, 146, 116],
+    [4, 64, 40, 5, 65, 41],
+    [11, 36, 16, 5, 37, 17],
+    [11, 36, 12, 5, 37, 13],
+
+    // 15
+    [5, 109, 87, 1, 110, 88],
+    [5, 65, 41, 5, 66, 42],
+    [5, 54, 24, 7, 55, 25],
+    [11, 36, 12, 7, 37, 13],
+
+    // 16
+    [5, 122, 98, 1, 123, 99],
+    [7, 73, 45, 3, 74, 46],
+    [15, 43, 19, 2, 44, 20],
+    [3, 45, 15, 13, 46, 16],
+
+    // 17
+    [1, 135, 107, 5, 136, 108],
+    [10, 74, 46, 1, 75, 47],
+    [1, 50, 22, 15, 51, 23],
+    [2, 42, 14, 17, 43, 15],
+
+    // 18
+    [5, 150, 120, 1, 151, 121],
+    [9, 69, 43, 4, 70, 44],
+    [17, 50, 22, 1, 51, 23],
+    [2, 42, 14, 19, 43, 15],
+
+    // 19
+    [3, 141, 113, 4, 142, 114],
+    [3, 70, 44, 11, 71, 45],
+    [17, 47, 21, 4, 48, 22],
+    [9, 39, 13, 16, 40, 14],
+
+    // 20
+    [3, 135, 107, 5, 136, 108],
+    [3, 67, 41, 13, 68, 42],
+    [15, 54, 24, 5, 55, 25],
+    [15, 43, 15, 10, 44, 16],
+
+    // 21
+    [4, 144, 116, 4, 145, 117],
+    [17, 68, 42],
+    [17, 50, 22, 6, 51, 23],
+    [19, 46, 16, 6, 47, 17],
+
+    // 22
+    [2, 139, 111, 7, 140, 112],
+    [17, 74, 46],
+    [7, 54, 24, 16, 55, 25],
+    [34, 37, 13],
+
+    // 23
+    [4, 151, 121, 5, 152, 122],
+    [4, 75, 47, 14, 76, 48],
+    [11, 54, 24, 14, 55, 25],
+    [16, 45, 15, 14, 46, 16],
+
+    // 24
+    [6, 147, 117, 4, 148, 118],
+    [6, 73, 45, 14, 74, 46],
+    [11, 54, 24, 16, 55, 25],
+    [30, 46, 16, 2, 47, 17],
+
+    // 25
+    [8, 132, 106, 4, 133, 107],
+    [8, 75, 47, 13, 76, 48],
+    [7, 54, 24, 22, 55, 25],
+    [22, 45, 15, 13, 46, 16],
+
+    // 26
+    [10, 142, 114, 2, 143, 115],
+    [19, 74, 46, 4, 75, 47],
+    [28, 50, 22, 6, 51, 23],
+    [33, 46, 16, 4, 47, 17],
+
+    // 27
+    [8, 152, 122, 4, 153, 123],
+    [22, 73, 45, 3, 74, 46],
+    [8, 53, 23, 26, 54, 24],
+    [12, 45, 15, 28, 46, 16],
+
+    // 28
+    [3, 147, 117, 10, 148, 118],
+    [3, 73, 45, 23, 74, 46],
+    [4, 54, 24, 31, 55, 25],
+    [11, 45, 15, 31, 46, 16],
+
+    // 29
+    [7, 146, 116, 7, 147, 117],
+    [21, 73, 45, 7, 74, 46],
+    [1, 53, 23, 37, 54, 24],
+    [19, 45, 15, 26, 46, 16],
+
+    // 30
+    [5, 145, 115, 10, 146, 116],
+    [19, 75, 47, 10, 76, 48],
+    [15, 54, 24, 25, 55, 25],
+    [23, 45, 15, 25, 46, 16],
+
+    // 31
+    [13, 145, 115, 3, 146, 116],
+    [2, 74, 46, 29, 75, 47],
+    [42, 54, 24, 1, 55, 25],
+    [23, 45, 15, 28, 46, 16],
+
+    // 32
+    [17, 145, 115],
+    [10, 74, 46, 23, 75, 47],
+    [10, 54, 24, 35, 55, 25],
+    [19, 45, 15, 35, 46, 16],
+
+    // 33
+    [17, 145, 115, 1, 146, 116],
+    [14, 74, 46, 21, 75, 47],
+    [29, 54, 24, 19, 55, 25],
+    [11, 45, 15, 46, 46, 16],
+
+    // 34
+    [13, 145, 115, 6, 146, 116],
+    [14, 74, 46, 23, 75, 47],
+    [44, 54, 24, 7, 55, 25],
+    [59, 46, 16, 1, 47, 17],
+
+    // 35
+    [12, 151, 121, 7, 152, 122],
+    [12, 75, 47, 26, 76, 48],
+    [39, 54, 24, 14, 55, 25],
+    [22, 45, 15, 41, 46, 16],
+
+    // 36
+    [6, 151, 121, 14, 152, 122],
+    [6, 75, 47, 34, 76, 48],
+    [46, 54, 24, 10, 55, 25],
+    [2, 45, 15, 64, 46, 16],
+
+    // 37
+    [17, 152, 122, 4, 153, 123],
+    [29, 74, 46, 14, 75, 47],
+    [49, 54, 24, 10, 55, 25],
+    [24, 45, 15, 46, 46, 16],
+
+    // 38
+    [4, 152, 122, 18, 153, 123],
+    [13, 74, 46, 32, 75, 47],
+    [48, 54, 24, 14, 55, 25],
+    [42, 45, 15, 32, 46, 16],
+
+    // 39
+    [20, 147, 117, 4, 148, 118],
+    [40, 75, 47, 7, 76, 48],
+    [43, 54, 24, 22, 55, 25],
+    [10, 45, 15, 67, 46, 16],
+
+    // 40
+    [19, 148, 118, 6, 149, 119],
+    [18, 75, 47, 31, 76, 48],
+    [34, 54, 24, 34, 55, 25],
+    [20, 45, 15, 61, 46, 16]
+  ];
+
+  const qrRSBlock = function(totalCount, dataCount) {
+    const _this = {};
+    _this.totalCount = totalCount;
+    _this.dataCount = dataCount;
+    return _this;
+  };
+
+  const _this = {};
+
+  const getRsBlockTable = function(typeNumber, errorCorrectionLevel) {
+
+    switch(errorCorrectionLevel) {
+    case QRErrorCorrectionLevel.L :
+      return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 0];
+    case QRErrorCorrectionLevel.M :
+      return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 1];
+    case QRErrorCorrectionLevel.Q :
+      return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 2];
+    case QRErrorCorrectionLevel.H :
+      return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 3];
+    default :
+      return undefined;
+    }
+  };
+
+  _this.getRSBlocks = function(typeNumber, errorCorrectionLevel) {
+
+    const rsBlock = getRsBlockTable(typeNumber, errorCorrectionLevel);
+
+    if (typeof rsBlock == 'undefined') {
+      throw 'bad rs block @ typeNumber:' + typeNumber +
+          '/errorCorrectionLevel:' + errorCorrectionLevel;
+    }
+
+    const length = rsBlock.length / 3;
+
+    const list = [];
+
+    for (let i = 0; i < length; i += 1) {
+
+      const count = rsBlock[i * 3 + 0];
+      const totalCount = rsBlock[i * 3 + 1];
+      const dataCount = rsBlock[i * 3 + 2];
+
+      for (let j = 0; j < count; j += 1) {
+        list.push(qrRSBlock(totalCount, dataCount) );
+      }
+    }
+
+    return list;
+  };
+
+  return _this;
+}();
+
+//---------------------------------------------------------------------
+// qrBitBuffer
+//---------------------------------------------------------------------
+
+const qrBitBuffer = function() {
+
+  const _buffer = [];
+  let _length = 0;
+
+  const _this = {};
+
+  _this.getBuffer = function() {
+    return _buffer;
+  };
+
+  _this.getAt = function(index) {
+    const bufIndex = Math.floor(index / 8);
+    return ( (_buffer[bufIndex] >>> (7 - index % 8) ) & 1) == 1;
+  };
+
+  _this.put = function(num, length) {
+    for (let i = 0; i < length; i += 1) {
+      _this.putBit( ( (num >>> (length - i - 1) ) & 1) == 1);
+    }
+  };
+
+  _this.getLengthInBits = function() {
+    return _length;
+  };
+
+  _this.putBit = function(bit) {
+
+    const bufIndex = Math.floor(_length / 8);
+    if (_buffer.length <= bufIndex) {
+      _buffer.push(0);
+    }
+
+    if (bit) {
+      _buffer[bufIndex] |= (0x80 >>> (_length % 8) );
+    }
+
+    _length += 1;
+  };
+
+  return _this;
+};
+
+//---------------------------------------------------------------------
+// qrNumber
+//---------------------------------------------------------------------
+
+const qrNumber = function(data) {
+
+  const _mode = QRMode.MODE_NUMBER;
+  const _data = data;
+
+  const _this = {};
+
+  _this.getMode = function() {
+    return _mode;
+  };
+
+  _this.getLength = function(buffer) {
+    return _data.length;
+  };
+
+  _this.write = function(buffer) {
+
+    const data = _data;
+
+    let i = 0;
+
+    while (i + 2 < data.length) {
+      buffer.put(strToNum(data.substring(i, i + 3) ), 10);
+      i += 3;
+    }
+
+    if (i < data.length) {
+      if (data.length - i == 1) {
+        buffer.put(strToNum(data.substring(i, i + 1) ), 4);
+      } else if (data.length - i == 2) {
+        buffer.put(strToNum(data.substring(i, i + 2) ), 7);
+      }
+    }
+  };
+
+  const strToNum = function(s) {
+    let num = 0;
+    for (let i = 0; i < s.length; i += 1) {
+      num = num * 10 + chatToNum(s.charAt(i) );
+    }
+    return num;
+  };
+
+  const chatToNum = function(c) {
+    if ('0' <= c && c <= '9') {
+      return c.charCodeAt(0) - '0'.charCodeAt(0);
+    }
+    throw 'illegal char :' + c;
+  };
+
+  return _this;
+};
+
+//---------------------------------------------------------------------
+// qrAlphaNum
+//---------------------------------------------------------------------
+
+const qrAlphaNum = function(data) {
+
+  const _mode = QRMode.MODE_ALPHA_NUM;
+  const _data = data;
+
+  const _this = {};
+
+  _this.getMode = function() {
+    return _mode;
+  };
+
+  _this.getLength = function(buffer) {
+    return _data.length;
+  };
+
+  _this.write = function(buffer) {
+
+    const s = _data;
+
+    let i = 0;
+
+    while (i + 1 < s.length) {
+      buffer.put(
+        getCode(s.charAt(i) ) * 45 +
+        getCode(s.charAt(i + 1) ), 11);
+      i += 2;
+    }
+
+    if (i < s.length) {
+      buffer.put(getCode(s.charAt(i) ), 6);
+    }
+  };
+
+  const getCode = function(c) {
+
+    if ('0' <= c && c <= '9') {
+      return c.charCodeAt(0) - '0'.charCodeAt(0);
+    } else if ('A' <= c && c <= 'Z') {
+      return c.charCodeAt(0) - 'A'.charCodeAt(0) + 10;
+    } else {
+      switch (c) {
+      case '\u0020' : return 36;
+      case '$' : return 37;
+      case '%' : return 38;
+      case '*' : return 39;
+      case '+' : return 40;
+      case '-' : return 41;
+      case '.' : return 42;
+      case '/' : return 43;
+      case ':' : return 44;
+      default :
+        throw 'illegal char :' + c;
+      }
+    }
+  };
+
+  return _this;
+};
+
+//---------------------------------------------------------------------
+// qr8BitByte
+//---------------------------------------------------------------------
+
+const qr8BitByte = function(data) {
+
+  const _mode = QRMode.MODE_8BIT_BYTE;
+  const _data = data;
+  const _bytes = qrcode.stringToBytes(data);
+
+  const _this = {};
+
+  _this.getMode = function() {
+    return _mode;
+  };
+
+  _this.getLength = function(buffer) {
+    return _bytes.length;
+  };
+
+  _this.write = function(buffer) {
+    for (let i = 0; i < _bytes.length; i += 1) {
+      buffer.put(_bytes[i], 8);
+    }
+  };
+
+  return _this;
+};
+
+//---------------------------------------------------------------------
+// qrKanji
+//---------------------------------------------------------------------
+
+const qrKanji = function(data) {
+
+  const _mode = QRMode.MODE_KANJI;
+  const _data = data;
+
+  const stringToBytes = qrcode.stringToBytes;
+  !function(c, code) {
+    // self test for sjis support.
+    const test = stringToBytes(c);
+    if (test.length != 2 || ( (test[0] << 8) | test[1]) != code) {
+      throw 'sjis not supported.';
+    }
+  }('\u53cb', 0x9746);
+
+  const _bytes = stringToBytes(data);
+
+  const _this = {};
+
+  _this.getMode = function() {
+    return _mode;
+  };
+
+  _this.getLength = function(buffer) {
+    return ~~(_bytes.length / 2);
+  };
+
+  _this.write = function(buffer) {
+
+    const data = _bytes;
+
+    let i = 0;
+
+    while (i + 1 < data.length) {
+
+      let c = ( (0xff & data[i]) << 8) | (0xff & data[i + 1]);
+
+      if (0x8140 <= c && c <= 0x9FFC) {
+        c -= 0x8140;
+      } else if (0xE040 <= c && c <= 0xEBBF) {
+        c -= 0xC140;
+      } else {
+        throw 'illegal char at ' + (i + 1) + '/' + c;
+      }
+
+      c = ( (c >>> 8) & 0xff) * 0xC0 + (c & 0xff);
+
+      buffer.put(c, 13);
+
+      i += 2;
+    }
+
+    if (i < data.length) {
+      throw 'illegal char at ' + (i + 1);
+    }
+  };
+
+  return _this;
+};
+
+//=====================================================================
+// GIF Support etc.
+//
+
+//---------------------------------------------------------------------
+// byteArrayOutputStream
+//---------------------------------------------------------------------
+
+const byteArrayOutputStream = function() {
+
+  const _bytes = [];
+
+  const _this = {};
+
+  _this.writeByte = function(b) {
+    _bytes.push(b & 0xff);
+  };
+
+  _this.writeShort = function(i) {
+    _this.writeByte(i);
+    _this.writeByte(i >>> 8);
+  };
+
+  _this.writeBytes = function(b, off, len) {
+    off = off || 0;
+    len = len || b.length;
+    for (let i = 0; i < len; i += 1) {
+      _this.writeByte(b[i + off]);
+    }
+  };
+
+  _this.writeString = function(s) {
+    for (let i = 0; i < s.length; i += 1) {
+      _this.writeByte(s.charCodeAt(i) );
+    }
+  };
+
+  _this.toByteArray = function() {
+    return _bytes;
+  };
+
+  _this.toString = function() {
+    let s = '';
+    s += '[';
+    for (let i = 0; i < _bytes.length; i += 1) {
+      if (i > 0) {
+        s += ',';
+      }
+      s += _bytes[i];
+    }
+    s += ']';
+    return s;
+  };
+
+  return _this;
+};
+
+//---------------------------------------------------------------------
+// base64EncodeOutputStream
+//---------------------------------------------------------------------
+
+const base64EncodeOutputStream = function() {
+
+  let _buffer = 0;
+  let _buflen = 0;
+  let _length = 0;
+  let _base64 = '';
+
+  const _this = {};
+
+  const writeEncoded = function(b) {
+    _base64 += String.fromCharCode(encode(b & 0x3f) );
+  };
+
+  const encode = function(n) {
+    if (n < 0) {
+      throw 'n:' + n;
+    } else if (n < 26) {
+      return 0x41 + n;
+    } else if (n < 52) {
+      return 0x61 + (n - 26);
+    } else if (n < 62) {
+      return 0x30 + (n - 52);
+    } else if (n == 62) {
+      return 0x2b;
+    } else if (n == 63) {
+      return 0x2f;
+    } else {
+      throw 'n:' + n;
+    }
+  };
+
+  _this.writeByte = function(n) {
+
+    _buffer = (_buffer << 8) | (n & 0xff);
+    _buflen += 8;
+    _length += 1;
+
+    while (_buflen >= 6) {
+      writeEncoded(_buffer >>> (_buflen - 6) );
+      _buflen -= 6;
+    }
+  };
+
+  _this.flush = function() {
+
+    if (_buflen > 0) {
+      writeEncoded(_buffer << (6 - _buflen) );
+      _buffer = 0;
+      _buflen = 0;
+    }
+
+    if (_length % 3 != 0) {
+      // padding
+      const padlen = 3 - _length % 3;
+      for (let i = 0; i < padlen; i += 1) {
+        _base64 += '=';
+      }
+    }
+  };
+
+  _this.toString = function() {
+    return _base64;
+  };
+
+  return _this;
+};
+
+//---------------------------------------------------------------------
+// base64DecodeInputStream
+//---------------------------------------------------------------------
+
+const base64DecodeInputStream = function(str) {
+
+  const _str = str;
+  let _pos = 0;
+  let _buffer = 0;
+  let _buflen = 0;
+
+  const _this = {};
+
+  _this.read = function() {
+
+    while (_buflen < 8) {
+
+      if (_pos >= _str.length) {
+        if (_buflen == 0) {
+          return -1;
+        }
+        throw 'unexpected end of file./' + _buflen;
+      }
+
+      const c = _str.charAt(_pos);
+      _pos += 1;
+
+      if (c == '=') {
+        _buflen = 0;
+        return -1;
+      } else if (c.match(/^\s$/) ) {
+        // ignore if whitespace.
+        continue;
+      }
+
+      _buffer = (_buffer << 6) | decode(c.charCodeAt(0) );
+      _buflen += 6;
+    }
+
+    const n = (_buffer >>> (_buflen - 8) ) & 0xff;
+    _buflen -= 8;
+    return n;
+  };
+
+  const decode = function(c) {
+    if (0x41 <= c && c <= 0x5a) {
+      return c - 0x41;
+    } else if (0x61 <= c && c <= 0x7a) {
+      return c - 0x61 + 26;
+    } else if (0x30 <= c && c <= 0x39) {
+      return c - 0x30 + 52;
+    } else if (c == 0x2b) {
+      return 62;
+    } else if (c == 0x2f) {
+      return 63;
+    } else {
+      throw 'c:' + c;
+    }
+  };
+
+  return _this;
+};
+
+//---------------------------------------------------------------------
+// gifImage (B/W)
+//---------------------------------------------------------------------
+
+const gifImage = function(width, height) {
+
+  const _width = width;
+  const _height = height;
+  const _data = new Array(width * height);
+
+  const _this = {};
+
+  _this.setPixel = function(x, y, pixel) {
+    _data[y * _width + x] = pixel;
+  };
+
+  _this.write = function(out) {
+
+    //---------------------------------
+    // GIF Signature
+
+    out.writeString('GIF87a');
+
+    //---------------------------------
+    // Screen Descriptor
+
+    out.writeShort(_width);
+    out.writeShort(_height);
+
+    out.writeByte(0x80); // 2bit
+    out.writeByte(0);
+    out.writeByte(0);
+
+    //---------------------------------
+    // Global Color Map
+
+    // black
+    out.writeByte(0x00);
+    out.writeByte(0x00);
+    out.writeByte(0x00);
+
+    // white
+    out.writeByte(0xff);
+    out.writeByte(0xff);
+    out.writeByte(0xff);
+
+    //---------------------------------
+    // Image Descriptor
+
+    out.writeString(',');
+    out.writeShort(0);
+    out.writeShort(0);
+    out.writeShort(_width);
+    out.writeShort(_height);
+    out.writeByte(0);
+
+    //---------------------------------
+    // Local Color Map
+
+    //---------------------------------
+    // Raster Data
+
+    const lzwMinCodeSize = 2;
+    const raster = getLZWRaster(lzwMinCodeSize);
+
+    out.writeByte(lzwMinCodeSize);
+
+    let offset = 0;
+
+    while (raster.length - offset > 255) {
+      out.writeByte(255);
+      out.writeBytes(raster, offset, 255);
+      offset += 255;
+    }
+
+    out.writeByte(raster.length - offset);
+    out.writeBytes(raster, offset, raster.length - offset);
+    out.writeByte(0x00);
+
+    //---------------------------------
+    // GIF Terminator
+    out.writeString(';');
+  };
+
+  const bitOutputStream = function(out) {
+
+    const _out = out;
+    let _bitLength = 0;
+    let _bitBuffer = 0;
+
+    const _this = {};
+
+    _this.write = function(data, length) {
+
+      if ( (data >>> length) != 0) {
+        throw 'length over';
+      }
+
+      while (_bitLength + length >= 8) {
+        _out.writeByte(0xff & ( (data << _bitLength) | _bitBuffer) );
+        length -= (8 - _bitLength);
+        data >>>= (8 - _bitLength);
+        _bitBuffer = 0;
+        _bitLength = 0;
+      }
+
+      _bitBuffer = (data << _bitLength) | _bitBuffer;
+      _bitLength = _bitLength + length;
+    };
+
+    _this.flush = function() {
+      if (_bitLength > 0) {
+        _out.writeByte(_bitBuffer);
+      }
+    };
+
+    return _this;
+  };
+
+  const getLZWRaster = function(lzwMinCodeSize) {
+
+    const clearCode = 1 << lzwMinCodeSize;
+    const endCode = (1 << lzwMinCodeSize) + 1;
+    let bitLength = lzwMinCodeSize + 1;
+
+    // Setup LZWTable
+    const table = lzwTable();
+
+    for (let i = 0; i < clearCode; i += 1) {
+      table.add(String.fromCharCode(i) );
+    }
+    table.add(String.fromCharCode(clearCode) );
+    table.add(String.fromCharCode(endCode) );
+
+    const byteOut = byteArrayOutputStream();
+    const bitOut = bitOutputStream(byteOut);
+
+    // clear code
+    bitOut.write(clearCode, bitLength);
+
+    let dataIndex = 0;
+
+    let s = String.fromCharCode(_data[dataIndex]);
+    dataIndex += 1;
+
+    while (dataIndex < _data.length) {
+
+      const c = String.fromCharCode(_data[dataIndex]);
+      dataIndex += 1;
+
+      if (table.contains(s + c) ) {
+
+        s = s + c;
+
+      } else {
+
+        bitOut.write(table.indexOf(s), bitLength);
+
+        if (table.size() < 0xfff) {
+
+          if (table.size() == (1 << bitLength) ) {
+            bitLength += 1;
+          }
+
+          table.add(s + c);
+        }
+
+        s = c;
+      }
+    }
+
+    bitOut.write(table.indexOf(s), bitLength);
+
+    // end code
+    bitOut.write(endCode, bitLength);
+
+    bitOut.flush();
+
+    return byteOut.toByteArray();
+  };
+
+  const lzwTable = function() {
+
+    const _map = {};
+    let _size = 0;
+
+    const _this = {};
+
+    _this.add = function(key) {
+      if (_this.contains(key) ) {
+        throw 'dup key:' + key;
+      }
+      _map[key] = _size;
+      _size += 1;
+    };
+
+    _this.size = function() {
+      return _size;
+    };
+
+    _this.indexOf = function(key) {
+      return _map[key];
+    };
+
+    _this.contains = function(key) {
+      return typeof _map[key] != 'undefined';
+    };
+
+    return _this;
+  };
+
+  return _this;
+};
+
+const createDataURL = function(width, height, getPixel) {
+  const gif = gifImage(width, height);
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      gif.setPixel(x, y, getPixel(x, y) );
+    }
+  }
+
+  const b = byteArrayOutputStream();
+  gif.write(b);
+
+  const base64 = base64EncodeOutputStream();
+  const bytes = b.toByteArray();
+  for (let i = 0; i < bytes.length; i += 1) {
+    base64.writeByte(bytes[i]);
+  }
+  base64.flush();
+
+  return 'data:image/gif;base64,' + base64;
+};
+
+export default qrcode;
+
+export const stringToBytes = qrcode.stringToBytes;

--- a/crates/copperline-web/www/netplay-room.js
+++ b/crates/copperline-web/www/netplay-room.js
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Invitations contain an opaque room capability, never SDP or TURN credentials.
+const ROOM = /^[A-Za-z0-9_-]{22}$/;
+export function roomFromInvite(value) {
+  value = value.trim();
+  if (ROOM.test(value)) return value;
+  try {
+    const room = new URLSearchParams(new URL(value).hash.slice(1)).get('room');
+    return ROOM.test(room ?? '') ? room : null;
+  } catch { return null; }
+}
+
+export function inviteUrl(room, page = location.href) {
+  if (!ROOM.test(room)) throw new Error('Invalid room');
+  const url = new URL(page);
+  // Do not accidentally share local media URLs or page configuration tokens.
+  url.search = '';
+  url.hash = new URLSearchParams({ room }).toString();
+  return url.href;
+}
+
+export function signalingUrl(value) {
+  const url = new URL(value);
+  if (url.username || url.password || url.search || url.hash ||
+      (url.protocol !== 'https:' && !(url.protocol === 'http:' && ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname)))) {
+    throw new Error('The room service must use HTTPS');
+  }
+  return url.href.replace(/\/$/, '');
+}
+
+export class RoomClient {
+  constructor(base, signal) {
+    this.base = signalingUrl(base);
+    this.signal = signal;
+    this.id = null;
+    this.auth = null;
+  }
+
+  async request(path, method = 'GET', body, signal = this.signal) {
+    const response = await fetch(`${this.base}${path}`, {
+      method, signal: signal ? AbortSignal.any([signal, AbortSignal.timeout(15000)]) : AbortSignal.timeout(15000),
+      mode: 'cors', credentials: 'omit', cache: 'no-store', referrerPolicy: 'no-referrer',
+      headers: { ...(body ? { 'Content-Type': 'application/json' } : {}),
+        ...(this.auth ? { Authorization: `Bearer ${this.auth}` } : {}) },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    if (Number(response.headers.get('Content-Length')) > 128 * 1024) throw new Error('Invalid room response');
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('Invalid room response');
+    let text = '', size = 0;
+    const decoder = new TextDecoder();
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > 128 * 1024) { await reader.cancel(); throw new Error('Invalid room response'); }
+      text += decoder.decode(value, { stream: true });
+    }
+    const value = JSON.parse(text + decoder.decode());
+    if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Invalid room response');
+    if (!response.ok) throw new Error(typeof value.error === 'string' ? value.error : 'Room request failed');
+    return value;
+  }
+
+  async create() {
+    const value = await this.request('/rooms', 'POST', {});
+    if (!ROOM.test(value.id ?? '') || !ROOM.test(value.owner ?? '')) throw new Error('Invalid room response');
+    this.id = value.id;
+    this.auth = value.owner;
+    return value;
+  }
+
+  async join(id) {
+    if (!ROOM.test(id ?? '')) throw new Error('Paste an invitation link or room code');
+    this.id = id;
+    this.auth = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16))))
+      .replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+    return this.request(`/rooms/${id}/join`, 'POST', { guest: this.auth });
+  }
+
+  publish(type, code) { return this.request(`/rooms/${this.id}/${type}`, 'POST', { code }); }
+
+  async waitForAnswer(expiresAt) {
+    while (!this.signal.aborted && Date.now() < expiresAt) {
+      const { answer } = await this.request(`/rooms/${this.id}/answer`);
+      if (typeof answer === 'string') return answer;
+      await new Promise((resolve, reject) => {
+        const done = () => { this.signal.removeEventListener('abort', cancel); resolve(); };
+        const timer = setTimeout(done, 1500);
+        const cancel = () => { clearTimeout(timer); this.signal.removeEventListener('abort', cancel); reject(this.signal.reason); };
+        this.signal.addEventListener('abort', cancel, { once: true });
+        if (this.signal.aborted) cancel();
+      });
+    }
+    throw new Error('The invitation expired. Host a new game to try again.');
+  }
+
+  end() {
+    if (!this.id || !this.auth) return Promise.resolve();
+    return this.request(`/rooms/${this.id}`, 'DELETE', undefined, null).catch(() => {});
+  }
+}

--- a/crates/copperline-web/www/netplay-room.test.js
+++ b/crates/copperline-web/www/netplay-room.test.js
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { RoomClient, inviteUrl, roomFromInvite, signalingUrl } from './netplay-room.js';
+const id = 'a'.repeat(22);
+test('invitations retain only the page location and opaque room ID', () => {
+  const url = inviteUrl(id, 'https://copperline.dev/try/?rom=private&token=secret#old');
+  assert.equal(url, `https://copperline.dev/try/#room=${id}`);
+  assert.equal(roomFromInvite(url), id);
+  assert.equal(roomFromInvite(id), id);
+  for (const value of ['bad', url + 'x', 'https://other.test/?room=' + id]) assert.equal(roomFromInvite(value), null);
+  assert.throws(() => inviteUrl('bad'));
+  for (const value of ['http://remote.test', 'https://u:p@remote.test', 'https://remote.test?secret=1']) assert.throws(() => signalingUrl(value));
+  assert.equal(signalingUrl('http://127.0.0.1:8787/'), 'http://127.0.0.1:8787');
+});
+test('room client uses independent owner authentication and bounds response bodies without content length', async t => {
+  const abort = new AbortController();
+  const room = new RoomClient('https://service.test', abort.signal);
+  const calls = [];
+  t.mock.method(globalThis, 'fetch', async (url, options) => {
+    calls.push({ url, options });
+    return Response.json({ id, owner: 'b'.repeat(22) });
+  });
+  await room.create();
+  await room.publish('offer', 'test-code');
+  assert.equal(calls[1].options.headers.Authorization, `Bearer ${'b'.repeat(22)}`);
+  assert.equal(calls[0].options.credentials, 'omit');
+  assert.equal(calls[0].options.referrerPolicy, 'no-referrer');
+  t.mock.method(globalThis, 'fetch', async () => new Response('x'.repeat(129 * 1024)));
+  await assert.rejects(room.request('/health'), /Invalid room response/);
+});
+test('waiting stops on cancellation and expired invitations', async t => {
+  t.mock.method(globalThis, 'fetch', async () => Response.json({ answer: null }));
+  const abort = new AbortController();
+  const room = new RoomClient('https://service.test', abort.signal);
+  await assert.rejects(room.waitForAnswer(Date.now() - 1), /expired/);
+  const waiting = room.waitForAnswer(Date.now() + 900000);
+  setTimeout(() => abort.abort(), 10);
+  await assert.rejects(waiting, { name: 'AbortError' });
+});

--- a/crates/copperline-web/www/netplay.js
+++ b/crates/copperline-web/www/netplay.js
@@ -144,7 +144,7 @@ export class RtcLink {
         };
         this.cancelGather = () => finish(new Error('Connection cancelled'));
         this.pc.addEventListener('icegatheringstatechange', changed);
-        timer = setTimeout(() => finish(new Error('Network address discovery timed out; check the STUN server')), 15000);
+        timer = setTimeout(() => finish(new Error('Network address discovery timed out. Copy diagnostics, then try a new session.')), 15000);
         changed();
       });
     }
@@ -157,7 +157,24 @@ export class RtcLink {
     if (relayOnly && !iceServers.some(server => [].concat(server.urls ?? []).some(url => /^turns?:/.test(url)))) {
       throw new Error('A relay is not available for this session');
     }
-    this.pc.setConfiguration({ iceServers, iceTransportPolicy: relayOnly ? 'relay' : 'all' });
+    const iceTransportPolicy = relayOnly ? 'relay' : 'all';
+    try { this.pc.setConfiguration({ iceServers, iceTransportPolicy }); }
+    catch (error) {
+      if (error.name !== 'SyntaxError') throw error;
+      // Some WebKit builds reject valid TURN transport queries. Retry using
+      // default UDP for turn: and TLS/TCP for turns:, retaining ports and keys.
+      // Plain TCP needs its query, so omit it only on this compatibility path.
+      const compatible = iceServers.map(server => ({ ...server,
+        urls: [].concat(server.urls ?? []).flatMap(url => {
+          if (/^turn:[^?]+\?transport=udp$/i.test(url) || /^turns:[^?]+\?transport=tcp$/i.test(url)) return [url.split('?')[0]];
+          if (/^turn:[^?]+\?transport=tcp$/i.test(url)) return [];
+          return [url];
+        }),
+      })).filter(server => server.urls.length);
+      if (JSON.stringify(compatible) === JSON.stringify(iceServers) ||
+          !compatible.some(server => server.urls.some(url => /^turns?:/.test(url)))) throw error;
+      this.pc.setConfiguration({ iceServers: compatible, iceTransportPolicy });
+    }
   }
 
   report() { return this.diagnostics.report(this.pc, this.channel); }

--- a/crates/copperline-web/www/netplay.js
+++ b/crates/copperline-web/www/netplay.js
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Signaling is copy/paste; only bounded input packets use the data channel.
+import { NetplayDiagnostics, connectionFailure } from './netplay-diagnostics.js';
+import { RoomClient, inviteUrl, roomFromInvite } from './netplay-room.js';
+import qrcode from './netplay-qr.js';
+
+// Signaling uses expiring room invitations or manual copy/paste codes.
+// Only bounded input packets use the data channel.
 const CODE_LIMIT = 96 * 1024;
 export const PACKET_LIMIT = 943;
 const QUEUE_LIMIT = 64;
@@ -59,11 +64,25 @@ export class RtcLink {
     this.onClose = onClose;
     this.timer = null;
     this.cancelGather = null;
+    this.diagnostics = new NetplayDiagnostics();
+    this.diagnostics.record('created', this.pc);
     this.pc.ondatachannel = event => this.attach(event.channel);
     this.pc.onconnectionstatechange = () => {
+      this.diagnostics.record('peer-state', this.pc);
+      this.diagnostics.capture(this.pc);
       if (['failed', 'closed'].includes(this.pc.connectionState)) {
-        this.close('Peer connection ended. Check the network and start a new session.');
+        this.close(connectionFailure(this.pc));
       }
+    };
+    this.pc.oniceconnectionstatechange = () => {
+      this.diagnostics.record('ice-state', this.pc);
+      this.diagnostics.capture(this.pc);
+    };
+    this.pc.onicegatheringstatechange = () => this.diagnostics.record('gathering-state', this.pc);
+    this.pc.onsignalingstatechange = () => this.diagnostics.record('signaling-state', this.pc);
+    this.pc.onicecandidateerror = event => {
+      this.diagnostics.iceError(event.errorCode);
+      this.diagnostics.record('ice-error', this.pc);
     };
   }
 
@@ -90,12 +109,18 @@ export class RtcLink {
     channel.onopen = () => {
       if (this.closed || this.opened) return;
       this.opened = true;
+      this.diagnostics.record('data-open', this.pc);
+      this.diagnostics.capture(this.pc);
       clearTimeout(this.timer);
       Promise.resolve().then(() => this.closed ? undefined : this.onOpen(this))
         .catch(error => { console.error('Netplay startup failed', error); this.close(String(error.message ?? error)); });
     };
-    channel.onclose = () => this.close('Peer disconnected');
+    channel.onclose = () => {
+      this.diagnostics.record('data-close', this.pc);
+      this.close('Peer disconnected. Copy diagnostics for a connection report.');
+    };
     channel.onerror = event => {
+      this.diagnostics.record('data-error', this.pc);
       console.error('Netplay data channel failed', event.error ?? event);
       this.close(`Netplay data channel failed${event.error?.message ? ': ' + event.error.message : ''}`);
     };
@@ -127,6 +152,16 @@ export class RtcLink {
     return encodeCode(this.pc.localDescription, this.settings);
   }
 
+  configureIce(iceServers, relayOnly = false) {
+    if (!Array.isArray(iceServers) || iceServers.length > 8) throw new Error('Invalid network configuration');
+    if (relayOnly && !iceServers.some(server => [].concat(server.urls ?? []).some(url => /^turns?:/.test(url)))) {
+      throw new Error('A relay is not available for this session');
+    }
+    this.pc.setConfiguration({ iceServers, iceTransportPolicy: relayOnly ? 'relay' : 'all' });
+  }
+
+  report() { return this.diagnostics.report(this.pc, this.channel); }
+
   async offer(settings) {
     this.settings = validateSettings(settings);
     this.attach(this.pc.createDataChannel(CHANNEL, { ordered: false, maxRetransmits: 0 }));
@@ -150,7 +185,7 @@ export class RtcLink {
     if (this.closed) throw new Error('Connection cancelled');
     if (!this.opened) {
       clearTimeout(this.timer);
-      this.timer = setTimeout(() => this.close('Peer connection timed out; try a LAN or VPN'), 60000);
+      this.timer = setTimeout(() => this.close('Peer connection timed out. Copy diagnostics, then start a new session.'), 60000);
     }
   }
 
@@ -170,6 +205,8 @@ export class RtcLink {
   close(reason = 'Disconnected. Start a new session to play again.') {
     if (this.closed) return;
     this.closed = true;
+    this.diagnostics.record('stopped', this.pc);
+    this.diagnostics.capture(this.pc);
     clearTimeout(this.timer);
     this.cancelGather?.();
     // Let the owner poll final queued packets for the core's failure reason
@@ -181,6 +218,8 @@ export class RtcLink {
   dispose() {
     this.incoming.length = 0;
     this.pc.ondatachannel = this.pc.onconnectionstatechange = null;
+    this.pc.oniceconnectionstatechange = this.pc.onicegatheringstatechange = null;
+    this.pc.onsignalingstatechange = this.pc.onicecandidateerror = null;
     if (this.channel) {
       this.channel.onopen = this.channel.onmessage = this.channel.onclose = this.channel.onerror = null;
       this.channel.close();
@@ -193,63 +232,120 @@ export class RtcLink {
 export function mountNetplayPanel(parent, { prepare, start, stop }) {
   const style = document.createElement('style');
   style.textContent = `
-    #netplay-panel { font-size: .8rem; line-height: 1.4; color: var(--ink-mute, #bbc0ca); }
+    #netplay-panel { font-size: .88rem; line-height: 1.4; color: var(--ink-mute, #bbc0ca); }
     #netplay-panel summary { cursor: pointer; font-weight: 600; color: var(--ink, #eee); }
     #netplay-panel p { margin: .6rem 0; }
     #netplay-panel label { display: block; margin-top: .6rem; }
     #netplay-panel input, #netplay-panel textarea, #netplay-panel select {
       display: block; box-sizing: border-box; width: 100%; margin-top: .2rem;
-      border: 1px solid var(--line, #454b57); border-radius: 6px; padding: .35rem;
+      border: 1px solid var(--line, #454b57); border-radius: 6px; padding: .4rem;
       background: rgba(10, 13, 22, .6); color: var(--ink, #eee); font: inherit;
     }
-    #netplay-panel textarea { resize: vertical; font-family: ui-monospace, monospace; font-size: .7rem; }
-    #netplay-panel .btn { margin-top: .4rem; width: 100%; justify-content: center; font-size: .8rem; padding: .35rem .5rem; }
+    #netplay-panel textarea { resize: vertical; font-family: ui-monospace, monospace; font-size: .8rem; }
+    #netplay-panel .btn { margin-top: .4rem; width: 100%; justify-content: center; font-size: .88rem; padding: .5rem; }
     #netplay-panel :disabled { opacity: .45; cursor: default; }
+    #netplay-panel [hidden] { display: none !important; }
     #netplay-panel #netplay-status { overflow-wrap: anywhere; color: var(--ink, #eee); }
+    #netplay-advanced { margin-top: .8rem; border-top: 1px solid var(--line, #454b57); padding-top: .6rem; }
+    #netplay-qr { margin: .8rem auto; max-width: 260px; background: white; padding: .25rem; }
+    #netplay-qr svg { display: block; width: 100%; height: auto; }
+    #netplay-panel label:has(input[type=checkbox]) { display: flex; align-items: center; gap: .5rem; }
+    #netplay-panel input[type=checkbox] { width: auto; margin: 0; }
+    @media (pointer: coarse) {
+      #netplay-panel input, #netplay-panel textarea, #netplay-panel select { font-size: 1rem; }
+    }
   `;
   document.head.appendChild(style);
   const root = document.createElement('details');
   root.id = 'netplay-panel';
   root.className = 'try-side-section';
   root.innerHTML = `<summary>Netplay</summary>
-    <p>Two browsers, matching ROMs and disks. Host is player 1; Join is player 2.</p>
-    <label>Input delay <select id="netplay-delay">${[0,1,2,3,4,5,6].map(n => `<option ${n === 2 ? 'selected' : ''}>${n}</option>`).join('')}</select></label>
-    <label>Rollback limit <select id="netplay-window">${Array.from({length:12}, (_, i) => `<option ${i === 7 ? 'selected' : ''}>${i + 1}</option>`).join('')}</select></label>
-    <label>Controllers <select id="netplay-controller"><option value="joystick">Joystick</option><option value="cd32">CD32 pad</option></select></label>
-    <label>STUN server <input id="netplay-stun" value="stun:stun.l.google.com:19302" spellcheck="false"></label>
-    <p>STUN helps find a route over the internet. Leave it blank for LAN-only setup. Some networks need a VPN.</p>
-    <button id="netplay-host" type="button">Host game</button>
-    <label>Code from the other player <textarea id="netplay-remote" rows="3" spellcheck="false"></textarea></label>
-    <button id="netplay-join" type="button">Join offer</button>
-    <button id="netplay-accept" type="button" disabled>Connect answer</button>
-    <label>Your connection code <textarea id="netplay-local" rows="3" readonly spellcheck="false"></textarea></label>
-    <button id="netplay-copy" type="button" disabled>Copy code</button>
+    <p>Load matching ROMs and disks on both devices. Starting a session replaces your running game.</p>
+    <div id="netplay-rooms">
+      <button id="netplay-room-host" type="button">Host game</button>
+      <label>Invitation link or room code <input id="netplay-room-code" autocomplete="off" autocapitalize="none" spellcheck="false"></label>
+      <button id="netplay-room-join" type="button">Join game</button>
+      <p id="netplay-service-status"></p>
+    </div>
+    <div id="netplay-invitation" hidden>
+      <label>Your invitation <input id="netplay-invite" readonly spellcheck="false"></label>
+      <button id="netplay-copy-invite" type="button">Copy invitation</button>
+      <button id="netplay-share" type="button" hidden>Share invitation</button>
+      <div id="netplay-qr" role="img" aria-label="Scan this QR code with the other device’s camera to join"></div>
+      <p>Scan with the other device’s camera, or share the link. Invitations expire after 15 minutes.</p>
+    </div>
     <button id="netplay-disconnect" type="button" disabled>Disconnect</button>
-    <p id="netplay-status" role="status">Load matching ROMs and disks, then host or join.</p>`;
+    <p id="netplay-status" role="status" aria-live="polite">Host a game or open an invitation to join.</p>
+    <button id="netplay-diagnostics" type="button" disabled>Copy diagnostics</button>
+    <textarea id="netplay-report" rows="5" readonly hidden aria-label="Connection diagnostics"></textarea>
+    <details id="netplay-advanced"><summary>Advanced</summary>
+      <label>Controllers <select id="netplay-controller"><option value="joystick">Joystick</option><option value="cd32">CD32 pad</option></select></label>
+      <label>Input delay <select id="netplay-delay">${[0,1,2,3,4,5,6].map(n => `<option ${n === 2 ? 'selected' : ''}>${n}</option>`).join('')}</select></label>
+      <label>Rollback limit <select id="netplay-window">${Array.from({length:12}, (_, i) => `<option ${i === 7 ? 'selected' : ''}>${i + 1}</option>`).join('')}</select></label>
+      <label><input id="netplay-relay-only" type="checkbox"> Use relay only for room connections</label>
+      <p>Room connections try a direct route and can use a relay automatically. Relay-only mode helps diagnose connection problems.</p>
+      <h4>Manual connection codes</h4>
+      <label>STUN server <input id="netplay-stun" value="stun:stun.l.google.com:19302" spellcheck="false"></label>
+      <p>Leave STUN blank for LAN-only discovery. Manual setup has no relay fallback.</p>
+      <button id="netplay-host" type="button">Host with manual codes</button>
+      <label>Code from the other player <textarea id="netplay-remote" rows="3" spellcheck="false"></textarea></label>
+      <button id="netplay-join" type="button">Join offer</button>
+      <button id="netplay-accept" type="button" disabled>Connect answer</button>
+      <label>Your connection code <textarea id="netplay-local" rows="3" readonly spellcheck="false"></textarea></label>
+      <button id="netplay-copy" type="button" disabled>Copy code</button>
+    </details>`;
   for (const button of root.querySelectorAll('button')) button.className = 'btn btn--ghost';
   root.addEventListener('keydown', event => event.stopPropagation());
   root.addEventListener('keyup', event => event.stopPropagation());
   parent.insertBefore(root, parent.querySelector('.try-side-section'));
   const field = name => root.querySelector(`#netplay-${name}`);
+  const service = document.querySelector('meta[name="copperline-netplay-service"]')?.content?.trim();
   let link = null;
+  let lastLink = null;
   const status = text => { field('status').textContent = text; };
   const controls = () => {
     const active = !!link;
-    for (const name of ['host', 'join', 'delay', 'window', 'controller', 'stun']) field(name).disabled = active;
+    for (const name of ['host', 'join', 'delay', 'window', 'controller', 'stun', 'relay-only', 'room-code']) field(name).disabled = active;
+    for (const name of ['room-host', 'room-join']) field(name).disabled = active || !service;
     field('disconnect').disabled = !active;
     field('copy').disabled = !field('local').value;
+    field('diagnostics').disabled = !lastLink;
     if (!active) field('accept').disabled = true;
   };
-  async function begin(host) {
+  field('service-status').textContent = service
+    ? 'Host is player 1; Join is player 2. Your game files stay on your device.'
+    : 'Room invitations are not configured on this page. Manual setup is available under Advanced.';
+  field('advanced').open = !service;
+  field('share').hidden = typeof navigator.share !== 'function';
+
+  function readInvitation() {
     if (link) return;
+    const room = new URLSearchParams(location.hash.slice(1)).get('room');
+    if (!room) return;
+    if (!roomFromInvite(room)) { root.open = true; status('This invitation is incomplete or damaged.'); return; }
+    field('room-code').value = room;
+    root.open = true;
+    status('Invitation ready. Load the host’s ROMs and disks, match the machine settings, then click Join game.');
+  }
+  readInvitation();
+  window.addEventListener('hashchange', readInvitation);
+
+  async function begin(mode) {
+    if (link) return;
+    const host = mode.endsWith('host');
+    const roomMode = mode.startsWith('room-');
     let current;
+    let settings;
     try {
       const remote = field('remote').value;
-      const settings = host ? newSettings(Number(field('delay').value), Number(field('window').value), field('controller').value)
-        : decodeCode(remote, 'offer').settings;
+      const roomId = roomFromInvite(field('room-code').value);
+      if (roomMode && !service) throw new Error('Room invitations are not configured on this page');
+      if (roomMode && !host && !roomId) throw new Error('Paste an invitation link or room code');
+      settings = host ? newSettings(Number(field('delay').value), Number(field('window').value), field('controller').value)
+        : roomMode ? null : decodeCode(remote, 'offer').settings;
       const stun = field('stun').value.trim();
-      if (stun && !/^stuns?:[^\s]+$/i.test(stun)) throw new Error('STUN server must start with stun: or stuns:');
-      current = new RtcLink({ iceServers: stun ? [{ urls: stun }] : [],
+      if (!roomMode && stun && !/^stuns?:[^\s]+$/i.test(stun)) throw new Error('STUN server must start with stun: or stuns:');
+      current = new RtcLink({ iceServers: !roomMode && stun ? [{ urls: stun }] : [],
         onOpen: async peer => {
           if (link !== peer) return;
           status('Connected. Checking the initial machines...');
@@ -257,31 +353,72 @@ export function mountNetplayPanel(parent, { prepare, start, stop }) {
         },
         onClose: (reason, peer) => {
           if (link !== peer) return;
+          peer.abort.abort();
+          peer.room?.end();
           link = null;
           field('local').value = '';
+          field('invite').value = '';
+          field('qr').replaceChildren();
+          field('invitation').hidden = true;
           controls();
           status(stop(reason, peer) ?? reason);
         },
       });
-      link = current;
+      current.abort = new AbortController();
+      link = lastLink = current;
       field('local').value = '';
+      field('report').hidden = true;
       controls();
-      status('Preparing a fresh session and gathering network addresses...');
+      status('Preparing a fresh session...');
       await prepare(current);
       if (link !== current) return;
-      const code = host ? await current.offer(settings) : await current.answer(remote);
-      if (link !== current) return;
-      field('local').value = code;
-      field('copy').disabled = false;
-      field('accept').disabled = !host;
-      status(host ? 'Send your offer code. Paste the reply and click Connect answer.' : 'Send your answer code back to the host. Keep this page open, or Disconnect to cancel.');
+      if (roomMode) {
+        current.room = new RoomClient(service, current.abort.signal);
+        status(host ? 'Creating your invitation...' : 'Joining the room...');
+        const network = host ? await current.room.create() : await current.room.join(roomId);
+        if (link !== current) { current.room.end(); return; }
+        if (!Number.isFinite(network.expiresAt) || network.expiresAt <= Date.now()) throw new Error('The invitation has expired');
+        if (!host) settings = decodeCode(network.offer, 'offer').settings;
+        current.configureIce(network.iceServers, field('relay-only').checked);
+        status('Finding a connection route...');
+        const code = host ? await current.offer(settings) : await current.answer(network.offer);
+        if (link !== current) return;
+        await current.room.publish(host ? 'offer' : 'answer', code);
+        if (link !== current) return;
+        if (host) {
+          const invitation = inviteUrl(current.room.id);
+          field('invite').value = invitation;
+          const qr = qrcode(0, 'M');
+          qr.addData(invitation);
+          qr.make();
+          field('qr').innerHTML = qr.createSvgTag({ cellSize: 4, margin: 16, scalable: true });
+          field('invitation').hidden = false;
+          status('Waiting for player 2. Share the invitation or scan the QR code.');
+          const answer = await current.room.waitForAnswer(network.expiresAt);
+          if (link !== current) return;
+          await current.accept(answer);
+        } else if (!current.opened) {
+          current.timer = setTimeout(() => current.close('Connection timed out. Copy diagnostics, then start a new room.'), 60000);
+        }
+        if (link === current && !current.opened) status('Connecting to the other player...');
+      } else {
+        status('Gathering network addresses...');
+        const code = host ? await current.offer(settings) : await current.answer(remote);
+        if (link !== current) return;
+        field('local').value = code;
+        field('copy').disabled = false;
+        field('accept').disabled = !host;
+        status(host ? 'Send your offer code. Paste the reply and click Connect answer.' : 'Send your answer code back to the host. Keep this page open, or Disconnect to cancel.');
+      }
     } catch (error) {
       if (current && link === current) current.close(String(error.message ?? error));
       else if (!current) status(String(error.message ?? error));
     }
   }
-  field('host').addEventListener('click', () => begin(true));
-  field('join').addEventListener('click', () => begin(false));
+  field('host').addEventListener('click', () => begin('manual-host'));
+  field('join').addEventListener('click', () => begin('manual-join'));
+  field('room-host').addEventListener('click', () => begin('room-host'));
+  field('room-join').addEventListener('click', () => begin('room-join'));
   field('accept').addEventListener('click', async () => {
     const current = link;
     if (!current) return;
@@ -289,7 +426,6 @@ export function mountNetplayPanel(parent, { prepare, start, stop }) {
     try {
       await current.accept(field('remote').value);
       if (link !== current) return;
-      field('accept').disabled = true;
       if (!current.opened) status('Connecting to the other player...');
     } catch (error) {
       if (link !== current) return;
@@ -297,11 +433,24 @@ export function mountNetplayPanel(parent, { prepare, start, stop }) {
       status(String(error.message ?? error));
     }
   });
-  field('copy').addEventListener('click', async () => {
-    try { await navigator.clipboard.writeText(field('local').value); status('Connection code copied'); }
-    catch { field('local').focus(); field('local').select(); status('Copy the selected connection code'); }
+  async function copy(name, message) {
+    try { await navigator.clipboard.writeText(field(name).value); status(message); }
+    catch { field(name).hidden = false; field(name).focus(); field(name).select(); status('Copy the selected text'); }
+  }
+  field('copy').addEventListener('click', () => copy('local', 'Connection code copied'));
+  field('copy-invite').addEventListener('click', () => copy('invite', 'Invitation copied'));
+  field('share').addEventListener('click', async () => {
+    try { await navigator.share({ title: 'Join my Copperline game', url: field('invite').value }); }
+    catch (error) { if (error.name !== 'AbortError') copy('invite', 'Invitation copied'); }
+  });
+  field('diagnostics').addEventListener('click', async () => {
+    const peer = lastLink;
+    if (!peer) return;
+    field('report').value = JSON.stringify(await peer.report(), null, 2);
+    await copy('report', 'Diagnostics copied. The report excludes connection codes, credentials and network addresses.');
   });
   field('disconnect').addEventListener('click', () => link?.close());
   window.addEventListener('pagehide', () => link?.close());
+  controls();
   return { get link() { return link; }, status, root };
 }

--- a/crates/copperline-web/www/netplay.test.js
+++ b/crates/copperline-web/www/netplay.test.js
@@ -156,3 +156,29 @@ test('relay-only configuration requires TURN and preserves the requested ICE pol
     assert.equal(config.iceTransportPolicy, 'all');
   } finally { link.close(); }
 });
+
+test('TURN query compatibility preserves UDP, TLS, credentials and relay-only policy', () => {
+  const link = new RtcLink({ PeerConnection: Peer });
+  const configurations = [];
+  link.pc.setConfiguration = value => {
+    configurations.push(value);
+    if (value.iceServers.some(server => [].concat(server.urls).some(url => url.includes('?')))) throw new DOMException('Invalid TURN URL query string', 'SyntaxError');
+  };
+  try {
+    const credentials = { username: 'temporary-user', credential: 'temporary-key' };
+    const servers = [{ urls: 'stun:example.test:3478' }, { ...credentials, urls: [
+      'turn:example.test:3478?transport=udp', 'turn:example.test:3478?transport=tcp',
+      'turns:example.test:443?transport=tcp', 'turns:example.test:5349',
+    ] }];
+    link.configureIce(servers, true);
+    assert.equal(configurations.length, 2);
+    assert.equal(configurations[0].iceServers, servers);
+    assert.deepEqual(configurations[1], { iceTransportPolicy: 'relay', iceServers: [
+      { urls: ['stun:example.test:3478'] },
+      { ...credentials, urls: ['turn:example.test:3478', 'turns:example.test:443', 'turns:example.test:5349'] },
+    ] });
+    assert.throws(() => link.configureIce([{ ...credentials, urls: 'turn:example.test:80?transport=tcp' }], true), { name: 'SyntaxError' });
+    link.pc.setConfiguration = () => { throw new DOMException('credentials invalid', 'InvalidAccessError'); };
+    assert.throws(() => link.configureIce(servers, true), { name: 'InvalidAccessError' });
+  } finally { link.close(); }
+});

--- a/crates/copperline-web/www/netplay.test.js
+++ b/crates/copperline-web/www/netplay.test.js
@@ -122,7 +122,7 @@ test('data-channel open runs once, remote close drains queued input before clean
   assert.equal(opens, 1);
   channel.onmessage({ data: new Uint8Array([7, 8]).buffer });
   channel.onclose();
-  assert.deepEqual(closed, { reason: 'Peer disconnected', received: [7, 8] });
+  assert.deepEqual(closed, { reason: 'Peer disconnected. Copy diagnostics for a connection report.', received: [7, 8] });
   assert.equal(link.closed, true);
   assert.equal(channel.onopen, null);
   assert.equal(link.pc.ondatachannel, null);
@@ -140,4 +140,19 @@ test('connection-state failure closes once and an open queued before cancellatio
   assert.equal(opens, 0);
   assert.equal(closes, 1);
   assert.equal(link.channel.readyState, 'closed');
+});
+
+
+test('relay-only configuration requires TURN and preserves the requested ICE policy', () => {
+  const link = new RtcLink({ PeerConnection: Peer });
+  let config;
+  link.pc.setConfiguration = value => { config = value; };
+  try {
+    assert.throws(() => link.configureIce([], true), /relay is not available/);
+    const servers = [{ urls: ['stun:example.test', 'turns:example.test:443'], username: 'temporary', credential: 'temporary' }];
+    link.configureIce(servers, true);
+    assert.deepEqual(config, { iceServers: servers, iceTransportPolicy: 'relay' });
+    link.configureIce(servers);
+    assert.equal(config.iceTransportPolicy, 'all');
+  } finally { link.close(); }
 });

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -69,15 +69,17 @@ The web build uses the same `.clstate` file format as the desktop version:
 
 ### Rollback netplay
 
-**Controls → Netplay** connects two browsers using WebRTC. The host sends an offer
-code, the joining player sends an answer, and the host connects that answer.
+**Controls → Netplay** connects two browsers using WebRTC. The host shares an
+invitation link or QR code; the other player opens it and clicks Join game.
+Advanced retains manual offer/answer codes for pages without a room service.
 Both pages start fresh machines with matching ROMs, disks and hardware settings.
 Each player controls one Amiga port; late input is predicted and corrected by
 rollback. See [browser netplay setup](netplay.md#browser-netplay) for the steps,
-controller mapping, STUN settings and restrictions.
+controller mapping, relay troubleshooting and restrictions.
 
 Netplay requires WebRTC data channels as well as WebAssembly. It works on a
-static site without a signaling server. A desktop UDP peer cannot join a browser
+static site; room invitations use a separate signaling service, while manual
+codes need no server. A desktop UDP peer cannot join a browser
 session. Save states, media changes, serial connections and pause are unavailable
 until disconnect.
 
@@ -97,7 +99,7 @@ The browser implementation consists of the following components:
 - **Audio pipeline:** Stereo 44.1 kHz float samples are transferred directly to an
   `AudioWorklet` processor for low-latency playback.
 - **Netplay:** The Rust core owns the shared rollback timeline and bounded packet
-  queues. `www/netplay.js` handles connection codes and the WebRTC data channel;
+  queues. `www/netplay.js` handles room invitations, manual codes and the WebRTC data channel;
   `try.js` owns the session lifecycle and locks controls that change the machine.
 
 ## Building the WebAssembly package locally
@@ -218,7 +220,9 @@ this does not add a clock to models without one. Failed startup restores the
 machine and leaves it available for local use or another startup attempt.
 
 `RtcLink` in `www/netplay.js` provides `offer(settings)`, `answer(offerCode)` and
-`accept(answerCode)`. Its `onOpen` callback is the point to construct the machine
+`accept(answerCode)`, with `configureIce(iceServers, relayOnly)` for temporary
+TURN credentials obtained from a trusted service. `report()` returns sanitized
+connection diagnostics. Its `onOpen` callback is the point to construct the machine
 and call `start_netplay`. Its `onClose` callback must stop the page's loops and
 free the machine. Immediately after startup, call `run_hidden(now, 0)` and
 `link.send(emu)` once to send the initial fingerprint. Then call `link.receive(emu)` before `run`/`run_hidden`, then

--- a/docs/guide/netplay.md
+++ b/docs/guide/netplay.md
@@ -8,8 +8,9 @@ This follows the approach described by [GGPO](https://github.com/pond3r/ggpo);
 it uses Copperline's own Rust implementation and wire protocol.
 
 Sessions connect directly to a known peer. Desktop builds use UDP; browsers use
-WebRTC with copy/paste connection codes and optional STUN address discovery.
-There is no lobby, relay, spectator mode or reconnect. Browser and desktop peers
+WebRTC with private room invitations and TURN relay fallback when the page has a
+room service configured. Manual connection codes remain available.
+There is no public lobby, spectator mode or automatic reconnect. Browser and desktop peers
 cannot connect to each other. Use the same Copperline build on both machines;
 mixed operating systems and browser engines have not yet been qualified.
 
@@ -21,15 +22,19 @@ and disks, and choose the same model, video standard, floppy speed, floppy sound
 disk setting on both pages. Setup starts a fresh machine, replacing any running
 local session.
 
-1. The host chooses **Input delay**, **Rollback limit** and **Controllers**, then
-   clicks **Host game**. Send **Your connection code** to the other player.
-2. The other player pastes it into **Code from the other player** and clicks
-   **Join offer**. Send the resulting answer code back to the host. The offer
-   supplies the controller and delay/window settings for both peers.
-3. The host pastes the answer into **Code from the other player** and clicks
-   **Connect answer**. Both pages cold-boot after checking that their initial
-   machines match. The panel reports confirmed frames, rollbacks and the latest
-   checked frame.
+1. The host clicks **Host game** and shares the invitation link using **Copy
+   invitation**, the device share sheet, or the QR code. **Advanced** contains
+   the controller type, input delay and rollback limit.
+2. The other player opens the link (or pastes it into the invitation field),
+   loads matching ROMs and disks, then clicks **Join game**. The offer and answer
+   are exchanged automatically. The host supplies the controller and delay settings.
+3. Both pages cold-boot after checking that their initial machines match. The
+   panel reports confirmed frames, rollbacks and the latest checked frame.
+
+Invitations allow one joining player and expire after 15 minutes. Expiry removes
+setup data from the service; it does not stop an established game. Share links
+privately: anyone with a live invitation can claim its remaining place. The link
+contains an opaque room ID, with no ROM URLs, connection codes or credentials.
 
 Host owns Amiga port 1; Join owns port 2. On each page, the usual first gamepad,
 keyboard joystick or touch controls drive that player's port. The keyboard
@@ -37,13 +42,25 @@ joystick mode is enabled on desktop browsers; touch devices start with touch
 controls. Cycle **Joystick** off to type ordinary Amiga keys. Both keyboards contribute to the shared keyboard. Mouse input is
 disabled. The desktop F11/F12 netplay shortcuts do not apply to the browser.
 
-The default STUN server helps WebRTC discover an internet route. Leave the field
-blank on both pages for LAN-only address discovery, or enter another `stun:` URL.
-Some NATs and firewalls still prevent a direct connection; use a shared LAN or
-VPN in that case. There is no TURN relay configuration in this panel.
-Connection codes contain WebRTC network addresses and session details; exchange
-them privately with the person you intend to play with. ROMs, disks and machine
-snapshots are not sent to the peer. WebRTC encrypts the data channel.
+Room setup uses a small signaling service. WebRTC tries direct routes and can
+fall back to a TURN relay. **Advanced → Use relay only** forces that route for
+troubleshooting. Relay credentials expire after 24 hours; start a new session
+for longer play. ROMs, disks and machine snapshots stay on each device. WebRTC
+encrypts the data channel, including traffic carried by a relay.
+
+If a connection ends, use **Copy diagnostics** on both devices. The report keeps
+ICE, peer, data-channel and DTLS states, candidate types and packet counters.
+It excludes network addresses, SDP, invitation/session tokens and credentials.
+A route that opens before DTLS fails needs different investigation from failed
+ICE discovery. Browser versions alone do not establish the cause.
+
+**Advanced → Manual connection codes** works without the room service. The host
+clicks **Host with manual codes**, sends its code to the guest, and the guest
+pastes it and clicks **Join offer**. The guest sends its answer back; the host
+pastes it and clicks **Connect answer**. The STUN field helps discover routes;
+leave it blank for LAN-only discovery. Manual setup has no relay fallback.
+Its large codes contain network addresses and session details, so exchange them
+privately. If the page has no room service configured, Advanced opens by default.
 
 Keep both pages open. A suspended tab can stall its peer and eventually time out;
 background execution depends on browser and device restrictions. Machine, media,
@@ -51,7 +68,7 @@ serial, floppy sound, pause and save-state controls are locked from setup until 
 Display and main output volume choices remain local. Floppy sound enablement
 and level are part of the machine fingerprint and must match. **Disconnect** cancels setup or stops
 play, discards session disk writes, and restores the selected cold-boot media.
-Either player can host or join again with new codes. The browser does not resume
+Either player can host or join again with a new invitation or new manual codes. The browser does not resume
 the abandoned network timeline as local play.
 
 ## Set up in the GUI

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -115,10 +115,31 @@ on subsequent retransmissions; a full outgoing queue reports backpressure.
 `netplay.js` also bounds its receive queue and stops draining Rust's send queue
 when the channel's buffered amount reaches 64 maximum-size packets.
 
-The page exchanges a versioned offer and answer by copy/paste, including the
-SDP and host-selected settings. It waits for ICE gathering to complete before
-creating either code; no signaling service or trickled candidates are needed.
-The optional STUN server supplies address discovery, with no TURN relay UI.
+The page exchanges a versioned offer and answer containing SDP and host-selected
+settings. It waits for ICE gathering to complete before creating either code.
+`netplay-room.js` sends these codes through the configured service; the host polls
+for an answer every 1.5 seconds until joined, cancelled or expired. Manual
+copy/paste remains available under Advanced and needs no signaling service.
+Neither path trickles candidates.
+
+`services/netplay` implements the Cloudflare Worker and SQLite Durable Object
+used for each invitation. Room IDs and separate owner/guest tokens each contain
+128 random bits. A serialized guest reservation admits one guest; role checks
+restrict offer publication, answer publication and answer retrieval. Records
+expire after 15 minutes via an alarm. DELETE ends setup early; cancellation also
+aborts pending browser requests. The service carries no emulator packets.
+Requests and responses are bounded, origins are allowlisted, and per-IP rate
+limits bound creation separately from polling. An origin header is a browser
+boundary, not authentication against arbitrary clients.
+
+TURN API keys stay in Worker secrets. The service issues temporary, 24-hour ICE
+credentials independently for each player; retries reuse the guest credentials
+within the room lifetime. Room creation fails when a production relay service
+is unavailable. Local development explicitly disables TURN requests. WebRTC
+selects direct or relay routes, or relay-only when requested in Advanced.
+`netplay-diagnostics.js` records whitelisted states, candidate types and numeric
+counters before disposal. It never exports SDP, candidate addresses or tokens.
+The diagnostic sample survives a closed peer connection.
 The [WebRTC data channel](https://www.w3.org/TR/webrtc/) is unordered and uses
 zero SCTP retransmissions, since the shared Copperline protocol already repeats
 unacknowledged inputs. Browser and native transports have no interoperability
@@ -205,7 +226,7 @@ required for the regression suite.
 After building the release web bundle, run `node tools/check-web-netplay.mjs` and
 `npm test --prefix crates/copperline-web/www`. CI also runs the native web wrapper
 unit tests, including failed startup, input routing and audio gain checks. The
-browser publishing workflow also checks the optimized bundle before copying `netplay.js` alongside
+browser publishing workflow also checks the optimized bundle before copying all netplay modules and the vendored QR license alongside
 the other page modules. For a served local page, the optional Playwright check
 `node tools/check-web-netplay-browser.mjs http://127.0.0.1:8000/` exercises actual
 Host/Join, cancellation, reconnect by cold boot, locked controls and mismatch
@@ -213,3 +234,13 @@ rejection in two Chromium contexts. It also verifies that a device-keyboard tap
 appears as a held key and subsequent release in transmitted input frames.
 `CHROME_PATH` selects an installed Chrome;
 `PLAYWRIGHT_MODULE` can point to a local Playwright module.
+
+Run `npm ci && npm test` in `services/netplay` for real local Worker lifecycle,
+role, quota and TURN-provider tests. With that service running on port 8787 and
+the site on 8765, `node tools/check-web-netplay-rooms.mjs` checks the invitation
+flow with the release WASM bundle. `NETPLAY_SERVICE` selects a deployed endpoint;
+`NETPLAY_RELAY_ONLY=1` requires an actual selected relay candidate and checked
+emulation frames. `NETPLAY_BROWSER=webkit` selects an installed Playwright WebKit.
+Desktop WebKit and mobile viewport tests do not qualify iOS hardware or beta Safari.
+The QR encoder is the unmodified `qrcode-generator` 2.0.4 ES module, distributed
+with its MIT license; no external image or QR service receives invitations.

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -137,6 +137,11 @@ credentials independently for each player; retries reuse the guest credentials
 within the room lifetime. Room creation fails when a production relay service
 is unavailable. Local development explicitly disables TURN requests. WebRTC
 selects direct or relay routes, or relay-only when requested in Advanced.
+The service filters alternate port 53 URLs from Cloudflare's response because
+browser port blocking can delay gathering even after usable candidates arrive.
+If a browser rejects TURN transport queries with a syntax error, the client
+retries with query-free UDP and TLS URLs. This preserves the ports, credentials
+and relay policy; plain TCP entries are omitted on that compatibility path.
 `netplay-diagnostics.js` records whitelisted states, candidate types and numeric
 counters before disposal. It never exports SDP, candidate addresses or tokens.
 The diagnostic sample survives a closed peer connection.

--- a/services/netplay/.gitignore
+++ b/services/netplay/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.wrangler/
+.dev.vars
+.env
+

--- a/services/netplay/README.md
+++ b/services/netplay/README.md
@@ -1,0 +1,84 @@
+# Browser netplay rooms
+
+This Cloudflare Worker exchanges WebRTC connection descriptions between two
+players. Each SQLite Durable Object holds one invitation for at most 15 minutes.
+Game inputs use WebRTC directly or through TURN; ROMs, disks and snapshots never
+pass through this service. The static site remains on GitHub Pages.
+
+## Deploy
+
+Use Node 24 or later. Install the pinned tools with `npm ci`, authenticate with
+`npx wrangler login`, and review the allowed site origins in `wrangler.jsonc`.
+Create a TURN key in Cloudflare Realtime and store its values as Worker secrets:
+
+```sh
+npx wrangler secret put TURN_KEY_ID
+npx wrangler secret put TURN_KEY_API_TOKEN
+npm run deploy
+```
+
+The first deployment creates the SQLite Durable Object namespace. Put the
+deployed HTTPS URL in the site shell:
+
+```html
+<meta name="copperline-netplay-service" content="https://YOUR-WORKER.workers.dev">
+```
+
+The URL is public configuration. Never put the TURN key or its API token in the
+site, source, logs or GitHub variables exposed to browsers. Temporary credentials
+are issued for each player and last 24 hours. They are not refreshed; longer
+games need a new session. Keep `REQUIRE_TURN` enabled in production: if TURN
+credential issuance fails, room creation reports an error rather than presenting
+a connection with no relay fallback.
+
+The WASM publishing workflow copies all netplay modules and the QR license to
+the site. It leaves the site's HTML, service URL and service worker intact.
+Worker changes are deployed separately with `npm run deploy`.
+
+## Limits and operations
+
+Invitations carry 128 random bits and admit one guest. Separate owner and guest
+tokens authorize changes; knowing the room ID alone does not grant host access.
+The first guest reservation wins, so share links only with the intended player.
+Setup expires after 15 minutes and DELETE removes it early. An established game
+continues independently of the signaling record. Closing a page attempts cleanup;
+expiry handles interrupted requests or suspended devices.
+
+Bodies are limited to 100 KiB and connection codes to 96 KiB. The service permits
+6 room creations and 120 total room requests per minute per client IP, using
+Cloudflare's per-location rate limiter. The browser polls every 1.5 seconds only
+while waiting for an answer. Shared networks share these quotas. CORS restricts
+browser origins; it does not authenticate non-browser clients. Avoid treating
+the quota as a global spending cap.
+
+Application logging is disabled and exceptions do not include provider messages
+or credentials. The Worker provider still handles request metadata. Check
+`GET /health` with an allowed `Origin` header for the service version and whether
+TURN secrets are configured; this does not test credential validity. A room
+creation and a relay-only browser session verify the actual relay path.
+
+Cloudflare's [Realtime pricing](https://developers.cloudflare.com/realtime/sfu/pricing/)
+has a shared SFU/TURN free allowance, followed by usage charges. Review current
+account limits and billing before enabling paid usage. The Worker and Durable
+Objects have their own quotas. There is no payment or plan upgrade in the deploy
+script.
+
+## Local checks
+
+```sh
+npm ci
+npm test
+npx wrangler deploy --dry-run
+npm run dev -- --env local
+```
+
+Local mode allows `http://127.0.0.1:8765`, disables TURN and makes no credential
+requests. Serve the site there, then run `node tools/check-web-netplay-rooms.mjs`
+from the repository root. The tool supplies the local service URL without editing
+the deployable page. Its `NETPLAY_SERVICE` and `NETPLAY_RELAY_ONLY=1` options test
+an explicitly selected deployed service and require a selected relay candidate.
+
+The Node tests run the Worker and Durable Objects in Miniflare, checking role
+boundaries, guest reservation, cleanup, request limits and TURN failure handling.
+An independent decoder checks the vendored QR encoder. Browser helper tests live
+in `crates/copperline-web/www`; run `npm test` there too.

--- a/services/netplay/README.md
+++ b/services/netplay/README.md
@@ -30,6 +30,11 @@ are issued for each player and last 24 hours. They are not refreshed; longer
 games need a new session. Keep `REQUIRE_TURN` enabled in production: if TURN
 credential issuance fails, room creation reports an error rather than presenting
 a connection with no relay fallback.
+The service removes Cloudflare's alternate port 53 URLs, which browsers can
+block and leave address discovery waiting until it times out. Other relay
+ports, including TLS on port 443, remain available.
+Browsers that reject TURN transport queries retry with default UDP and TLS URLs;
+plain TCP entries are omitted only for those browsers.
 
 The WASM publishing workflow copies all netplay modules and the QR license to
 the site. It leaves the site's HTML, service URL and service worker intact.

--- a/services/netplay/package-lock.json
+++ b/services/netplay/package-lock.json
@@ -1,0 +1,1758 @@
+{
+  "name": "copperline-netplay-signaling",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "copperline-netplay-signaling",
+      "devDependencies": {
+        "@zxing/library": "0.23.0",
+        "miniflare": "4.20260730.0",
+        "wrangler": "4.129.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260903.1.tgz",
+      "integrity": "sha512-FG+4mGxAXhKiL/1temH42alevIkumtYXNidhTa//3yULpzux6APw5UNVocI/vCQ1yG1YOEZRfbVy8lyuipM9MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-o241VefnjG8eG+kGap5CjgV4zOT5UaAmS3OR1VZCpNj7vkXGxvp9KftKvtQgcCsIqJKaKx+7Xd7xq0L1DjkfPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260903.1.tgz",
+      "integrity": "sha512-/VEvvtQ/XKf6HlBbg6FbvpwcpfYUcx6Fv6RkASY8DyEmUyuJ8rc7Qxil83ClRFoBzz/GY0BV94UZ6F+wers/hg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260903.1.tgz",
+      "integrity": "sha512-OWhihGC6KoTXF4u2C1AonfpgXeM4/7p/1IXuALqXESmFUpLLP5gZhRzjSk/gWW+mrCZDfSrvnjifl+lRqselbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260903.1.tgz",
+      "integrity": "sha512-soPMF9/aMHlHKK7M0vq5HrRRicPbnZO1F6ZZ7JWN8EltxWJU5L7CEq7CxjO878DzyPx7gYvqBFy3SVgdZKZjMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.23.0.tgz",
+      "integrity": "sha512-6fkkoFwP8CHxl6ugnPsj74PLJgX2iRv5zczGAyt5OBzQgxFhuhF0NCEc4t4OvSr8xAv2MRLlI0Iu9ZGDZQ2urA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ts-custom-error": "^3.3.1"
+      },
+      "engines": {
+        "node": ">= 24.0.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260730.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260730.0.tgz",
+      "integrity": "sha512-1Z9SB9r/o//80UA02Re3QhtcecSHAyAjf5EcKBfQVlQrCg7Miy79hl2PvtkwFLIaJ5rcrOPdDcRr577okwZPsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.28.0",
+        "workerd": "1.20260730.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260730.1.tgz",
+      "integrity": "sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/miniflare/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/miniflare/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260730.1.tgz",
+      "integrity": "sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/miniflare/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/miniflare/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260730.1.tgz",
+      "integrity": "sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/miniflare/node_modules/workerd": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260730.1.tgz",
+      "integrity": "sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260730.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260730.1",
+        "@cloudflare/workerd-linux-64": "1.20260730.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260730.1",
+        "@cloudflare/workerd-windows-64": "1.20260730.1"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260903.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260903.1.tgz",
+      "integrity": "sha512-xJzt2RnCy7ulOULmZy/4JLbEPg1uisp9lVoOUsEz+UVhDsTmrSQ0rBXZMGcXuhr2HCGKs89bg8nnbbzvBSX1Ig==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260903.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260903.1",
+        "@cloudflare/workerd-linux-64": "1.20260903.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260903.1",
+        "@cloudflare/workerd-windows-64": "1.20260903.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.129.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.129.0.tgz",
+      "integrity": "sha512-PGPvs9UPoFrwxT0VogpESSZGvZIctAuTK3wGsLLPHtHsSgS85kNdvtpa2d14UzG8gwLWD64XUGFPGG9tOXG9VQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260903.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260903.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260903.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/miniflare": {
+      "version": "5.20260903.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260903.0-alpha.tgz",
+      "integrity": "sha512-VCZIFxOqFXeibRBJWwTlppqbv2lkeO10IX3QBRGK9j1QiMAfH/OSsCvbjp1MslBMhVZmy2VTRlVaVnsKnbDp6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260903.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/services/netplay/package.json
+++ b/services/netplay/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "copperline-netplay-signaling",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev --ip 127.0.0.1 --port 8787",
+    "deploy": "wrangler deploy --env=\"\"",
+    "test": "node --test *.test.js"
+  },
+  "devDependencies": {
+    "@zxing/library": "0.23.0",
+    "miniflare": "4.20260730.0",
+    "wrangler": "4.129.0"
+  }
+}

--- a/services/netplay/qr.test.js
+++ b/services/netplay/qr.test.js
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { BinaryBitmap, HybridBinarizer, QRCodeReader, RGBLuminanceSource } from '@zxing/library';
+import qrcode from '../../crates/copperline-web/www/netplay-qr.js';
+import { inviteUrl } from '../../crates/copperline-web/www/netplay-room.js';
+test('an independent QR decoder recovers the exact private invitation', () => {
+  const invitation = inviteUrl('aB_0-9'.repeat(3) + 'xyZ1', 'https://copperline.dev/try/?rom=private');
+  const qr = qrcode(0, 'M'); qr.addData(invitation); qr.make();
+  const modules = qr.getModuleCount(), scale = 4, border = 4;
+  const size = (modules + 2 * border) * scale;
+  const pixels = new Uint8ClampedArray(size * size).fill(255);
+  for (let y = 0; y < modules; y++) for (let x = 0; x < modules; x++) {
+    if (!qr.isDark(y, x)) continue;
+    for (let dy = 0; dy < scale; dy++) for (let dx = 0; dx < scale; dx++) {
+      pixels[((y + border) * scale + dy) * size + (x + border) * scale + dx] = 0;
+    }
+  }
+  const bitmap = new BinaryBitmap(new HybridBinarizer(new RGBLuminanceSource(pixels, size, size)));
+  assert.equal(new QRCodeReader().decode(bitmap).getText(), invitation);
+});

--- a/services/netplay/worker.js
+++ b/services/netplay/worker.js
@@ -57,9 +57,14 @@ async function iceServers(env) {
   });
   if (!response.ok) throw new Error('Relay credentials are unavailable');
   const value = await response.json();
-  if (!Array.isArray(value.iceServers) || !value.iceServers.some(server =>
-    [].concat(server.urls ?? []).some(url => /^turns?:/.test(url)))) throw new Error('Invalid relay response');
-  return { iceServers: value.iceServers, relay: true };
+  if (!Array.isArray(value.iceServers)) throw new Error('Invalid relay response');
+  // Browsers block alternate port 53, delaying non-trickle ICE gathering.
+  // https://developers.cloudflare.com/realtime/turn/generate-credentials/
+  const servers = value.iceServers.map(server => ({ ...server,
+    urls: [].concat(server.urls ?? []).filter(url => typeof url === 'string' && !/:53(?:\?|$)/.test(url)),
+  })).filter(server => server.urls.length);
+  if (!servers.some(server => server.urls.some(url => /^turns?:/.test(url)))) throw new Error('Invalid relay response');
+  return { iceServers: servers, relay: true };
 }
 
 export default {

--- a/services/netplay/worker.js
+++ b/services/netplay/worker.js
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { DurableObject } from 'cloudflare:workers';
+
+const ROOM_TTL = 15 * 60 * 1000;
+const BODY_LIMIT = 100 * 1024;
+const TOKEN = /^[A-Za-z0-9_-]{22}$/;
+const turnUrl = id => `https://rtc.live.cloudflare.com/v1/turn/keys/${encodeURIComponent(id)}/credentials/generate-ice-servers`;
+const json = (body, status = 200) => Response.json(body, { status, headers: { 'Cache-Control': 'no-store' } });
+const token = () => btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16))))
+  .replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+
+class RequestError extends Error {}
+
+async function readJson(request) {
+  if (!request.headers.get('Content-Type')?.startsWith('application/json')) throw new RequestError('Expected JSON');
+  const reader = request.body?.getReader();
+  if (!reader) throw new RequestError('Expected JSON');
+  const chunks = [];
+  let size = 0;
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    size += value.length;
+    if (size > BODY_LIMIT) { await reader.cancel(); throw new RequestError('Request too large'); }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.length; }
+  let value;
+  try { value = JSON.parse(new TextDecoder().decode(bytes)); }
+  catch { throw new RequestError('Invalid JSON'); }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new RequestError('Expected JSON object');
+  return value;
+}
+
+function connectionCode(code, type) {
+  if (typeof code !== 'string' || code.length > 96 * 1024 || !code.startsWith('CLNP1.')) return false;
+  try {
+    const value = JSON.parse(atob(code.slice(6)));
+    return value?.description?.type === type && typeof value.description.sdp === 'string'
+      && value.description.sdp.startsWith('v=0\r\n');
+  } catch { return false; }
+}
+
+async function iceServers(env) {
+  if (!env.TURN_KEY_ID || !env.TURN_KEY_API_TOKEN) {
+    if (env.REQUIRE_TURN !== 'false') throw new Error('Relay service is not configured');
+    // Explicit local-development mode: no third-party network requests.
+    return { iceServers: [], relay: false };
+  }
+  const response = await fetch(turnUrl(env.TURN_KEY_ID), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${env.TURN_KEY_API_TOKEN}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ttl: 86400 }),
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!response.ok) throw new Error('Relay credentials are unavailable');
+  const value = await response.json();
+  if (!Array.isArray(value.iceServers) || !value.iceServers.some(server =>
+    [].concat(server.urls ?? []).some(url => /^turns?:/.test(url)))) throw new Error('Invalid relay response');
+  return { iceServers: value.iceServers, relay: true };
+}
+
+export default {
+  async fetch(request, env) {
+    const origin = request.headers.get('Origin');
+    const allowed = (env.ALLOWED_ORIGINS ?? '').split(',').map(value => value.trim());
+    if (!origin || !allowed.includes(origin)) return json({ error: 'Origin not allowed' }, 403);
+    const cors = {
+      'Access-Control-Allow-Origin': origin,
+      'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+      'Access-Control-Max-Age': '600',
+      'Cache-Control': 'no-store',
+      Vary: 'Origin',
+    };
+    if (request.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+    let response;
+    try {
+      const path = new URL(request.url).pathname;
+      const match = /^\/rooms\/([A-Za-z0-9_-]{22})(?:\/(offer|join|answer))?$/.exec(path);
+      if (path === '/health' && request.method === 'GET') {
+        response = json({ service: 'copperline-netplay', version: 1,
+          relay: !!(env.TURN_KEY_ID && env.TURN_KEY_API_TOKEN) });
+      } else if ((path === '/rooms' && request.method === 'POST') || match) {
+        // Bound both creation and room traffic. Keys are never persisted or logged.
+        const key = request.headers.get('CF-Connecting-IP') ?? 'local';
+        if (!env.ROOM_RATE_LIMIT || !(await env.ROOM_RATE_LIMIT.limit({ key })).success ||
+            (!match && (!env.ROOM_CREATE_LIMIT || !(await env.ROOM_CREATE_LIMIT.limit({ key })).success))) {
+          response = json({ error: 'Too many requests. Wait a minute and try again.' }, 429);
+        } else {
+          const id = match?.[1] ?? token();
+          const stub = env.ROOMS.get(env.ROOMS.idFromName(id));
+          const url = new URL(request.url);
+          url.pathname = match ? `/${match[2] ?? ''}` : '/create';
+          // The namespace ID stays server-side; the invitation is a random capability.
+          const inner = new Request(url, request);
+          inner.headers.set('X-Room-ID', id);
+          response = await stub.fetch(inner);
+        }
+      } else response = json({ error: 'Not found' }, 404);
+    } catch {
+      // Never echo API/provider errors, request bodies or secrets to clients/logs.
+      response = json({ error: 'The room service could not complete the request. Try again.' }, 503);
+    }
+    const headers = new Headers(response.headers);
+    for (const [key, value] of Object.entries(cors)) headers.set(key, value);
+    return new Response(response.body, { status: response.status, headers });
+  },
+};
+
+export class NetplayRoom extends DurableObject {
+  async fetch(request) {
+    // Serialize the two-player reservation across awaits, including TURN issuance.
+    return this.ctx.blockConcurrencyWhile(async () => {
+      try { return await this.handle(request); }
+      catch (error) {
+        return json({ error: error instanceof RequestError ? error.message : 'Room request failed' },
+          error instanceof RequestError ? 400 : 503);
+      }
+    });
+  }
+
+  async handle(request) {
+    const path = new URL(request.url).pathname;
+    const room = await this.ctx.storage.get('room');
+    if (path === '/create' && request.method === 'POST') {
+      if (room) return json({ error: 'Room already exists' }, 409);
+      const body = await readJson(request);
+      if (Object.keys(body).length) return json({ error: 'Invalid room request' }, 400);
+      let ice;
+      try { ice = await iceServers(this.env); }
+      catch { return json({ error: 'Relay service is unavailable. Please try again later.' }, 503); }
+      const owner = token();
+      const expiresAt = Date.now() + ROOM_TTL;
+      await this.ctx.storage.put('room', { owner, expiresAt, offer: null, guest: null, answer: null });
+      await this.ctx.storage.setAlarm(expiresAt);
+      return json({ id: request.headers.get('X-Room-ID'), owner, expiresAt, ...ice }, 201);
+    }
+    if (!room || room.expiresAt <= Date.now()) {
+      if (room) await this.ctx.storage.deleteAll();
+      return json({ error: 'This invitation has expired or ended. Ask the host for a new link.' }, 410);
+    }
+    const bearer = /^Bearer ([A-Za-z0-9_-]{22})$/.exec(request.headers.get('Authorization') ?? '')?.[1];
+    if (path === '/join' && request.method === 'POST') {
+      const body = await readJson(request);
+      if (!TOKEN.test(body.guest ?? '')) return json({ error: 'Invalid join request' }, 400);
+      if (!room.offer) return json({ error: 'The host is still preparing. Try again in a moment.' }, 409);
+      if (room.guest && room.guest !== body.guest) return json({ error: 'This room already has two players.' }, 409);
+      if (!room.guest) {
+        let ice;
+        try { ice = await iceServers(this.env); }
+        catch { return json({ error: 'Relay service is unavailable. Please try again later.' }, 503); }
+        room.guest = body.guest;
+        room.guestIce = ice;
+        await this.ctx.storage.put('room', room);
+      }
+      return json({ offer: room.offer, expiresAt: room.expiresAt, ...room.guestIce });
+    }
+    const owner = bearer === room.owner;
+    const guest = room.guest && bearer === room.guest;
+    if (!owner && !guest) return json({ error: 'Room access denied' }, 403);
+    if (path === '/' && request.method === 'DELETE') {
+      await this.ctx.storage.deleteAll();
+      await this.ctx.storage.deleteAlarm();
+      return json({ ended: true });
+    }
+    if (path === '/offer' && request.method === 'POST' && owner) {
+      const body = await readJson(request);
+      if (!connectionCode(body.code, 'offer')) return json({ error: 'Invalid offer' }, 400);
+      if (room.offer && room.offer !== body.code) return json({ error: 'Start a new room to change the offer' }, 409);
+      room.offer = body.code;
+      await this.ctx.storage.put('room', room);
+      return json({ ready: true });
+    }
+    if (path === '/answer' && request.method === 'POST' && guest) {
+      const body = await readJson(request);
+      if (!connectionCode(body.code, 'answer')) return json({ error: 'Invalid answer' }, 400);
+      if (room.answer && room.answer !== body.code) return json({ error: 'Start a new room to change the answer' }, 409);
+      room.answer = body.code;
+      await this.ctx.storage.put('room', room);
+      return json({ ready: true });
+    }
+    if (path === '/answer' && request.method === 'GET' && owner) return json({ answer: room.answer });
+    return json({ error: 'Not found' }, 404);
+  }
+
+  async alarm() { await this.ctx.storage.deleteAll(); }
+}

--- a/services/netplay/worker.js
+++ b/services/netplay/worker.js
@@ -95,14 +95,19 @@ export default {
           const url = new URL(request.url);
           url.pathname = match ? `/${match[2] ?? ''}` : '/create';
           // The namespace ID stays server-side; the invitation is a random capability.
-          const inner = new Request(url, request);
+          // Consume the bounded body before forwarding. An early Durable Object
+          // response (for example, an expired invitation) must not leave a
+          // network-backed upload being read after this fetch has returned.
+          const body = request.method === 'POST' ? JSON.stringify(await readJson(request)) : undefined;
+          const inner = new Request(url, { method: request.method, headers: request.headers, body });
           inner.headers.set('X-Room-ID', id);
           response = await stub.fetch(inner);
         }
       } else response = json({ error: 'Not found' }, 404);
-    } catch {
+    } catch (error) {
       // Never echo API/provider errors, request bodies or secrets to clients/logs.
-      response = json({ error: 'The room service could not complete the request. Try again.' }, 503);
+      response = error instanceof RequestError ? json({ error: error.message }, 400)
+        : json({ error: 'The room service could not complete the request. Try again.' }, 503);
     }
     const headers = new Headers(response.headers);
     for (const [key, value] of Object.entries(cors)) headers.set(key, value);

--- a/services/netplay/worker.test.js
+++ b/services/netplay/worker.test.js
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Miniflare } from 'miniflare';
+
+const origin = 'https://copperline.dev';
+const guest = 'g'.repeat(22);
+const code = type => 'CLNP1.' + btoa(JSON.stringify({ description: { type, sdp: 'v=0\r\ns=-\r\n' } }));
+const options = {
+  modules: true, scriptPath: new URL('./worker.js', import.meta.url).pathname,
+  compatibilityDate: '2026-07-30',
+  durableObjects: { ROOMS: { className: 'NetplayRoom', useSQLite: true } },
+  ratelimits: {
+    ROOM_RATE_LIMIT: { namespace_id: '1', simple: { limit: 120, period: 60 } },
+    ROOM_CREATE_LIMIT: { namespace_id: '2', simple: { limit: 6, period: 60 } },
+  },
+  bindings: { ALLOWED_ORIGINS: origin, REQUIRE_TURN: 'false' },
+};
+function client(mf) {
+  return async (path, method = 'GET', body, auth, extra = {}) => {
+    const response = await mf.dispatchFetch('https://service.test' + path, {
+      method, headers: { Origin: origin, 'Content-Type': 'application/json',
+        ...(auth ? { Authorization: `Bearer ${auth}` } : {}), ...extra },
+      ...(body === undefined ? {} : { body: typeof body === 'string' ? body : JSON.stringify(body) }),
+    });
+    return { status: response.status, headers: response.headers,
+      body: response.status === 204 ? null : await response.json() };
+  };
+}
+
+test('real Worker runtime: rooms enforce roles, reserve one guest, exchange codes and expire on cancellation', async t => {
+  const mf = new Miniflare(options); t.after(() => mf.dispose());
+  const call = client(mf);
+  assert.equal((await call('/rooms', 'POST', {}, null, { Origin: 'https://other.test' })).status, 403);
+  const preflight = await call('/rooms', 'OPTIONS');
+  assert.equal(preflight.status, 204);
+  assert.equal(preflight.headers.get('Access-Control-Allow-Origin'), origin);
+  assert.equal((await call('/rooms', 'POST', '{')).status, 400);
+  assert.equal((await call('/rooms', 'POST', 'x'.repeat(103000))).status, 400);
+  const created = await call('/rooms', 'POST', {});
+  assert.equal(created.status, 201);
+  assert.equal(created.headers.get('Cache-Control'), 'no-store');
+  const { id, owner, expiresAt } = created.body;
+  assert.match(id, /^[A-Za-z0-9_-]{22}$/);
+  assert.notEqual(id, owner);
+  assert.ok(expiresAt > Date.now() && expiresAt <= Date.now() + 900000);
+  const path = `/rooms/${id}`;
+  assert.equal((await call(path + '/join', 'POST', { guest })).status, 409);
+  assert.equal((await call(path + '/offer', 'POST', { code: code('offer') }, id)).status, 403);
+  assert.equal((await call(path + '/offer', 'POST', { code: code('answer') }, owner)).status, 400);
+  assert.equal((await call(path + '/offer', 'POST', { code: code('offer') }, owner)).status, 200);
+  const joins = await Promise.all([guest, 'h'.repeat(22)].map(value => call(path + '/join', 'POST', { guest: value })));
+  assert.deepEqual(joins.map(value => value.status).sort(), [200, 409]);
+  const winner = joins[0].status === 200 ? guest : 'h'.repeat(22);
+  assert.equal((await call(path + '/join', 'POST', { guest: winner })).status, 200);
+  assert.equal((await call(path + '/answer', 'GET', undefined, winner)).status, 404);
+  assert.deepEqual((await call(path + '/answer', 'GET', undefined, owner)).body, { answer: null });
+  assert.equal((await call(path + '/answer', 'POST', { code: code('answer') }, owner)).status, 404);
+  assert.equal((await call(path + '/answer', 'POST', { code: code('answer') }, winner)).status, 200);
+  assert.equal((await call(path + '/answer', 'GET', undefined, owner)).body.answer, code('answer'));
+  assert.equal((await call(path, 'DELETE', undefined, winner)).status, 200);
+  assert.equal((await call(path + '/answer', 'GET', undefined, owner)).status, 410);
+});
+
+test('production refuses to create a room without TURN; creation quota is separate from polling', async t => {
+  const mf = new Miniflare({ ...options, bindings: { ...options.bindings, REQUIRE_TURN: 'true' } });
+  t.after(() => mf.dispose());
+  const call = client(mf);
+  assert.equal((await call('/rooms', 'POST', {})).status, 503);
+  for (let i = 0; i < 5; i++) await call('/rooms', 'POST', {});
+  assert.equal((await call('/rooms', 'POST', {})).status, 429);
+  assert.equal((await call(`/rooms/${guest}/answer`)).status, 410);
+});
+
+test('TURN credentials stay scoped to players and provider failures are redacted', async t => {
+  let requests = 0;
+  const mf = new Miniflare({ ...options,
+    bindings: { ...options.bindings, REQUIRE_TURN: 'true', TURN_KEY_ID: 'private-key-id', TURN_KEY_API_TOKEN: 'private-api-token' },
+    outboundService: async request => {
+      requests++;
+      assert.equal(request.headers.get('Authorization'), 'Bearer private-api-token');
+      assert.deepEqual(await request.json(), { ttl: 86400 });
+      if (requests > 1) return new Response('private-api-token provider failure', { status: 500 });
+      return Response.json({ iceServers: [{ urls: ['turn:relay.test:3478'], username: 'temporary-user', credential: 'temporary-credential' }] });
+    },
+  });
+  t.after(() => mf.dispose());
+  const call = client(mf);
+  const created = await call('/rooms', 'POST', {});
+  assert.equal(created.status, 201);
+  assert.equal(created.body.relay, true);
+  assert.ok(!JSON.stringify(created.body).includes('private-'));
+  const failed = await call('/rooms', 'POST', {});
+  assert.equal(failed.status, 503);
+  assert.ok(!JSON.stringify(failed.body).includes('private-'));
+});

--- a/services/netplay/worker.test.js
+++ b/services/netplay/worker.test.js
@@ -81,7 +81,13 @@ test('TURN credentials stay scoped to players and provider failures are redacted
       assert.equal(request.headers.get('Authorization'), 'Bearer private-api-token');
       assert.deepEqual(await request.json(), { ttl: 86400 });
       if (requests > 1) return new Response('private-api-token provider failure', { status: 500 });
-      return Response.json({ iceServers: [{ urls: ['turn:relay.test:3478'], username: 'temporary-user', credential: 'temporary-credential' }] });
+      return Response.json({ iceServers: [
+        { urls: 'stun:relay.test:53' },
+        { urls: ['stun:relay.test:3478', 'stun:relay.test:53'] },
+        { urls: ['turn:relay.test:3478?transport=udp', 'turn:relay.test:53?transport=udp',
+          'turns:relay.test:5349?transport=tcp', 'turns:relay.test:443?transport=tcp'],
+          username: 'temporary-user', credential: 'temporary-credential' },
+      ] });
     },
   });
   t.after(() => mf.dispose());
@@ -89,6 +95,11 @@ test('TURN credentials stay scoped to players and provider failures are redacted
   const created = await call('/rooms', 'POST', {});
   assert.equal(created.status, 201);
   assert.equal(created.body.relay, true);
+  assert.deepEqual(created.body.iceServers, [
+    { urls: ['stun:relay.test:3478'] },
+    { urls: ['turn:relay.test:3478?transport=udp', 'turns:relay.test:5349?transport=tcp',
+      'turns:relay.test:443?transport=tcp'], username: 'temporary-user', credential: 'temporary-credential' },
+  ]);
   assert.ok(!JSON.stringify(created.body).includes('private-'));
   const failed = await call('/rooms', 'POST', {});
   assert.equal(failed.status, 503);

--- a/services/netplay/wrangler.jsonc
+++ b/services/netplay/wrangler.jsonc
@@ -1,0 +1,82 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "copperline-netplay",
+  "main": "worker.js",
+  "compatibility_date": "2026-07-30",
+  "workers_dev": true,
+  "vars": {
+    "ALLOWED_ORIGINS": "https://copperline.dev,https://copperline.github.io",
+    "REQUIRE_TURN": "true"
+  },
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "ROOMS",
+        "class_name": "NetplayRoom"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": [
+        "NetplayRoom"
+      ]
+    }
+  ],
+  "ratelimits": [
+    {
+      "name": "ROOM_RATE_LIMIT",
+      "namespace_id": "19732001",
+      "simple": {
+        "limit": 120,
+        "period": 60
+      }
+    },
+    {
+      "name": "ROOM_CREATE_LIMIT",
+      "namespace_id": "19732003",
+      "simple": {
+        "limit": 6,
+        "period": 60
+      }
+    }
+  ],
+  "observability": {
+    "enabled": false
+  },
+  "env": {
+    "local": {
+      "vars": {
+        "ALLOWED_ORIGINS": "http://127.0.0.1:8765",
+        "REQUIRE_TURN": "false"
+      },
+      "durable_objects": {
+        "bindings": [
+          {
+            "name": "ROOMS",
+            "class_name": "NetplayRoom"
+          }
+        ]
+      },
+      "ratelimits": [
+        {
+          "name": "ROOM_RATE_LIMIT",
+          "namespace_id": "19732002",
+          "simple": {
+            "limit": 120,
+            "period": 60
+          }
+        },
+        {
+          "name": "ROOM_CREATE_LIMIT",
+          "namespace_id": "19732004",
+          "simple": {
+            "limit": 6,
+            "period": 60
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tools/check-web-netplay-browser.mjs
+++ b/tools/check-web-netplay-browser.mjs
@@ -31,7 +31,9 @@ try {
     page.on('pageerror', error => errors.push(error.message));
     await page.goto(url.href);
     await page.locator('#boot:enabled').waitFor({ timeout: 30000 });
-    await page.locator('#netplay-panel summary').click();
+    if (await page.locator('#netplay-open').count()) await page.locator('#netplay-open').click();
+    else await page.locator('#netplay-panel > summary').click();
+    await page.locator('#netplay-advanced').evaluate(panel => { panel.open = true; });
     await page.locator('#netplay-stun').fill('');
     pages.push(page);
   }

--- a/tools/check-web-netplay-rooms.mjs
+++ b/tools/check-web-netplay-rooms.mjs
@@ -62,7 +62,14 @@ try {
   const [host, guest] = pages;
   const invitation = async () => {
     await host.locator('#netplay-room-host').click();
-    await host.waitForFunction(() => document.querySelector('#netplay-invite').value.includes('#room='), null, { timeout: 30000 });
+    await host.waitForFunction(() => document.querySelector('#netplay-invite').value.includes('#room='), null, { timeout: 30000 })
+      .catch(async error => {
+        console.error('Host setup:', await host.locator('#netplay-status').textContent());
+        await host.locator('#netplay-diagnostics').click();
+        await host.waitForFunction(() => window.__copied?.startsWith('{'));
+        console.error('Host diagnostics:', await host.evaluate(() => window.__copied));
+        throw error;
+      });
     return host.locator('#netplay-invite').inputValue();
   };
   const cancelled = await invitation();

--- a/tools/check-web-netplay-rooms.mjs
+++ b/tools/check-web-netplay-rooms.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Test the site against a local room service. Set NETPLAY_SERVICE for a deployed
+// service and NETPLAY_RELAY_ONLY=1 to require a verified TURN route.
+import assert from 'node:assert/strict';
+import { mkdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+const url = new URL(process.argv[2] ?? 'http://127.0.0.1:8765/try/');
+const service = new URL(process.env.NETPLAY_SERVICE ?? 'http://127.0.0.1:8787');
+const relayOnly = process.env.NETPLAY_RELAY_ONLY === '1';
+const output = resolve(process.argv[3] ?? '/tmp/copperline-netplay-rooms-browser');
+await mkdir(output, { recursive: true });
+const module = process.env.PLAYWRIGHT_MODULE;
+const playwright = await import(module ? pathToFileURL(resolve(module)).href : 'playwright');
+const engine = process.env.NETPLAY_BROWSER ?? 'chromium';
+const browser = await playwright[engine].launch({
+  ...(engine === 'chromium' ? { executablePath: process.env.CHROME_PATH,
+    args: ['--autoplay-policy=no-user-gesture-required', '--disable-background-timer-throttling',
+      '--disable-renderer-backgrounding', '--disable-backgrounding-occluded-windows'] } : {}),
+});
+const errors = [];
+const shutdownNotices = [];
+let phase = 'setup';
+try {
+  const pages = [];
+  for (let player = 0; player < 2; player++) {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 1000 }, serviceWorkers: 'block' });
+    await context.route('**/*', route => {
+      const target = new URL(route.request().url());
+      return [url.origin, service.origin].includes(target.origin) ? route.continue() : route.abort();
+    });
+    await context.addInitScript(base => {
+      // Use a test endpoint without changing the deployable page configuration.
+      new MutationObserver(() => {
+        const meta = document.querySelector('meta[name="copperline-netplay-service"]');
+        if (meta && meta.content !== base) meta.content = base;
+      }).observe(document, { childList: true, subtree: true });
+      Object.defineProperty(navigator, 'clipboard', { value: { writeText: async text => { window.__copied = text; } } });
+    }, service.origin);
+    const page = await context.newPage();
+    page.on('pageerror', error => {
+      // WebKit logs a native console error when its send queue meets a remote
+      // shutdown before the closing event arrives (RTCDataChannel.cpp). Keep
+      // it visible and permit it only during deliberately ended sessions.
+      if (engine === 'webkit' && ['disconnect', 'mismatch'].includes(phase)
+          && error.message === 'Error sending binary data through RTCDataChannel.') {
+        shutdownNotices.push({ phase, message: error.message });
+      } else errors.push({ phase, message: error.message });
+    });
+    await page.goto(url.href);
+    await page.locator('#boot:enabled').waitFor({ timeout: 30000 });
+    if (await page.locator('#netplay-open').count()) await page.locator('#netplay-open').click();
+    else await page.locator('#netplay-panel > summary').click();
+    if (relayOnly) {
+      await page.locator('#netplay-advanced > summary').click();
+      await page.locator('#netplay-relay-only').check();
+      await page.locator('#netplay-advanced > summary').click();
+    }
+    pages.push(page);
+  }
+  const [host, guest] = pages;
+  const invitation = async () => {
+    await host.locator('#netplay-room-host').click();
+    await host.waitForFunction(() => document.querySelector('#netplay-invite').value.includes('#room='), null, { timeout: 30000 });
+    return host.locator('#netplay-invite').inputValue();
+  };
+  const cancelled = await invitation();
+  phase = 'disconnect';
+  await host.locator('#netplay-disconnect').click();
+  await guest.locator('#netplay-room-code').fill(cancelled);
+  await guest.locator('#netplay-room-join').click();
+  await guest.waitForFunction(() => /expired|ended/.test(document.querySelector('#netplay-status').textContent));
+  assert.equal(await guest.locator('#boot').isEnabled(), true);
+  async function connect() {
+    phase = 'connecting';
+    const link = await invitation();
+    assert.equal(new URL(link).search, '');
+    await host.locator('#netplay-qr svg').waitFor();
+    await host.locator('#netplay-copy-invite').click();
+    assert.equal(await host.evaluate(() => window.__copied), link);
+    // Fragment navigation must reveal the panel and populate Join on an already loaded page.
+    await guest.evaluate(link => { location.hash = new URL(link).hash; }, link);
+    await guest.waitForFunction(() => document.querySelector('#netplay-room-code').value === new URLSearchParams(location.hash.slice(1)).get('room'));
+    await host.locator('#netplay-panel').screenshot({ path: `${output}/invitation.png` });
+    await guest.locator('#netplay-room-join').click();
+    await Promise.all(pages.map(page => page.waitForFunction(() => window.__emu?.netplay_status()[6] >= 120,
+      null, { timeout: 90000 })));
+    phase = 'playing';
+    return link;
+  }
+  const link = await connect();
+  for (const [i, page] of pages.entries()) {
+    for (const id of ['boot', 'machine', 'video', 'reset', 'pause', 'df0', 'df1']) {
+      assert.equal(await page.locator(`#${id}`).isDisabled(), true, `${id} must stay locked`);
+    }
+    await page.evaluate(() => { window.__copied = ''; });
+    await page.locator('#netplay-diagnostics').click();
+    await page.waitForFunction(() => window.__copied?.startsWith('{'));
+    const report = JSON.parse(await page.evaluate(() => window.__copied));
+    assert.equal(report.connection.peer, 'connected');
+    assert.equal(report.stats.dtls, 'connected');
+    if (relayOnly) assert.equal(report.stats.selectedPair.local, 'relay');
+    assert.ok(!JSON.stringify(report).includes(new URL(link).hash.slice(6)));
+    console.log(`Player ${i + 1}: ${JSON.stringify({ status: await page.evaluate(() => [...window.__emu.netplay_status()]), route: report.stats.selectedPair })}`);
+  }
+  phase = 'disconnect';
+  await host.locator('#netplay-disconnect').click();
+  await Promise.all(pages.map(page => page.locator('#netplay-room-host:enabled').waitFor()));
+  await guest.evaluate(() => { window.__copied = ''; });
+  await guest.locator('#netplay-diagnostics').click();
+  await guest.waitForFunction(() => window.__copied?.startsWith('{'));
+  assert.ok(JSON.parse(await guest.evaluate(() => window.__copied)).stats);
+  await connect();
+  phase = 'disconnect';
+  await guest.locator('#netplay-disconnect').click();
+  await Promise.all(pages.map(page => page.locator('#netplay-room-host:enabled').waitFor()));
+  await guest.locator('#video').selectOption('NTSC');
+  phase = 'mismatch';
+  const mismatch = await invitation();
+  await guest.locator('#netplay-room-code').fill(mismatch);
+  await guest.locator('#netplay-room-join').click();
+  await Promise.all(pages.map(page => page.waitForFunction(() => /mismatch|different/i.test(document.querySelector('#netplay-status').textContent), null, { timeout: 30000 })));
+  await host.setViewportSize({ width: 390, height: 844 });
+  await host.locator('#netplay-open').click();
+  await host.locator('#netplay-panel').screenshot({ path: `${output}/mobile.png` });
+  assert.deepEqual(errors, []);
+  if (shutdownNotices.length) console.log('WebKit native shutdown notices:', JSON.stringify(shutdownNotices));
+  console.log('Room invitations, cancellation, reconnect, machine mismatch, diagnostics and responsive rendering passed');
+} finally { await browser.close(); }


### PR DESCRIPTION
Browser netplay currently requires exchanging large offer/answer codes and exposes little information when a connection fails. Add private invitation links, locally generated QR codes and native sharing, with automatic signaling and temporary TURN credentials from a small Cloudflare service. Manual codes remain under Advanced; Copy diagnostics retains ICE, DTLS and route information after disconnect without exporting addresses or credentials.

The service filters Cloudflare's alternate port 53 URLs to avoid non-trickle ICE gathering timeouts. A client compatibility path retains default UDP and TLS routes when a browser rejects valid TURN transport queries.

The service reserves one guest per expiring room, enforces owner/guest roles and request quotas, and fails room creation when production TURN credentials are unavailable. The WASM publishing workflow now copies every netplay module and the QR license; the site-owned service URL remains in the HTML shell. Deployment and lifecycle limits are documented under services/netplay and in the browser/netplay guides.

Validation: 16 browser helper tests; 4 real Worker/QR tests; two-peer room sessions through 120 checked frames in Chrome and desktop WebKit 26.5; cancellation, reconnect, machine mismatch and post-disconnect diagnostics; manual netplay including transmitted keyboard input; desktop/mobile layouts and offline AROS boot; Worker production dry run; cargo fmt --check and locked all-target/all-feature Clippy. The published site and deployed Worker passed the full Chrome and desktop WebKit 26.5 relay-only suites, including two relay candidates and 120 checked frames. One earlier live WebKit run timed out; two subsequent complete runs passed, so that intermittent failure remains unexplained. Both engines also passed with the local Worker using real Cloudflare credentials. Actual iOS/iPadOS 27 beta hardware remains unverified.
