### PR TITLE
Transfer host browser game setup before netplay

### DIFF
--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -146,6 +146,7 @@ jobs:
              crates/copperline-web/www/render-stride.js \
              crates/copperline-web/www/netplay.js \
              crates/copperline-web/www/netplay-room.js \
+             crates/copperline-web/www/netplay-media.js \
              crates/copperline-web/www/netplay-diagnostics.js \
              crates/copperline-web/www/netplay-qr.js \
              crates/copperline-web/www/netplay-qr.LICENSE \

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The manual is published at [copperline.dev/docs](https://copperline.dev/docs/) a
 - [WHDLoad Support](docs/guide/whdload.md) - Direct WHDLoad package loading
 - [Direct Executable Launching](docs/guide/run.md) - Running cross-compiled Amiga binaries
 - [Floppy Hardware Bridge](docs/guide/fluxbridge.md) - Real floppy drives via Greaseweazle
-- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions through desktop GUI/CLI or browser WebRTC with invitation links, QR sharing and relay fallback, plus input prediction, rollback and matching-machine checks
+- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions through desktop GUI/CLI or browser WebRTC with QR invitations, host ROM/disk/configuration transfer and relay fallback, plus input prediction, rollback and matching-machine checks
 - [Headless Mode](docs/guide/headless.md) - Scripted runs and screenshot/frame dumps
 - [Debugging](docs/debugger/window.md) - In-window, headless, and GDB debugging
 - [VS Code](docs/debugger/vscode.md) - Setup and illustrated source debugging; [Bartman with Copperline](docs/debugger/vscode-bartman.md) covers fork installation and visual profiling

--- a/crates/copperline-web/www/netplay-diagnostics.js
+++ b/crates/copperline-web/www/netplay-diagnostics.js
@@ -61,7 +61,7 @@ export class NetplayDiagnostics {
     };
     // Call sites supply fixed event names. Do not accept arbitrary reason strings.
     const kinds = ['created', 'peer-state', 'ice-state', 'gathering-state', 'signaling-state',
-      'data-open', 'data-close', 'data-error', 'ice-error', 'stopped', 'copy'];
+      'data-open', 'data-close', 'data-error', 'ice-error', 'gathering-deadline', 'stopped', 'copy'];
     if (kinds.includes(event)) this.events.push({ event, elapsedMs: Math.round(performance.now() - this.started),
       peer: this.connection.peer, ice: this.connection.ice });
     if (this.events.length > 40) this.events.shift();

--- a/crates/copperline-web/www/netplay-media.js
+++ b/crates/copperline-web/www/netplay-media.js
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Session media travels over the encrypted peer connection, never signaling.
+export const MEDIA_VERSION = 'host-v1';
+export const MEDIA_CHANNEL = 'copperline-setup-v1';
+export const MEDIA_CHUNK = 16 * 1024;
+const MANIFEST_LIMIT = 8192;
+const MEDIA_LIMIT = 36 * 1024 * 1024;
+const BUFFER_LIMIT = 256 * 1024;
+const kinds = ['rom', 'ext', 'df0', 'df1'];
+const digest = async bytes => [...new Uint8Array(await crypto.subtle.digest('SHA-256', bytes))]
+  .map(byte => byte.toString(16).padStart(2, '0')).join('');
+
+export function validateManifest(value) {
+  const config = value?.config;
+  if (value?.type !== MEDIA_VERSION || !config ||
+      !['A500', 'A1200'].includes(config.model) || !['PAL', 'NTSC'].includes(config.video) ||
+      ![0, 100, 200, 400, 800].includes(config.floppySpeed) ||
+      typeof config.floppySounds !== 'boolean' || typeof config.monoAudio !== 'boolean' ||
+      typeof config.build !== 'string' || !config.build.length || config.build.length > 128 ||
+      !Array.isArray(value.files) || !value.files.length || value.files.length > kinds.length) {
+    throw new Error('Invalid host machine configuration');
+  }
+  const seen = new Set();
+  let total = 0;
+  const files = value.files.map(file => {
+    if (!file || !kinds.includes(file.kind) || seen.has(file.kind) ||
+        !Number.isSafeInteger(file.size) || file.size < 1 ||
+        file.size > (['rom', 'ext'].includes(file.kind) ? 2 : 16) * 1024 * 1024 ||
+        typeof file.hash !== 'string' || !/^[a-f0-9]{64}$/.test(file.hash) ||
+        typeof file.label !== 'string' || !file.label.length || file.label.length > 256 ||
+        typeof file.writable !== 'boolean') throw new Error('Invalid host media description');
+    seen.add(file.kind);
+    total += file.size;
+    return { kind: file.kind, size: file.size, hash: file.hash, label: file.label, writable: file.writable };
+  });
+  if (!seen.has('rom') || total > MEDIA_LIMIT) throw new Error('Host media is too large or incomplete');
+  return { type: MEDIA_VERSION, config: { model: config.model, video: config.video,
+    floppySpeed: config.floppySpeed, floppySounds: config.floppySounds,
+    monoAudio: config.monoAudio, build: config.build }, files };
+}
+
+export async function describeMedia(snapshot) {
+  const media = [
+    { kind: 'rom', bytes: snapshot.rom?.rom, label: snapshot.rom?.label, writable: false },
+    { kind: 'ext', bytes: snapshot.rom?.ext, label: 'Extended ROM', writable: false },
+    ...[0, 1].map(drive => ({ kind: `df${drive}`, bytes: snapshot.disks[drive]?.bytes,
+      label: snapshot.disks[drive]?.name, writable: snapshot.disks[drive]?.writable })),
+  ].filter(file => file.bytes != null);
+  for (const file of media) {
+    if (!(file.bytes instanceof Uint8Array)) throw new Error('Host media bytes are unavailable');
+  }
+  const config = { model: snapshot.model, video: snapshot.video, floppySpeed: snapshot.floppySpeed,
+    floppySounds: snapshot.floppySounds, monoAudio: snapshot.monoAudio, build: snapshot.build };
+  // Validate lengths before hashing or allocating any transport buffers.
+  const manifest = validateManifest({ type: MEDIA_VERSION, config, files: media.map(file => ({
+    kind: file.kind, size: file.bytes.length, hash: '0'.repeat(64),
+    label: String(file.label ?? file.kind).slice(0, 256), writable: !!file.writable,
+  })) });
+  for (let i = 0; i < media.length; i++) manifest.files[i].hash = await digest(media[i].bytes);
+  return { manifest, media };
+}
+
+export class MediaTransfer {
+  constructor(channel, { host, progress = () => {}, fail = () => {} }) {
+    this.channel = channel;
+    this.host = host;
+    this.progress = progress;
+    this.fail = fail;
+    this.closed = false;
+    this.finished = false;
+    this.abort = new AbortController();
+    this.files = [];
+    this.index = this.offset = this.received = 0;
+    this.ready = new Promise((resolve, reject) => { this.opened = resolve; this.openFailed = reject; });
+    this.done = new Promise((resolve, reject) => { this.complete = resolve; this.failed = reject; });
+    // A remote close can arrive before the input channel invokes its onOpen.
+    this.ready.catch(() => {});
+    this.done.catch(() => {});
+    channel.binaryType = 'arraybuffer';
+    channel.bufferedAmountLowThreshold = BUFFER_LIMIT / 2;
+    channel.onopen = () => { this.touch(); this.opened(); };
+    channel.onmessage = event => {
+      try { this.accept(event.data); } catch (error) { this.stop(error); }
+    };
+    channel.onclose = () => { if (!this.finished) this.stop(new Error('Game setup transfer was interrupted')); };
+    channel.onerror = () => this.stop(new Error('Game setup transfer failed'));
+    if (channel.readyState === 'open') channel.onopen();
+  }
+
+  touch() {
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => this.stop(new Error('Game setup transfer timed out. Start a new session.')), 30000);
+  }
+
+  stop(error = new Error('Game setup transfer cancelled')) {
+    if (this.closed) return;
+    this.closed = true;
+    clearTimeout(this.timer);
+    this.abort.abort(error);
+    this.files = [];
+    this.openFailed(error);
+    this.failed(error);
+    if (!this.finished) this.fail(error);
+  }
+
+  async write(data) {
+    if (this.closed || this.channel.readyState !== 'open') throw new Error('Game setup transfer cancelled');
+    if (this.channel.bufferedAmount > BUFFER_LIMIT) {
+      await new Promise((resolve, reject) => {
+        const cleanup = () => {
+          this.channel.removeEventListener('bufferedamountlow', drained);
+          this.abort.signal.removeEventListener('abort', cancelled);
+        };
+        const drained = () => { cleanup(); resolve(); };
+        const cancelled = () => { cleanup(); reject(this.abort.signal.reason); };
+        this.channel.addEventListener('bufferedamountlow', drained);
+        this.abort.signal.addEventListener('abort', cancelled, { once: true });
+        if (this.abort.signal.aborted) cancelled();
+        else if (this.channel.bufferedAmount <= BUFFER_LIMIT / 2) drained();
+      });
+    }
+    if (this.closed) throw new Error('Game setup transfer cancelled');
+    this.channel.send(data);
+    this.touch();
+  }
+
+  async send(snapshot) {
+    if (!this.host || this.sending) throw new Error('Unexpected game setup transfer');
+    this.sending = true;
+    const { manifest, media } = await describeMedia(snapshot);
+    await this.ready;
+    const text = JSON.stringify(manifest);
+    if (text.length > MANIFEST_LIMIT) throw new Error('Host media description is too large');
+    await this.write(text);
+    const total = manifest.files.reduce((sum, file) => sum + file.size, 0);
+    let sent = 0;
+    for (const file of media) {
+      for (let offset = 0; offset < file.bytes.length; offset += MEDIA_CHUNK) {
+        const chunk = file.bytes.subarray(offset, offset + MEDIA_CHUNK);
+        await this.write(chunk);
+        sent += chunk.length;
+        this.progress('Sending', sent, total);
+      }
+    }
+    this.sent = true;
+    await this.done;
+  }
+
+  receive() {
+    if (this.host) throw new Error('Unexpected game setup receiver');
+    return this.done;
+  }
+
+  accept(data) {
+    if (this.closed || this.finished) throw new Error('Unexpected game setup message');
+    this.touch();
+    if (this.host) {
+      if (!this.sent || data !== '{"verified":true}') throw new Error('Invalid game setup acknowledgement');
+      this.finished = true;
+      clearTimeout(this.timer);
+      this.complete();
+      return;
+    }
+    if (!this.manifest) {
+      if (typeof data !== 'string' || data.length > MANIFEST_LIMIT) throw new Error('Invalid host media description');
+      this.manifest = validateManifest(JSON.parse(data));
+      this.files = this.manifest.files.map(file => new Uint8Array(file.size));
+      this.total = this.files.reduce((sum, file) => sum + file.length, 0);
+      return;
+    }
+    const file = this.files[this.index];
+    if (!(data instanceof ArrayBuffer) || !data.byteLength || data.byteLength > MEDIA_CHUNK ||
+        !file || this.offset + data.byteLength > file.length) throw new Error('Invalid game setup chunk');
+    file.set(new Uint8Array(data), this.offset);
+    this.offset += data.byteLength;
+    this.received += data.byteLength;
+    this.progress('Receiving', this.received, this.total);
+    if (this.offset === file.length) { this.index++; this.offset = 0; }
+    if (this.index === this.files.length) this.verify().catch(error => this.stop(error));
+  }
+
+  async verify() {
+    const files = this.files;
+    for (let i = 0; i < files.length; i++) {
+      if (await digest(files[i]) !== this.manifest.files[i].hash) throw new Error('Received game files did not match the host. Start a new session.');
+      if (this.closed) return;
+    }
+    const snapshot = { ...this.manifest.config, rom: { rom: null, ext: null, label: '' }, disks: Array(4).fill(null) };
+    this.manifest.files.forEach((file, i) => {
+      if (file.kind === 'rom') { snapshot.rom.rom = files[i]; snapshot.rom.label = file.label; }
+      else if (file.kind === 'ext') snapshot.rom.ext = files[i];
+      else snapshot.disks[Number(file.kind.slice(2))] = { bytes: files[i], name: file.label, writable: file.writable };
+    });
+    await this.write('{"verified":true}');
+    if (this.closed) return;
+    this.finished = true;
+    this.files = [];
+    clearTimeout(this.timer);
+    this.complete(snapshot);
+  }
+}

