### PR TITLE
Synchronize browser netplay disk swaps and ejections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,6 +522,7 @@ jobs:
           RUSTFLAGS="-C target-feature=+simd128" cargo build --release --target wasm32-unknown-unknown --locked
           wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/copperline_web.wasm
           node ../../tools/check-web-netplay.mjs pkg
+          node ../../tools/check-web-netplay-swaps.mjs pkg
       - name: Browser page controller tests
         working-directory: crates/copperline-web/www
         run: npm test

--- a/.github/workflows/wasm-demo.yml
+++ b/.github/workflows/wasm-demo.yml
@@ -126,6 +126,7 @@ jobs:
           SMOKE
           node pkg-smoke.mjs
           node ../../tools/check-web-netplay.mjs pkg
+          node ../../tools/check-web-netplay-swaps.mjs pkg
           rm pkg-smoke.mjs pkg-smoke-glue.mjs
       - name: Check out the website repository
         uses: actions/checkout@v7
@@ -147,6 +148,7 @@ jobs:
              crates/copperline-web/www/netplay.js \
              crates/copperline-web/www/netplay-room.js \
              crates/copperline-web/www/netplay-media.js \
+             crates/copperline-web/www/netplay-swap.js \
              crates/copperline-web/www/netplay-diagnostics.js \
              crates/copperline-web/www/netplay-qr.js \
              crates/copperline-web/www/netplay-qr.LICENSE \

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The manual is published at [copperline.dev/docs](https://copperline.dev/docs/) a
 - [WHDLoad Support](docs/guide/whdload.md) - Direct WHDLoad package loading
 - [Direct Executable Launching](docs/guide/run.md) - Running cross-compiled Amiga binaries
 - [Floppy Hardware Bridge](docs/guide/fluxbridge.md) - Real floppy drives via Greaseweazle
-- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions through desktop GUI/CLI or browser WebRTC with QR invitations, host ROM/disk/configuration transfer and relay fallback, plus input prediction, rollback and matching-machine checks
+- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions through desktop GUI/CLI or browser WebRTC with QR invitations, host ROM/disk/configuration transfer, synchronized browser disk swaps and relay fallback, plus input prediction, rollback and matching-machine checks
 - [Headless Mode](docs/guide/headless.md) - Scripted runs and screenshot/frame dumps
 - [Debugging](docs/debugger/window.md) - In-window, headless, and GDB debugging
 - [VS Code](docs/debugger/vscode.md) - Setup and illustrated source debugging; [Bartman with Copperline](docs/debugger/vscode-bartman.md) covers fork installation and visual profiling

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -211,6 +211,7 @@ pub struct WebEmu {
     // this local preference when draining its host audio buffer instead.
     netplay_volume: u8,
     netplay_eligible: bool,
+    netplay_swap: Option<netplay::DiskSwap>,
     config: Config,
     emu: Emulator,
     audio: Rc<RefCell<Vec<f32>>>,
@@ -361,6 +362,7 @@ impl WebEmu {
             netplay_input: Default::default(),
             netplay_volume: 100,
             netplay_eligible: true,
+            netplay_swap: None,
             config: cfg,
             emu,
             audio,

--- a/crates/copperline-web/src/netplay.rs
+++ b/crates/copperline-web/src/netplay.rs
@@ -225,11 +225,12 @@ impl WebEmu {
         if bytes.is_empty() {
             floppy.eject_disk_image(drive)
         } else {
-            floppy.insert_memory_disk_image_bytes(
+            floppy.insert_memory_disk_image_bytes_with_limit(
                 drive,
                 bytes,
                 format!("netplay-df{drive}").into(),
                 !writable,
+                16 * 1024 * 1024,
             )
         }
         .map_err(js_err)?;
@@ -271,12 +272,14 @@ impl WebEmu {
         );
         if !bytes.is_empty() {
             // Decode before the two-phase commit, without changing drive state.
-            copperline::floppy::FloppyController::default().insert_memory_disk_image_bytes(
-                0,
-                bytes,
-                "replacement".into(),
-                !writable,
-            )?;
+            copperline::floppy::FloppyController::default()
+                .insert_memory_disk_image_bytes_with_limit(
+                    0,
+                    bytes,
+                    "replacement".into(),
+                    !writable,
+                    16 * 1024 * 1024,
+                )?;
         }
         Ok(())
     }

--- a/crates/copperline-web/src/netplay.rs
+++ b/crates/copperline-web/src/netplay.rs
@@ -5,6 +5,12 @@
 use super::*;
 use copperline::netplay::{Connection, PacketQueue, Settings};
 
+pub(super) struct DiskSwap {
+    stop: u64,
+    disk: Option<(usize, Vec<u8>, bool)>,
+    applied: bool,
+}
+
 fn integer(value: f64, min: u8, max: u8, name: &str) -> Result<u8, JsValue> {
     if !value.is_finite()
         || value.fract() != 0.0
@@ -102,9 +108,178 @@ impl WebEmu {
     pub fn netplay_release_input(&mut self) {
         self.netplay_input = Default::default();
     }
+
+    /// Freeze at the current frame while the reliable channel negotiates a
+    /// common boundary. Input packets continue to reconcile and acknowledge.
+    pub fn netplay_hold(&mut self) -> Result<f64, JsValue> {
+        let peer = self
+            .netplay
+            .as_ref()
+            .ok_or_else(|| JsValue::from_str("No netplay session"))?;
+        if !peer.status().connected || self.netplay_swap.is_some() {
+            return Err(JsValue::from_str(
+                "A connected, idle netplay session is required",
+            ));
+        }
+        let stop = peer.status().frame;
+        self.netplay_swap = Some(DiskSwap {
+            stop,
+            disk: None,
+            applied: false,
+        });
+        self.anchor = None;
+        Ok(stop as f64)
+    }
+
+    /// Both stopped peers catch up to the greater of their two frame numbers.
+    pub fn netplay_stop_at(&mut self, frame: f64) -> Result<(), JsValue> {
+        let current = self
+            .netplay
+            .as_ref()
+            .ok_or_else(|| JsValue::from_str("No netplay session"))?
+            .status()
+            .frame;
+        let swap = self
+            .netplay_swap
+            .as_mut()
+            .ok_or_else(|| JsValue::from_str("No disk swap in progress"))?;
+        if !frame.is_finite()
+            || frame.fract() != 0.0
+            || frame < current as f64
+            || frame > (current + 32) as f64
+            || swap.disk.is_some()
+            || swap.applied
+        {
+            return Err(JsValue::from_str("Invalid disk swap frame"));
+        }
+        swap.stop = frame as u64;
+        self.anchor = None;
+        Ok(())
+    }
+
+    pub fn netplay_swap_ready(&self) -> bool {
+        self.netplay_swap.as_ref().is_some_and(|swap| {
+            self.netplay.as_ref().is_some_and(|peer| {
+                peer.status().frame == swap.stop && peer.status().ready_to_capture()
+            })
+        })
+    }
+
+    /// Digests before and after the change are compared over the reliable
+    /// channel; neither peer resumes on a mismatch.
+    pub fn netplay_swap_digest(&self) -> Result<Vec<u8>, JsValue> {
+        if !self.netplay_swap_ready() {
+            return Err(JsValue::from_str("Disk swap is not at a confirmed frame"));
+        }
+        self.netplay
+            .as_ref()
+            .unwrap()
+            .confirmed_state_digest(&self.emu)
+            .map(|hash| hash.to_vec())
+            .map_err(js_err)
+    }
+
+    /// Validate an image without touching the live drive. Empty bytes mean eject.
+    pub fn netplay_validate_disk(
+        &self,
+        drive: f64,
+        bytes: Vec<u8>,
+        writable: bool,
+    ) -> Result<(), JsValue> {
+        let drive = usize::from(integer(drive, 0, 1, "drive")?);
+        self.validate_netplay_disk(drive, bytes, writable)
+            .map_err(js_err)
+    }
+
+    pub fn netplay_stage_disk(
+        &mut self,
+        drive: f64,
+        bytes: Vec<u8>,
+        writable: bool,
+    ) -> Result<(), JsValue> {
+        let drive = usize::from(integer(drive, 0, 1, "drive")?);
+        if !self.netplay_swap_ready()
+            || self
+                .netplay_swap
+                .as_ref()
+                .is_none_or(|s| s.applied || s.disk.is_some())
+        {
+            return Err(JsValue::from_str("Disk swap is not ready for an image"));
+        }
+        self.validate_netplay_disk(drive, bytes.clone(), writable)
+            .map_err(js_err)?;
+        self.netplay_swap.as_mut().unwrap().disk = Some((drive, bytes, writable));
+        Ok(())
+    }
+
+    pub fn netplay_apply_disk(&mut self) -> Result<(), JsValue> {
+        if !self.netplay_swap_ready() {
+            return Err(JsValue::from_str("Disk swap is not at a confirmed frame"));
+        }
+        let swap = self.netplay_swap.as_mut().unwrap();
+        let (drive, bytes, writable) = swap
+            .disk
+            .take()
+            .ok_or_else(|| JsValue::from_str("No verified replacement disk"))?;
+        let floppy = &mut self.emu.bus_mut().floppy;
+        if bytes.is_empty() {
+            floppy.eject_disk_image(drive)
+        } else {
+            floppy.insert_memory_disk_image_bytes(
+                drive,
+                bytes,
+                format!("netplay-df{drive}").into(),
+                !writable,
+            )
+        }
+        .map_err(js_err)?;
+        swap.applied = true;
+        self.anchor = None;
+        Ok(())
+    }
+
+    pub fn netplay_resume(&mut self) -> Result<(), JsValue> {
+        if !self.netplay_swap_ready() || !self.netplay_swap.as_ref().is_some_and(|s| s.applied) {
+            return Err(JsValue::from_str("Disk swap has not been applied"));
+        }
+        self.netplay_swap = None;
+        self.anchor = None;
+        Ok(())
+    }
 }
 
 impl WebEmu {
+    fn validate_netplay_disk(
+        &self,
+        drive: usize,
+        bytes: Vec<u8>,
+        writable: bool,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.netplay
+                .as_ref()
+                .is_some_and(|peer| peer.status().connected),
+            "No connected netplay session"
+        );
+        anyhow::ensure!(
+            self.emu.bus().floppy.drive_connected(drive),
+            "Floppy drive is not connected"
+        );
+        anyhow::ensure!(
+            bytes.len() <= 16 * 1024 * 1024,
+            "Replacement disk exceeds 16 MiB"
+        );
+        if !bytes.is_empty() {
+            // Decode before the two-phase commit, without changing drive state.
+            copperline::floppy::FloppyController::default().insert_memory_disk_image_bytes(
+                0,
+                bytes,
+                "replacement".into(),
+                !writable,
+            )?;
+        }
+        Ok(())
+    }
     fn start_netplay_inner(
         &mut self,
         settings: Settings,
@@ -181,6 +356,14 @@ impl WebEmu {
         let target = emulated + (now_ms - wall) / 1000.0;
         let mut stepped = 0;
         while self.emu.bus().emulated_seconds() < target && stepped < max_frames.min(8) {
+            if self
+                .netplay_swap
+                .as_ref()
+                .is_some_and(|swap| peer.status().frame >= swap.stop)
+            {
+                self.anchor = Some((now_ms, self.emu.bus().emulated_seconds()));
+                break;
+            }
             if !peer
                 .step(&mut self.emu, self.netplay_input, true)
                 .map_err(js_err)?

--- a/crates/copperline-web/www/netplay-swap.js
+++ b/crates/copperline-web/www/netplay-swap.js
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Host-controlled media commits on a confirmed, stopped rollback boundary.
+export const SWAP_VERSION = 'disk-v1';
+export const SWAP_CHANNEL = 'copperline-disks-v1';
+export const DISK_LIMIT = 16 * 1024 * 1024;
+const CHUNK = 16 * 1024;
+const BUFFER = 256 * 1024;
+const hex = bytes => [...bytes].map(byte => byte.toString(16).padStart(2, '0')).join('');
+const digest = async bytes => hex(new Uint8Array(await crypto.subtle.digest('SHA-256', bytes)));
+const frameNumber = value => Number.isSafeInteger(value) && value >= 0;
+
+export function validateDisk(value) {
+  if (!value || ![0, 1].includes(value.drive) || !Number.isSafeInteger(value.size) ||
+      value.size < 0 || value.size > DISK_LIMIT || typeof value.writable !== 'boolean' ||
+      typeof value.name !== 'string' || value.name.length > 256 ||
+      typeof value.hash !== 'string' || !/^[a-f0-9]{64}$/.test(value.hash) ||
+      (!value.size && value.writable)) throw new Error('Invalid replacement disk description');
+  return { drive: value.drive, size: value.size, writable: value.writable, name: value.name, hash: value.hash };
+}
+
+export class DiskSwaps {
+  constructor(channel, { host, machine, status = () => {}, changed = () => {}, fail = () => {} }) {
+    Object.assign(this, { channel, host, machine, status, changed, fail });
+    this.abort = new AbortController();
+    this.id = 0;
+    this.busy = this.closed = false;
+    channel.binaryType = 'arraybuffer';
+    channel.bufferedAmountLowThreshold = BUFFER / 2;
+    channel.onmessage = event => {
+      try { this.accept(event.data); } catch (error) { this.stop(error); }
+    };
+    channel.onclose = () => this.stop(new Error('Disk swap connection ended'));
+    channel.onerror = () => this.stop(new Error('Disk swap connection failed'));
+  }
+
+  emu() {
+    if (this.closed) throw new Error('Disk swap cancelled');
+    const machine = this.machine();
+    if (!machine?.netplay_status()[0]) throw new Error('Wait for the game to connect before changing disks');
+    return machine;
+  }
+
+  touch() {
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => this.stop(new Error('Disk swap timed out')), 30000);
+  }
+
+  begin() {
+    this.busy = true;
+    this.touch();
+    this.deadline = setTimeout(() => this.stop(new Error('Disk swap exceeded three minutes')), 180000);
+    this.status('Pausing both players for a disk change...');
+    this.changed();
+  }
+
+  finish() {
+    clearTimeout(this.timer);
+    clearTimeout(this.deadline);
+    const disk = this.disk;
+    this.disk = this.bytes = this.pending = null;
+    this.busy = false;
+    this.phase = null;
+    this.status(disk.size ? `DF${disk.drive}: ${disk.name} — both players resumed` : `DF${disk.drive} ejected — both players resumed`);
+    this.changed(disk);
+  }
+
+  stop(error = new Error('Disk swap cancelled')) {
+    if (this.closed) return;
+    this.closed = true;
+    clearTimeout(this.timer);
+    clearTimeout(this.deadline);
+    this.abort.abort(error);
+    this.pending?.reject(error);
+    this.disk = this.bytes = this.pending = null;
+    this.busy = false;
+    this.fail(error);
+  }
+
+  async write(data) {
+    if (this.closed || this.channel.readyState !== 'open') throw new Error('Disk swap connection is unavailable');
+    if (this.channel.bufferedAmount > BUFFER) {
+      await new Promise((resolve, reject) => {
+        const cleanup = () => {
+          this.channel.removeEventListener('bufferedamountlow', drained);
+          this.abort.signal.removeEventListener('abort', cancelled);
+        };
+        const drained = () => { cleanup(); resolve(); };
+        const cancelled = () => { cleanup(); reject(this.abort.signal.reason); };
+        this.channel.addEventListener('bufferedamountlow', drained);
+        this.abort.signal.addEventListener('abort', cancelled, { once: true });
+        if (this.abort.signal.aborted) cancelled();
+        else if (this.channel.bufferedAmount <= BUFFER / 2) drained();
+      });
+    }
+    if (this.closed) throw new Error('Disk swap cancelled');
+    this.channel.send(data);
+    this.touch();
+  }
+
+  send(type, fields = {}) { return this.write(JSON.stringify({ type, id: this.id, ...fields })); }
+
+  expect(type) {
+    if (this.pending) throw new Error('Overlapping disk swap reply');
+    const result = new Promise((resolve, reject) => { this.pending = { type, resolve, reject }; });
+    result.catch(() => {});
+    return result;
+  }
+
+  async exchange(type, reply, fields) {
+    const response = this.expect(reply);
+    await this.send(type, fields);
+    return response;
+  }
+
+  async ready() {
+    while (!this.emu().netplay_swap_ready()) {
+      await new Promise((resolve, reject) => {
+        const cancelled = () => { clearTimeout(timer); reject(this.abort.signal.reason); };
+        const timer = setTimeout(() => { this.abort.signal.removeEventListener('abort', cancelled); resolve(); }, 20);
+        this.abort.signal.addEventListener('abort', cancelled, { once: true });
+        if (this.abort.signal.aborted) cancelled();
+      });
+    }
+    return hex(this.emu().netplay_swap_digest());
+  }
+
+  async swap(drive, disk) {
+    if (!this.host || this.busy || this.closed) throw new Error('Only the host can start one disk change at a time');
+    const bytes = disk?.bytes ?? new Uint8Array();
+    if (!(bytes instanceof Uint8Array) || bytes.length > DISK_LIMIT || (disk && !bytes.length)) throw new Error('Select a disk image of up to 16 MiB');
+    // Invalid local files leave the current game running.
+    this.emu().netplay_validate_disk(drive, bytes, !!disk?.writable);
+    this.begin();
+    try {
+      const description = validateDisk({ drive, size: bytes.length, writable: !!disk?.writable,
+        name: String(disk?.name ?? '').slice(0, 256), hash: await digest(bytes) });
+      this.disk = description;
+      this.id++;
+      const frame = this.emu().netplay_hold();
+      const held = await this.exchange('begin', 'held', { disk: description });
+      if (!frameNumber(held.frame) || Math.abs(held.frame - frame) > 32) throw new Error('Invalid peer disk swap frame');
+      const target = Math.max(frame, held.frame);
+      this.emu().netplay_stop_at(target);
+      const [peer, own] = await Promise.all([this.exchange('target', 'ready', { frame: target }), this.ready()]);
+      if (peer.hash !== own) throw new Error('Players differ before the disk change');
+      this.emu().netplay_stage_disk(drive, bytes, description.writable);
+      const prepared = this.expect('prepared');
+      for (let offset = 0; offset < bytes.length; offset += CHUNK) {
+        await this.write(bytes.subarray(offset, offset + CHUNK));
+        this.status(`Sending replacement disk: ${Math.floor(Math.min(offset + CHUNK, bytes.length) * 100 / bytes.length)}%`);
+      }
+      await this.send('end');
+      await prepared;
+      this.emu().netplay_apply_disk();
+      const applied = await this.exchange('apply', 'applied');
+      if (applied.hash !== hex(this.emu().netplay_swap_digest())) throw new Error('Players differ after the disk change');
+      await this.send('resume');
+      this.emu().netplay_resume();
+      this.finish();
+    } catch (error) { this.stop(error); throw error; }
+  }
+
+  accept(data) {
+    if (this.closed) return;
+    this.touch();
+    if (data instanceof ArrayBuffer) {
+      if (this.host || this.phase !== 'receiving' || !data.byteLength || data.byteLength > CHUNK ||
+          this.offset + data.byteLength > this.bytes.length) throw new Error('Invalid replacement disk chunk');
+      this.bytes.set(new Uint8Array(data), this.offset);
+      this.offset += data.byteLength;
+      this.status(`Receiving replacement disk: ${Math.floor(this.offset * 100 / this.bytes.length)}%`);
+      return;
+    }
+    if (typeof data !== 'string' || data.length > 2048) throw new Error('Invalid disk swap message');
+    const message = JSON.parse(data);
+    if (!message || !Number.isSafeInteger(message.id)) throw new Error('Invalid disk swap identifier');
+    if (this.host) {
+      if (message.id !== this.id || message.type !== this.pending?.type) throw new Error('Unexpected disk swap reply');
+      const { resolve } = this.pending;
+      this.pending = null;
+      resolve(message);
+      return;
+    }
+    if (message.type === 'begin') {
+      if (this.busy || message.id !== this.id + 1) throw new Error('Unexpected disk swap request');
+      const disk = validateDisk(message.disk);
+      const frame = this.emu().netplay_hold();
+      this.id = message.id;
+      this.disk = disk;
+      this.phase = 'held';
+      this.begin();
+      this.send('held', { frame }).catch(error => this.stop(error));
+      return;
+    }
+    if (!this.busy || message.id !== this.id) throw new Error('Unexpected disk swap identifier');
+    if (message.type === 'target' && this.phase === 'held') {
+      if (!frameNumber(message.frame)) throw new Error('Invalid disk swap frame');
+      this.emu().netplay_stop_at(message.frame);
+      this.phase = 'waiting';
+      this.ready().then(hash => {
+        if (this.closed) return;
+        this.bytes = new Uint8Array(this.disk.size);
+        this.offset = 0;
+        this.phase = 'receiving';
+        return this.send('ready', { hash });
+      }).catch(error => this.stop(error));
+    } else if (message.type === 'end' && this.phase === 'receiving' && this.offset === this.disk.size) {
+      this.phase = 'verifying';
+      this.verify().catch(error => this.stop(error));
+    } else if (message.type === 'apply' && this.phase === 'prepared') {
+      this.emu().netplay_apply_disk();
+      this.phase = 'applied';
+      this.send('applied', { hash: hex(this.emu().netplay_swap_digest()) }).catch(error => this.stop(error));
+    } else if (message.type === 'resume' && this.phase === 'applied') {
+      this.emu().netplay_resume();
+      this.finish();
+    } else throw new Error('Unexpected disk swap phase');
+  }
+
+  async verify() {
+    if (await digest(this.bytes) !== this.disk.hash) throw new Error('Replacement disk did not match the host');
+    if (this.closed) return;
+    this.emu().netplay_stage_disk(this.disk.drive, this.bytes, this.disk.writable);
+    this.bytes = null;
+    this.phase = 'prepared';
+    await this.send('prepared');
+  }
+}

--- a/crates/copperline-web/www/netplay-swap.js
+++ b/crates/copperline-web/www/netplay-swap.js
@@ -126,6 +126,7 @@ export class DiskSwaps {
 
   async swap(drive, disk) {
     if (!this.host || this.busy || this.closed) throw new Error('Only the host can start one disk change at a time');
+    if (this.channel.readyState !== 'open') throw new Error('The disk transfer channel is not ready yet');
     const bytes = disk?.bytes ?? new Uint8Array();
     if (!(bytes instanceof Uint8Array) || bytes.length > DISK_LIMIT || (disk && !bytes.length)) throw new Error('Select a disk image of up to 16 MiB');
     // Invalid local files leave the current game running.

--- a/crates/copperline-web/www/netplay-swap.test.js
+++ b/crates/copperline-web/www/netplay-swap.test.js
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { DiskSwaps, DISK_LIMIT, validateDisk } from './netplay-swap.js';
+
+class Wire extends EventTarget {
+  readyState = 'open';
+  bufferedAmount = 0;
+  maximum = 0;
+  send(value) {
+    const data = typeof value === 'string' ? value : value.slice().buffer;
+    const size = typeof data === 'string' ? data.length : data.byteLength;
+    this.bufferedAmount += size;
+    this.maximum = Math.max(this.maximum, this.bufferedAmount);
+    setTimeout(() => {
+      this.bufferedAmount -= size;
+      this.peer.onmessage?.({ data: this.transform?.(data) ?? data });
+      if (this.bufferedAmount <= this.bufferedAmountLowThreshold) this.dispatchEvent(new Event('bufferedamountlow'));
+    }, 0);
+  }
+}
+
+class Machine {
+  constructor(frame) { this.frame = frame; this.disks = [null, null]; this.events = []; this.ready = true; }
+  netplay_status() { return [1, this.frame]; }
+  netplay_validate_disk(drive, bytes) { assert.ok([0, 1].includes(drive)); if (bytes[0] === 255) throw new Error('Invalid disk image'); }
+  netplay_hold() { this.events.push('hold'); this.held = true; return this.frame; }
+  netplay_stop_at(frame) { this.events.push('target'); this.frame = frame; }
+  netplay_swap_ready() { return this.ready; }
+  netplay_swap_digest() { return new Uint8Array([this.frame, ...this.disks.map(disk => disk?.bytes[0] ?? 0), this.mismatch ?? 0]); }
+  netplay_stage_disk(drive, bytes, writable) { this.events.push('stage'); this.pending = { drive, bytes: bytes.slice(), writable }; }
+  netplay_apply_disk() { this.events.push('apply'); this.disks[this.pending.drive] = this.pending; this.pending = null; }
+  netplay_resume() { this.events.push('resume'); this.held = false; }
+}
+
+function pair(t) {
+  const wires = [new Wire(), new Wire()];
+  wires[0].peer = wires[1]; wires[1].peer = wires[0];
+  const machines = [new Machine(120), new Machine(124)];
+  const swaps = [];
+  const fail = error => swaps.forEach(swap => swap.stop(error));
+  for (let i = 0; i < 2; i++) swaps.push(new DiskSwaps(wires[i], { host: !i, machine: () => machines[i], fail }));
+  t.after(() => { swaps.forEach(swap => swap.stop()); wires.forEach(wire => { wire.onmessage = null; }); });
+  return { host: swaps[0], guest: swaps[1], machines, wires };
+}
+const disk = value => ({ bytes: new Uint8Array(901120).fill(value), name: `Disk ${value}.adf`, writable: false });
+async function idle(guest) {
+  for (let i = 0; guest.busy && i < 100; i++) await new Promise(resolve => setTimeout(resolve, 5));
+  assert.equal(guest.busy, false);
+}
+
+test('repeated DF0/DF1 swaps and ejections wait for matching boundaries and bounded transfers', async t => {
+  const { host, guest, machines, wires } = pair(t);
+  for (const [drive, image] of [[0, disk(7)], [0, disk(8)], [1, { ...disk(9), writable: true }], [0, null], [0, disk(7)]]) {
+    await host.swap(drive, image);
+    await idle(guest);
+    assert.deepEqual(machines[0].disks, machines[1].disks);
+    assert.equal(machines[0].frame, 124);
+    for (const machine of machines) {
+      assert.deepEqual(machine.events.splice(0), ['hold', 'target', 'stage', 'apply', 'resume']);
+      assert.equal(machine.held, false);
+    }
+    assert.equal(guest.bytes, null);
+  }
+  assert.ok(wires[0].maximum <= 256 * 1024 + 16 * 1024);
+});
+
+test('neither drive changes until both frames and the received disk are verified', async t => {
+  const { host, guest, machines, wires } = pair(t);
+  machines[1].ready = false;
+  const sending = host.swap(0, disk(4));
+  await new Promise(resolve => setTimeout(resolve, 30));
+  assert.equal(guest.phase, 'waiting');
+  assert.deepEqual(machines.map(machine => machine.disks[0]), [null, null]);
+  wires[0].bufferedAmount = 512 * 1024;
+  machines[1].ready = true;
+  await new Promise(resolve => setTimeout(resolve, 30));
+  assert.equal(guest.phase, 'receiving');
+  assert.deepEqual(machines.map(machine => machine.disks[0]), [null, null]);
+  wires[0].bufferedAmount = 0;
+  wires[0].dispatchEvent(new Event('bufferedamountlow'));
+  await sending;
+  await idle(guest);
+});
+
+test('invalid local files preserve the game; the guest cannot initiate a swap', async t => {
+  const { host, guest, machines } = pair(t);
+  await assert.rejects(host.swap(0, disk(255)), /Invalid disk image/);
+  await assert.rejects(guest.swap(0, disk(1)), /Only the host/);
+  assert.equal(host.closed, false);
+  assert.deepEqual(machines.map(machine => machine.events), [[], []]);
+});
+
+test('corruption and before/after state mismatches stop both peers without resuming', async t => {
+  for (const failure of ['corrupt', 'before', 'after']) {
+    const { host, machines, wires } = pair(t);
+    if (failure === 'before') machines[1].mismatch = 1;
+    if (failure === 'after') {
+      const apply = machines[1].netplay_apply_disk.bind(machines[1]);
+      machines[1].netplay_apply_disk = () => { apply(); machines[1].mismatch = 1; };
+    }
+    wires[0].transform = data => {
+      if (failure === 'corrupt' && data instanceof ArrayBuffer) new Uint8Array(data)[0] ^= 1;
+      return data;
+    };
+    await assert.rejects(host.swap(0, disk(7)), /differ|did not match/);
+    assert.ok(machines.every(machine => !machine.events.includes('resume')));
+    if (failure !== 'after') assert.deepEqual(machines.map(machine => machine.disks[0]), [null, null]);
+  }
+});
+
+test('cancellation releases blocked transfers and discards partially received bytes', async t => {
+  const { host, guest, machines, wires } = pair(t);
+  const sending = host.swap(0, disk(5));
+  const result = assert.rejects(sending, /cancelled/);
+  await new Promise(resolve => setTimeout(resolve, 2));
+  wires[0].bufferedAmount = 512 * 1024;
+  await new Promise(resolve => setTimeout(resolve, 30));
+  guest.stop(new Error('cancelled'));
+  await result;
+  assert.equal(guest.bytes, null);
+  assert.ok(machines.every(machine => !machine.events.includes('resume')));
+});
+
+test('metadata limits and unsolicited, oversized or out-of-order messages fail closed', t => {
+  const valid = { drive: 0, size: 901120, writable: false, name: 'Disk.adf', hash: 'a'.repeat(64) };
+  assert.deepEqual(validateDisk(valid), valid);
+  for (const invalid of [{ drive: 2 }, { drive: 0.5 }, { size: -1 }, { size: DISK_LIMIT + 1 },
+    { size: 1.5 }, { name: 'a'.repeat(257) }, { writable: 'false' }, { hash: 'bad' }, { size: 0, writable: true }]) {
+    assert.throws(() => validateDisk({ ...valid, ...invalid }));
+  }
+  for (const message of [new ArrayBuffer(1), '{', ' '.repeat(2049), JSON.stringify({ type: 'resume', id: 1 })]) {
+    const { guest } = pair(t);
+    guest.channel.onmessage({ data: message });
+    assert.equal(guest.closed, true);
+  }
+});
+
+test('a peer that never reaches the confirmed boundary times out without changing disks', async t => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const { guest, machines } = pair(t);
+  machines[1].ready = false;
+  guest.channel.onmessage({ data: JSON.stringify({ type: 'begin', id: 1,
+    disk: { drive: 0, size: 901120, name: 'Disk.adf', writable: false, hash: 'a'.repeat(64) } }) });
+  // Ignore the reply here: this test exercises the receiver's finite deadline.
+  guest.channel.peer.onmessage = null;
+  guest.channel.onmessage({ data: JSON.stringify({ type: 'target', id: 1, frame: 124 }) });
+  t.mock.timers.tick(30000);
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(guest.closed, true);
+  assert.deepEqual(machines[1].disks, [null, null]);
+  assert.equal(machines[1].events.includes('resume'), false);
+});

--- a/crates/copperline-web/www/netplay-swap.test.js
+++ b/crates/copperline-web/www/netplay-swap.test.js
@@ -83,6 +83,20 @@ test('neither drive changes until both frames and the received disk are verified
   await idle(guest);
 });
 
+test('a connecting disk channel leaves the game running and can be retried once open', async t => {
+  const { host, guest, machines, wires } = pair(t);
+  wires[0].readyState = 'connecting';
+  await assert.rejects(host.swap(0, disk(7)), /not ready yet/);
+  assert.equal(host.closed, false);
+  assert.equal(host.busy, false);
+  assert.deepEqual(machines.map(machine => machine.events), [[], []]);
+  wires[0].readyState = 'open';
+  await host.swap(0, disk(7));
+  await idle(guest);
+  assert.deepEqual(machines[0].disks, machines[1].disks);
+  assert.ok(machines.every(machine => machine.events.includes('resume')));
+});
+
 test('invalid local files preserve the game; the guest cannot initiate a swap', async t => {
   const { host, guest, machines } = pair(t);
   await assert.rejects(host.swap(0, disk(255)), /Invalid disk image/);

--- a/crates/copperline-web/www/netplay.js
+++ b/crates/copperline-web/www/netplay.js
@@ -410,7 +410,8 @@ export function mountNetplayPanel(parent, { prepare, start, stop, getMedia, useM
     field('diagnostics').disabled = !lastLink;
     const swapEnabled = !!link?.host && link.settings?.swaps === SWAP_VERSION;
     field('disks').hidden = !swapEnabled;
-    const canSwap = swapEnabled && !!getMachine?.(link)?.netplay_status()[0] && !link.swaps?.busy && !readingDisk;
+    const canSwap = swapEnabled && link.swaps?.channel.readyState === 'open'
+      && !!getMachine?.(link)?.netplay_status()[0] && !link.swaps.busy && !readingDisk;
     for (const name of ['disk-drive', 'disk-file', 'disk-writable', 'disk-eject']) field(name).disabled = !canSwap;
     if (!active) field('accept').disabled = true;
   };

--- a/crates/copperline-web/www/netplay.js
+++ b/crates/copperline-web/www/netplay.js
@@ -4,6 +4,7 @@ import { NetplayDiagnostics, connectionFailure } from './netplay-diagnostics.js'
 import { RoomClient, inviteUrl, roomFromInvite } from './netplay-room.js';
 import qrcode from './netplay-qr.js';
 import { MEDIA_CHANNEL, MEDIA_VERSION, MediaTransfer } from './netplay-media.js';
+import { SWAP_CHANNEL, SWAP_VERSION, DISK_LIMIT, DiskSwaps } from './netplay-swap.js';
 
 // Signaling uses expiring room invitations or manual copy/paste codes.
 // Only bounded input packets use the data channel.
@@ -17,12 +18,13 @@ export function validateSettings(value) {
       !Number.isInteger(value.delay) || value.delay < 0 || value.delay > 6 ||
       !Number.isInteger(value.window) || value.window < 1 || value.window > 12 ||
       !['joystick', 'cd32'].includes(value.controller) ||
-      (value.media !== undefined && value.media !== MEDIA_VERSION)) {
+      (value.media !== undefined && value.media !== MEDIA_VERSION) ||
+      (value.swaps !== undefined && value.swaps !== SWAP_VERSION)) {
     throw new Error('Invalid netplay settings in connection code');
   }
   return { session: value.session.toLowerCase(), delay: value.delay,
     window: value.window, controller: value.controller,
-    ...(value.media ? { media: value.media } : {}) };
+    ...(value.media ? { media: value.media } : {}), ...(value.swaps ? { swaps: value.swaps } : {}) };
 }
 
 export function encodeCode(description, settings) {
@@ -55,6 +57,7 @@ export function newSettings(delay, window, controller) {
 
 export class RtcLink {
   constructor({ iceServers = [], onOpen = () => {}, onClose = () => {},
+    swapCallbacks = {},
     PeerConnection = globalThis.RTCPeerConnection } = {}) {
     if (!PeerConnection) throw new Error('This browser does not support WebRTC data channels');
     this.pc = new PeerConnection({ iceServers });
@@ -68,6 +71,8 @@ export class RtcLink {
     this.timer = null;
     this.cancelGather = null;
     this.media = null;
+    this.swaps = null;
+    this.swapCallbacks = swapCallbacks;
     this.mediaReady = new Promise((resolve, reject) => { this.mediaAttached = resolve; this.mediaFailed = reject; });
     this.mediaReady.catch(() => {});
     this.diagnostics = new NetplayDiagnostics();
@@ -93,6 +98,17 @@ export class RtcLink {
   }
 
   attach(channel) {
+    if (channel.label === SWAP_CHANNEL) {
+      if (this.closed || this.swaps || this.settings?.swaps !== SWAP_VERSION ||
+          channel.ordered !== true || channel.maxRetransmits != null || channel.maxPacketLifeTime != null) {
+        channel.close();
+        this.close('Unexpected disk swap channel. Refresh both pages.');
+        return;
+      }
+      this.swaps = new DiskSwaps(channel, { ...this.swapCallbacks, host: this.host,
+        fail: error => this.close(error.message) });
+      return;
+    }
     if (channel.label === MEDIA_CHANNEL) {
       if (this.closed || this.media || this.settings?.media !== MEDIA_VERSION ||
           channel.ordered !== true || channel.maxRetransmits != null || channel.maxPacketLifeTime != null) {
@@ -209,6 +225,7 @@ export class RtcLink {
     this.host = true;
     this.attach(this.pc.createDataChannel(CHANNEL, { ordered: false, maxRetransmits: 0 }));
     if (this.settings.media === MEDIA_VERSION) this.attach(this.pc.createDataChannel(MEDIA_CHANNEL, { ordered: true }));
+    if (this.settings.swaps === SWAP_VERSION) this.attach(this.pc.createDataChannel(SWAP_CHANNEL, { ordered: true }));
     return this.gather(await this.pc.createOffer());
   }
 
@@ -273,6 +290,13 @@ export class RtcLink {
   }
 
   dispose() {
+    if (this.swaps) {
+      const channel = this.swaps.channel;
+      channel.onmessage = channel.onclose = channel.onerror = null;
+      this.swaps.stop();
+      channel.close();
+      this.swaps = null;
+    }
     if (this.media) {
       const channel = this.media.channel;
       channel.onopen = channel.onmessage = channel.onclose = channel.onerror = null;
@@ -294,7 +318,7 @@ export class RtcLink {
 }
 
 // The panel inserts itself into old static page shells, as the other controls do.
-export function mountNetplayPanel(parent, { prepare, start, stop, getMedia, useMedia }) {
+export function mountNetplayPanel(parent, { prepare, start, stop, getMedia, useMedia, getMachine, diskChanged }) {
   const style = document.createElement('style');
   style.textContent = `
     #netplay-panel { font-size: .88rem; line-height: 1.4; color: var(--ink-mute, #bbc0ca); }
@@ -341,6 +365,14 @@ export function mountNetplayPanel(parent, { prepare, start, stop, getMedia, useM
     </div>
     <button id="netplay-disconnect" type="button" disabled>Disconnect</button>
     <p id="netplay-status" role="status" aria-live="polite">Host a game or open an invitation to join.</p>
+    <div id="netplay-disks" hidden>
+      <p>The host can change disks here. Both players pause during the transfer and resume together.</p>
+      <label>Drive <select id="netplay-disk-drive"><option value="0">DF0</option><option value="1">DF1</option></select></label>
+      <label>Swap disk <input id="netplay-disk-file" type="file" accept=".adf,.adz,.dms,.ipf,.scp,.gz,.zip"></label>
+      <label><input id="netplay-disk-writable" type="checkbox"> Allow writes to the replacement disk</label>
+      <button id="netplay-disk-eject" type="button">Eject selected drive</button>
+      <p>Writable changes stay in this session and are discarded when a disk is replaced or the session ends.</p>
+    </div>
     <button id="netplay-diagnostics" type="button" disabled>Copy diagnostics</button>
     <textarea id="netplay-report" rows="5" readonly hidden aria-label="Connection diagnostics"></textarea>
     <details id="netplay-advanced"><summary>Advanced</summary>
@@ -367,6 +399,7 @@ export function mountNetplayPanel(parent, { prepare, start, stop, getMedia, useM
   const service = document.querySelector('meta[name="copperline-netplay-service"]')?.content?.trim();
   let link = null;
   let lastLink = null;
+  let readingDisk = false;
   const status = text => { field('status').textContent = text; };
   const controls = () => {
     const active = !!link;
@@ -375,6 +408,10 @@ export function mountNetplayPanel(parent, { prepare, start, stop, getMedia, useM
     field('disconnect').disabled = !active;
     field('copy').disabled = !field('local').value;
     field('diagnostics').disabled = !lastLink;
+    const swapEnabled = !!link?.host && link.settings?.swaps === SWAP_VERSION;
+    field('disks').hidden = !swapEnabled;
+    const canSwap = swapEnabled && !!getMachine?.(link)?.netplay_status()[0] && !link.swaps?.busy && !readingDisk;
+    for (const name of ['disk-drive', 'disk-file', 'disk-writable', 'disk-eject']) field(name).disabled = !canSwap;
     if (!active) field('accept').disabled = true;
   };
   field('service-status').textContent = service
@@ -406,11 +443,15 @@ export function mountNetplayPanel(parent, { prepare, start, stop, getMedia, useM
       const roomId = roomFromInvite(field('room-code').value);
       if (roomMode && !service) throw new Error('Room invitations are not configured on this page');
       if (roomMode && !host && !roomId) throw new Error('Paste an invitation link or room code');
-      settings = host ? { ...newSettings(Number(field('delay').value), Number(field('window').value), field('controller').value), media: MEDIA_VERSION }
+      settings = host ? { ...newSettings(Number(field('delay').value), Number(field('window').value), field('controller').value), media: MEDIA_VERSION, swaps: SWAP_VERSION }
         : roomMode ? null : decodeCode(remote, 'offer').settings;
       const stun = field('stun').value.trim();
       if (!roomMode && stun && !/^stuns?:[^\s]+$/i.test(stun)) throw new Error('STUN server must start with stun: or stuns:');
       current = new RtcLink({ iceServers: !roomMode && stun ? [{ urls: stun }] : [],
+        swapCallbacks: {
+          machine: () => getMachine(current), status,
+          changed: disk => { if (link === current) { if (disk) diskChanged(current, disk); controls(); } },
+        },
         onOpen: async peer => {
           if (link !== peer) return;
           if (settings.media === MEDIA_VERSION) {
@@ -492,6 +533,28 @@ export function mountNetplayPanel(parent, { prepare, start, stop, getMedia, useM
   field('join').addEventListener('click', () => begin('manual-join'));
   field('room-host').addEventListener('click', () => begin('room-host'));
   field('room-join').addEventListener('click', () => begin('room-join'));
+  field('disk-file').addEventListener('change', async () => {
+    const current = link;
+    const file = field('disk-file').files?.[0];
+    if (!file || !current?.host || !current.swaps || readingDisk) return;
+    const drive = Number(field('disk-drive').value);
+    const writable = field('disk-writable').checked;
+    readingDisk = true;
+    controls();
+    try {
+      if (!file.size || file.size > DISK_LIMIT) throw new Error('Select a disk image of up to 16 MiB');
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      if (link !== current) return;
+      await current.swaps.swap(drive, { bytes, name: file.name, writable });
+    } catch (error) { if (link === current) status(String(error.message ?? error)); }
+    finally { readingDisk = false; field('disk-file').value = ''; controls(); }
+  });
+  field('disk-eject').addEventListener('click', async () => {
+    const current = link;
+    if (!current?.host || !current.swaps || readingDisk) return;
+    try { await current.swaps.swap(Number(field('disk-drive').value), null); }
+    catch (error) { if (link === current) status(String(error.message ?? error)); }
+  });
   field('accept').addEventListener('click', async () => {
     const current = link;
     if (!current) return;
@@ -525,5 +588,5 @@ export function mountNetplayPanel(parent, { prepare, start, stop, getMedia, useM
   field('disconnect').addEventListener('click', () => link?.close());
   window.addEventListener('pagehide', () => link?.close());
   controls();
-  return { get link() { return link; }, status, root };
+  return { get link() { return link; }, status: text => { controls(); if (!link?.swaps?.busy) status(text); }, root };
 }

--- a/crates/copperline-web/www/netplay.test.js
+++ b/crates/copperline-web/www/netplay.test.js
@@ -32,20 +32,25 @@ test('connection codes round-trip only valid settings and the expected descripti
   assert.throws(() => validateSettings({ ...settings, controller: 'mouse' }));
   assert.throws(() => validateSettings({ ...settings, session: 'bad' }));
   assert.notEqual(newSettings(0, 1, 'cd32').session, newSettings(0, 1, 'cd32').session);
-  const shared = { ...settings, media: 'host-v1' };
+  const shared = { ...settings, media: 'host-v1', swaps: 'disk-v1' };
   assert.deepEqual(decodeCode(encodeCode(description('offer'), shared), 'offer').settings, shared);
   assert.throws(() => validateSettings({ ...settings, media: 'unknown' }));
+  assert.throws(() => validateSettings({ ...settings, swaps: 'unknown' }));
 });
 
 test('setup-enabled offers create a reliable channel and reject incompatible setup channels', async () => {
   const link = new RtcLink({ PeerConnection: Peer });
-  await link.offer({ ...settings, media: 'host-v1' });
+  await link.offer({ ...settings, media: 'host-v1', swaps: 'disk-v1' });
   assert.equal(link.media.channel.label, 'copperline-setup-v1');
   assert.equal(link.media.channel.ordered, true);
   assert.equal(link.media.channel.maxRetransmits, undefined);
+  assert.equal(link.swaps.channel.label, 'copperline-disks-v1');
+  assert.equal(link.swaps.channel.ordered, true);
+  assert.equal(link.swaps.channel.maxRetransmits, undefined);
   link.close();
   assert.equal(link.media, null);
   assert.equal(link.mediaReady, null);
+  assert.equal(link.swaps, null);
   const other = new RtcLink({ PeerConnection: Peer });
   other.attach(new Channel('copperline-setup-v1', { ordered: false, maxRetransmits: 0 }));
   assert.equal(other.closed, true);

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -7538,6 +7538,14 @@ if (typeof WebEmu.prototype.start_netplay === 'function') {
   netplayPanel = mountNetplayPanel(
     $('reset').closest('.try-side-section')?.parentElement ?? shell.parentElement,
     {
+      getMachine: link => netplayPanel?.link === link && netplayMachineReady ? emu : null,
+      diskChanged: (link, disk) => {
+        if (netplayPanel?.link !== link) return;
+        diskNames[disk.drive] = disk.size ? disk.name : null;
+        lastFddTrack = null;
+        updateStatusDisks();
+        updateFloppyImageControls();
+      },
       prepare: async (link, { receiveMedia }) => {
         if (!wasm || (!receiveMedia && !bootRom)) throw new Error('Load a ROM before setting up netplay');
         keepUploadedDisksForRebuild();

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -76,6 +76,9 @@ The host sends ROMs, floppy images and machine settings over the encrypted peer
 connection. The guest verifies them before startup and uses them only for the
 session; its remembered ROM and local choices are preserved. Both pages start
 fresh machines with matching ROMs, disks and hardware settings.
+During play the host can use **Netplay → Swap disk** or **Eject selected drive**;
+both peers pause and apply the disk change together. The guest receives each
+replacement automatically, including repeated swaps in DF0.
 Each player controls one Amiga port; late input is predicted and corrected by
 rollback. See [browser netplay setup](netplay.md#browser-netplay) for the steps,
 controller mapping, relay troubleshooting and restrictions.
@@ -104,6 +107,7 @@ The browser implementation consists of the following components:
 - **Netplay:** The Rust core owns the shared rollback timeline and bounded packet
   queues. `www/netplay.js` handles room invitations, manual codes and WebRTC;
   `www/netplay-media.js` transfers and verifies the host setup on a reliable channel.
+  `www/netplay-swap.js` coordinates host disk changes on confirmed frame boundaries.
   `try.js` owns the session lifecycle and locks controls that change the machine.
 
 ## Building the WebAssembly package locally
@@ -244,6 +248,15 @@ For another transport, pass each complete received packet to
 an empty array. Preserve packet boundaries; do not interpret packets as text.
 The supported browser transport uses an unordered data channel with
 `maxRetransmits: 0`; Copperline performs input retransmission itself.
+
+Set `settings.swaps = "disk-v1"` and supply `swapCallbacks.machine` (returning
+the current `WebEmu`) to enable the separate reliable disk channel. Optional
+`status` and `changed` callbacks update the page. The host calls
+`link.swaps.swap(drive, {bytes, name, writable})`, or passes `null` to eject.
+Keep polling and running the emulator during this operation: Rust stops forward
+execution at the negotiated boundary but must still process input and acknowledgements.
+Do not call the underlying hold/stage/apply/resume methods independently; both
+peers must complete the coordination protocol before either resumes.
 
 `netplay_status()` returns `[connected, frame, confirmed, acknowledged, rollbacks,
 replayed, checked]`, with `connected` represented by 0 or 1. It returns an empty

--- a/docs/guide/browser.md
+++ b/docs/guide/browser.md
@@ -22,6 +22,8 @@ The web version runs at [copperline.dev/try](https://copperline.dev/try/):
   By default, images mount read-only. Check **Open disks writable** to enable in-memory
   modifications. Use **Blank DF0/DF1** to create an empty formatted disk, and **Download DF0/DF1**
   to export modified disk images. URL query parameters: `?df0=<url>&df1=<url>`.
+  Gzip images may expand to at most 128 MiB; netplay replacements have a smaller
+  16 MiB limit on both the file and its expanded contents.
 - **Display options:**
   - **Monitor presentation:** Select CRT shader and bezel frames (**1084**, **Classic**,
     **CRT filter**, or **Plain**).

--- a/docs/guide/netplay.md
+++ b/docs/guide/netplay.md
@@ -58,6 +58,23 @@ to 2 MiB each and floppy images to 16 MiB each. Starting from a running machine
 uses the current contents of writable disks; it still cold-boots rather than
 transferring a running save state.
 
+### Changing disks during browser play
+
+When a game asks for another disk, the host opens **Controls → Netplay**, selects
+**DF0** (or DF1) under **Drive**, and chooses the next image under **Swap disk**.
+Both machines pause, the guest receives and verifies the replacement, and both
+resume at the same emulated frame. The guest does not need to select a file.
+This works with games that require all disks in DF0. **Eject selected drive**
+performs a synchronized removal if a game needs to see an empty drive first;
+choose the next disk when ready. The ordinary local disk controls remain locked.
+
+Replacement images are limited to 16 MiB and default to write-protected.
+**Allow writes to the replacement disk** supports uncompressed standard and UAE
+extended ADFs. Writable changes are held only in the mounted session image;
+replacing that disk or disconnecting discards them. Invalid local files leave
+the game running. An interrupted transfer or a state mismatch ends the session
+rather than allowing the players to continue with different disks.
+
 If a connection ends, use **Copy diagnostics** on both devices. The report keeps
 ICE, peer, data-channel and DTLS states, candidate types and packet counters.
 It excludes network addresses, SDP, invitation/session tokens and credentials.

--- a/docs/guide/netplay.md
+++ b/docs/guide/netplay.md
@@ -68,7 +68,9 @@ This works with games that require all disks in DF0. **Eject selected drive**
 performs a synchronized removal if a game needs to see an empty drive first;
 choose the next disk when ready. The ordinary local disk controls remain locked.
 
-Replacement images are limited to 16 MiB and default to write-protected.
+Replacement images are limited to 16 MiB, including after gzip/zip expansion,
+and default to write-protected. The controls become available once the disk
+transfer channel is connected.
 **Allow writes to the replacement disk** supports uncompressed standard and UAE
 extended ADFs. Writable changes are held only in the mounted session image;
 replacing that disk or disconnecting discards them. Invalid local files leave

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -181,7 +181,10 @@ inputs are retained, and wall-clock pacing is reanchored around the pause.
 The peers compare SHA-256 digests of the complete confirmed machine state,
 transfer at most 16 MiB in 16 KiB chunks with 256 KiB send-buffer backpressure,
 verify the image digest, and decode into a temporary controller before agreeing
-to apply. Both live drives change at the stopped boundary with canonical
+to apply. The core decoder enforces the same 16 MiB bound on gzip/zip expansion
+during validation and insertion; the ordinary gzip floppy loader has a 128 MiB
+expanded-size cap for larger flux captures. Host controls wait for the separate
+disk channel to open. Both live drives change at the stopped boundary with canonical
 `netplay-dfN` metadata and memory backing. A second full-state digest comparison
 precedes resume. Empty payloads perform an eject. Transaction IDs, message phases,
 metadata and chunk sizes are checked; overlapping requests are rejected. Thirty

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -105,6 +105,10 @@ session as local play.
 ## Browser transport and lifecycle
 
 `Connection<T: Transport>` owns the handshake, rollback and timeout logic.
+Same-process checkpoints include the CPU adapter's sampled interrupt level and
+microcode poll hold. Restoring the chipset without these latches can recognize
+an interrupt one instruction early after replay. They remain outside file save
+states; the rollback prefix and initial fingerprint change with the build.
 `Session` remains the native alias for `Connection<UdpTransport>`; `Options`
 contains its UDP endpoints. Transport-independent `Settings` contains the player,
 session ID, input delay and prediction limit. Timers use `timebase::Instant` on
@@ -164,6 +168,26 @@ before allocating, verifies every digest and acknowledges completion before
 the host boots. A 30-second inactivity timer and a three-minute overall deadline
 bound setup. Cancellation rejects pending operations and discards partial data.
 Media stays off the signaling service; a TURN relay carries encrypted peer traffic.
+
+`netplay-swap.js` negotiates `swaps: "disk-v1"` and an ordered, reliable
+`copperline-disks-v1` channel. Only the host initiates transactions. Each peer
+first holds its current frame; they then advance to the greater of those two
+frames, bounded to a 32-frame difference. `WebEmu::run_netplay` enforces this
+ceiling while continuing input polling and reconciliation. Both peers wait for
+the stop frame to be confirmed and acknowledged, so no prediction history can
+restore media from before the change. Input delay and already sampled future
+inputs are retained, and wall-clock pacing is reanchored around the pause.
+
+The peers compare SHA-256 digests of the complete confirmed machine state,
+transfer at most 16 MiB in 16 KiB chunks with 256 KiB send-buffer backpressure,
+verify the image digest, and decode into a temporary controller before agreeing
+to apply. Both live drives change at the stopped boundary with canonical
+`netplay-dfN` metadata and memory backing. A second full-state digest comparison
+precedes resume. Empty payloads perform an eject. Transaction IDs, message phases,
+metadata and chunk sizes are checked; overlapping requests are rejected. Thirty
+seconds without control/transfer progress or three minutes total ends the session.
+Cancellation discards buffered bytes and frees the machine through the normal
+disconnect path. No save-state or input-packet format changes are required.
 
 Host/Join freezes the chosen cold-boot media and frees any local emulator.
 After media verification, the wrapper builds a fresh machine, fixes the RTC seed,
@@ -247,7 +271,10 @@ required for the regression suite.
 
 After building the release web bundle, run `node tools/check-web-netplay.mjs` and
 `npm test --prefix crates/copperline-web/www`. CI also runs the native web wrapper
-unit tests, including failed startup, input routing and audio gain checks. The
+unit tests, including failed startup, input routing and audio gain checks.
+`node tools/check-web-netplay-swaps.mjs` exercises repeated replacements and
+ejections on real release WASM with packet loss, reordering and asymmetric pacing,
+then checks continued state agreement after each change. The
 browser publishing workflow also checks the optimized bundle before copying all netplay modules and the vendored QR license alongside
 the other page modules. For a served local page, the optional Playwright check
 `node tools/check-web-netplay-browser.mjs http://127.0.0.1:8000/` exercises actual

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -286,6 +286,15 @@ struct MachineRuntimeState {
     cpu_clock_carry: u32,
 }
 
+/// Same-process rollback also needs the interrupt sample consumed at the next
+/// instruction boundary. File saves intentionally omit these adapter latches.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct MachineRollbackState {
+    bus: crate::bus::RollbackState,
+    sampled_irq_level: u8,
+    ipl_sample_held: bool,
+}
+
 /// Longest 68000-family instruction worth attributing to one PC when
 /// marking executed code: opcode plus full extension words. A larger
 /// jump between instruction boundaries is a branch or an exception, not
@@ -347,14 +356,15 @@ struct CpuBus {
     /// PREVIOUS instruction's last bus access -- a level that rises during an
     /// instruction's trailing internal cycles is not seen until one
     /// instruction later. Transient: re-sampled on every access, never
-    /// serialized (a loaded state re-samples within one instruction).
+    /// serialized in file saves (a loaded state re-samples within one instruction).
+    /// Exact rollback captures it in `MachineRollbackState`.
     sampled_irq_level: u8,
     /// Set by the core's `ipl_hold_sample` poll-point marker: the current
     /// `sampled_irq_level` is the instruction's microcode poll value and
     /// later accesses in the same instruction must not re-latch it (e.g.
     /// RMW instructions poll during the final prefetch, BEFORE their
     /// writeback). Cleared when the boundary decision consumes the sample.
-    /// Transient like `sampled_irq_level`; never serialized.
+    /// File-save transient like `sampled_irq_level`; captured for rollback.
     ipl_sample_held: bool,
     /// Start PC of the instruction currently inside the core, used only by
     /// `COPPERLINE_DIAG_CPU_SYNC` to filter internal-cycle trace lines.
@@ -1472,7 +1482,12 @@ impl M68kMachine {
     }
 
     pub(crate) fn write_rollback_state<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
-        serialize_component(w, &self.bus.bus.rollback_state(), "rollback latches")?;
+        let runtime = MachineRollbackState {
+            bus: self.bus.bus.rollback_state(),
+            sampled_irq_level: self.bus.sampled_irq_level,
+            ipl_sample_held: self.bus.ipl_sample_held,
+        };
+        serialize_component(w, &runtime, "rollback latches")?;
         self.write_state(w)
     }
 
@@ -1493,7 +1508,7 @@ impl M68kMachine {
     fn apply_state_inner<R: std::io::Read>(
         &mut self,
         r: &mut R,
-        rollback: Option<crate::bus::RollbackState>,
+        rollback: Option<MachineRollbackState>,
     ) -> Result<()> {
         let cpu: CpuCore = deserialize_component(r, "CPU core")?;
         let runtime: MachineRuntimeState = deserialize_component(r, "machine runtime")?;
@@ -1504,7 +1519,9 @@ impl M68kMachine {
         bus.adopt_host_resources(&mut self.bus.bus)?;
         bus.adopt_ui_debug_state(&mut self.bus.bus);
         if let Some(runtime) = rollback {
-            bus.restore_rollback_state(runtime);
+            bus.restore_rollback_state(runtime.bus);
+            self.bus.sampled_irq_level = runtime.sampled_irq_level;
+            self.bus.ipl_sample_held = runtime.ipl_sample_held;
         } else {
             bus.reset_transient_video_after_state_load();
         }
@@ -7272,6 +7289,51 @@ mod tests {
         assert_eq!(machine.d(0), 0x11);
         assert_eq!(machine.pc(), 0x0000_0106);
         assert_eq!(machine.bus().delivered_irq_pending, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn rollback_preserves_the_previous_instruction_interrupt_sample() -> Result<()> {
+        for held in [false, true] {
+            let mut bus = test_bus_with_pc(0x100);
+            write_program(
+                &mut bus,
+                0x100,
+                &[0x46fc, 0x2000, 0x4e71, 0x4e71, 0x4e71, 0x60fe],
+            );
+            write_program(&mut bus, 0x200, &[0x7007, 0x60fe]);
+            set_autovector(&mut bus, 3, 0x200);
+            bus.paula.intena = INT_MASTER | INT_VERTB;
+            bus.irq_latency_setting = 5;
+            let mut machine = M68kMachine::new(bus, CpuModel::M68000, false)?;
+            machine.step_slice(1)?;
+            machine.bus_mut().paula.intreq = INT_VERTB;
+            machine.bus_mut().advance_devices(10);
+            assert_eq!(machine.bus.sampled_irq_level, 0);
+            machine.bus.ipl_sample_held = held;
+            let mut checkpoint = Vec::new();
+            machine.write_rollback_state(&mut checkpoint)?;
+            machine.step_slice(1)?;
+            assert_eq!(
+                machine.pc(),
+                0x106,
+                "the old sample delays interrupt recognition"
+            );
+            let mut expected = Vec::new();
+            machine.write_rollback_state(&mut expected)?;
+            machine.step_slice(5)?;
+            assert_eq!(machine.d(0), 7);
+            machine.apply_rollback_state(&mut std::io::Cursor::new(&checkpoint))?;
+            assert_eq!(machine.bus.sampled_irq_level, 0);
+            assert_eq!(machine.bus.ipl_sample_held, held);
+            machine.step_slice(1)?;
+            let mut actual = Vec::new();
+            machine.write_rollback_state(&mut actual)?;
+            assert_eq!(
+                actual, expected,
+                "replay must take the interrupt on the same instruction"
+            );
+        }
         Ok(())
     }
 

--- a/src/floppy/formats.rs
+++ b/src/floppy/formats.rs
@@ -13,6 +13,10 @@ use log::debug;
 use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
 
+// Allow large multi-revolution flux captures while bounding gzip expansion.
+// Network callers impose their smaller transfer limit on the expanded image.
+pub(super) const GZIP_IMAGE_LIMIT: usize = 128 * 1024 * 1024;
+
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(super) struct FloppyImage {
     pub(super) path: PathBuf,
@@ -67,6 +71,7 @@ impl FloppyImage {
             config.path.clone(),
             config.write_protected,
             FloppyImageBacking::File,
+            GZIP_IMAGE_LIMIT,
         )
     }
 
@@ -78,15 +83,28 @@ impl FloppyImage {
         path: PathBuf,
         write_protected: bool,
     ) -> Result<Self> {
-        Self::from_bytes_with_backing(packed, path, write_protected, FloppyImageBacking::File)
+        Self::from_bytes_with_backing(
+            packed,
+            path,
+            write_protected,
+            FloppyImageBacking::File,
+            GZIP_IMAGE_LIMIT,
+        )
     }
 
     pub(super) fn from_memory_bytes(
         packed: Vec<u8>,
         path: PathBuf,
         write_protected: bool,
+        expanded_limit: usize,
     ) -> Result<Self> {
-        Self::from_bytes_with_backing(packed, path, write_protected, FloppyImageBacking::Memory)
+        Self::from_bytes_with_backing(
+            packed,
+            path,
+            write_protected,
+            FloppyImageBacking::Memory,
+            expanded_limit,
+        )
     }
 
     fn from_bytes_with_backing(
@@ -94,11 +112,16 @@ impl FloppyImage {
         path: PathBuf,
         write_protected: bool,
         backing: FloppyImageBacking,
+        expanded_limit: usize,
     ) -> Result<Self> {
         let (data, write_protected, legacy_extended_adf) = if packed.starts_with(GZIP_SIGNATURE) {
-            let unpacked = decode_gzip_floppy_image(&packed)?;
+            let unpacked = decode_gzip_floppy_image(&packed, expanded_limit)?;
             decode_floppy_payload(unpacked, true, &path)?
         } else if packed.starts_with(ZIP_SIGNATURE) {
+            ensure!(
+                ADF_SIZE <= expanded_limit,
+                "expanded floppy image exceeds {expanded_limit} bytes"
+            );
             let unpacked = decode_zip_floppy_image(&packed)?;
             decode_floppy_payload(unpacked, true, &path)?
         } else {
@@ -244,12 +267,18 @@ pub(super) fn decode_floppy_payload(
     Ok((data, write_protected, legacy_extended_adf))
 }
 
-pub(super) fn decode_gzip_floppy_image(data: &[u8]) -> Result<Vec<u8>> {
+pub(super) fn decode_gzip_floppy_image(data: &[u8], limit: usize) -> Result<Vec<u8>> {
     ensure!(data.starts_with(GZIP_SIGNATURE), "missing gzip signature");
     // Every member, not just the first: a concatenated ADZ would otherwise
     // decode to a fraction of the disk, which the format dispatch could only
     // report as an unknown format rather than as the half-read image it is.
-    gzip::inflate_members(data, None).context("decompressing gzip-compressed floppy image")
+    let unpacked = gzip::inflate_members(data, Some(limit as u64))
+        .context("decompressing gzip-compressed floppy image")?;
+    ensure!(
+        unpacked.len() <= limit,
+        "expanded floppy image exceeds {limit} bytes"
+    );
+    Ok(unpacked)
 }
 
 pub(super) fn decode_zip_floppy_image(data: &[u8]) -> Result<Vec<u8>> {

--- a/src/floppy/mod.rs
+++ b/src/floppy/mod.rs
@@ -11,7 +11,9 @@ use crate::chipset::paula::PAULA_CLOCK_HZ;
 use crate::config::{FloppyConfig, FloppyDriveConfig};
 use crate::gzip;
 use anyhow::{bail, ensure, Context, Result};
-use formats::{FloppyImage, FloppyImageBacking, FloppyImageData, FloppyTrackImage};
+use formats::{
+    FloppyImage, FloppyImageBacking, FloppyImageData, FloppyTrackImage, GZIP_IMAGE_LIMIT,
+};
 use log::{debug, warn};
 // The bridge's retry path traces, and its media reporting is worth an info
 // line; both are compiled out with the feature.
@@ -737,6 +739,26 @@ impl FloppyController {
         label: PathBuf,
         write_protected: bool,
     ) -> Result<()> {
+        self.insert_memory_disk_image_bytes_with_limit(
+            drive_idx,
+            bytes,
+            label,
+            write_protected,
+            GZIP_IMAGE_LIMIT,
+        )
+    }
+
+    /// Insert memory-backed media with a byte limit on both the supplied file
+    /// and its expanded gzip/zip payload. A rejected image leaves the drive
+    /// unchanged, including when decompression reaches the limit.
+    pub fn insert_memory_disk_image_bytes_with_limit(
+        &mut self,
+        drive_idx: usize,
+        bytes: Vec<u8>,
+        label: PathBuf,
+        write_protected: bool,
+        limit: usize,
+    ) -> Result<()> {
         ensure!(
             drive_idx < self.drives.len(),
             "invalid floppy drive df{}",
@@ -752,7 +774,8 @@ impl FloppyController {
             "floppy.df{drive_idx} is a physical drive; take the drive off the bay before \
              using a disk image in it"
         );
-        let image = FloppyImage::from_memory_bytes(bytes, label, write_protected)
+        ensure!(bytes.len() <= limit, "floppy image exceeds {limit} bytes");
+        let image = FloppyImage::from_memory_bytes(bytes, label, write_protected, limit)
             .with_context(|| format!("loading floppy.df{} image", drive_idx))?;
         ensure!(
             write_protected || !image.write_protected,

--- a/src/floppy/tests.rs
+++ b/src/floppy/tests.rs
@@ -203,6 +203,57 @@ fn mfm_encode_decode_round_trip_sector_data() -> Result<()> {
 }
 
 #[test]
+fn gzip_floppy_limit_covers_the_whole_multi_member_stream() -> Result<()> {
+    // Small fixtures exercise the allocation boundary without large archives.
+    let first = [1; 64];
+    let mut packed = gzip_bytes(&first)?;
+    assert_eq!(decode_gzip_floppy_image(&packed, 64)?, first);
+    assert!(decode_gzip_floppy_image(&packed, 63)
+        .unwrap_err()
+        .to_string()
+        .contains("exceeds"));
+    packed.extend_from_slice(&gzip_bytes(&[2; 64])?);
+    assert_eq!(decode_gzip_floppy_image(&packed, 128)?.len(), 128);
+    assert!(decode_gzip_floppy_image(&packed, 127)
+        .unwrap_err()
+        .to_string()
+        .contains("exceeds"));
+    Ok(())
+}
+
+#[test]
+fn bounded_memory_insert_preserves_the_disk_when_expansion_is_rejected() -> Result<()> {
+    let mut ctrl = FloppyController::default();
+    ctrl.insert_memory_disk_image_bytes(0, vec![1; ADF_SIZE], "original.adf".into(), true)?;
+    let before = bincode::serialize(&ctrl)?;
+    let replacement = gzip_bytes(&vec![2; ADF_SIZE])?;
+    let err = ctrl
+        .insert_memory_disk_image_bytes_with_limit(
+            0,
+            replacement.clone(),
+            "replacement.adz".into(),
+            true,
+            ADF_SIZE - 1,
+        )
+        .unwrap_err();
+    assert!(format!("{err:#}").contains("expanded floppy image exceeds"));
+    assert_eq!(bincode::serialize(&ctrl)?, before);
+    ctrl.insert_memory_disk_image_bytes_with_limit(
+        0,
+        replacement,
+        "replacement.adz".into(),
+        true,
+        ADF_SIZE,
+    )?;
+    let image = ctrl.drives[0].image.as_ref().unwrap();
+    assert!(image.write_protected);
+    assert!(
+        matches!(&image.data, FloppyImageData::StandardAdf(bytes) if bytes == &vec![2; ADF_SIZE])
+    );
+    Ok(())
+}
+
+#[test]
 fn multi_member_adz_decompresses_every_member() -> Result<()> {
     // Concatenated gzip members are one valid gzip stream (`cat a.gz
     // b.gz`), and only the whole of it is the ADF: a decoder that stopped
@@ -214,7 +265,7 @@ fn multi_member_adz_decompresses_every_member() -> Result<()> {
     let mut packed = gzip_bytes(first)?;
     packed.extend_from_slice(&gzip_bytes(second)?);
 
-    let decoded = decode_gzip_floppy_image(&packed)?;
+    let decoded = decode_gzip_floppy_image(&packed, GZIP_IMAGE_LIMIT)?;
     assert_eq!(decoded.len(), ADF_SIZE);
     assert_eq!(&decoded[ADF_SIZE - 4..], b"TAIL");
     Ok(())

--- a/src/netplay/mod.rs
+++ b/src/netplay/mod.rs
@@ -321,6 +321,17 @@ impl<T: Transport> Connection<T> {
         }
     }
 
+    /// A transport-coordinated media change may only touch a fully confirmed
+    /// boundary. No retained prediction can subsequently restore older media.
+    pub fn confirmed_state_digest(&self, emu: &Emulator) -> Result<[u8; 32]> {
+        ensure!(self.failure.is_none(), "netplay session has failed");
+        ensure!(
+            self.status().ready_to_capture(),
+            "netplay frame is not confirmed"
+        );
+        Ok(digest(&emu.netplay_snapshot()?))
+    }
+
     /// Poll, repair late input, and optionally advance a frame. `false` is a
     /// normal wait for handshake/input. Continue polling while waiting.
     pub fn step(&mut self, emu: &mut Emulator, input: Input, advance: bool) -> Result<bool> {

--- a/tools/check-web-netplay-rooms.mjs
+++ b/tools/check-web-netplay-rooms.mjs
@@ -180,6 +180,37 @@ try {
     assert.ok(!JSON.stringify(report).includes(new URL(link).hash.slice(6)));
     console.log(`Player ${i + 1}: ${JSON.stringify({ status: await page.evaluate(() => [...window.__emu.netplay_status()]), route: report.stats.selectedPair })}`);
   }
+  // Record the real WASM commit boundary; each peer must apply once at the
+  // same frame, produce the same state digest, and keep checking future frames.
+  await Promise.all(pages.map(page => page.evaluate(() => {
+    window.__diskCommits = [];
+    const emu = window.__emu, apply = emu.netplay_apply_disk.bind(emu);
+    emu.netplay_apply_disk = () => {
+      apply();
+      window.__diskCommits.push({ frame: emu.netplay_status()[1], hash: [...emu.netplay_swap_digest()] });
+    };
+  })));
+  assert.equal(await guest.locator('#netplay-disks').isVisible(), false);
+  let commits = 0;
+  for (const [drive, value] of [[0, 3], [0, 4], [0, null], [0, 3], [1, 5]]) {
+    await host.locator('#netplay-disk-file:enabled').waitFor();
+    await host.locator('#netplay-disk-drive').selectOption(String(drive));
+    if (value === null) await host.locator('#netplay-disk-eject').click();
+    else await host.locator('#netplay-disk-file').setInputFiles({ name: `replacement-${value}.adf`,
+      mimeType: 'application/octet-stream', buffer: Buffer.alloc(901120, value) });
+    commits++;
+    await Promise.all(pages.map(page => page.waitForFunction(count => window.__diskCommits.length === count,
+      commits, { timeout: 30000 })));
+    const boundaries = await Promise.all(pages.map(page => page.evaluate(() => window.__diskCommits.at(-1))));
+    assert.deepEqual(boundaries[0], boundaries[1], 'swap must commit identical states at one frame');
+    const checked = (Math.ceil(boundaries[0].frame / 60) + 2) * 60;
+    await Promise.all(pages.map(page => page.waitForFunction(frame => window.__emu?.netplay_status()[6] >= frame,
+      checked, { timeout: 90000 })));
+    for (const page of pages) assert.equal(await page.evaluate(drive => window.__emu.disk_name(drive), drive),
+      value === null ? undefined : `netplay-df${drive}`);
+    console.log(`DF${drive} ${value === null ? 'ejection' : 'swap'} at frame ${boundaries[0].frame}; both checked ${checked}`);
+  }
+  await host.locator('#netplay-panel').screenshot({ path: `${output}/disk-swaps.png` });
   phase = 'disconnect';
   await host.locator('#netplay-disconnect').click();
   await Promise.all(pages.map(page => page.locator('#netplay-room-host:enabled').waitFor()));
@@ -189,10 +220,30 @@ try {
   await guest.waitForFunction(() => window.__copied?.startsWith('{'));
   assert.ok(JSON.parse(await guest.evaluate(() => window.__copied)).stats);
   await connect();
+  // Interrupt an actual replacement transfer while both cores are held.
+  await host.evaluate(() => {
+    const send = RTCDataChannel.prototype.send;
+    RTCDataChannel.prototype.send = function(data) {
+      if (this.label === 'copperline-disks-v1') {
+        if (typeof data !== 'string') return;
+        if (JSON.parse(data).type === 'end') { window.__heldDiskTransfer = true; return; }
+      }
+      return send.call(this, data);
+    };
+    window.__restoreDiskSend = () => { RTCDataChannel.prototype.send = send; };
+  });
+  await host.locator('#netplay-disk-file:enabled').waitFor();
+  await host.locator('#netplay-disk-file').setInputFiles({ name: 'interrupted.adf',
+    mimeType: 'application/octet-stream', buffer: Buffer.alloc(901120, 6) });
+  await host.waitForFunction(() => window.__heldDiskTransfer === true);
+  await Promise.all(pages.map(page => page.waitForFunction(() => window.__emu?.netplay_swap_ready())));
+  const heldFrames = await Promise.all(pages.map(page => page.evaluate(() => window.__emu.netplay_status()[1])));
+  assert.equal(heldFrames[0], heldFrames[1]);
   phase = 'disconnect';
   await guest.locator('#netplay-disconnect').click();
   await Promise.all(pages.map(page => page.locator('#netplay-room-host:enabled').waitFor()));
   await restored();
+  await host.evaluate(() => window.__restoreDiskSend());
   const remembered = await guest.evaluate(() => new Promise((resolve, reject) => {
     const request = indexedDB.open('copperline');
     request.onerror = () => reject(request.error);
@@ -210,5 +261,5 @@ try {
   await host.locator('#netplay-panel').screenshot({ path: `${output}/mobile.png` });
   assert.deepEqual(errors, []);
   if (shutdownNotices.length) console.log('WebKit native shutdown notices:', JSON.stringify(shutdownNotices));
-  console.log('Invitations, verified host ROM/disks/configuration, transfer cancellation, reconnect, guest restoration, diagnostics and responsive rendering passed');
+  console.log('Invitations, verified host setup, repeated synchronized swaps/ejections, transfer cancellation, reconnect, guest restoration, diagnostics and responsive rendering passed');
 } finally { await browser.close(); }

--- a/tools/check-web-netplay-rooms.mjs
+++ b/tools/check-web-netplay-rooms.mjs
@@ -157,7 +157,20 @@ try {
     phase = 'playing';
     return link;
   }
+  // Model a disk channel that opens later than input/setup. The game can
+  // run, but a disk action must remain unavailable until its channel opens.
+  await host.evaluate(() => {
+    const state = Object.getOwnPropertyDescriptor(RTCDataChannel.prototype, 'readyState');
+    Object.defineProperty(RTCDataChannel.prototype, 'readyState', { ...state, get() {
+      return this.label === 'copperline-disks-v1' ? 'connecting' : state.get.call(this);
+    } });
+    window.__openDiskChannel = () => Object.defineProperty(RTCDataChannel.prototype, 'readyState', state);
+  });
   const link = await connect();
+  assert.equal(await host.locator('#netplay-disk-file').isDisabled(), true);
+  assert.equal(await host.locator('#netplay-disk-eject').isDisabled(), true);
+  await host.evaluate(() => window.__openDiskChannel());
+  await host.locator('#netplay-disk-file:enabled').waitFor();
   for (const [i, page] of pages.entries()) {
     for (const id of ['boot', 'machine', 'video', 'reset', 'pause', 'df0', 'df1']) {
       assert.equal(await page.locator(`#${id}`).isDisabled(), true, `${id} must stay locked`);

--- a/tools/check-web-netplay-swaps.mjs
+++ b/tools/check-web-netplay-swaps.mjs
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { gzipSync } from 'node:zlib';
 import { DiskSwaps } from '../crates/copperline-web/www/netplay-swap.js';
 
 const root = fileURLToPath(new URL('../', import.meta.url));
@@ -19,7 +20,7 @@ class Wire extends EventTarget {
   readyState = 'open';
   bufferedAmount = 0;
   send(data) {
-    data = typeof data === 'string' ? data : data.slice().buffer;
+    data = typeof data === 'string' ? data : Uint8Array.from(data).buffer;
     setTimeout(() => this.peer.onmessage?.({ data }), 1);
   }
 }
@@ -80,7 +81,8 @@ for (const [model, video, delay, window] of [['A500', 'PAL', 0, 8], ['A500', 'PA
     for (const [drive, value, writable] of [[0, 7, false], [0, 8, true], [1, 9, false], [0, null, false], [0, 7, false]]) {
       let finished = false;
       const sending = swaps[0].swap(drive, value === null ? null : {
-        bytes: new Uint8Array(901120).fill(value), name: `Disk ${value}.adf`, writable,
+        bytes: value === 9 ? gzipSync(new Uint8Array(901120).fill(value)) : new Uint8Array(901120).fill(value),
+        name: `Disk ${value}.${value === 9 ? 'adz' : 'adf'}`, writable,
       }).then(() => { finished = true; });
       sending.catch(() => {});
       await pump(() => finished && !swaps[1].busy);

--- a/tools/check-web-netplay-swaps.mjs
+++ b/tools/check-web-netplay-swaps.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real release WASM, reliable disk control, and lossy/reordered input packets.
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DiskSwaps } from '../crates/copperline-web/www/netplay-swap.js';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const pkg = resolve(process.argv[2] ?? resolve(root, 'crates/copperline-web/pkg'));
+const glue = await readFile(`${pkg}/copperline_web.js`, 'utf8');
+const { default: init, WebEmu } = await import(`data:text/javascript;base64,${Buffer.from(glue).toString('base64')}`);
+await init({ module_or_path: await readFile(`${pkg}/copperline_web_bg.wasm`) });
+const rom = new Uint8Array(await readFile(resolve(root, 'assets/aros/aros-amiga-m68k-rom.bin')));
+const ext = new Uint8Array(await readFile(resolve(root, 'assets/aros/aros-amiga-m68k-ext.bin')));
+
+class Wire extends EventTarget {
+  readyState = 'open';
+  bufferedAmount = 0;
+  send(data) {
+    data = typeof data === 'string' ? data : data.slice().buffer;
+    setTimeout(() => this.peer.onmessage?.({ data }), 1);
+  }
+}
+
+for (const [model, video, delay, window] of [['A500', 'PAL', 0, 8], ['A500', 'PAL', 2, 8], ['A1200', 'NTSC', 6, 1]]) {
+  const peers = [0, 1].map(player => {
+    const emu = new WebEmu(model, video, 2);
+    emu.load_rom(rom, ext);
+    emu.insert_floppy(0, new Uint8Array(901120), 'original.adf');
+    emu.start_netplay(player + 1, '0123456789abcdef0123456789abcdef', delay, window, 'joystick');
+    return emu;
+  });
+  const wires = [new Wire(), new Wire()];
+  wires[0].peer = wires[1]; wires[1].peer = wires[0];
+  const swaps = [];
+  let failure, tick = 0, sequence = 0, queued = [];
+  for (let i = 0; i < 2; i++) swaps.push(new DiskSwaps(wires[i], { host: !i, machine: () => peers[i],
+    fail: error => { failure = error; swaps.forEach(swap => swap.stop(error)); },
+    changed: disk => { if (disk) console.log(`Player ${i + 1} changed DF${disk.drive} at frame ${peers[i].netplay_status()[1]}`); } }));
+  async function pump(until, limit = Infinity) {
+    for (let count = 0; count < 4000 && !until(); count++) {
+      if (failure) throw failure;
+      for (let i = 0; i < 2; i++) {
+        const emu = peers[i], frame = emu.netplay_status()[1];
+        emu.key_event('Space', frame % 13 < 3);
+        emu.set_joystick_port2(frame % 11 < 4, false, false, false, frame % 9 < 3, false);
+        emu.run_hidden(tick * 20, frame < limit && (i || tick % 61 < 55) ? 1 : 0);
+        emu.take_audio();
+        for (;;) {
+          const packet = emu.netplay_take_packet();
+          if (!packet.length) break;
+          sequence++;
+          if (sequence % 7 === 0) continue;
+          queued.push({ due: tick + sequence % 4, target: 1 - i, packet });
+          if (sequence % 11 === 0) queued.push({ due: tick + 5, target: 1 - i, packet });
+        }
+      }
+      const ready = queued.filter(item => item.due <= tick);
+      queued = queued.filter(item => item.due > tick);
+      for (const item of ready.reverse()) peers[item.target].netplay_receive(item.packet);
+      tick++;
+      await new Promise(resolve => setTimeout(resolve, 1));
+    }
+    if (failure) throw failure;
+    assert.ok(until(), `timeline stalled: ${peers.map(emu => [...emu.netplay_status()])}`);
+  }
+  try {
+    await pump(() => peers.every(emu => emu.netplay_status()[6] >= 120), 120);
+    for (const invalid of [-1, 2, 1.5, 256, NaN, Infinity]) {
+      assert.throws(() => peers[0].netplay_validate_disk(invalid, new Uint8Array(), false));
+    }
+    assert.throws(() => peers[0].netplay_apply_disk());
+    assert.throws(() => peers[0].netplay_resume());
+    assert.throws(() => peers[0].netplay_stage_disk(0, new Uint8Array(), false));
+    assert.throws(() => peers[0].netplay_swap_digest());
+    await assert.rejects(swaps[0].swap(0, { bytes: new Uint8Array(9), name: 'bad.adf', writable: false }));
+    assert.equal(swaps[0].closed, false);
+    for (const [drive, value, writable] of [[0, 7, false], [0, 8, true], [1, 9, false], [0, null, false], [0, 7, false]]) {
+      let finished = false;
+      const sending = swaps[0].swap(drive, value === null ? null : {
+        bytes: new Uint8Array(901120).fill(value), name: `Disk ${value}.adf`, writable,
+      }).then(() => { finished = true; });
+      sending.catch(() => {});
+      await pump(() => finished && !swaps[1].busy);
+      await sending;
+      for (const emu of peers) {
+        assert.equal(emu.disk_name(drive), value === null ? undefined : `netplay-df${drive}`);
+        assert.equal(emu.floppy_write_protected(drive), value === null ? undefined : !writable);
+      }
+      const next = (Math.ceil(Math.max(...peers.map(emu => emu.netplay_status()[1])) / 60) + 2) * 60;
+      await pump(() => peers.every(emu => emu.netplay_status()[6] >= next), next);
+      console.log(`${model}/${video} delay=${delay} window=${window}: DF${drive} ${value === null ? 'ejected' : 'replaced'}, checked frame ${next}`);
+    }
+    peers.forEach(emu => emu.netplay_hold());
+    for (const invalid of [-1, 1.5, NaN, Infinity, peers[0].netplay_status()[1] - 1, peers[0].netplay_status()[1] + 33]) {
+      assert.throws(() => peers[0].netplay_stop_at(invalid));
+    }
+    assert.throws(() => peers[0].netplay_resume());
+  } finally {
+    swaps.forEach(swap => swap.stop());
+    wires.forEach(wire => { wire.onmessage = null; });
+    peers.forEach(emu => emu.free());
+  }
+}
+console.log('Release WASM synchronized swaps, ejections, numeric boundaries and post-swap rollback passed');


### PR DESCRIPTION
Games that request another disk in DF0 can now continue during browser netplay. The host selects a replacement image or ejects a drive in the Netplay panel; the guest receives the image automatically. Both machines stop at a confirmed, acknowledged frame, verify the file and their complete machine states, apply the change, compare again, and resume together.

The separate reliable channel bounds image size before and after gzip/zip expansion, messages, buffering and transfer time, rejects overlapping or out-of-order operations, and tears down interrupted sessions. Swap controls wait for their separate transfer channel to open. Ordinary local media controls remain locked. Replacement disks default to write-protected; writable images remain session-local and their writes are discarded on replacement or disconnect.

Longer packet-loss tests exposed an existing rollback omission: the CPU adapter's sampled interrupt level and microcode poll hold survived from the abandoned future. Capturing these in the process-local rollback prefix prevents an interrupt being taken one instruction early. File save-state and input packet formats are unchanged.

Validation:
- 31 browser helper tests, 152 floppy tests, 96 CPU tests, 24 netplay tests, and six web wrapper tests passed.
- Required formatting and locked all-target/all-feature Clippy passed for the root and web crate.
- Release WASM completed repeated DF0/DF1 replacements and ejections through 1,020 confirmed/checksummed frames per A500/PAL delay 0, A500/PAL delay 2, and A1200/NTSC delay 6 configuration, with input loss, duplication, reordering and asymmetric pacing. Existing release-WASM input/presentation tests also passed.
- Paired Chrome and desktop WebKit sessions completed repeated swaps and continued checksummed gameplay; both also verified cancellation during a held replacement transfer and restoration of the guest's original setup.
- The published site (website commit 14bc76b) passed paired Chrome and desktop WebKit relay-only tests through the production TURN service, including repeated swaps/ejection, cancellation and reconnect. Live desktop/mobile layout, module precaching and offline AROS startup also passed. Live JS/WASM assets match the published commit byte-for-byte.
- A focused CPU regression reproduces the interrupt-latch restoration requirement. The longer AROS replay check that failed before the fix now passes.

CI and the browser publisher run the new release-WASM regression and ship the disk module. README, browser usage, embedding API and internals documentation are updated. Physical iOS/iPadOS 27 beta devices remain a real-device verification step.
