### PR TITLE
Support two mice in desktop and browser netplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The manual is published at [copperline.dev/docs](https://copperline.dev/docs/) a
 - [WHDLoad Support](docs/guide/whdload.md) - Direct WHDLoad package loading
 - [Direct Executable Launching](docs/guide/run.md) - Running cross-compiled Amiga binaries
 - [Floppy Hardware Bridge](docs/guide/fluxbridge.md) - Real floppy drives via Greaseweazle
-- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions through desktop GUI/CLI or browser WebRTC with QR invitations, host ROM/disk/configuration transfer, synchronized browser disk swaps and relay fallback, plus input prediction, rollback and matching-machine checks
+- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions with mice, joysticks or CD32 pads through desktop GUI/CLI or browser WebRTC with QR invitations, host ROM/disk/configuration transfer, synchronized browser disk swaps and relay fallback, plus input prediction, rollback and matching-machine checks
 - [Headless Mode](docs/guide/headless.md) - Scripted runs and screenshot/frame dumps
 - [Debugging](docs/debugger/window.md) - In-window, headless, and GDB debugging
 - [VS Code](docs/debugger/vscode.md) - Setup and illustrated source debugging; [Bartman with Copperline](docs/debugger/vscode-bartman.md) covers fork installation and visual profiling

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -206,7 +206,7 @@ const MAX_CATCHUP_SECONDS: f64 = 0.1;
 #[wasm_bindgen]
 pub struct WebEmu {
     netplay: Option<copperline::netplay::Connection<copperline::netplay::PacketQueue>>,
-    netplay_input: copperline::netplay::Input,
+    netplay_input: copperline::netplay::LocalInput,
     // Netplay keeps Paula's serialized output gain fixed; the browser applies
     // this local preference when draining its host audio buffer instead.
     netplay_volume: u8,
@@ -896,7 +896,7 @@ impl WebEmu {
     /// reverse table would have to be duplicated in the page glue.
     pub fn key_raw(&mut self, rawkey: u8, pressed: bool) {
         if self.netplay.is_some() {
-            self.netplay_input.set_key(rawkey & 0x7f, pressed);
+            self.netplay_input.held.set_key(rawkey & 0x7f, pressed);
             return;
         }
         self.emu.bus_mut().enqueue_key_event(rawkey & 0x7F, pressed);
@@ -960,7 +960,7 @@ impl WebEmu {
         if self.netplay.is_some() {
             if self.netplay_mouse() {
                 if let Some(index) = [0, 2, 1].get(usize::from(button)) {
-                    self.netplay_input.set_mouse_button(*index, pressed);
+                    self.netplay_input.held.set_mouse_button(*index, pressed);
                 }
             }
             return;
@@ -996,6 +996,7 @@ impl WebEmu {
             // connection assigns it to this peer's negotiated Amiga port.
             if port == 2 && !self.netplay_mouse() {
                 self.netplay_input
+                    .held
                     .set_joystick([up, down, left, right, fire, button2]);
             }
             return;
@@ -1026,6 +1027,7 @@ impl WebEmu {
         if self.netplay.is_some() {
             if port == 2 && !self.netplay_mouse() {
                 self.netplay_input
+                    .held
                     .set_cd32_buttons([play, rwd, ffw, green, yellow]);
             }
             return;

--- a/crates/copperline-web/src/lib.rs
+++ b/crates/copperline-web/src/lib.rs
@@ -913,7 +913,7 @@ impl WebEmu {
     /// Relative mouse motion in emulated hi-res pixels (pointer-lock
     /// movementX/Y, or scaled cursor deltas when unlocked).
     pub fn mouse_delta(&mut self, dx: f64, dy: f64) {
-        if self.netplay.is_some() {
+        if self.netplay.is_some() && !self.netplay_mouse() {
             return;
         }
         if !dx.is_finite() || !dy.is_finite() {
@@ -923,6 +923,10 @@ impl WebEmu {
         self.mouse_remainder.1 += dy;
         let ix = take_integral_delta(&mut self.mouse_remainder.0);
         let iy = take_integral_delta(&mut self.mouse_remainder.1);
+        if self.netplay.is_some() {
+            self.netplay_input.add_mouse_delta(ix, iy);
+            return;
+        }
         // Into the pending pool, not the counters: `run` drains it a
         // bounded amount per emulated frame (see `mouse_pending`).
         self.mouse_pending.0 = self.mouse_pending.0.saturating_add(ix);
@@ -954,6 +958,11 @@ impl WebEmu {
     /// Mouse buttons: 0 = left, 1 = middle, 2 = right (MouseEvent.button).
     pub fn mouse_button(&mut self, button: u8, pressed: bool) {
         if self.netplay.is_some() {
+            if self.netplay_mouse() {
+                if let Some(index) = [0, 2, 1].get(usize::from(button)) {
+                    self.netplay_input.set_mouse_button(*index, pressed);
+                }
+            }
             return;
         }
         let input = &mut self.emu.bus_mut().input;
@@ -985,7 +994,7 @@ impl WebEmu {
         if self.netplay.is_some() {
             // The page's primary controller always arrives on port 2; the
             // connection assigns it to this peer's negotiated Amiga port.
-            if port == 2 {
+            if port == 2 && !self.netplay_mouse() {
                 self.netplay_input
                     .set_joystick([up, down, left, right, fire, button2]);
             }
@@ -1015,7 +1024,7 @@ impl WebEmu {
         yellow: bool,
     ) {
         if self.netplay.is_some() {
-            if port == 2 {
+            if port == 2 && !self.netplay_mouse() {
                 self.netplay_input
                     .set_cd32_buttons([play, rwd, ffw, green, yellow]);
             }

--- a/crates/copperline-web/src/netplay.rs
+++ b/crates/copperline-web/src/netplay.rs
@@ -464,25 +464,32 @@ mod tests {
             let before = web.emu.netplay_snapshot()?;
             web.mouse_delta(12.5, -3.25);
             web.mouse_delta(-1.0, 0.75);
-            assert_eq!((web.netplay_input.mouse_dx, web.netplay_input.mouse_dy), (12, -3));
+            assert_eq!(web.netplay_input.mouse_pending, (12, -3));
             assert_eq!(web.mouse_remainder, (-0.5, 0.5));
             web.mouse_delta(f64::NAN, f64::INFINITY);
             for (button, bit) in [(0, 0), (1, 2), (2, 1)] {
                 web.mouse_button(button, true);
-                assert_eq!(web.netplay_input.mouse_buttons, 1 << bit);
+                assert_eq!(web.netplay_input.held.mouse_buttons, 1 << bit);
                 web.set_joystick_port2(true, true, true, true, true, true);
                 web.set_cd32_buttons_port2(true, true, true, true, true);
-                assert_eq!(web.netplay_input.mouse_buttons, 1 << bit);
-                assert_eq!(web.netplay_input.buttons, 0);
+                assert_eq!(web.netplay_input.held.mouse_buttons, 1 << bit);
+                assert_eq!(web.netplay_input.held.buttons, 0);
                 web.mouse_button(button, false);
-                assert_eq!(web.netplay_input.mouse_buttons, 0);
+                assert_eq!(web.netplay_input.held.mouse_buttons, 0);
             }
             web.key_event("ArrowUp", true);
-            assert_ne!(web.netplay_input.keys, [0; 16]);
-            assert!(web.emu.netplay_snapshot()? == before, "host input bypassed the timeline");
+            assert_ne!(web.netplay_input.held.keys, [0; 16]);
+            assert!(
+                web.emu.netplay_snapshot()? == before,
+                "host input bypassed the timeline"
+            );
             web.netplay_release_input();
             assert_eq!(web.netplay_input, Default::default());
             assert_eq!(web.mouse_remainder, (0.0, 0.0));
+            web.mouse_delta(70_000.0, -90_000.0);
+            assert_eq!(web.netplay_input.mouse_pending, (70_000, -90_000));
+            web.netplay_release_input();
+            assert_eq!(web.netplay_input.mouse_pending, (0, 0));
         }
         Ok(())
     }
@@ -497,18 +504,18 @@ mod tests {
                 let on = |i| i == bit;
                 web.set_joystick_port2(on(0), on(1), on(2), on(3), on(4), on(5));
                 web.set_cd32_buttons_port2(on(6), on(7), on(8), on(9), on(10));
-                assert_eq!(web.netplay_input.buttons, 1 << bit);
+                assert_eq!(web.netplay_input.held.buttons, 1 << bit);
                 // The secondary page controller cannot overwrite the primary.
                 web.set_joystick_port(1, false, false, false, false, false, false);
                 web.set_cd32_buttons_port(1, false, false, false, false, false);
-                assert_eq!(web.netplay_input.buttons, 1 << bit);
+                assert_eq!(web.netplay_input.held.buttons, 1 << bit);
             }
             assert!(web.key_event("Space", true));
             web.key_raw(0x20, true);
-            assert_eq!(web.netplay_input.keys[8], 1);
-            assert_eq!(web.netplay_input.keys[4], 1);
+            assert_eq!(web.netplay_input.held.keys[8], 1);
+            assert_eq!(web.netplay_input.held.keys[4], 1);
             web.key_raw(0x20, false);
-            assert_eq!(web.netplay_input.keys[4], 0);
+            assert_eq!(web.netplay_input.held.keys[4], 0);
             web.netplay_release_input();
             assert_eq!(web.netplay_input, Default::default());
             for volume in [0, 35, 100] {

--- a/crates/copperline-web/src/netplay.rs
+++ b/crates/copperline-web/src/netplay.rs
@@ -48,11 +48,12 @@ impl WebEmu {
             rollback_frames: integer(window, 1, 12, "rollback window")?,
         };
         let device = match controller {
+            "mouse" => PortDevice::Mouse,
             "joystick" => PortDevice::Joystick,
             "cd32" => PortDevice::Cd32Pad,
             _ => {
                 return Err(JsValue::from_str(
-                    "Netplay controller must be joystick or cd32",
+                    "Netplay controller must be mouse, joystick or cd32",
                 ))
             }
         };
@@ -107,6 +108,7 @@ impl WebEmu {
     /// Release this peer's held keys/controller without touching the guest directly.
     pub fn netplay_release_input(&mut self) {
         self.netplay_input = Default::default();
+        self.mouse_remainder = (0.0, 0.0);
     }
 
     /// Freeze at the current frame while the reliable channel negotiates a
@@ -250,6 +252,12 @@ impl WebEmu {
 }
 
 impl WebEmu {
+    pub(super) fn netplay_mouse(&self) -> bool {
+        self.netplay.as_ref().is_some_and(|peer| {
+            self.emu.bus().input.ports[peer.player()].device == PortDevice::Mouse
+        })
+    }
+
     fn validate_netplay_disk(
         &self,
         drive: usize,
@@ -348,7 +356,7 @@ impl WebEmu {
         let started = Instant::now();
         let peer = self.netplay.as_mut().unwrap();
         let before = peer.status();
-        peer.step(&mut self.emu, self.netplay_input, false)
+        peer.step_local(&mut self.emu, &mut self.netplay_input, false)
             .map_err(js_err)?;
         if !before.connected {
             self.anchor = None;
@@ -368,7 +376,7 @@ impl WebEmu {
                 break;
             }
             if !peer
-                .step(&mut self.emu, self.netplay_input, true)
+                .step_local(&mut self.emu, &mut self.netplay_input, true)
                 .map_err(js_err)?
             {
                 self.anchor = Some((now_ms, self.emu.bus().emulated_seconds()));
@@ -445,6 +453,37 @@ mod tests {
         assert!(web.netplay.is_none());
         web.emu.disable_time_travel();
         web.start_netplay_inner(settings(0), PortDevice::Cd32Pad)?;
+        Ok(())
+    }
+
+    #[test]
+    fn netplay_mouse_routes_both_players_without_touching_the_live_machine() -> anyhow::Result<()> {
+        for player in 0..2 {
+            let mut web = WebEmu::new(None, None, Some(0.0)).unwrap();
+            web.start_netplay_inner(settings(player), PortDevice::Mouse)?;
+            let before = web.emu.netplay_snapshot()?;
+            web.mouse_delta(12.5, -3.25);
+            web.mouse_delta(-1.0, 0.75);
+            assert_eq!((web.netplay_input.mouse_dx, web.netplay_input.mouse_dy), (12, -3));
+            assert_eq!(web.mouse_remainder, (-0.5, 0.5));
+            web.mouse_delta(f64::NAN, f64::INFINITY);
+            for (button, bit) in [(0, 0), (1, 2), (2, 1)] {
+                web.mouse_button(button, true);
+                assert_eq!(web.netplay_input.mouse_buttons, 1 << bit);
+                web.set_joystick_port2(true, true, true, true, true, true);
+                web.set_cd32_buttons_port2(true, true, true, true, true);
+                assert_eq!(web.netplay_input.mouse_buttons, 1 << bit);
+                assert_eq!(web.netplay_input.buttons, 0);
+                web.mouse_button(button, false);
+                assert_eq!(web.netplay_input.mouse_buttons, 0);
+            }
+            web.key_event("ArrowUp", true);
+            assert_ne!(web.netplay_input.keys, [0; 16]);
+            assert!(web.emu.netplay_snapshot()? == before, "host input bypassed the timeline");
+            web.netplay_release_input();
+            assert_eq!(web.netplay_input, Default::default());
+            assert_eq!(web.mouse_remainder, (0.0, 0.0));
+        }
         Ok(())
     }
 

--- a/crates/copperline-web/www/netplay.js
+++ b/crates/copperline-web/www/netplay.js
@@ -9,7 +9,7 @@ import { SWAP_CHANNEL, SWAP_VERSION, DISK_LIMIT, DiskSwaps } from './netplay-swa
 // Signaling uses expiring room invitations or manual copy/paste codes.
 // Only bounded input packets use the data channel.
 const CODE_LIMIT = 96 * 1024;
-export const PACKET_LIMIT = 943;
+export const PACKET_LIMIT = 1103;
 const QUEUE_LIMIT = 64;
 const CHANNEL = 'copperline-netplay-v1';
 
@@ -17,7 +17,7 @@ export function validateSettings(value) {
   if (!value || !/^[0-9a-f]{32}$/i.test(value.session ?? '') ||
       !Number.isInteger(value.delay) || value.delay < 0 || value.delay > 6 ||
       !Number.isInteger(value.window) || value.window < 1 || value.window > 12 ||
-      !['joystick', 'cd32'].includes(value.controller) ||
+      !['joystick', 'cd32', 'mouse'].includes(value.controller) ||
       (value.media !== undefined && value.media !== MEDIA_VERSION) ||
       (value.swaps !== undefined && value.swaps !== SWAP_VERSION)) {
     throw new Error('Invalid netplay settings in connection code');
@@ -376,7 +376,8 @@ export function mountNetplayPanel(parent, { prepare, start, stop, getMedia, useM
     <button id="netplay-diagnostics" type="button" disabled>Copy diagnostics</button>
     <textarea id="netplay-report" rows="5" readonly hidden aria-label="Connection diagnostics"></textarea>
     <details id="netplay-advanced"><summary>Advanced</summary>
-      <label>Controllers <select id="netplay-controller"><option value="joystick">Joystick</option><option value="cd32">CD32 pad</option></select></label>
+      <label>Controllers <select id="netplay-controller"><option value="joystick">Joystick</option><option value="cd32">CD32 pad</option><option value="mouse">Two mice</option></select></label>
+      <p>For two-mouse games, choose Two mice before hosting. Each player’s mouse or touch trackpad controls their own Amiga port.</p>
       <label>Input delay <select id="netplay-delay">${[0,1,2,3,4,5,6].map(n => `<option ${n === 2 ? 'selected' : ''}>${n}</option>`).join('')}</select></label>
       <label>Rollback limit <select id="netplay-window">${Array.from({length:12}, (_, i) => `<option ${i === 7 ? 'selected' : ''}>${i + 1}</option>`).join('')}</select></label>
       <label><input id="netplay-relay-only" type="checkbox"> Use relay only for room connections</label>

--- a/crates/copperline-web/www/netplay.test.js
+++ b/crates/copperline-web/www/netplay.test.js
@@ -29,7 +29,7 @@ test('connection codes round-trip only valid settings and the expected descripti
   for (const key of ['delay', 'window']) {
     for (const value of [-1, 1.5, 257, NaN, Infinity, '2']) assert.throws(() => validateSettings({ ...settings, [key]: value }));
   }
-  assert.throws(() => validateSettings({ ...settings, controller: 'mouse' }));
+  assert.throws(() => validateSettings({ ...settings, controller: 'analogue' }));
   assert.throws(() => validateSettings({ ...settings, session: 'bad' }));
   assert.notEqual(newSettings(0, 1, 'cd32').session, newSettings(0, 1, 'cd32').session);
   const shared = { ...settings, media: 'host-v1', swaps: 'disk-v1' };
@@ -127,13 +127,13 @@ test('packet queues bound throttled-browser bursts and respect send backpressure
   assert.equal(received.at(-1), 99);
   let drained = 0;
   const emu = { netplay_take_packet: () => ++drained < 3 ? new Uint8Array([1]) : new Uint8Array() };
-  channel.bufferedAmount = 943 * 64;
+  channel.bufferedAmount = 1103 * 64;
   link.send(emu);
   assert.equal(drained, 0);
   channel.bufferedAmount = 0;
   link.send(emu);
   assert.equal(channel.sent.length, 2);
-  channel.onmessage({ data: new ArrayBuffer(944) });
+  channel.onmessage({ data: new ArrayBuffer(1104) });
   assert.equal(link.closed, true);
 });
 
@@ -221,4 +221,11 @@ test('TURN query compatibility preserves UDP, TLS, credentials and relay-only po
     link.pc.setConfiguration = () => { throw new DOMException('credentials invalid', 'InvalidAccessError'); };
     assert.throws(() => link.configureIce(servers, true), { name: 'InvalidAccessError' });
   } finally { link.close(); }
+});
+
+test('two-mouse controller settings survive signaling', () => {
+  const mice = { ...settings, controller: 'mouse' };
+  assert.deepEqual(validateSettings(mice), mice);
+  const description = { type: 'offer', sdp: 'v=0\r\n' };
+  assert.deepEqual(decodeCode(encodeCode(description, mice), 'offer').settings, mice);
 });

--- a/crates/copperline-web/www/try.js
+++ b/crates/copperline-web/www/try.js
@@ -113,6 +113,7 @@ let netplayMachineReady = false;
 let netplayTimer = null;
 let machineGeneration = 0;
 const netplayBusy = () => !!netplayPanel?.link;
+const netplayMouse = () => netplayBusy() && netplayPanel.link.settings?.controller === 'mouse';
 const netplayDisabled = new Map();
 const NETPLAY_LOCKED_IDS = ['boot', 'machine', 'video', 'reset', 'pause', 'savestate',
   'loadstate', 'quicksave', 'quickload', 'savedstates', 'kick', 'kickurl', 'kicklist',
@@ -1792,6 +1793,7 @@ function applyJoystick() {
 
 // Returns true when the key was captured for the joystick.
 function joystickKey(code, pressed) {
+  if (netplayMouse()) return false;
   const map =
     joyMode === 'keys'
       ? JOY_KEYS_TWO_BUTTON
@@ -1806,6 +1808,7 @@ function joystickKey(code, pressed) {
 }
 
 function setJoyMode(mode) {
+  if (netplayMouse()) mode = 'off';
   joyMode = mode;
   $('joy').textContent = `Joystick: ${joyMode}`;
   if (fsUi) fsUi.joy.textContent = `Joystick: ${joyMode}`;
@@ -2045,7 +2048,7 @@ const cssToEmu = () => {
 canvas.addEventListener('mousedown', (e) => {
   if (!emu || !running) return;
   e.preventDefault();
-  if (!netplayBusy() && document.pointerLockElement !== canvas && e.button === 0) {
+  if ((!netplayBusy() || netplayMouse()) && document.pointerLockElement !== canvas && e.button === 0) {
     canvas.requestPointerLock?.();
   }
   emu.mouse_button(e.button, true);
@@ -2072,6 +2075,7 @@ window.addEventListener('mousemove', (e) => {
 });
 document.addEventListener('pointerlockchange', () => {
   lastPos = null;
+  if (netplayMouse() && document.pointerLockElement !== canvas) emu?.netplay_release_input();
 });
 
 // --- touch ---------------------------------------------------------------
@@ -7599,7 +7603,7 @@ if (typeof WebEmu.prototype.start_netplay === 'function') {
         // machines can then report a mismatch even if one closes first.
         emu.run_hidden(performance.now(), 0);
         link.send(emu);
-        setJoyMode(hasTouch ? 'touch' : settings.controller === 'cd32' ? 'cd32' : 'keys');
+        setJoyMode(settings.controller === 'mouse' ? 'off' : hasTouch ? 'touch' : settings.controller === 'cd32' ? 'cd32' : 'keys');
         let lastStatus = 0;
         netplayTimer = setInterval(() => {
           if (!netplayMachineReady || netplayPanel.link !== link || !emu) return;

--- a/docs/guide/netplay.md
+++ b/docs/guide/netplay.md
@@ -40,8 +40,15 @@ contains an opaque room ID, with no ROM URLs, connection codes or credentials.
 Host owns Amiga port 1; Join owns port 2. On each page, the usual first gamepad,
 keyboard joystick or touch controls drive that player's port. The keyboard
 joystick mode is enabled on desktop browsers; touch devices start with touch
-controls. Cycle **Joystick** off to type ordinary Amiga keys. Both keyboards contribute to the shared keyboard. Mouse input is
-disabled. The desktop F11/F12 netplay shortcuts do not apply to the browser.
+controls. Cycle **Joystick** off to type ordinary Amiga keys. Both keyboards
+contribute to the shared keyboard. The desktop F11/F12 netplay shortcuts do not
+apply to the browser.
+
+For games that use two mice, such as two-player Lemmings, the host chooses
+**Advanced → Controllers → Two mice** before hosting. Each player's mouse then
+drives their own Amiga port, including left, right and middle mouse buttons.
+Touch devices can use the canvas trackpad for movement and left/right clicks.
+Click the screen to capture the mouse; Escape releases it. Keyboard joystick mode stays off so both players can type ordinary Amiga keys.
 
 Room setup uses a small signaling service. WebRTC tries direct routes and can
 fall back to a TURN relay. **Advanced → Use relay only** forces that route for
@@ -121,12 +128,14 @@ then enable **Netplay** on both computers.
 4. Use the same **Input delay** and **Rollback limit**, then click **Run** on
    both computers. The windows wait for each other before emulation begins.
 
-Enabling netplay changes mouse/analogue/empty ports to joysticks, turns serial
+Enabling netplay changes analogue, gamepad-mouse and empty ports to joysticks, turns serial
 and JIT off, disables run-ahead and warp boot, and enables power on. Existing
-joystick/CD32 ports stay selected. These changes are visible on the other
+mouse/joystick/CD32 ports stay selected. These changes are visible on the other
 configuration pages; Run reapplies them after model or configuration changes.
 ROMs, media and storage selections remain yours to choose;
-Run explains any incompatible device or connection setting.
+Run explains any incompatible device or connection setting. For a two-mouse
+game, select **Mouse** on both controller ports on both computers. For a
+two-joystick game, select **Joystick** on both ports.
 
 **F11** disconnects and returns to the Netplay page with the connection details
 intact. A connection failure also returns there, showing its error. Correct the
@@ -178,22 +187,28 @@ use the same `--rtc-time` on both peers to choose another starting time.
 
 ## Controls
 
-Player 1 controls Amiga port 1; player 2 controls port 2. On either computer,
-a connected gamepad drives the local port. Without a gamepad, the first keyboard
-controller mapping drives it: by default arrows move, right Ctrl fires, and
+Player 1 controls Amiga port 1; player 2 controls port 2. For joystick/CD32
+ports, a connected gamepad drives the local port. Without a gamepad, the first
+keyboard controller mapping drives it: by default arrows move, right Ctrl fires, and
 left Alt is the second button. The existing saved input mappings apply.
-Either port may be `joystick` or `cd32`, provided both peers use the same settings.
+Either port may be `mouse`, `joystick` or `cd32`, provided both peers use the same
+settings. A mouse port takes that player's host mouse, with keyboard typing
+enabled automatically. For two mice, pass `--port1 mouse --port2 mouse` on both
+computers. Mixed mouse and joystick/CD32 configurations also work on desktop.
 
-Press **F12** to switch between keyboard controller mode and typing on the
-Amiga keyboard. Typing mode sends keys such as Return and the arrows to the guest
+For joystick/CD32 ports, press **F12** to switch between keyboard controller
+mode and typing on the Amiga keyboard. Typing mode sends keys such as Return and the arrows to the guest
 instead of consuming them as controller bindings. Keyboard input from the two
 peers is combined: a key stays pressed while either player holds it. Losing
 window focus releases local held controls on the next sampled frame.
 
 The host Quit and Fullscreen shortcuts remain available (Cmd+Q/Cmd+F on macOS,
-Alt+Q/Alt+F elsewhere). Menus, resets, pause, debugger access, mouse input, save
-states, and media changes are unavailable while connected. Press F11 to return to setup, or close the window to end the session;
-the remaining peer stops after its timeout.
+Alt+Q/Alt+F elsewhere). Click the display to capture the mouse; Cmd+G on macOS
+or Alt+G elsewhere releases or captures it. Menus, resets, pause, debugger access,
+save states, and media changes are unavailable while connected. Press F11 to
+return to setup, or close the window to end the session; the remaining peer stops
+after its timeout. Scripted mouse and analogue input remain unavailable during
+netplay.
 
 ## Delay and connection limits
 

--- a/docs/guide/netplay.md
+++ b/docs/guide/netplay.md
@@ -238,8 +238,8 @@ large corrections can produce audible as well as visual discontinuities.
 
 ## Supported machines and verification
 
-Use a cold boot with interpreter execution, both digital controllers, serial off,
-and rewind/run-ahead disabled. Floppy images become session-local memory images;
+Use a cold boot with interpreter execution, matching mouse/joystick/CD32 port
+configurations on both peers, serial off, and rewind/run-ahead disabled. Floppy images become session-local memory images;
 guest disk writes can be rolled back and do **not** modify the original files.
 Disk changes and in-session saves are not persisted.
 

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -43,7 +43,8 @@ future inputs never seed an earlier prediction.
 
 A delayed local input is submitted only once, even when repeated polling stalls
 on the same frame. Interactive frontends use `Connection::step_local`, which
-consumes pending mouse motion only on that first submission. Handshake and
+consumes pending mouse motion only on that first submission. `LocalInput` keeps
+32-bit pending counts separate from the 16-bit per-frame wire deltas. Handshake and
 confirmation polls preserve it, as do subsequent polls of an already sampled
 frame. Each sample takes at most 100 counts per axis, retaining the remainder
 for later frames to avoid ambiguous 8-bit JOYDAT wraparound. Mouse ports receive

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -32,15 +32,23 @@ cycle accounting, independent of the ordinary frontend's CPU-budget quantum.
 The scheduler state and transport remain outside serialized guest state; the
 save-state version is unchanged.
 
-An input contains eleven digital controller bits and a 128-key held-state bitmap.
+An input contains eleven digital controller bits, a 128-key held-state bitmap,
+signed mouse X/Y deltas and three held mouse buttons.
 Each peer owns one port. Key bitmaps are ORed, and transitions from the previous
 merged bitmap are enqueued in raw-key order at the frame boundary. Controller
-and keyboard prediction both repeat the most recent remote input at or before
-that frame. Out-of-order future inputs never seed an earlier prediction.
+buttons and keyboard prediction repeat the most recent remote held state at or
+before that frame. Predicted mouse motion is zero: relative movement belongs to
+one frame and must not repeat while waiting for another packet. Out-of-order
+future inputs never seed an earlier prediction.
 
 A delayed local input is submitted only once, even when repeated polling stalls
-on the same frame. Both timelines start with the negotiated number of neutral
-delay frames. A frame can advance only while both remote input and the remote
+on the same frame. Interactive frontends use `Connection::step_local`, which
+consumes pending mouse motion only on that first submission. Handshake and
+confirmation polls preserve it, as do subsequent polls of an already sampled
+frame. Each sample takes at most 100 counts per axis, retaining the remainder
+for later frames to avoid ambiguous 8-bit JOYDAT wraparound. Mouse ports receive
+motion and mouse buttons; digital-controller updates cannot replace their device.
+Both timelines start with the negotiated number of neutral delay frames. A frame can advance only while both remote input and the remote
 acknowledgement remain within the configured prediction window. This also bounds
 unacknowledged local history when only one direction of the connection works.
 
@@ -74,12 +82,15 @@ for replay. It retains eight recent checkpoint hashes. Snapshot storage has a
 
 ## Wire protocol
 
-`wire.rs` defines protocol version 1. Packets carry `CLNP`, protocol and
+`wire.rs` defines protocol version 2. Packets carry `CLNP`, protocol and
 save-state versions, a 16-byte session ID, a 32-byte initial-machine fingerprint,
 player index, handshake-ready flag, delay/window settings, cumulative input
 acknowledgement, the latest confirmed checkpoint, and up to 32 input records.
 Integers are little-endian. Records contain an eight-byte frame number, two-byte
-controller bitmap, and sixteen-byte key bitmap. The maximum packet is 943 bytes.
+controller bitmap, sixteen-byte key bitmap, two signed two-byte mouse deltas,
+and one byte containing the three mouse buttons. Each record is 31 bytes and
+the maximum packet is 1103 bytes. Version 1 peers are rejected as incompatible;
+the file save-state version is unchanged.
 
 The initial fingerprint hashes Copperline's display build version and the entire
 normalized initial machine snapshot, including ROM and in-memory floppy data.
@@ -115,7 +126,7 @@ session ID, input delay and prediction limit. Timers use `timebase::Instant` on
 both targets. Neither target serializes transport or wall-clock state.
 
 The web wrapper owns `Connection<PacketQueue>`. Each direction holds at most
-64 packets of at most 943 bytes. Incoming bursts evict the oldest datagram, relying
+64 packets of at most 1103 bytes. Incoming bursts evict the oldest datagram, relying
 on subsequent retransmissions; a full outgoing queue reports backpressure.
 `netplay.js` also bounds its receive queue and stops draining Rust's send queue
 when the channel's buffered amount reaches 64 maximum-size packets.
@@ -194,7 +205,7 @@ disconnect path. No save-state or input-packet format changes are required.
 
 Host/Join freezes the chosen cold-boot media and frees any local emulator.
 After media verification, the wrapper builds a fresh machine, fixes the RTC seed,
-disables serial and sets both digital controllers before fingerprinting it.
+disables serial and sets both selected controllers before fingerprinting it.
 JS numeric settings enter Rust as `f64` and are checked for finiteness, integer
 values and range before narrowing. Setup operations carry their connection
 identity across awaits so cancellation cannot publish a late machine or code.
@@ -249,10 +260,13 @@ the caller normally.
 
 The regression suite covers:
 
-- Zero and nonzero input delay, repeat-last prediction, batched late arrivals,
-  duplicate inputs, bounded stalls, recovery, and once-only local sampling.
+- Zero and nonzero input delay, held-state prediction with zero predicted mouse
+  motion, batched late arrivals,
+  duplicate inputs, bounded stalls, recovery, and once-only local sampling,
+  including pending mouse movement accumulated across stalls.
 - Byte-identical replay against an uninterrupted 68000 workload that reads both
-  JOYDAT registers and CIA fire inputs, writes RAM, and drives a display colour.
+  JOYDAT registers and CIA fire inputs, writes RAM, and drives a display colour,
+  with two mice, two joysticks, two CD32 pads and mixed mouse/CD32 ports.
 - Two complete emulators connected through local UDP proxies with deterministic
   loss, delay, duplication, reordering, and asymmetric pauses, with zero, default,
   and maximum input delay; both must confirm the same checkpoint and end with
@@ -283,7 +297,9 @@ the other page modules. For a served local page, the optional Playwright check
 `node tools/check-web-netplay-browser.mjs http://127.0.0.1:8000/` exercises actual
 Host/Join, cancellation, reconnect by cold boot, locked controls and mismatch
 rejection in two Chromium contexts. It also verifies that a device-keyboard tap
-appears as a held key and subsequent release in transmitted input frames.
+appears as a held key and subsequent release in transmitted input frames, and
+that two-mouse sessions route DOM movement and button press/release events on
+both pages while leaving keyboard joystick mode off.
 `CHROME_PATH` selects an installed Chrome;
 `PLAYWRIGHT_MODULE` can point to a local Playwright module.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1407,7 +1407,7 @@ where
             })
             || joy_after.iter().any(|j| usize::from(j.3) != options.player)
         {
-            bail!("netplay supports cold boot, disks inserted at time 0, local-port --joy-after and keyboard input; state loads, media changes, mouse/analogue input, debugging, warp and recording are unavailable");
+            bail!("netplay supports cold boot, disks inserted at time 0, local-port --joy-after and keyboard input; state loads, media changes, scripted mouse/analogue input, debugging, warp and recording are unavailable");
         }
         Some(options)
     } else {

--- a/src/netplay/mod.rs
+++ b/src/netplay/mod.rs
@@ -39,16 +39,6 @@ pub struct Input {
 impl Input {
     pub const BUTTONS: u16 = 0x7ff;
 
-    pub fn add_mouse_delta(&mut self, dx: i32, dy: i32) {
-        let add = |old: i16, delta: i32| {
-            i32::from(old)
-                .saturating_add(delta)
-                .clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16
-        };
-        self.mouse_dx = add(self.mouse_dx, dx);
-        self.mouse_dy = add(self.mouse_dy, dy);
-    }
-
     pub fn set_mouse_button(&mut self, button: u8, pressed: bool) {
         if button < 3 {
             let mask = 1 << button;
@@ -92,6 +82,38 @@ impl Input {
 
     fn merged_keys(inputs: [Self; 2]) -> [u8; 16] {
         std::array::from_fn(|i| inputs[0].keys[i] | inputs[1].keys[i])
+    }
+}
+
+/// Frontend-held controls and unsampled motion, outside the wire timeline.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LocalInput {
+    pub held: Input,
+    pub mouse_pending: (i32, i32),
+}
+
+impl LocalInput {
+    pub fn add_mouse_delta(&mut self, dx: i32, dy: i32) {
+        self.mouse_pending.0 = self.mouse_pending.0.saturating_add(dx);
+        self.mouse_pending.1 = self.mouse_pending.1.saturating_add(dy);
+    }
+
+    fn sample(&self) -> Input {
+        // Stay below the signed wrap limit of the 8-bit JOYDAT counters.
+        Input {
+            mouse_dx: self.mouse_pending.0.clamp(-100, 100) as i16,
+            mouse_dy: self.mouse_pending.1.clamp(-100, 100) as i16,
+            ..self.held
+        }
+    }
+}
+
+impl From<Input> for LocalInput {
+    fn from(input: Input) -> Self {
+        Self {
+            held: input.without_motion(),
+            mouse_pending: (i32::from(input.mouse_dx), i32::from(input.mouse_dy)),
+        }
     }
 }
 
@@ -368,8 +390,8 @@ impl<T: Transport> Connection<T> {
 
     /// Poll, repair late input, and optionally advance a frame. `false` is a
     /// normal wait for handshake/input. Continue polling while waiting.
-    pub fn step(&mut self, emu: &mut Emulator, mut input: Input, advance: bool) -> Result<bool> {
-        self.step_local(emu, &mut input, advance)
+    pub fn step(&mut self, emu: &mut Emulator, input: Input, advance: bool) -> Result<bool> {
+        self.step_local(emu, &mut input.into(), advance)
     }
 
     /// Consume mouse motion only when a new local frame is sampled. Motion
@@ -377,7 +399,7 @@ impl<T: Transport> Connection<T> {
     pub fn step_local(
         &mut self,
         emu: &mut Emulator,
-        input: &mut Input,
+        input: &mut LocalInput,
         advance: bool,
     ) -> Result<bool> {
         if let Some(error) = &self.failure {
@@ -390,7 +412,12 @@ impl<T: Transport> Connection<T> {
         result
     }
 
-    fn step_inner(&mut self, emu: &mut Emulator, input: &mut Input, advance: bool) -> Result<bool> {
+    fn step_inner(
+        &mut self,
+        emu: &mut Emulator,
+        input: &mut LocalInput,
+        advance: bool,
+    ) -> Result<bool> {
         // A finite receive budget keeps window input responsive under a burst.
         let mut buffer = [0; wire::MAX_PACKET + 1];
         for _ in 0..64 {
@@ -439,7 +466,7 @@ impl<T: Transport> Connection<T> {
             }
         }
         ensure!(
-            input.buttons & !Input::BUTTONS == 0 && input.mouse_buttons & !7 == 0,
+            input.held.buttons & !Input::BUTTONS == 0 && input.held.mouse_buttons & !7 == 0,
             "invalid local netplay controller input"
         );
         let now = Instant::now();
@@ -452,16 +479,11 @@ impl<T: Transport> Connection<T> {
             "netplay peer timed out"
         );
         let mut stepped = false;
-        // Stay below the signed wrap limit of the 8-bit JOYDAT counters.
-        let sampled = Input {
-            mouse_dx: input.mouse_dx.clamp(-100, 100),
-            mouse_dy: input.mouse_dy.clamp(-100, 100),
-            ..*input
-        };
+        let sampled = input.sample();
         if self.connected && advance {
             if self.rollback.submit_local(sampled) {
-                input.mouse_dx -= sampled.mouse_dx;
-                input.mouse_dy -= sampled.mouse_dy;
+                input.mouse_pending.0 -= i32::from(sampled.mouse_dx);
+                input.mouse_pending.1 -= i32::from(sampled.mouse_dy);
             }
             // Send sampled input before replay, emulation, or pacing can add
             // another frame of avoidable network latency.

--- a/src/netplay/mod.rs
+++ b/src/netplay/mod.rs
@@ -24,16 +24,43 @@ use std::collections::BTreeMap;
 #[cfg(not(target_arch = "wasm32"))]
 use std::net::SocketAddr;
 
-/// A held digital controller and Amiga keyboard, sampled once per frame.
+/// Controller buttons, relative mouse motion and held keys for one frame.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Input {
     /// Up, down, left, right, red, blue, play, rewind, forward, green, yellow.
     pub buttons: u16,
     pub keys: [u8; 16],
+    pub mouse_dx: i16,
+    pub mouse_dy: i16,
+    /// Left, right and middle mouse buttons.
+    pub mouse_buttons: u8,
 }
 
 impl Input {
     pub const BUTTONS: u16 = 0x7ff;
+
+    pub fn add_mouse_delta(&mut self, dx: i32, dy: i32) {
+        let add = |old: i16, delta: i32| {
+            i32::from(old)
+                .saturating_add(delta)
+                .clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16
+        };
+        self.mouse_dx = add(self.mouse_dx, dx);
+        self.mouse_dy = add(self.mouse_dy, dy);
+    }
+
+    pub fn set_mouse_button(&mut self, button: u8, pressed: bool) {
+        if button < 3 {
+            let mask = 1 << button;
+            self.mouse_buttons = (self.mouse_buttons & !mask) | (u8::from(pressed) << button);
+        }
+    }
+
+    fn without_motion(mut self) -> Self {
+        self.mouse_dx = 0;
+        self.mouse_dy = 0;
+        self
+    }
 
     /// Direction switches, red/fire and blue/second button, in wire order.
     pub fn set_joystick(&mut self, held: [bool; 6]) {
@@ -274,8 +301,15 @@ impl<T: Transport> Connection<T> {
             !emu.time_travel_enabled(),
             "netplay cannot record reverse history"
         );
-        ensure!(emu.bus().input.ports.iter().all(|p| matches!(p.device, crate::bus::PortDevice::Joystick | crate::bus::PortDevice::Cd32Pad)),
-            "netplay requires joystick or CD32 controllers on both ports (--port1 joystick --port2 joystick)");
+        ensure!(
+            emu.bus().input.ports.iter().all(|p| matches!(
+                p.device,
+                crate::bus::PortDevice::Mouse
+                    | crate::bus::PortDevice::Joystick
+                    | crate::bus::PortDevice::Cd32Pad
+            )),
+            "netplay requires mouse, joystick or CD32 controllers on both ports"
+        );
         let mut identity_hash = Sha256::new();
         identity_hash.update(env!("COPPERLINE_DISPLAY_VERSION").as_bytes());
         identity_hash.update(emu.netplay_snapshot()?);
@@ -334,7 +368,18 @@ impl<T: Transport> Connection<T> {
 
     /// Poll, repair late input, and optionally advance a frame. `false` is a
     /// normal wait for handshake/input. Continue polling while waiting.
-    pub fn step(&mut self, emu: &mut Emulator, input: Input, advance: bool) -> Result<bool> {
+    pub fn step(&mut self, emu: &mut Emulator, mut input: Input, advance: bool) -> Result<bool> {
+        self.step_local(emu, &mut input, advance)
+    }
+
+    /// Consume mouse motion only when a new local frame is sampled. Motion
+    /// arriving during a handshake or a repeated stalled poll stays pending.
+    pub fn step_local(
+        &mut self,
+        emu: &mut Emulator,
+        input: &mut Input,
+        advance: bool,
+    ) -> Result<bool> {
         if let Some(error) = &self.failure {
             anyhow::bail!("{error}");
         }
@@ -345,7 +390,7 @@ impl<T: Transport> Connection<T> {
         result
     }
 
-    fn step_inner(&mut self, emu: &mut Emulator, input: Input, advance: bool) -> Result<bool> {
+    fn step_inner(&mut self, emu: &mut Emulator, input: &mut Input, advance: bool) -> Result<bool> {
         // A finite receive budget keeps window input responsive under a burst.
         let mut buffer = [0; wire::MAX_PACKET + 1];
         for _ in 0..64 {
@@ -394,7 +439,7 @@ impl<T: Transport> Connection<T> {
             }
         }
         ensure!(
-            input.buttons & !Input::BUTTONS == 0,
+            input.buttons & !Input::BUTTONS == 0 && input.mouse_buttons & !7 == 0,
             "invalid local netplay controller input"
         );
         let now = Instant::now();
@@ -407,8 +452,17 @@ impl<T: Transport> Connection<T> {
             "netplay peer timed out"
         );
         let mut stepped = false;
+        // Stay below the signed wrap limit of the 8-bit JOYDAT counters.
+        let sampled = Input {
+            mouse_dx: input.mouse_dx.clamp(-100, 100),
+            mouse_dy: input.mouse_dy.clamp(-100, 100),
+            ..*input
+        };
         if self.connected && advance {
-            self.rollback.submit_local(input);
+            if self.rollback.submit_local(sampled) {
+                input.mouse_dx -= sampled.mouse_dx;
+                input.mouse_dy -= sampled.mouse_dy;
+            }
             // Send sampled input before replay, emulation, or pacing can add
             // another frame of avoidable network latency.
             self.send_packet(true)?;
@@ -417,7 +471,7 @@ impl<T: Transport> Connection<T> {
             let mut machine = EmulatedMachine(emu);
             self.rollback.reconcile(&mut machine)?;
             if advance {
-                stepped = self.rollback.advance(&mut machine, input)?;
+                stepped = self.rollback.advance(&mut machine, sampled)?;
             }
             for (&frame, expected) in &self.peer_hashes {
                 if let Some(actual) = self.rollback.hashes.get(&frame) {
@@ -494,6 +548,22 @@ impl Machine for EmulatedMachine<'_> {
     }
     fn frame(&mut self, inputs: [Input; 2], previous_keys: [u8; 16], replay: bool) -> Result<()> {
         for (port, input) in inputs.iter().enumerate() {
+            if self.0.bus().input.ports[port].device == crate::bus::PortDevice::Mouse {
+                let hardware = &mut self.0.bus_mut().input;
+                hardware.add_mouse_delta(
+                    port,
+                    i32::from(input.mouse_dx),
+                    i32::from(input.mouse_dy),
+                );
+                for button in 0..3 {
+                    hardware.set_mouse_button(
+                        port,
+                        button,
+                        input.mouse_buttons & (1 << button) != 0,
+                    );
+                }
+                continue;
+            }
             let on = |bit: u32| input.buttons & (1u16 << bit) != 0u16;
             self.0
                 .bus_mut()

--- a/src/netplay/rollback.rs
+++ b/src/netplay/rollback.rs
@@ -112,11 +112,16 @@ impl Rollback {
     }
 
     fn simulate(&mut self, machine: &mut impl Machine, number: u64, replay: bool) -> Result<()> {
-        let remote = self
-            .remote
-            .range(..=number)
-            .next_back()
-            .map_or(Input::default(), |(_, v)| *v);
+        let remote = self.remote.range(..=number).next_back().map_or(
+            Input::default(),
+            |(&frame, &input)| {
+                if frame == number {
+                    input
+                } else {
+                    input.without_motion()
+                }
+            },
+        );
         let local = *self
             .local
             .get(&number)
@@ -189,8 +194,15 @@ impl Rollback {
         Ok(())
     }
 
-    pub fn submit_local(&mut self, input: Input) {
-        self.local.entry(self.current + self.delay).or_insert(input);
+    pub fn submit_local(&mut self, input: Input) -> bool {
+        if let std::collections::btree_map::Entry::Vacant(entry) =
+            self.local.entry(self.current + self.delay)
+        {
+            entry.insert(input);
+            true
+        } else {
+            false
+        }
     }
 
     pub fn advance(&mut self, machine: &mut impl Machine, input: Input) -> Result<bool> {

--- a/src/netplay/tests.rs
+++ b/src/netplay/tests.rs
@@ -763,43 +763,97 @@ fn mouse_motion_is_consumed_once_when_sampling_through_stalls() -> Result<()> {
     };
     let mut peer =
         Connection::with_transport(settings, PacketQueue::default(), &mut machine, &cfg)?;
-    let mut pending = Input {
+    let mut pending: LocalInput = Input {
         mouse_dx: 250,
         mouse_dy: -250,
         mouse_buttons: 7,
         ..Default::default()
-    };
+    }
+    .into();
     assert!(!peer.step_local(&mut machine, &mut pending, true)?);
-    assert_eq!(pending.mouse_dx, 250, "handshake must retain motion");
+    assert_eq!(pending.mouse_pending.0, 250, "handshake must retain motion");
     // Isolate sampling from the handshake already exercised by the paired tests.
     peer.connected = true;
     assert!(!peer.step_local(&mut machine, &mut pending, false)?);
     assert_eq!(
-        pending.mouse_dx, 250,
+        pending.mouse_pending.0, 250,
         "confirmation polls must retain motion"
     );
     assert!(peer.step_local(&mut machine, &mut pending, true)?);
-    assert_eq!(pending.mouse_dx, 150);
+    assert_eq!(pending.mouse_pending.0, 150);
     assert!(!peer.step_local(&mut machine, &mut pending, true)?);
-    assert_eq!(pending.mouse_dx, 50, "a stalled frame is sampled once");
+    assert_eq!(
+        pending.mouse_pending.0, 50,
+        "a stalled frame is sampled once"
+    );
     pending.add_mouse_delta(7, -7);
     assert!(!peer.step_local(&mut machine, &mut pending, true)?);
     assert_eq!(
-        pending.mouse_dx, 57,
+        pending.mouse_pending.0, 57,
         "new motion waits for the next unsampled frame"
     );
     peer.rollback.receive(0, Input::default())?;
     peer.rollback.acknowledge(2)?;
     assert!(peer.step_local(&mut machine, &mut pending, true)?);
-    assert_eq!(pending.mouse_dx, 57);
+    assert_eq!(pending.mouse_pending.0, 57);
     peer.rollback.receive(1, Input::default())?;
     assert!(peer.step_local(&mut machine, &mut pending, true)?);
-    assert_eq!((pending.mouse_dx, pending.mouse_dy), (0, 0));
-    assert_eq!(pending.mouse_buttons, 7);
+    assert_eq!(pending.mouse_pending, (0, 0));
+    assert_eq!(pending.held.mouse_buttons, 7);
     assert_eq!(
         machine.bus().input.joydat(0),
         0xff01,
         "257 counts wrap in hardware exactly once"
     );
+    Ok(())
+}
+
+#[test]
+fn large_pending_mouse_motion_reaches_the_wire_without_truncation() -> Result<()> {
+    let mut machine = emulator()?;
+    machine
+        .bus_mut()
+        .input
+        .set_port_device(0, crate::bus::PortDevice::Mouse);
+    let mut peer = Connection::with_transport(
+        Settings {
+            player: 0,
+            session: [24; 16],
+            input_delay: 0,
+            rollback_frames: 1,
+        },
+        PacketQueue::default(),
+        &mut machine,
+        &safe_config()?,
+    )?;
+    let mut pending = LocalInput::default();
+    pending.add_mouse_delta(70_000, -90_000);
+    let mut transmitted = BTreeMap::new();
+    for frame in 0..900 {
+        let remote = wire::Packet {
+            session: [24; 16],
+            identity: peer.identity,
+            player: 1,
+            ready: true,
+            delay: 0,
+            window: 1,
+            ack: frame,
+            inputs: vec![(frame, Input::default())],
+            checksum: None,
+        };
+        peer.transport_mut().push(&remote.encode())?;
+        assert!(peer.step_local(&mut machine, &mut pending, true)?);
+        while let Some(bytes) = peer.transport_mut().pop() {
+            for (number, input) in wire::Packet::decode(&bytes).unwrap().inputs {
+                assert!(input.mouse_dx.abs() <= 100 && input.mouse_dy.abs() <= 100);
+                transmitted.insert(number, input);
+            }
+        }
+    }
+    assert_eq!(pending.mouse_pending, (0, 0));
+    let total = transmitted.values().fold((0i32, 0i32), |(x, y), input| {
+        (x + i32::from(input.mouse_dx), y + i32::from(input.mouse_dy))
+    });
+    assert_eq!(total, (70_000, -90_000));
     Ok(())
 }

--- a/src/netplay/tests.rs
+++ b/src/netplay/tests.rs
@@ -34,6 +34,9 @@ impl Machine for ToyMachine {
 fn input(frame: u64, player: u64) -> Input {
     let mut i = Input {
         buttons: ((frame * (player + 3) / 7) % 2048) as u16,
+        mouse_dx: (frame % 19) as i16 - 9,
+        mouse_dy: 11 - ((frame + player) % 23) as i16,
+        mouse_buttons: ((frame / 3 + player) % 8) as u8,
         ..Default::default()
     };
     i.set_key(0x40, (frame + player) % 11 < 3);
@@ -190,6 +193,27 @@ fn wire_round_trip_and_bounded_rejection() {
         checksum: Some((60, [3; 32])),
     };
     let bytes = packet.encode();
+    let mut full = packet.clone();
+    full.inputs = (0..wire::MAX_INPUTS as u64)
+        .map(|frame| {
+            (
+                frame,
+                Input {
+                    mouse_dx: i16::MIN,
+                    mouse_dy: i16::MAX,
+                    mouse_buttons: 7,
+                    ..Default::default()
+                },
+            )
+        })
+        .collect();
+    let maximum = full.encode();
+    assert_eq!(maximum.len(), wire::MAX_PACKET);
+    assert!(maximum.len() <= 1200);
+    assert_eq!(wire::Packet::decode(&maximum), Some(full));
+    let mut invalid_mouse = bytes.clone();
+    invalid_mouse[wire::HEADER + wire::INPUT_RECORD - 1] = 8;
+    assert!(wire::Packet::decode(&invalid_mouse).is_none());
     assert_eq!(wire::Packet::decode(&bytes), Some(packet));
     for end in 0..bytes.len() {
         assert!(wire::Packet::decode(&bytes[..end]).is_none());
@@ -259,8 +283,21 @@ fn emulator() -> Result<Emulator> {
 
 #[test]
 fn emulator_replay_matches_uninterrupted_machine_bytes() -> Result<()> {
+    use crate::bus::PortDevice::{Cd32Pad, Joystick, Mouse};
+    for devices in [[Joystick; 2], [Cd32Pad; 2], [Mouse; 2], [Mouse, Cd32Pad]] {
+        replay_matches_devices(devices)?;
+    }
+    Ok(())
+}
+
+fn replay_matches_devices(devices: [crate::bus::PortDevice; 2]) -> Result<()> {
     let mut baseline = emulator()?;
     let mut predicted = emulator()?;
+    for emu in [&mut baseline, &mut predicted] {
+        for (port, device) in devices.into_iter().enumerate() {
+            emu.bus_mut().input.set_port_device(port, device);
+        }
+    }
     let mut rb = Rollback::new(0, 0, 8);
     let mut previous = [0; 16];
     for f in 0..60 {
@@ -669,5 +706,100 @@ fn udp_transport_discards_foreign_source_and_keeps_expected_peer() -> Result<()>
     expected.send_to(&[2, 3], transport.socket.local_addr()?)?;
     assert_eq!(receive(&mut transport, &mut bytes)?, Some(2));
     assert_eq!(&bytes[..2], &[2, 3]);
+    Ok(())
+}
+
+#[test]
+fn mouse_prediction_holds_buttons_without_repeating_motion() -> Result<()> {
+    let mut machine = emulator()?;
+    machine
+        .bus_mut()
+        .input
+        .set_port_device(1, crate::bus::PortDevice::Mouse);
+    let mut rb = Rollback::new(0, 0, 8);
+    rb.receive(
+        0,
+        Input {
+            mouse_dx: -17,
+            mouse_dy: 23,
+            mouse_buttons: 7,
+            ..Default::default()
+        },
+    )?;
+    for _ in 0..4 {
+        assert!(rb.advance(&mut EmulatedMachine(&mut machine), Input::default())?);
+        assert_eq!(machine.bus().input.joydat(1), 0x17ef);
+        let port = &machine.bus().input.ports[1];
+        assert!(port.fire && port.button2 && port.button3);
+    }
+    // A future packet must not seed motion or held buttons on an earlier frame.
+    rb.receive(
+        6,
+        Input {
+            mouse_dx: 80,
+            mouse_dy: -80,
+            ..Default::default()
+        },
+    )?;
+    assert!(rb.advance(&mut EmulatedMachine(&mut machine), Input::default())?);
+    assert_eq!(machine.bus().input.joydat(1), 0x17ef);
+    Ok(())
+}
+
+#[test]
+fn mouse_motion_is_consumed_once_when_sampling_through_stalls() -> Result<()> {
+    let mut machine = emulator()?;
+    machine
+        .bus_mut()
+        .input
+        .set_port_device(0, crate::bus::PortDevice::Mouse);
+    let mut cfg = crate::config::Config::try_from(crate::config::RawConfig::default())?;
+    cfg.serial.mode = crate::config::SerialMode::Off;
+    let settings = Settings {
+        player: 0,
+        session: [23; 16],
+        input_delay: 0,
+        rollback_frames: 1,
+    };
+    let mut peer =
+        Connection::with_transport(settings, PacketQueue::default(), &mut machine, &cfg)?;
+    let mut pending = Input {
+        mouse_dx: 250,
+        mouse_dy: -250,
+        mouse_buttons: 7,
+        ..Default::default()
+    };
+    assert!(!peer.step_local(&mut machine, &mut pending, true)?);
+    assert_eq!(pending.mouse_dx, 250, "handshake must retain motion");
+    // Isolate sampling from the handshake already exercised by the paired tests.
+    peer.connected = true;
+    assert!(!peer.step_local(&mut machine, &mut pending, false)?);
+    assert_eq!(
+        pending.mouse_dx, 250,
+        "confirmation polls must retain motion"
+    );
+    assert!(peer.step_local(&mut machine, &mut pending, true)?);
+    assert_eq!(pending.mouse_dx, 150);
+    assert!(!peer.step_local(&mut machine, &mut pending, true)?);
+    assert_eq!(pending.mouse_dx, 50, "a stalled frame is sampled once");
+    pending.add_mouse_delta(7, -7);
+    assert!(!peer.step_local(&mut machine, &mut pending, true)?);
+    assert_eq!(
+        pending.mouse_dx, 57,
+        "new motion waits for the next unsampled frame"
+    );
+    peer.rollback.receive(0, Input::default())?;
+    peer.rollback.acknowledge(2)?;
+    assert!(peer.step_local(&mut machine, &mut pending, true)?);
+    assert_eq!(pending.mouse_dx, 57);
+    peer.rollback.receive(1, Input::default())?;
+    assert!(peer.step_local(&mut machine, &mut pending, true)?);
+    assert_eq!((pending.mouse_dx, pending.mouse_dy), (0, 0));
+    assert_eq!(pending.mouse_buttons, 7);
+    assert_eq!(
+        machine.bus().input.joydat(0),
+        0xff01,
+        "257 counts wrap in hardware exactly once"
+    );
     Ok(())
 }

--- a/src/netplay/wire.rs
+++ b/src/netplay/wire.rs
@@ -6,10 +6,10 @@
 use super::Input;
 
 const MAGIC: &[u8; 4] = b"CLNP";
-pub const VERSION: u16 = 1;
+pub const VERSION: u16 = 2;
 pub const MAX_INPUTS: usize = 32;
 pub const HEADER: usize = 4 + 2 + 4 + 16 + 32 + 4 + 8 + 8 + 32 + 1;
-pub const INPUT_RECORD: usize = 8 + 2 + 16;
+pub const INPUT_RECORD: usize = 8 + 2 + 16 + 2 + 2 + 1;
 pub const MAX_PACKET: usize = HEADER + MAX_INPUTS * INPUT_RECORD;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -50,6 +50,9 @@ impl Packet {
             out.extend_from_slice(&frame.to_le_bytes());
             out.extend_from_slice(&input.buttons.to_le_bytes());
             out.extend_from_slice(&input.keys);
+            out.extend_from_slice(&input.mouse_dx.to_le_bytes());
+            out.extend_from_slice(&input.mouse_dy.to_le_bytes());
+            out.push(input.mouse_buttons);
         }
         out
     }
@@ -107,13 +110,17 @@ impl Packet {
             {
                 return None;
             }
-            inputs.push((
-                number,
-                Input {
-                    buttons,
-                    keys: take(&mut bytes)?,
-                },
-            ));
+            let input = Input {
+                buttons,
+                keys: take(&mut bytes)?,
+                mouse_dx: i16::from_le_bytes(take(&mut bytes)?),
+                mouse_dy: i16::from_le_bytes(take(&mut bytes)?),
+                mouse_buttons: take::<1>(&mut bytes)?[0],
+            };
+            if input.mouse_buttons & !7 != 0 {
+                return None;
+            }
+            inputs.push((number, input));
         }
         Some(Self {
             session,

--- a/src/video/launcher/netplay.rs
+++ b/src/video/launcher/netplay.rs
@@ -139,7 +139,10 @@ impl LauncherState {
             self.setup.warp_boot = false;
             self.setup.warp_until = None;
             for port in &mut self.setup.port_devices {
-                if !matches!(port, PortDevice::Joystick | PortDevice::Cd32Pad) {
+                if !matches!(
+                    port,
+                    PortDevice::Mouse | PortDevice::Joystick | PortDevice::Cd32Pad
+                ) {
                     *port = PortDevice::Joystick;
                 }
             }

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -5666,7 +5666,10 @@ fn netplay_setup_edits_all_controls_without_persisting_connection_details() -> R
     assert!(!state.row_applies(F::NetplayPeer));
     state.toggle_netplay();
     assert!(state.row_toggle(F::NetplayEnabled));
-    assert_eq!(state.setup.port_devices, [PortDevice::Joystick; 2]);
+    assert_eq!(
+        state.setup.port_devices,
+        [PortDevice::Mouse, PortDevice::Joystick]
+    );
     assert_eq!(state.setup.serial_mode, SerialMode::Off);
     for (field, value) in [
         (F::NetplayBind, "[::]:19732"),
@@ -5732,4 +5735,26 @@ fn netplay_setup_rejects_invalid_details_and_generates_fresh_codes() {
     }
     setup.enabled = false;
     assert!(setup.options().unwrap().is_none());
+}
+
+#[test]
+fn netplay_preserves_each_supported_port_device() {
+    let mut state = LauncherState::new(MachineSetup::default());
+    state.netplay.enabled = true;
+    for device in [
+        PortDevice::Mouse,
+        PortDevice::Joystick,
+        PortDevice::Cd32Pad,
+        PortDevice::Analogue,
+        PortDevice::GamepadMouse,
+        PortDevice::None,
+    ] {
+        state.setup.port_devices = [device; 2];
+        state.prepare_netplay_machine();
+        let expected = match device {
+            PortDevice::Mouse | PortDevice::Joystick | PortDevice::Cd32Pad => device,
+            _ => PortDevice::Joystick,
+        };
+        assert_eq!(state.setup.port_devices, [expected; 2]);
+    }
 }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -2360,6 +2360,13 @@ impl App {
     /// a mouse plugged in. With no mouse on either port, live mouse input is
     /// dropped.
     fn mouse_port(&self) -> Option<usize> {
+        if let Some(peer) = &self.netplay {
+            let port = peer.player();
+            return self.emu.bus().input.ports[port]
+                .device
+                .is_mouse()
+                .then_some(port);
+        }
         self.emu
             .bus()
             .input
@@ -4819,6 +4826,11 @@ impl ApplicationHandler for App {
         event: DeviceEvent,
     ) {
         if self.netplay.is_some() {
+            if let DeviceEvent::MouseMotion { delta } = event {
+                if self.mouse_captured && self.main_window_focused {
+                    self.add_host_mouse_delta(delta.0, delta.1);
+                }
+            }
             return;
         }
         match event {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -937,7 +937,7 @@ fn analyzer_default_heat_window(bus: &crate::bus::Bus) -> (u32, u32) {
 
 pub struct App {
     netplay: Option<crate::netplay::Session>,
-    netplay_input: crate::netplay::Input,
+    netplay_input: crate::netplay::LocalInput,
     netplay_keyboard_controller: bool,
     netplay_setup: Option<crate::video::launcher::NetplaySetup>,
     // Linux serves clipboard selections from the owning instance.
@@ -2356,9 +2356,9 @@ impl App {
         }
     }
 
-    /// The port live host-mouse input drives: the lowest-numbered port with
-    /// a mouse plugged in. With no mouse on either port, live mouse input is
-    /// dropped.
+    /// Live host-mouse input drives the lowest-numbered mouse port locally.
+    /// During netplay it drives only this peer's assigned port, if that port
+    /// holds a mouse. Otherwise live mouse input is dropped.
     fn mouse_port(&self) -> Option<usize> {
         if let Some(peer) = &self.netplay {
             let port = peer.player();
@@ -2924,7 +2924,7 @@ impl App {
         let held = self.auto_joy_held[port];
         if let Some(session) = &self.netplay {
             if port == session.player() {
-                self.netplay_input.buttons = [
+                self.netplay_input.held.buttons = [
                     held.up,
                     held.down,
                     held.left,

--- a/src/video/window/app_input.rs
+++ b/src/video/window/app_input.rs
@@ -195,9 +195,8 @@ impl App {
 
     pub(super) fn release_mouse_buttons(&mut self) {
         if self.netplay.is_some() {
-            self.netplay_input.mouse_buttons = 0;
-            self.netplay_input.mouse_dx = 0;
-            self.netplay_input.mouse_dy = 0;
+            self.netplay_input.held.mouse_buttons = 0;
+            self.netplay_input.mouse_pending = (0, 0);
             return;
         }
         if let Some(port) = self.mouse_port() {
@@ -512,7 +511,7 @@ impl App {
     /// A transition from the host keyboard.
     pub(super) fn handle_amiga_key_event(&mut self, rawkey: u8, pressed: bool) {
         if self.netplay.is_some() {
-            self.netplay_input.set_key(rawkey, pressed);
+            self.netplay_input.held.set_key(rawkey, pressed);
             return;
         }
         self.handle_amiga_key_event_from(KeySource::Host, rawkey, pressed);

--- a/src/video/window/app_input.rs
+++ b/src/video/window/app_input.rs
@@ -194,6 +194,12 @@ impl App {
     }
 
     pub(super) fn release_mouse_buttons(&mut self) {
+        if self.netplay.is_some() {
+            self.netplay_input.mouse_buttons = 0;
+            self.netplay_input.mouse_dx = 0;
+            self.netplay_input.mouse_dy = 0;
+            return;
+        }
         if let Some(port) = self.mouse_port() {
             let input = &mut self.emu.bus_mut().input;
             for index in 0..3 {
@@ -351,6 +357,10 @@ impl App {
         let Some(port) = self.mouse_port() else {
             return;
         };
+        if self.netplay.is_some() {
+            self.netplay_input.add_mouse_delta(dx, dy);
+            return;
+        }
         self.apply_scripted_mouse_delta(port as u8, dx, dy);
     }
 

--- a/src/video/window/app_netplay.rs
+++ b/src/video/window/app_netplay.rs
@@ -93,7 +93,7 @@ impl App {
         }
         state.fire &=
             crate::config::autofire_asserted(self.autofire_hz, self.emu.bus().emulated_seconds());
-        self.netplay_input.buttons = [
+        self.netplay_input.held.buttons = [
             state.up,
             state.down,
             state.left,
@@ -155,7 +155,7 @@ impl App {
         loop {
             let session = self.netplay.as_mut().unwrap();
             let before = session.status().rollbacks;
-            session.step(&mut self.emu, self.netplay_input, false)?;
+            session.step_local(&mut self.emu, &mut self.netplay_input, false)?;
             let status = session.status();
             if status.rollbacks != before {
                 self.reset_render_pipeline();
@@ -230,7 +230,7 @@ impl App {
                 {
                     self.keyboard_joy_held[0].set(*code, pressed);
                 } else if let Some(rawkey) = host_to_amiga_rawkey(*code) {
-                    self.netplay_input.set_key(rawkey, pressed);
+                    self.netplay_input.held.set_key(rawkey, pressed);
                 }
                 true
             }
@@ -292,7 +292,7 @@ impl App {
                             _ => None,
                         };
                         if let Some(index) = index {
-                            self.netplay_input.set_mouse_button(index, pressed);
+                            self.netplay_input.held.set_mouse_button(index, pressed);
                         }
                     }
                 }

--- a/src/video/window/app_netplay.rs
+++ b/src/video/window/app_netplay.rs
@@ -11,7 +11,9 @@ impl App {
         ));
         self.netplay = Some(session);
         self.netplay_input = Default::default();
-        self.netplay_keyboard_controller = true;
+        self.netplay_keyboard_controller = self.mouse_port().is_none();
+        self.mouse_delta_remainder = (0.0, 0.0);
+        self.last_display_cursor_pos = None;
         self.show_osd("Netplay: waiting for peer (F11 to cancel)".to_string());
     }
 
@@ -57,6 +59,7 @@ impl App {
     }
 
     pub(super) fn leave_netplay(&mut self, error: Option<String>) {
+        self.set_mouse_captured(false);
         self.netplay = None;
         self.netplay_input = Default::default();
         self.keyboard_joy_held = Default::default();
@@ -75,6 +78,9 @@ impl App {
     }
 
     pub(super) fn pump_netplay_input(&mut self) {
+        if self.mouse_port().is_some() {
+            return;
+        }
         let pad = self.gamepad.poll();
         let port = self.netplay.as_ref().unwrap().player();
         if pad.is_none() && self.auto_joy_engaged[port] {
@@ -109,13 +115,20 @@ impl App {
         let session = self.netplay.as_mut().unwrap();
         let before = session.status();
         let connected = before.connected;
-        let stepped = session.step(&mut self.emu, self.netplay_input, true)?;
+        let stepped = session.step_local(&mut self.emu, &mut self.netplay_input, true)?;
         let after = session.status();
         if after.rollbacks != before.rollbacks {
             self.reset_render_pipeline();
         }
         if !connected && after.connected {
-            self.show_osd("Netplay connected: arrows + right Ctrl, or gamepad".to_string());
+            self.show_osd(
+                if self.mouse_port().is_some() {
+                    "Netplay connected: mouse controls your port"
+                } else {
+                    "Netplay connected: arrows + right Ctrl, or gamepad"
+                }
+                .to_string(),
+            );
         }
         if !stepped {
             self.emu.reanchor_realtime_clock();
@@ -183,6 +196,9 @@ impl App {
                     match code {
                         KeyCode::KeyQ => event_loop.exit(),
                         KeyCode::KeyF => self.toggle_fullscreen(),
+                        KeyCode::KeyG if self.mouse_port().is_some() => {
+                            self.set_mouse_captured(!self.mouse_captured)
+                        }
                         _ => {}
                     }
                     return true;
@@ -194,7 +210,7 @@ impl App {
                     return true;
                 }
                 if *code == KeyCode::F12 {
-                    if pressed {
+                    if pressed && self.mouse_port().is_none() {
                         self.netplay_keyboard_controller = !self.netplay_keyboard_controller;
                         self.keyboard_joy_held = Default::default();
                         self.netplay_input = Default::default();
@@ -225,8 +241,60 @@ impl App {
             WindowEvent::Focused(focused) => {
                 self.main_window_focused = *focused;
                 if !focused {
+                    self.set_mouse_captured(false);
+                    self.mouse_delta_remainder = (0.0, 0.0);
+                    self.last_display_cursor_pos = None;
                     self.netplay_input = Default::default();
                     self.keyboard_joy_held = Default::default();
+                }
+                true
+            }
+            WindowEvent::CursorMoved { position, .. } => {
+                self.last_cursor_phys = Some(*position);
+                let display_src = self.display_canvas_src();
+                let pos = self
+                    .render
+                    .as_ref()
+                    .and_then(|r| main_cursor_position(r, display_src, *position));
+                self.cursor_pos = pos;
+                if !self.mouse_captured && self.main_window_focused {
+                    self.track_uncaptured_cursor_motion(pos);
+                }
+                true
+            }
+            WindowEvent::CursorLeft { .. } => {
+                self.cursor_pos = None;
+                self.last_display_cursor_pos = None;
+                if !self.mouse_captured {
+                    self.release_mouse_buttons();
+                }
+                true
+            }
+            WindowEvent::MouseInput { state, button, .. } => {
+                if self.mouse_port().is_some() && self.main_window_focused {
+                    let pressed = *state == ElementState::Pressed;
+                    let over_display = self.cursor_pos.is_some_and(cursor_in_display);
+                    if pressed
+                        && !self.mouse_captured
+                        && over_display
+                        && self.mouse_capture != crate::config::MouseCapture::Manual
+                    {
+                        self.set_mouse_captured(true);
+                        if self.mouse_captured {
+                            return true;
+                        }
+                    }
+                    if !pressed || self.mouse_captured || over_display {
+                        let index = match button {
+                            MouseButton::Left => Some(0),
+                            MouseButton::Right => Some(1),
+                            MouseButton::Middle => Some(2),
+                            _ => None,
+                        };
+                        if let Some(index) = index {
+                            self.netplay_input.set_mouse_button(index, pressed);
+                        }
+                    }
                 }
                 true
             }

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -11632,12 +11632,12 @@ fn netplay_routes_local_inputs_and_blocks_unilateral_menu_actions() -> anyhow::R
     app.handle_amiga_key_event(0x40, true);
     app.auto_joy_held[0].red = true;
     app.apply_auto_joy_state(0);
-    assert_ne!(app.netplay_input.keys[8] & 1, 0);
-    assert_eq!(app.netplay_input.buttons, 1 << 4);
+    assert_ne!(app.netplay_input.held.keys[8] & 1, 0);
+    assert_eq!(app.netplay_input.held.buttons, 1 << 4);
     app.auto_joy_held[1].up = true;
     app.apply_auto_joy_state(1);
     assert_eq!(
-        app.netplay_input.buttons,
+        app.netplay_input.held.buttons,
         1 << 4,
         "the remote port cannot replace local input"
     );
@@ -11649,7 +11649,7 @@ fn netplay_routes_local_inputs_and_blocks_unilateral_menu_actions() -> anyhow::R
         "only the netplay timeline may touch the machine"
     );
     app.handle_amiga_key_event(0x40, false);
-    assert_eq!(app.netplay_input.keys[8], 0);
+    assert_eq!(app.netplay_input.held.keys[8], 0);
     Ok(())
 }
 #[test]
@@ -11837,16 +11837,21 @@ fn netplay_host_mouse_owns_only_the_local_mouse_port() -> anyhow::Result<()> {
         assert!(!app.netplay_keyboard_controller);
         let before = app.emu.netplay_snapshot()?;
         app.add_mouse_delta_i32(15, -23);
-        app.netplay_input.set_mouse_button(0, true);
+        app.netplay_input.held.set_mouse_button(0, true);
         app.pump_netplay_input();
         assert_eq!(
-            (app.netplay_input.mouse_dx, app.netplay_input.mouse_dy),
+            (
+                app.netplay_input.mouse_pending.0,
+                app.netplay_input.mouse_pending.1
+            ),
             (15, -23)
         );
-        assert_eq!(app.netplay_input.mouse_buttons, 1);
+        assert_eq!(app.netplay_input.held.mouse_buttons, 1);
         assert!(app.emu.netplay_snapshot()? == before);
         app.release_mouse_buttons();
         assert_eq!(app.netplay_input, Default::default());
+        app.add_mouse_delta_i32(70_000, -90_000);
+        assert_eq!(app.netplay_input.mouse_pending, (70_000, -90_000));
         assert!(app.emu.netplay_snapshot()? == before);
     }
     Ok(())

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -11802,3 +11802,52 @@ fn netplay_gui_peers_connect_and_can_return_to_setup_and_retry() -> anyhow::Resu
     }
     Ok(())
 }
+
+#[test]
+fn netplay_host_mouse_owns_only_the_local_mouse_port() -> anyhow::Result<()> {
+    for player in 0..2 {
+        let mut app = test_app();
+        app.emu
+            .bus_mut()
+            .rtc
+            .set_seed(Some(crate::netplay::RTC_SEED), false);
+        app.emu.bus_mut().paula.serial = Box::new(crate::serial::NullSerialSink);
+        for port in 0..2 {
+            app.emu
+                .bus_mut()
+                .input
+                .set_port_device(port, crate::bus::PortDevice::Mouse);
+        }
+        let mut cfg = crate::config::Config::try_from(crate::config::RawConfig::default())?;
+        cfg.serial.mode = crate::config::SerialMode::Off;
+        let session = crate::netplay::Session::new(
+            crate::netplay::Options {
+                bind: "127.0.0.1:0".parse()?,
+                peer: "127.0.0.1:19732".parse()?,
+                player,
+                session: [31; 16],
+                input_delay: 0,
+                rollback_frames: 8,
+            },
+            &mut app.emu,
+            &cfg,
+        )?;
+        app.attach_netplay(session);
+        assert_eq!(app.mouse_port(), Some(player));
+        assert!(!app.netplay_keyboard_controller);
+        let before = app.emu.netplay_snapshot()?;
+        app.add_mouse_delta_i32(15, -23);
+        app.netplay_input.set_mouse_button(0, true);
+        app.pump_netplay_input();
+        assert_eq!(
+            (app.netplay_input.mouse_dx, app.netplay_input.mouse_dy),
+            (15, -23)
+        );
+        assert_eq!(app.netplay_input.mouse_buttons, 1);
+        assert!(app.emu.netplay_snapshot()? == before);
+        app.release_mouse_buttons();
+        assert_eq!(app.netplay_input, Default::default());
+        assert!(app.emu.netplay_snapshot()? == before);
+    }
+    Ok(())
+}

--- a/tools/check-web-netplay-browser.mjs
+++ b/tools/check-web-netplay-browser.mjs
@@ -86,11 +86,11 @@ try {
     const emu = window.__emu;
     const take = emu.netplay_take_packet.bind(emu);
     const [protocol, , headerBytes, inputBytes] = emu.constructor.netplay_packet_layout();
-    if (protocol !== 1 || headerBytes !== 111 || inputBytes !== 26) throw new Error('Packet decoder layout changed');
+    if (protocol !== 2 || headerBytes !== 111 || inputBytes !== 31) throw new Error('Packet decoder layout changed');
     window.__testKeyFrames = [];
     emu.netplay_take_packet = () => {
       const packet = take();
-      // Protocol v1: 111-byte header, then 26-byte input records. Check the
+      // Protocol v2: 111-byte header, then 31-byte input records. Check the
       // emitted held-key states, not merely the UI's keydown/up callbacks.
       const view = new DataView(packet.buffer, packet.byteOffset, packet.byteLength);
       for (let offset = headerBytes; offset + inputBytes <= packet.length; offset += inputBytes) {
@@ -124,9 +124,45 @@ try {
   await host.locator('#netplay-panel').screenshot({ path: `${output}/netplay-desktop.png` });
   await host.locator('#netplay-disconnect').click();
   await Promise.all(pages.map(page => page.waitForFunction(() => !window.__emu && !document.querySelector('#netplay-host').disabled)));
+  await host.locator('#netplay-controller').selectOption('mouse');
   await connect();
   await Promise.all(pages.map(page => page.waitForFunction(() => window.__emu?.netplay_status()[6] >= 60,
     null, { timeout: 60000 })));
+  for (const page of pages) {
+    await page.bringToFront();
+    assert.equal(await page.locator('#joy').textContent(), 'Joystick: off');
+    await page.evaluate(() => {
+      const emu = window.__emu;
+      const take = emu.netplay_take_packet.bind(emu);
+      window.__testMouseFrames = [];
+      emu.netplay_take_packet = () => {
+        const packet = take();
+        const view = new DataView(packet.buffer, packet.byteOffset, packet.byteLength);
+        for (let offset = 111; offset + 31 <= packet.length; offset += 31) {
+          window.__testMouseFrames.push([Number(view.getBigUint64(offset, true)),
+            view.getInt16(offset + 26, true), view.getInt16(offset + 28, true), packet[offset + 30]]);
+        }
+        return packet;
+      };
+      const canvas = document.querySelector('canvas');
+      canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 40, clientY: 40, bubbles: true }));
+      canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 46, clientY: 43, bubbles: true }));
+      // Right and middle clicks exercise the DOM-to-Amiga button mapping
+      // without requesting pointer lock from a synthetic gesture.
+      canvas.dispatchEvent(new MouseEvent('mousedown', { button: 2, bubbles: true }));
+      canvas.dispatchEvent(new MouseEvent('mousedown', { button: 1, bubbles: true }));
+    });
+    await page.waitForFunction(() => window.__testMouseFrames.some(([, dx, dy, buttons]) => dx > 0 && dy > 0 && buttons === 6));
+    await page.evaluate(() => {
+      window.dispatchEvent(new MouseEvent('mouseup', { button: 2 }));
+      window.dispatchEvent(new MouseEvent('mouseup', { button: 1 }));
+    });
+    await page.waitForFunction(() => {
+      const frames = window.__testMouseFrames;
+      const held = frames.find(([, , , buttons]) => buttons === 6);
+      return held && frames.some(([frame, dx, dy, buttons]) => frame > held[0] && dx === 0 && dy === 0 && buttons === 0);
+    });
+  }
   await guest.locator('#netplay-disconnect').click();
   await Promise.all(pages.map(page => page.locator('#netplay-host:enabled').waitFor()));
   // Manual signaling also transfers the host setup over the peer connection.
@@ -142,5 +178,5 @@ try {
   await host.locator('#sidebar-toggle').click();
   await host.locator('#netplay-panel').screenshot({ path: `${output}/netplay-mobile.png` });
   assert.deepEqual(errors, []);
-  console.log('Host/Join, cancellation, restart, control locking, host setup transfer and browser rendering passed');
+  console.log('Host/Join, cancellation, restart, two-mouse input, control locking, host setup transfer and browser rendering passed');
 } finally { await browser.close(); }

--- a/tools/check-web-netplay.mjs
+++ b/tools/check-web-netplay.mjs
@@ -23,10 +23,10 @@ function fresh(model = 'A500', video = 'PAL') {
 }
 
 const [protocol, packetLimit, headerBytes, inputBytes] = WebEmu.netplay_packet_layout();
-assert.equal(protocol, 1);
+assert.equal(protocol, 2);
 assert.equal(packetLimit, PACKET_LIMIT, 'Rust and WebRTC packet limits must match');
 assert.equal(headerBytes, 111);
-assert.equal(inputBytes, 26);
+assert.equal(inputBytes, 31);
 const validation = fresh();
 try {
   for (const player of [-1, 0, 3, 1.5, 257, NaN, Infinity]) {
@@ -39,7 +39,7 @@ try {
     assert.throws(() => validation.start_netplay(1, code, 2, window, 'joystick'));
   }
   assert.throws(() => validation.start_netplay(1, 'bad', 2, 8, 'joystick'));
-  assert.throws(() => validation.start_netplay(1, code, 2, 8, 'mouse'));
+  assert.throws(() => validation.start_netplay(1, code, 2, 8, 'analogue'));
   const saved = validation.save_state();
   validation.start_netplay(1, code, 2, 8, 'joystick');
   for (const mutate of [() => validation.reset(), () => validation.save_state(),
@@ -55,15 +55,19 @@ try {
   assert.throws(() => warm.start_netplay(1, code, 2, 8, 'joystick'));
 } finally { warm.free(); }
 
-for (const [model, video, delay, window] of [['A500', 'PAL', 0, 8], ['A500', 'PAL', 2, 8], ['A1200', 'NTSC', 6, 1]]) {
+for (const [model, video, delay, window, controller] of [
+  ['A500', 'PAL', 0, 8, 'cd32'], ['A500', 'PAL', 2, 8, 'cd32'], ['A1200', 'NTSC', 6, 1, 'cd32'],
+  ['A500', 'PAL', 0, 8, 'mouse'], ['A500', 'PAL', 2, 8, 'mouse'], ['A1200', 'NTSC', 6, 1, 'mouse'],
+]) {
   const peers = [fresh(model, video), fresh(model, video)];
   try {
     peers.forEach((emu, player) => {
       emu.insert_floppy(0, new Uint8Array(901120), player ? 'other/path.adf' : 'disk.adf');
       emu.set_volume_percent(player ? 40 : 100);
-      emu.start_netplay(player + 1, code, delay, window, 'cd32');
+      emu.start_netplay(player + 1, code, delay, window, controller);
     });
     let queued = [];
+    const mouseFrame = [-1, -1];
     let packets = 0;
     let checkedSoundGuard = false;
     for (let tick = 0; tick < 1800; tick++) {
@@ -73,6 +77,13 @@ for (const [model, video, delay, window] of [['A500', 'PAL', 0, 8], ['A500', 'PA
         emu.set_joystick_port(2, frame % 9 < 3, false, false, false, frame % 7 < 3, false);
         emu.set_cd32_buttons_port(2, frame % 5 < 2, frame % 7 < 2, frame % 11 < 3, frame % 13 < 4, frame % 17 < 3);
         emu.key_event('Space', frame % 13 < 4);
+        if (controller === 'mouse' && mouseFrame[player] !== frame) {
+          emu.mouse_delta(frame % 19 - 9, 11 - (frame + player) % 23);
+          for (const [button, bit] of [[0, 0], [2, 1], [1, 2]]) {
+            emu.mouse_button(button, !!((frame % 8) & (1 << bit)));
+          }
+          mouseFrame[player] = frame;
+        }
         const advance = frame < 120 && (player !== 0 || tick % 90 < 30 || tick % 90 >= 42);
         // Deliberately different rendering cadence, display settings and audio
         // levels: host presentation must not enter machine checkpoint hashes.
@@ -96,7 +107,12 @@ for (const [model, video, delay, window] of [['A500', 'PAL', 0, 8], ['A500', 'PA
               | (sampled % 5 < 2 ? 64 : 0) | (sampled % 7 < 2 ? 128 : 0)
               | (sampled % 11 < 3 ? 256 : 0) | (sampled % 13 < 4 ? 512 : 0)
               | (sampled % 17 < 3 ? 1024 : 0);
-            assert.equal(view.getUint16(offset + 8, true), expected, 'controller routing');
+            assert.equal(view.getUint16(offset + 8, true), controller === 'mouse' ? 0 : expected, 'controller routing');
+            if (controller === 'mouse') {
+              assert.equal(view.getInt16(offset + 26, true), sampled % 19 - 9, 'mouse X sampled once');
+              assert.equal(view.getInt16(offset + 28, true), 11 - (sampled + player) % 23, 'mouse Y sampled once');
+              assert.equal(bytes[offset + 30], sampled % 8, 'three mouse buttons');
+            }
             assert.equal(bytes[offset + 10 + 8], sampled % 13 < 4 ? 1 : 0, 'Space key routing');
           }
           packets++;
@@ -128,7 +144,7 @@ for (const [model, video, delay, window] of [['A500', 'PAL', 0, 8], ['A500', 'PA
     const pixels = peers.map(emu => Buffer.from(new Uint8Array(wasm.memory.buffer,
       emu.present_ptr(), emu.present_width() * emu.present_rows() * 4)));
     assert.deepEqual(pixels[0], pixels[1]);
-    console.log(`${model}/${video} delay=${delay} window=${window}: 120 confirmed/checksummed frames; identical render`);
+    console.log(`${model}/${video} ${controller} delay=${delay} window=${window}: 120 confirmed/checksummed frames; identical render`);
   } finally { peers.forEach(emu => emu.free()); }
 }
 console.log('WASM netplay numeric boundaries, session guards, packet loss/reordering and presentation isolation passed');


### PR DESCRIPTION
Netplay previously rejected mouse controllers and discarded mouse events. This adds two-mouse play on desktop and in the browser, so each player's mouse drives their assigned Amiga port. Browser hosts select **Advanced → Controllers → Two mice**; desktop users select Mouse on both ports. Desktop sessions also support mixed mouse and joystick/CD32 configurations.

Mouse movement is sampled once per frame and retained across connection stalls. Prediction holds buttons but adds no movement; corrected frames replay the original deltas. The input protocol advances to version 2, so both peers need the updated build. The file save-state format is unchanged.

The existing Browser demo workflow publishes the updated WASM and JavaScript together. The selector and its help text are generated by that JavaScript, so `copperline.github.io` needs no separate hand-written page or signaling-service change.

Validation:
- 29 native netplay regressions and 7 web-wrapper tests, including lossless draining of large mouse events, replay equivalence for two mice and mixed controllers, stalled sampling, button routing and packet bounds.
- 32 JavaScript tests, formatting and all-target/all-feature Clippy with warnings denied.
- Optimized release WASM: A500/PAL and A1200/NTSC peers reached matching checksums and identical pixels with packet loss, duplication, reordering and asymmetric pacing; synchronized disk swaps also passed.
- Two Chrome contexts using the existing website shell: Host/Join, reconnect, mouse movement and button press/release events on both peers, control locking and host setup transfer passed.