--- a/crates/copperline-web/www/netplay-media.test.js
+++ b/crates/copperline-web/www/netplay-media.test.js
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { MEDIA_CHUNK, MEDIA_VERSION, MediaTransfer, describeMedia, validateManifest } from './netplay-media.js';
+
+function snapshot(overrides = {}) {
+  return { model: 'A1200', video: 'NTSC', floppySpeed: 800, floppySounds: false, monoAudio: true,
+    build: 'test build', rom: { rom: new Uint8Array(512 * 1024).fill(7), ext: new Uint8Array(128 * 1024).fill(8), label: 'Host ROM' },
+    disks: [{ bytes: new Uint8Array(901120).fill(9), name: 'host.adf', writable: true },
+      { bytes: new Uint8Array(901120).fill(10), name: 'second.adf', writable: false }, null, null], ...overrides };
+}
+
+class Wire extends EventTarget {
+  readyState = 'open';
+  bufferedAmount = 0;
+  maximum = 0;
+  send(value) {
+    const data = typeof value === 'string' ? value : value.slice().buffer;
+    const size = typeof data === 'string' ? data.length : data.byteLength;
+    this.bufferedAmount += size;
+    this.maximum = Math.max(this.maximum, this.bufferedAmount);
+    setTimeout(() => {
+      this.bufferedAmount -= size;
+      if (this.peer.readyState === 'open') this.peer.onmessage?.({ data: this.transform?.(data) ?? data });
+      if (this.bufferedAmount <= this.bufferedAmountLowThreshold) this.dispatchEvent(new Event('bufferedamountlow'));
+    }, 0);
+  }
+}
+
+function pair(t) {
+  const outgoing = new Wire(), incoming = new Wire();
+  outgoing.peer = incoming; incoming.peer = outgoing;
+  let host, guest;
+  const fail = error => { host?.stop(error); guest?.stop(error); };
+  host = new MediaTransfer(outgoing, { host: true, fail });
+  guest = new MediaTransfer(incoming, { host: false, fail });
+  t.after(() => { host.stop(); guest.stop(); outgoing.readyState = incoming.readyState = 'closed'; });
+  return { host, guest, outgoing, incoming };
+}
+
+test('host ROM, extended ROM, both drives and machine settings arrive unchanged with bounded buffering', async t => {
+  const { host, guest, outgoing } = pair(t);
+  const source = snapshot();
+  const sending = host.send(source);
+  const received = await guest.receive();
+  await sending;
+  assert.deepEqual(received, source);
+  assert.notEqual(received.rom.rom.buffer, source.rom.rom.buffer);
+  assert.ok(outgoing.maximum <= 256 * 1024 + MEDIA_CHUNK);
+  assert.equal(host.finished, true);
+  assert.equal(guest.finished, true);
+});
+
+test('all browser model, video and speed options validate; malformed metadata is rejected before allocation', async () => {
+  const { manifest } = await describeMedia(snapshot());
+  for (const model of ['A500', 'A1200']) for (const video of ['PAL', 'NTSC']) for (const floppySpeed of [0, 100, 200, 400, 800]) {
+    assert.doesNotThrow(() => validateManifest({ ...manifest, config: { ...manifest.config, model, video, floppySpeed } }));
+  }
+  for (const [field, value] of [['model', 'unknown'], ['video', 'unknown'], ['floppySpeed', 257],
+    ['floppySounds', 'false'], ['monoAudio', null], ['build', 'x'.repeat(129)]]) {
+    assert.throws(() => validateManifest({ ...manifest, config: { ...manifest.config, [field]: value } }));
+  }
+  for (const field of [{ size: 1e9 }, { size: -1 }, { size: 1.5 }, { hash: 'bad' },
+    { kind: 'unknown' }, { label: 'x'.repeat(257) }, { writable: 1 }]) {
+    assert.throws(() => validateManifest({ ...manifest, files: [{ ...manifest.files[0], ...field }] }));
+  }
+  assert.throws(() => validateManifest({ ...manifest, files: [manifest.files[0], manifest.files[0]] }));
+  assert.throws(() => validateManifest({ ...manifest, files: manifest.files.slice(1) }));
+  assert.throws(() => validateManifest({ ...manifest, type: 'future' }));
+});
+
+test('corrupt media never receives a verification acknowledgement', async t => {
+  const { host, guest, outgoing } = pair(t);
+  let changed = false;
+  outgoing.transform = data => {
+    if (!changed && data instanceof ArrayBuffer) { new Uint8Array(data)[0] ^= 1; changed = true; }
+    return data;
+  };
+  const results = await Promise.allSettled([host.send(snapshot()), guest.receive()]);
+  assert.ok(results.every(result => result.status === 'rejected' && /did not match/.test(result.reason.message)));
+  assert.equal(host.finished, false);
+});
+
+test('cancellation releases a sender waiting for backpressure and a partial receiver', async t => {
+  const { host, guest, outgoing } = pair(t);
+  outgoing.bufferedAmount = 512 * 1024;
+  const sending = host.send(snapshot());
+  setTimeout(() => host.stop(new Error('cancelled')), 20);
+  const results = await Promise.allSettled([sending, guest.receive()]);
+  assert.ok(results.every(result => result.status === 'rejected' && /cancelled/.test(result.reason.message)));
+  assert.equal(guest.files.length, 0);
+});
+
+test('out-of-order messages, oversized chunks and premature acknowledgements fail the session', async t => {
+  const { manifest } = await describeMedia(snapshot());
+  for (const data of [new ArrayBuffer(1), '{', JSON.stringify({ type: MEDIA_VERSION, files: [] })]) {
+    const { guest } = pair(t);
+    guest.channel.onmessage({ data });
+    await assert.rejects(guest.receive());
+  }
+  const { guest } = pair(t);
+  guest.channel.onmessage({ data: JSON.stringify(manifest) });
+  guest.channel.onmessage({ data: new ArrayBuffer(MEDIA_CHUNK + 1) });
+  await assert.rejects(guest.receive(), /chunk/);
+  const { host } = pair(t);
+  host.channel.onmessage({ data: '{"verified":true}' });
+  await assert.rejects(host.done, /acknowledgement/);
+});

--- a/crates/copperline-web/www/netplay.js
+++ b/crates/copperline-web/www/netplay.js
@@ -3,6 +3,7 @@
 import { NetplayDiagnostics, connectionFailure } from './netplay-diagnostics.js';
 import { RoomClient, inviteUrl, roomFromInvite } from './netplay-room.js';
 import qrcode from './netplay-qr.js';
+import { MEDIA_CHANNEL, MEDIA_VERSION, MediaTransfer } from './netplay-media.js';
 
 // Signaling uses expiring room invitations or manual copy/paste codes.
 // Only bounded input packets use the data channel.
@@ -15,11 +16,13 @@ export function validateSettings(value) {
   if (!value || !/^[0-9a-f]{32}$/i.test(value.session ?? '') ||
       !Number.isInteger(value.delay) || value.delay < 0 || value.delay > 6 ||
       !Number.isInteger(value.window) || value.window < 1 || value.window > 12 ||
-      !['joystick', 'cd32'].includes(value.controller)) {
+      !['joystick', 'cd32'].includes(value.controller) ||
+      (value.media !== undefined && value.media !== MEDIA_VERSION)) {
     throw new Error('Invalid netplay settings in connection code');
   }
   return { session: value.session.toLowerCase(), delay: value.delay,
-    window: value.window, controller: value.controller };
+    window: value.window, controller: value.controller,
+    ...(value.media ? { media: value.media } : {}) };
 }
 
 export function encodeCode(description, settings) {
@@ -64,6 +67,9 @@ export class RtcLink {
     this.onClose = onClose;
     this.timer = null;
     this.cancelGather = null;
+    this.media = null;
+    this.mediaReady = new Promise((resolve, reject) => { this.mediaAttached = resolve; this.mediaFailed = reject; });
+    this.mediaReady.catch(() => {});
     this.diagnostics = new NetplayDiagnostics();
     this.diagnostics.record('created', this.pc);
     this.pc.ondatachannel = event => this.attach(event.channel);
@@ -87,6 +93,18 @@ export class RtcLink {
   }
 
   attach(channel) {
+    if (channel.label === MEDIA_CHANNEL) {
+      if (this.closed || this.media || this.settings?.media !== MEDIA_VERSION ||
+          channel.ordered !== true || channel.maxRetransmits != null || channel.maxPacketLifeTime != null) {
+        channel.close();
+        this.close('Unexpected game setup channel. Refresh both pages and start a new session.');
+        return;
+      }
+      this.media = new MediaTransfer(channel, { host: this.host,
+        fail: error => this.close(error.message) });
+      this.mediaAttached(this.media);
+      return;
+    }
     if (this.closed || this.channel || channel.label !== CHANNEL ||
         channel.ordered || channel.maxRetransmits !== 0) {
       channel.close();
@@ -181,13 +199,16 @@ export class RtcLink {
 
   async offer(settings) {
     this.settings = validateSettings(settings);
+    this.host = true;
     this.attach(this.pc.createDataChannel(CHANNEL, { ordered: false, maxRetransmits: 0 }));
+    if (this.settings.media === MEDIA_VERSION) this.attach(this.pc.createDataChannel(MEDIA_CHANNEL, { ordered: true }));
     return this.gather(await this.pc.createOffer());
   }
 
   async answer(code) {
     const { description, settings } = decodeCode(code, 'offer');
     this.settings = settings;
+    this.host = false;
     await this.pc.setRemoteDescription(description);
     if (this.closed) throw new Error('Connection cancelled');
     return this.gather(await this.pc.createAnswer());
@@ -196,7 +217,7 @@ export class RtcLink {
   async accept(code) {
     const { description, settings } = decodeCode(code, 'answer');
     if (JSON.stringify(settings) !== JSON.stringify(this.settings)) {
-      throw new Error('Answer belongs to a different netplay session');
+      throw new Error('Answer belongs to a different netplay session or version. Refresh both pages and try again.');
     }
     await this.pc.setRemoteDescription(description);
     if (this.closed) throw new Error('Connection cancelled');
@@ -204,6 +225,17 @@ export class RtcLink {
       clearTimeout(this.timer);
       this.timer = setTimeout(() => this.close('Peer connection timed out. Copy diagnostics, then start a new session.'), 60000);
     }
+  }
+
+  async transferMedia(snapshot, progress) {
+    if (this.closed) throw new Error('Game setup transfer cancelled');
+    this.timer = setTimeout(() => this.close('Game setup transfer timed out. Start a new session.'), 180000);
+    try {
+      const transfer = await this.mediaReady;
+      transfer.progress = progress;
+      if (this.host) await transfer.send(snapshot);
+      else return await transfer.receive();
+    } finally { clearTimeout(this.timer); }
   }
 
   receive(emu) {
@@ -226,6 +258,7 @@ export class RtcLink {
     this.diagnostics.capture(this.pc);
     clearTimeout(this.timer);
     this.cancelGather?.();
+    this.mediaFailed(new Error('Game setup transfer cancelled'));
     // Let the owner poll final queued packets for the core's failure reason
     // before freeing the machine. A remote close can follow its hello packet.
     try { this.onClose(reason, this); }
@@ -233,6 +266,14 @@ export class RtcLink {
   }
 
   dispose() {
+    if (this.media) {
+      const channel = this.media.channel;
+      channel.onopen = channel.onmessage = channel.onclose = channel.onerror = null;
+      this.media.stop();
+      channel.close();
+      this.media = null;
+    }
+    this.mediaReady = this.mediaAttached = this.mediaFailed = null;
     this.incoming.length = 0;
     this.pc.ondatachannel = this.pc.onconnectionstatechange = null;
     this.pc.oniceconnectionstatechange = this.pc.onicegatheringstatechange = null;
@@ -246,7 +287,7 @@ export class RtcLink {
 }
 
 // The panel inserts itself into old static page shells, as the other controls do.
-export function mountNetplayPanel(parent, { prepare, start, stop }) {
+export function mountNetplayPanel(parent, { prepare, start, stop, getMedia, useMedia }) {
   const style = document.createElement('style');
   style.textContent = `
     #netplay-panel { font-size: .88rem; line-height: 1.4; color: var(--ink-mute, #bbc0ca); }
@@ -277,7 +318,7 @@ export function mountNetplayPanel(parent, { prepare, start, stop }) {
   root.id = 'netplay-panel';
   root.className = 'try-side-section';
   root.innerHTML = `<summary>Netplay</summary>
-    <p>Load matching ROMs and disks on both devices. Starting a session replaces your running game.</p>
+    <p>The host shares their ROMs, disks and machine settings with player 2. Starting a session replaces your running game.</p>
     <div id="netplay-rooms">
       <button id="netplay-room-host" type="button">Host game</button>
       <label>Invitation link or room code <input id="netplay-room-code" autocomplete="off" autocapitalize="none" spellcheck="false"></label>
@@ -330,7 +371,7 @@ export function mountNetplayPanel(parent, { prepare, start, stop }) {
     if (!active) field('accept').disabled = true;
   };
   field('service-status').textContent = service
-    ? 'Host is player 1; Join is player 2. Your game files stay on your device.'
+    ? 'Host is player 1; Join is player 2. Received files are used only for this session.'
     : 'Room invitations are not configured on this page. Manual setup is available under Advanced.';
   field('advanced').open = !service;
   field('share').hidden = typeof navigator.share !== 'function';
@@ -342,7 +383,7 @@ export function mountNetplayPanel(parent, { prepare, start, stop }) {
     if (!roomFromInvite(room)) { root.open = true; status('This invitation is incomplete or damaged.'); return; }
     field('room-code').value = room;
     root.open = true;
-    status('Invitation ready. Load the host’s ROMs and disks, match the machine settings, then click Join game.');
+    status('Invitation ready. Click Join game to receive the host’s files and machine settings.');
   }
   readInvitation();
   window.addEventListener('hashchange', readInvitation);
@@ -358,13 +399,21 @@ export function mountNetplayPanel(parent, { prepare, start, stop }) {
       const roomId = roomFromInvite(field('room-code').value);
       if (roomMode && !service) throw new Error('Room invitations are not configured on this page');
       if (roomMode && !host && !roomId) throw new Error('Paste an invitation link or room code');
-      settings = host ? newSettings(Number(field('delay').value), Number(field('window').value), field('controller').value)
+      settings = host ? { ...newSettings(Number(field('delay').value), Number(field('window').value), field('controller').value), media: MEDIA_VERSION }
         : roomMode ? null : decodeCode(remote, 'offer').settings;
       const stun = field('stun').value.trim();
       if (!roomMode && stun && !/^stuns?:[^\s]+$/i.test(stun)) throw new Error('STUN server must start with stun: or stuns:');
       current = new RtcLink({ iceServers: !roomMode && stun ? [{ urls: stun }] : [],
         onOpen: async peer => {
           if (link !== peer) return;
+          if (settings.media === MEDIA_VERSION) {
+            status(host ? 'Sending game setup...' : 'Receiving the host’s game setup...');
+            const received = await peer.transferMedia(host ? getMedia(peer) : null, (action, bytes, total) => {
+              if (link === peer) status(`${action} game setup: ${Math.floor(bytes * 100 / total)}%`);
+            });
+            if (link !== peer) return;
+            if (!host) useMedia(peer, received);
+          }
           status('Connected. Checking the initial machines...');
           await start(peer, settings, host ? 1 : 2);
         },
@@ -387,7 +436,7 @@ export function mountNetplayPanel(parent, { prepare, start, stop }) {
       field('report').hidden = true;
       controls();
       status('Preparing a fresh session...');
-      await prepare(current);
+      await prepare(current, { host, receiveMedia: !host && (roomMode || settings?.media === MEDIA_VERSION) });
       if (link !== current) return;
       if (roomMode) {
         current.room = new RoomClient(service, current.abort.signal);

--- a/crates/copperline-web/www/netplay.js
+++ b/crates/copperline-web/www/netplay.js
@@ -162,7 +162,14 @@ export class RtcLink {
         };
         this.cancelGather = () => finish(new Error('Connection cancelled'));
         this.pc.addEventListener('icegatheringstatechange', changed);
-        timer = setTimeout(() => finish(new Error('Network address discovery timed out. Copy diagnostics, then try a new session.')), 15000);
+        timer = setTimeout(() => {
+          // One slow/unreachable ICE server must not discard usable routes
+          // from the others. Later candidates may be omitted from this offer.
+          if (/^a=candidate:/m.test(this.pc.localDescription?.sdp ?? '')) {
+            this.diagnostics.record('gathering-deadline', this.pc);
+            finish();
+          } else finish(new Error('Network address discovery timed out without a usable route. Copy diagnostics, then try a new session.'));
+        }, 15000);
         changed();
       });
     }

--- a/crates/copperline-web/www/netplay.test.js
+++ b/crates/copperline-web/www/netplay.test.js
@@ -32,6 +32,23 @@ test('connection codes round-trip only valid settings and the expected descripti
   assert.throws(() => validateSettings({ ...settings, controller: 'mouse' }));
   assert.throws(() => validateSettings({ ...settings, session: 'bad' }));
   assert.notEqual(newSettings(0, 1, 'cd32').session, newSettings(0, 1, 'cd32').session);
+  const shared = { ...settings, media: 'host-v1' };
+  assert.deepEqual(decodeCode(encodeCode(description('offer'), shared), 'offer').settings, shared);
+  assert.throws(() => validateSettings({ ...settings, media: 'unknown' }));
+});
+
+test('setup-enabled offers create a reliable channel and reject incompatible setup channels', async () => {
+  const link = new RtcLink({ PeerConnection: Peer });
+  await link.offer({ ...settings, media: 'host-v1' });
+  assert.equal(link.media.channel.label, 'copperline-setup-v1');
+  assert.equal(link.media.channel.ordered, true);
+  assert.equal(link.media.channel.maxRetransmits, undefined);
+  link.close();
+  assert.equal(link.media, null);
+  assert.equal(link.mediaReady, null);
+  const other = new RtcLink({ PeerConnection: Peer });
+  other.attach(new Channel('copperline-setup-v1', { ordered: false, maxRetransmits: 0 }));
+  assert.equal(other.closed, true);
 });
 
 test('host accepts only its answer and negotiates an unordered channel without retransmission', async () => {

--- a/crates/copperline-web/www/netplay.test.js
+++ b/crates/copperline-web/www/netplay.test.js
@@ -80,6 +80,24 @@ test('cancelling ICE gathering rejects the pending offer and closes only once', 
   assert.equal(link.pc.connectionState, 'closed');
 });
 
+test('the gathering deadline preserves collected routes but rejects an empty offer', async t => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  for (const candidate of ['', 'a=candidate:1 1 udp 1 192.0.2.1 3478 typ relay\r\n']) {
+    const link = new RtcLink({ PeerConnection: Peer });
+    link.pc.iceGatheringState = 'gathering';
+    link.pc.createOffer = async () => ({ type: 'offer', sdp: 'v=0\r\n' + candidate });
+    const offer = link.offer(settings);
+    await new Promise(resolve => setImmediate(resolve));
+    t.mock.timers.tick(15000);
+    if (candidate) {
+      assert.ok(decodeCode(await offer, 'offer').description.sdp.includes(candidate));
+      assert.equal(link.closed, false);
+      assert.equal(link.diagnostics.events.at(-1).event, 'gathering-deadline');
+    } else await assert.rejects(offer, /without a usable route/);
+    link.close();
+  }
+});
+
 test('a delayed offer cannot resurrect a cancelled link', async () => {
   const link = new RtcLink({ PeerConnection: Peer });
   let finish;

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -6,7 +6,7 @@
 // (the click also unlocks the AudioContext), then runs one
 // requestAnimationFrame loop: step the core to the wall clock, blit the
 // presentation buffer to the canvas, and post the frame's audio to the
-// worklet. Netplay optionally contacts the selected STUN server and its peer.
+// worklet. Netplay uses room signaling and transfers setup media to its peer.
 
 import init, { WebEmu } from './pkg/copperline_web.js';
 import {
@@ -117,7 +117,7 @@ const netplayDisabled = new Map();
 const NETPLAY_LOCKED_IDS = ['boot', 'machine', 'video', 'reset', 'pause', 'savestate',
   'loadstate', 'quicksave', 'quickload', 'savedstates', 'kick', 'kickurl', 'kicklist',
   'df0', 'df1', 'df0url', 'df0list', 'eject', 'eject1', 'blank-df0', 'blank-df1',
-  'download-df0', 'download-df1', 'writable-floppies', 'floppy-speed', 'floppy-sounds',
+  'download-df0', 'download-df1', 'writable-floppies', 'floppy-speed', 'floppy-sounds', 'mono-audio',
   'serial-connect', 'serial-url', 'serial-raw'];
 
 function syncNetplayControls() {
@@ -863,8 +863,9 @@ async function boot(request = null) {
     // shell, or the list not knowing better) builds the default A500. The
     // video argument picks PAL/NTSC the same way; a bundle older than both
     // ignores the extra arguments.
+    const model = snapshot?.model ?? machineModel;
     const machine = new WebEmu(
-      (snapshot?.model ?? machineModel) ?? undefined,
+      model ?? undefined,
       (snapshot?.video ?? videoStandard) ?? undefined,
       PAGE_FLOPPY_DRIVES,
     );
@@ -900,11 +901,9 @@ async function boot(request = null) {
     }
     pendingDisks.fill(null);
     machine.set_volume_percent(Number($('vol').value));
-    if (floppySoundsToggle) machine.set_floppy_sounds(floppySoundsToggle.checked);
-    else if (configFloppySounds !== null) machine.set_floppy_sounds(configFloppySounds);
-    if (monoAudioToggle) machine.set_mono_audio(monoAudioToggle.checked);
-    else if (configMonoAudio !== null) machine.set_mono_audio(configMonoAudio);
-    if (floppySpeed !== null) machine.set_floppy_speed(floppySpeed);
+    machine.set_floppy_sounds(snapshot?.floppySounds ?? floppySoundsToggle?.checked ?? configFloppySounds ?? true);
+    machine.set_mono_audio(snapshot?.monoAudio ?? monoAudioToggle?.checked ?? configMonoAudio ?? false);
+    machine.set_floppy_speed(snapshot?.floppySpeed ?? floppySpeed ?? 100);
     if (overscanMode !== null) machine.set_overscan?.(overscanMode);
     machine.set_monitor_bezel?.(monitorBezelOn());
     machine.set_scaling?.(scalingMode);
@@ -934,8 +933,8 @@ async function boot(request = null) {
     setLoadStatus(
       // A ROM-less boot is only ever a landing place for a state load,
       // which overwrites this line the moment it lands.
-      (bootRom
-        ? `booted ${bootRom.label}${machineModel ? ` on the ${machineModel}` : ''}`
+      (rom
+        ? `booted ${rom.label}${model ? ` on the ${model}` : ''}`
         : 'machine built, waiting for the state') +
         (inserted ? ` - ${inserted}` : ''),
     );
@@ -7539,14 +7538,17 @@ if (typeof WebEmu.prototype.start_netplay === 'function') {
   netplayPanel = mountNetplayPanel(
     $('reset').closest('.try-side-section')?.parentElement ?? shell.parentElement,
     {
-      prepare: async link => {
-        if (!wasm || !bootRom) throw new Error('Load a ROM before setting up netplay');
+      prepare: async (link, { receiveMedia }) => {
+        if (!wasm || (!receiveMedia && !bootRom)) throw new Error('Load a ROM before setting up netplay');
         keepUploadedDisksForRebuild();
         const disks = pendingDisks.slice();
         for (let drive = 0; drive < PAGE_FLOPPY_DRIVES; drive++) {
-          if (diskNames[drive] && !disks[drive]) throw new Error(`Load the DF${drive} image again before netplay`);
+          if (!receiveMedia && diskNames[drive] && !disks[drive]) throw new Error(`Load the DF${drive} image again before netplay`);
         }
-        netplayPreparing = { link, rom: bootRom, model: machineModel, video: videoStandard, disks };
+        netplayPreparing = { link, rom: bootRom, model: machineModel, video: videoStandard, disks,
+          names: diskNames.slice(), build: WebEmu.build_info(), floppySpeed: floppySpeed ?? 100,
+          floppySounds: floppySoundsToggle?.checked ?? configFloppySounds ?? true,
+          monoAudio: monoAudioToggle?.checked ?? configMonoAudio ?? false };
         machineGeneration++;
         netplayHostKeyFrame = 0;
         if (statesPanelOpen) toggleStatesPanel();
@@ -7561,8 +7563,23 @@ if (typeof WebEmu.prototype.start_netplay === 'function') {
         serialDisconnect('Serial disabled during netplay');
         syncNetplayControls();
         overlay.style.display = '';
-        setLoadStatus('Netplay setup: emulation starts when the peer connects');
+        setLoadStatus('Netplay setup: emulation starts after the host’s files are verified');
         await buildAudioStack(false);
+      },
+      getMedia: link => {
+        if (netplayPreparing?.link !== link) throw new Error('Game setup was cancelled');
+        return netplayPreparing;
+      },
+      useMedia: (link, snapshot) => {
+        if (netplayPreparing?.link !== link) throw new Error('Game setup was cancelled');
+        if (snapshot.build !== WebEmu.build_info()) throw new Error('The host is using a different emulator build. Refresh both pages.');
+        netplayPreparing = { ...snapshot, link, original: netplayPreparing };
+        // Display the active configuration without writing local preferences.
+        machineSel.value = snapshot.model;
+        videoSel.value = snapshot.video;
+        floppySpeedSel.value = String(snapshot.floppySpeed);
+        if (floppySoundsToggle) floppySoundsToggle.checked = snapshot.floppySounds;
+        if (monoAudioToggle) monoAudioToggle.checked = snapshot.monoAudio;
       },
       start: async (link, settings, player) => {
         const snapshot = netplayPreparing;
@@ -7614,7 +7631,14 @@ if (typeof WebEmu.prototype.start_netplay === 'function') {
           emu?.free();
           emu = null;
           window.__emu = null;
-          netplayPreparing.disks.forEach((disk, drive) => { pendingDisks[drive] = disk; });
+          const original = netplayPreparing.original ?? netplayPreparing;
+          original.disks.forEach((disk, drive) => { pendingDisks[drive] = disk; });
+          original.names.forEach((name, drive) => { diskNames[drive] = name; });
+          machineSel.value = original.model;
+          videoSel.value = original.video;
+          floppySpeedSel.value = String(original.floppySpeed);
+          if (floppySoundsToggle) floppySoundsToggle.checked = original.floppySounds;
+          if (monoAudioToggle) monoAudioToggle.checked = original.monoAudio;
           netplayPreparing = null;
           audioCtx?.suspend().catch(() => {});
           overlay.style.display = '';

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -72,7 +72,10 @@ The web build uses the same `.clstate` file format as the desktop version:
 **Controls → Netplay** connects two browsers using WebRTC. The host shares an
 invitation link or QR code; the other player opens it and clicks Join game.
 Advanced retains manual offer/answer codes for pages without a room service.
-Both pages start fresh machines with matching ROMs, disks and hardware settings.
+The host sends ROMs, floppy images and machine settings over the encrypted peer
+connection. The guest verifies them before startup and uses them only for the
+session; its remembered ROM and local choices are preserved. Both pages start
+fresh machines with matching ROMs, disks and hardware settings.
 Each player controls one Amiga port; late input is predicted and corrected by
 rollback. See [browser netplay setup](netplay.md#browser-netplay) for the steps,
 controller mapping, relay troubleshooting and restrictions.
@@ -99,7 +102,8 @@ The browser implementation consists of the following components:
 - **Audio pipeline:** Stereo 44.1 kHz float samples are transferred directly to an
   `AudioWorklet` processor for low-latency playback.
 - **Netplay:** The Rust core owns the shared rollback timeline and bounded packet
-  queues. `www/netplay.js` handles room invitations, manual codes and the WebRTC data channel;
+  queues. `www/netplay.js` handles room invitations, manual codes and WebRTC;
+  `www/netplay-media.js` transfers and verifies the host setup on a reliable channel.
   `try.js` owns the session lifecycle and locks controls that change the machine.
 
 ## Building the WebAssembly package locally
@@ -223,7 +227,11 @@ machine and leaves it available for local use or another startup attempt.
 `accept(answerCode)`, with `configureIce(iceServers, relayOnly)` for temporary
 TURN credentials obtained from a trusted service. `report()` returns sanitized
 connection diagnostics. Its `onOpen` callback is the point to construct the machine
-and call `start_netplay`. Its `onClose` callback must stop the page's loops and
+and call `start_netplay`. The page sets `settings.media = "host-v1"` to add a
+reliable setup channel; its `onOpen` awaits `transferMedia(hostSnapshot, progress)`
+on the host, or `transferMedia(null, progress)` on the guest, which returns the
+verified host snapshot. Embedders that omit this setting must supply matching
+media themselves. Its `onClose` callback must stop the page's loops and
 free the machine. Immediately after startup, call `run_hidden(now, 0)` and
 `link.send(emu)` once to send the initial fingerprint. Then call `link.receive(emu)` before `run`/`run_hidden`, then
 `link.send(emu)` afterwards, including polls that advance zero frames. Polls with

--- a/docs/guide/netplay.md
+++ b/docs/guide/netplay.md
@@ -17,18 +17,19 @@ mixed operating systems and browser engines have not yet been qualified.
 (browser-netplay)=
 ## Set up in the browser
 
-On the [browser page](browser.md), open **Controls → Netplay**. Load the same ROM
-and disks, and choose the same model, video standard, floppy speed, floppy sounds and writable
-disk setting on both pages. Setup starts a fresh machine, replacing any running
-local session.
+On the [browser page](browser.md), open **Controls → Netplay**. The host loads
+the ROM and disks and chooses the machine settings. The guest receives that
+setup automatically over the encrypted peer connection. Both pages need the
+same emulator build. Setup starts a fresh machine, replacing any running local session.
 
 1. The host clicks **Host game** and shares the invitation link using **Copy
    invitation**, the device share sheet, or the QR code. **Advanced** contains
    the controller type, input delay and rollback limit.
 2. The other player opens the link (or pastes it into the invitation field),
-   loads matching ROMs and disks, then clicks **Join game**. The offer and answer
-   are exchanged automatically. The host supplies the controller and delay settings.
-3. Both pages cold-boot after checking that their initial machines match. The
+   then clicks **Join game**. The offer and answer are exchanged automatically.
+   A progress message tracks the transfer of ROMs, both inserted floppy images
+   and machine settings. The host also supplies the controller and delay settings.
+3. The guest verifies every file before both pages cold-boot and check their initial machines. The
    panel reports confirmed frames, rollbacks and the latest checked frame.
 
 Invitations allow one joining player and expire after 15 minutes. Expiry removes
@@ -45,8 +46,17 @@ disabled. The desktop F11/F12 netplay shortcuts do not apply to the browser.
 Room setup uses a small signaling service. WebRTC tries direct routes and can
 fall back to a TURN relay. **Advanced → Use relay only** forces that route for
 troubleshooting. Relay credentials expire after 24 hours; start a new session
-for longer play. ROMs, disks and machine snapshots stay on each device. WebRTC
-encrypts the data channel, including traffic carried by a relay.
+for longer play. WebRTC encrypts game files and input packets, including traffic
+carried by a relay. The signaling service receives no ROM or disk bytes.
+
+Received files are held only for the session and are not saved into the guest's
+remembered-ROM storage. Disconnect restores the guest's previous media choices
+and settings. The host shares the main and extended ROMs, DF0/DF1 images and their
+write-protection flags, model, video standard, floppy speed, drive sounds and
+mono/stereo setting. Display preferences and volume stay local. ROMs are limited
+to 2 MiB each and floppy images to 16 MiB each. Starting from a running machine
+uses the current contents of writable disks; it still cold-boots rather than
+transferring a running save state.
 
 If a connection ends, use **Copy diagnostics** on both devices. The report keeps
 ICE, peer, data-channel and DTLS states, candidate types and packet counters.
@@ -59,6 +69,7 @@ clicks **Host with manual codes**, sends its code to the guest, and the guest
 pastes it and clicks **Join offer**. The guest sends its answer back; the host
 pastes it and clicks **Connect answer**. The STUN field helps discover routes;
 leave it blank for LAN-only discovery. Manual setup has no relay fallback.
+Current pages transfer host files and settings after manual signaling too.
 Its large codes contain network addresses and session details, so exchange them
 privately. If the page has no room service configured, Advanced opens by default.
 

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -117,7 +117,10 @@ on subsequent retransmissions; a full outgoing queue reports backpressure.
 when the channel's buffered amount reaches 64 maximum-size packets.
 
 The page exchanges a versioned offer and answer containing SDP and host-selected
-settings. It waits for ICE gathering to complete before creating either code.
+settings. It waits up to 15 seconds for ICE gathering before creating either
+code. At the deadline it uses collected candidates if any are available; a slow
+server cannot invalidate routes gathered from other servers. An empty candidate
+set still fails setup, and diagnostics record a gathering-deadline event.
 `netplay-room.js` sends these codes through the configured service; the host polls
 for an answer every 1.5 seconds until joined, cancelled or expired. Manual
 copy/paste remains available under Advanced and needs no signaling service.

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -84,8 +84,9 @@ controller bitmap, and sixteen-byte key bitmap. The maximum packet is 943 bytes.
 The initial fingerprint hashes Copperline's display build version and the entire
 normalized initial machine snapshot, including ROM and in-memory floppy data.
 It does not fingerprint uncommitted source modifications: development peers must
-build the same source. No executable, ROM, disk image, or serialized guest state
-is received from a peer. An ID separates sessions; the packet format supplies
+build the same source. This input protocol carries no executable, ROM, disk image
+or serialized guest state. Browser setup transfers ROMs and disks over a separate
+reliable channel before the input handshake. An ID separates sessions; the packet format supplies
 neither cryptographic peer authentication nor encryption. Browser WebRTC adds
 transport encryption; native UDP needs a VPN for that protection.
 
@@ -145,19 +146,32 @@ and relay policy; plain TCP entries are omitted on that compatibility path.
 `netplay-diagnostics.js` records whitelisted states, candidate types and numeric
 counters before disposal. It never exports SDP, candidate addresses or tokens.
 The diagnostic sample survives a closed peer connection.
-The [WebRTC data channel](https://www.w3.org/TR/webrtc/) is unordered and uses
+The input [WebRTC data channel](https://www.w3.org/TR/webrtc/) is unordered and uses
 zero SCTP retransmissions, since the shared Copperline protocol already repeats
 unacknowledged inputs. Browser and native transports have no interoperability
 adapter. Codes are bounded and checked before passing SDP to WebRTC.
 
+`netplay-media.js` adds an ordered, reliable `copperline-setup-v1` channel when
+the offer's settings include `media: "host-v1"`. An 8 KiB bounded manifest
+describes the build, supported browser machine settings, ROM/extended ROM and
+DF0/DF1 images with SHA-256 digests. Each ROM is bounded to 2 MiB, each disk to
+16 MiB, and the total to 36 MiB. Binary messages contain at most 16 KiB; the
+sender waits for buffer drainage above 256 KiB. The receiver validates metadata
+before allocating, verifies every digest and acknowledges completion before
+the host boots. A 30-second inactivity timer and a three-minute overall deadline
+bound setup. Cancellation rejects pending operations and discards partial data.
+Media stays off the signaling service; a TURN relay carries encrypted peer traffic.
+
 Host/Join freezes the chosen cold-boot media and frees any local emulator.
-On channel open, the wrapper builds a fresh machine, fixes the RTC seed,
+After media verification, the wrapper builds a fresh machine, fixes the RTC seed,
 disables serial and sets both digital controllers before fingerprinting it.
 JS numeric settings enter Rust as `f64` and are checked for finiteness, integer
 values and range before narrowing. Setup operations carry their connection
 identity across awaits so cancellation cannot publish a late machine or code.
 Disconnect and runtime failures stop all session loops and free the emulator;
-the chosen pre-session media remains available for another cold boot.
+the chosen pre-session media remains available for another cold boot. The guest
+uses a separate received snapshot; it never overwrites `bootRom`, `lastDisks`
+or IndexedDB. Disconnect restores its original control values and disk names.
 
 Netplay calls use the shared precise frame stepper, with browser pacing capped
 at eight frames per call. Zero-frame polls can reconcile and acknowledge input

--- a/services/netplay/README.md
+++ b/services/netplay/README.md
@@ -36,6 +36,8 @@ block and leave address discovery waiting until it times out. Other relay
 ports, including TLS on port 443, remain available.
 Browsers that reject TURN transport queries retry with default UDP and TLS URLs;
 plain TCP entries are omitted only for those browsers.
+If discovery reaches its 15-second deadline with usable candidates, the browser
+proceeds with those routes instead of waiting for every configured server.
 
 The WASM publishing workflow copies all netplay modules and the QR license to
 the site. It leaves the site's HTML, service URL and service worker intact.
@@ -83,6 +85,8 @@ requests. Serve the site there, then run `node tools/check-web-netplay-rooms.mjs
 from the repository root. The tool supplies the local service URL without editing
 the deployable page. Its `NETPLAY_SERVICE` and `NETPLAY_RELAY_ONLY=1` options test
 an explicitly selected deployed service and require a selected relay candidate.
+`NETPLAY_GATHER_DEADLINE_TEST=1` exercises the discovery deadline with real
+candidates and connectivity while holding the exposed gathering state open.
 
 The Node tests run the Worker and Durable Objects in Miniflare, checking role
 boundaries, guest reservation, cleanup, request limits and TURN failure handling.

--- a/services/netplay/README.md
+++ b/services/netplay/README.md
@@ -2,8 +2,9 @@
 
 This Cloudflare Worker exchanges WebRTC connection descriptions between two
 players. Each SQLite Durable Object holds one invitation for at most 15 minutes.
-Game inputs use WebRTC directly or through TURN; ROMs, disks and snapshots never
-pass through this service. The static site remains on GitHub Pages.
+Game inputs and host-to-guest setup files use encrypted WebRTC directly or
+through TURN. ROMs and disks never pass through this signaling Worker; running
+snapshots are not transferred. The static site remains on GitHub Pages.
 
 ## Deploy
 

--- a/tools/check-web-netplay-browser.mjs
+++ b/tools/check-web-netplay-browser.mjs
@@ -129,18 +129,18 @@ try {
     null, { timeout: 60000 })));
   await guest.locator('#netplay-disconnect').click();
   await Promise.all(pages.map(page => page.locator('#netplay-host:enabled').waitFor()));
-  // A different hardware setup must stop both sides instead of running locally.
+  // Manual signaling also transfers the host setup over the peer connection.
   await guest.locator('#video').selectOption('NTSC');
   await connect();
-  await Promise.all(pages.map(page => page.waitForFunction(() =>
-    !window.__emu && !document.querySelector('#netplay-host').disabled,
-  null, { timeout: 30000 })));
-  const messages = await Promise.all(pages.map(page => page.locator('#netplay-status').textContent()));
-  console.log(`Mismatched machines: ${messages.join('; ')}`);
-  assert.ok(messages.every(message => /mismatch|different/i.test(message)), messages.join('; '));
+  await Promise.all(pages.map(page => page.waitForFunction(() => window.__emu?.netplay_status()[6] >= 60,
+    null, { timeout: 60000 })));
+  assert.equal(await guest.locator('#video').inputValue(), 'PAL');
+  await guest.locator('#netplay-disconnect').click();
+  await Promise.all(pages.map(page => page.locator('#netplay-host:enabled').waitFor()));
+  assert.equal(await guest.locator('#video').inputValue(), 'NTSC');
   await host.setViewportSize({ width: 390, height: 844 });
   await host.locator('#sidebar-toggle').click();
   await host.locator('#netplay-panel').screenshot({ path: `${output}/netplay-mobile.png` });
   assert.deepEqual(errors, []);
-  console.log('Host/Join, cancellation, restart, control locking, mismatch rejection and browser rendering passed');
+  console.log('Host/Join, cancellation, restart, control locking, host setup transfer and browser rendering passed');
 } finally { await browser.close(); }

--- a/tools/check-web-netplay-rooms.mjs
+++ b/tools/check-web-netplay-rooms.mjs
@@ -9,6 +9,7 @@ import { pathToFileURL } from 'node:url';
 const url = new URL(process.argv[2] ?? 'http://127.0.0.1:8765/try/');
 const service = new URL(process.env.NETPLAY_SERVICE ?? 'http://127.0.0.1:8787');
 const relayOnly = process.env.NETPLAY_RELAY_ONLY === '1';
+const exerciseGatherDeadline = process.env.NETPLAY_GATHER_DEADLINE_TEST === '1';
 const output = resolve(process.argv[3] ?? '/tmp/copperline-netplay-rooms-browser');
 await mkdir(output, { recursive: true });
 const module = process.env.PLAYWRIGHT_MODULE;
@@ -33,14 +34,21 @@ try {
       }
       return [url.origin, service.origin].includes(target.origin) ? route.continue() : route.abort();
     });
-    await context.addInitScript(base => {
+    await context.addInitScript(({ base, exerciseGatherDeadline }) => {
       // Use a test endpoint without changing the deployable page configuration.
       new MutationObserver(() => {
         const meta = document.querySelector('meta[name="copperline-netplay-service"]');
         if (meta && meta.content !== base) meta.content = base;
       }).observe(document, { childList: true, subtree: true });
       Object.defineProperty(navigator, 'clipboard', { value: { writeText: async text => { window.__copied = text; } } });
-    }, service.origin);
+      if (exerciseGatherDeadline) {
+        // Keep real ICE candidates and connectivity, but make the wrapper use
+        // its deadline path even when the browser finishes gathering quickly.
+        const Peer = RTCPeerConnection, schedule = setTimeout;
+        window.RTCPeerConnection = class extends Peer { get iceGatheringState() { return 'gathering'; } };
+        window.setTimeout = (callback, delay, ...args) => schedule(callback, delay === 15000 ? 2000 : delay, ...args);
+      }
+    }, { base: service.origin, exerciseGatherDeadline });
     const page = await context.newPage();
     page.on('pageerror', error => {
       // WebKit logs a native console error when its send queue meets a remote
@@ -160,6 +168,7 @@ try {
     const report = JSON.parse(await page.evaluate(() => window.__copied));
     assert.equal(report.connection.peer, 'connected');
     assert.equal(report.stats.dtls, 'connected');
+    if (exerciseGatherDeadline) assert.ok(report.events.some(event => event.event === 'gathering-deadline'));
     assert.deepEqual(await page.evaluate(() => ({ model: window.__emu.machine_model(), video: window.__emu.video_standard(), speed: window.__emu.floppy_speed() })),
       { model: 'A1200', video: 'NTSC', speed: 400 });
     assert.deepEqual(await page.evaluate(() => [0, 1].map(drive => ({ name: window.__emu.disk_name(drive),

--- a/tools/check-web-netplay-rooms.mjs
+++ b/tools/check-web-netplay-rooms.mjs
@@ -28,6 +28,9 @@ try {
     const context = await browser.newContext({ viewport: { width: 1440, height: 1000 }, serviceWorkers: 'block' });
     await context.route('**/*', route => {
       const target = new URL(route.request().url());
+      if (target.origin === url.origin && target.pathname.endsWith('/copperline.json')) {
+        return route.fulfill({ json: { mono_audio: player === 0 } });
+      }
       return [url.origin, service.origin].includes(target.origin) ? route.continue() : route.abort();
     });
     await context.addInitScript(base => {
@@ -60,6 +63,27 @@ try {
     pages.push(page);
   }
   const [host, guest] = pages;
+  // Only the host has the game files. Deliberately disagree on every copied
+  // setting and the guest ROM so checked frames prove the transfer took effect.
+  await host.locator('#machine').selectOption('A1200');
+  await host.locator('#video').selectOption('NTSC');
+  await host.locator('#floppy-speed').selectOption('400');
+  await host.locator('#floppy-sounds').uncheck();
+  if (await host.locator('#mono-audio').count()) await host.locator('#mono-audio').check();
+  await host.locator('#writable-floppies').check();
+  const disk = Buffer.alloc(901120);
+  await host.locator('#df0').setInputFiles({ name: 'host-df0.adf', mimeType: 'application/octet-stream', buffer: disk });
+  await host.locator('#df1').setInputFiles({ name: 'host-df1.adf', mimeType: 'application/octet-stream', buffer: disk });
+  await guest.locator('#kick').setInputFiles({ name: 'guest-original.rom', mimeType: 'application/octet-stream', buffer: Buffer.alloc(256 * 1024) });
+  await guest.waitForFunction(() => document.querySelector('#load-status').textContent.includes('guest-original.rom'));
+  const restored = async () => {
+    assert.equal(await guest.locator('#machine').inputValue(), 'A500');
+    assert.equal(await guest.locator('#video').inputValue(), 'PAL');
+    assert.equal(await guest.locator('#floppy-speed').inputValue(), '100');
+    assert.equal(await guest.locator('#floppy-sounds').isChecked(), true);
+    if (await guest.locator('#mono-audio').count()) assert.equal(await guest.locator('#mono-audio').isChecked(), false);
+    assert.equal(await guest.locator('#boot').textContent(), 'Boot Kickstart');
+  };
   const invitation = async () => {
     await host.locator('#netplay-room-host').click();
     await host.waitForFunction(() => document.querySelector('#netplay-invite').value.includes('#room='), null, { timeout: 30000 })
@@ -79,6 +103,24 @@ try {
   await guest.locator('#netplay-room-join').click();
   await guest.waitForFunction(() => /expired|ended/.test(document.querySelector('#netplay-status').textContent));
   assert.equal(await guest.locator('#boot').isEnabled(), true);
+  // Hold the media bytes after the manifest, then cancel from the receiver.
+  await host.evaluate(() => {
+    const send = RTCDataChannel.prototype.send;
+    window.__restoreSetupSend = () => { RTCDataChannel.prototype.send = send; };
+    RTCDataChannel.prototype.send = function (data) {
+      if (this.label === 'copperline-setup-v1' && typeof data !== 'string') return;
+      return send.call(this, data);
+    };
+  });
+  const interrupted = await invitation();
+  await guest.locator('#netplay-room-code').fill(interrupted);
+  await guest.locator('#netplay-room-join').click();
+  await guest.waitForFunction(() => /Receiving/.test(document.querySelector('#netplay-status').textContent));
+  await guest.locator('#netplay-disconnect').click();
+  await Promise.all(pages.map(page => page.locator('#netplay-room-host:enabled').waitFor()));
+  assert.ok(await guest.evaluate(() => !window.__emu));
+  await restored();
+  await host.evaluate(() => window.__restoreSetupSend());
   async function connect() {
     phase = 'connecting';
     const link = await invitation();
@@ -92,7 +134,18 @@ try {
     await host.locator('#netplay-panel').screenshot({ path: `${output}/invitation.png` });
     await guest.locator('#netplay-room-join').click();
     await Promise.all(pages.map(page => page.waitForFunction(() => window.__emu?.netplay_status()[6] >= 120,
-      null, { timeout: 90000 })));
+      null, { timeout: 90000 }))).catch(async error => {
+      for (const [i, page] of pages.entries()) {
+        console.error(`Player ${i + 1} setup:`, await page.locator('#netplay-status').textContent());
+        await page.evaluate(() => { window.__copied = ''; });
+        if (await page.locator('#netplay-diagnostics').isEnabled()) {
+          await page.locator('#netplay-diagnostics').click();
+          await page.waitForFunction(() => window.__copied?.startsWith('{'));
+          console.error(`Player ${i + 1} diagnostics:`, await page.evaluate(() => window.__copied));
+        }
+      }
+      throw error;
+    });
     phase = 'playing';
     return link;
   }
@@ -107,6 +160,13 @@ try {
     const report = JSON.parse(await page.evaluate(() => window.__copied));
     assert.equal(report.connection.peer, 'connected');
     assert.equal(report.stats.dtls, 'connected');
+    assert.deepEqual(await page.evaluate(() => ({ model: window.__emu.machine_model(), video: window.__emu.video_standard(), speed: window.__emu.floppy_speed() })),
+      { model: 'A1200', video: 'NTSC', speed: 400 });
+    assert.deepEqual(await page.evaluate(() => [0, 1].map(drive => ({ name: window.__emu.disk_name(drive),
+      protected: window.__emu.floppy_write_protected(drive) }))),
+    [{ name: 'netplay-df0', protected: false }, { name: 'netplay-df1', protected: false }]);
+    assert.equal(await page.locator('#floppy-sounds').isChecked(), false);
+    if (await page.locator('#mono-audio').count()) assert.equal(await page.locator('#mono-audio').isChecked(), true);
     if (relayOnly) assert.equal(report.stats.selectedPair.local, 'relay');
     assert.ok(!JSON.stringify(report).includes(new URL(link).hash.slice(6)));
     console.log(`Player ${i + 1}: ${JSON.stringify({ status: await page.evaluate(() => [...window.__emu.netplay_status()]), route: report.stats.selectedPair })}`);
@@ -114,6 +174,7 @@ try {
   phase = 'disconnect';
   await host.locator('#netplay-disconnect').click();
   await Promise.all(pages.map(page => page.locator('#netplay-room-host:enabled').waitFor()));
+  await restored();
   await guest.evaluate(() => { window.__copied = ''; });
   await guest.locator('#netplay-diagnostics').click();
   await guest.waitForFunction(() => window.__copied?.startsWith('{'));
@@ -122,16 +183,23 @@ try {
   phase = 'disconnect';
   await guest.locator('#netplay-disconnect').click();
   await Promise.all(pages.map(page => page.locator('#netplay-room-host:enabled').waitFor()));
-  await guest.locator('#video').selectOption('NTSC');
-  phase = 'mismatch';
-  const mismatch = await invitation();
-  await guest.locator('#netplay-room-code').fill(mismatch);
-  await guest.locator('#netplay-room-join').click();
-  await Promise.all(pages.map(page => page.waitForFunction(() => /mismatch|different/i.test(document.querySelector('#netplay-status').textContent), null, { timeout: 30000 })));
+  await restored();
+  const remembered = await guest.evaluate(() => new Promise((resolve, reject) => {
+    const request = indexedDB.open('copperline');
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const db = request.result;
+      const record = db.transaction('roms').objectStore('roms').get('kick');
+      record.onerror = () => { db.close(); reject(record.error); };
+      record.onsuccess = () => { resolve({ label: record.result?.label, length: record.result?.rom.length,
+        unchanged: record.result?.rom.every(byte => byte === 0) }); db.close(); };
+    };
+  }));
+  assert.deepEqual(remembered, { label: 'guest-original.rom', length: 256 * 1024, unchanged: true });
   await host.setViewportSize({ width: 390, height: 844 });
   await host.locator('#netplay-open').click();
   await host.locator('#netplay-panel').screenshot({ path: `${output}/mobile.png` });
   assert.deepEqual(errors, []);
   if (shutdownNotices.length) console.log('WebKit native shutdown notices:', JSON.stringify(shutdownNotices));
-  console.log('Room invitations, cancellation, reconnect, machine mismatch, diagnostics and responsive rendering passed');
+  console.log('Invitations, verified host ROM/disks/configuration, transfer cancellation, reconnect, guest restoration, diagnostics and responsive rendering passed');
 } finally { await browser.close(); }


### PR DESCRIPTION
Browser guests currently have to load the host's ROMs and disks and match every machine setting before joining. Transfer that setup over a separate reliable WebRTC channel, then verify each file before starting either emulator. Room invitations and manual signaling both support the transfer.

The setup includes main/extended ROMs, DF0/DF1 images and write protection, model, video standard, floppy speed, drive sounds and mono/stereo output. The receiver validates a bounded manifest and SHA-256 digests; buffering, inactivity and total duration are bounded. Disconnect cancels partial transfers and restores the guest's original media/configuration without replacing its remembered ROM. The signaling service receives no game files. Update publishing, offline assets, user guidance and embedding documentation accordingly.

A slow ICE endpoint can leave discovery open after usable relay candidates arrive. The browser now proceeds with those candidates at the 15-second deadline, while retaining empty-candidate failures and recording the fallback in diagnostics.

Validation: 23 browser helper tests, including full media equality, all supported configuration variants, corruption rejection, bounded buffering, cancellation and ICE deadlines; full live Chrome and WebKit 26.5 suites through Cloudflare TURN with different guest ROM/configuration and host-only writable ADFs through 120 checked frames; transfer cancellation, reconnect, guest restoration and unchanged IndexedDB ROM; live Chrome and WebKit runs deliberately exercising the gathering deadline with real relay candidates; direct Chrome/WebKit sessions; manual signaling and keyboard-input regression suite; responsive layout and offline AROS boot; cargo fmt --check and locked all-target/all-feature Clippy. Actual iOS/iPadOS 27 beta hardware remains unverified.
