### PR TITLE
Transfer desktop netplay setup and synchronize host floppy swaps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ default = [
 ]
 # Native NAT traversal and encrypted relay fallback. The portable/WASM core
 # keeps using its frontend-provided transport.
-netplay-internet = ["dep:iroh", "dep:tokio", "dep:base64", "dep:serde_json"]
+netplay-internet = ["dep:iroh", "dep:tokio", "dep:base64"]
 # MT-32 emulation through CopperlineHQ/mt32-rs, reachable as a MIDI-Out
 # target. Off builds carry none of it.
 mt32 = ["dep:mt32-rs"]
@@ -56,7 +56,7 @@ coppersynth = ["dep:coppersynth"]
 # Library page is absent, and `[whdload]` keys that only the library uses
 # are parsed and ignored so a configuration written by a full build still
 # loads. See src/gamelib/.
-game-library = ["dep:ureq", "dep:serde_json", "dep:zeroize", "dep:base64"]
+game-library = ["dep:ureq", "dep:zeroize", "dep:base64"]
 # The MHI virtual MPEG audio decoder board (src/mhi.rs, `[mhi]`): pulls in
 # Symphonia's pure-Rust MPEG audio decoder. Kept a default-on feature (not an
 # unconditional dependency) so builds that do not want the board -- the
@@ -128,7 +128,7 @@ bench-bin = []
 # over loopback TCP for driving the emulator from scripts and external tools
 # (`--control` headless, `--control-gui` windowed). Uses std::net + threads,
 # so browser builds (--no-default-features) compile it out.
-control = ["dep:serde_json", "dep:base64"]
+control = ["dep:base64"]
 # User-mode NAT backend for emulated NICs (`[a2065] net = "nat"`, src/net/nat/):
 # a slirp-style virtual gateway giving the guest outbound IPv4 with no host
 # privileges. Uses std::net + threads, so browser builds compile it out.
@@ -141,7 +141,7 @@ net-bridge = ["dep:pcap", "dep:libloading"]
 # The `copperline-ctl` command-line client for the control protocol, and
 # its `--mcp` mode (src/control/mcp.rs), an MCP server over stdio that
 # exposes the protocol as tools for coding agents.
-ctl-bin = ["dep:serde_json", "control", "dap"]
+ctl-bin = ["control", "dap"]
 # The `copperline-import-uae` converter for WinUAE/Amiberry/FS-UAE
 # configuration files.
 import-uae-bin = ["dep:toml_edit"]
@@ -156,7 +156,7 @@ gdb = ["control"]
 # the MCP mode, so it needs serde_json like `control`, plus gimli and
 # object for DWARF and ELF. Off in player builds with the rest of the
 # debugger surface.
-dap = ["control", "dep:serde_json", "dep:gimli", "dep:object"]
+dap = ["control", "dep:gimli", "dep:object"]
 # Real floppy drives through FluxBridge (src/fluxbridge/): the Greaseweazle
 # driver enabled on the dependency below stands in for a disk image on any bay.
 # FluxBridge is a pure-Rust library, so there is nothing to install and no C++
@@ -176,7 +176,7 @@ anyhow = "1"
 log = "0.4"
 env_logger = { version = "0.11", optional = true }
 serde = { version = "1", features = ["derive", "rc"] }
-serde_json = { version = "1", optional = true }
+serde_json = "1"
 base64 = { version = "0.23", optional = true }
 sha2 = { version = "0.11", default-features = false }
 # DWARF and ELF readers for the DAP adapter's debug-info module

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The manual is published at [copperline.dev/docs](https://copperline.dev/docs/) a
 - [WHDLoad Support](docs/guide/whdload.md) - Direct WHDLoad package loading
 - [Direct Executable Launching](docs/guide/run.md) - Running cross-compiled Amiga binaries
 - [Floppy Hardware Bridge](docs/guide/fluxbridge.md) - Real floppy drives via Greaseweazle
-- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions with mice, joysticks or CD32 pads through desktop GUI/CLI (direct IP or encrypted Internet invitations with automatic NAT traversal and relay fallback), or browser WebRTC with QR invitations, host ROM/disk/configuration transfer, synchronized browser disk swaps and relay fallback, plus input prediction, rollback and matching-machine checks. Detailed desktop transport logs are opt-in with `COPPERLINE_NETPLAY_DEBUG=1`.
+- [Rollback Netplay](docs/guide/netplay.md) - two-player sessions with mice, joysticks or CD32 pads through desktop GUI/CLI (direct IP or encrypted Internet invitations with automatic NAT traversal and relay fallback), or browser WebRTC with QR invitations. Both frontends transfer the host's ROMs, disks and machine settings and synchronize host floppy swaps. Desktop also shares WHDLoad, `--run`, and IDE/SCSI/LIDE game volumes using temporary session storage. Detailed desktop transport logs are opt-in with `COPPERLINE_NETPLAY_DEBUG=1`.
 - [Headless Mode](docs/guide/headless.md) - Scripted runs and screenshot/frame dumps
 - [Debugging](docs/debugger/window.md) - In-window, headless, and GDB debugging
 - [VS Code](docs/debugger/vscode.md) - Setup and illustrated source debugging; [Bartman with Copperline](docs/debugger/vscode-bartman.md) covers fork installation and visual profiling

--- a/crates/copperline-player/Cargo.lock
+++ b/crates/copperline-player/Cargo.lock
@@ -535,6 +535,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "serde-big-array",
+ "serde_json",
  "sha2",
  "symphonia-bundle-mp3",
  "symphonia-core",
@@ -1448,6 +1449,12 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -2811,6 +2818,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4150,6 +4170,12 @@ name = "zlib-rs"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/crates/copperline-web/Cargo.lock
+++ b/crates/copperline-web/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "ringbuf",
  "serde",
  "serde-big-array",
+ "serde_json",
  "sha2",
  "tempfile",
  "thread-priority",
@@ -502,6 +503,12 @@ name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -795,6 +802,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1338,6 +1358,12 @@ name = "zlib-rs"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/docs/guide/netplay.md
+++ b/docs/guide/netplay.md
@@ -1,6 +1,6 @@
 # Rollback netplay
 
-Copperline can run a two-player floppy game across two desktop instances or two browsers.
+Copperline can run a two-player game across two desktop instances or two browsers.
 Each peer emulates the whole Amiga and owns one controller port. Both players
 see their own input after a small configurable delay. Copperline predicts late
 remote input, then restores and replays frames when that prediction was wrong.
@@ -112,8 +112,10 @@ the abandoned network timeline as local play.
 ## Set up in the GUI
 
 Open **Machine Configuration → Netplay** (or start Copperline with no arguments).
-Choose the machine, ROM and floppy images on the existing configuration pages,
-then enable **Netplay** on both computers.
+The host chooses the machine, ROM and game media on the existing configuration
+pages, including WHDLoad or supported hard-drive images. Enable **Netplay** on
+both computers. The guest receives the host's setup and needs no local copy of
+the game files.
 
 ### Internet connections
 
@@ -129,8 +131,8 @@ through an HTTPS relay. No port forwarding is normally needed.
    the other player, then click **Run**.
 2. The guest chooses **Join (port 2)**, pastes the code into **Invitation**, and
    clicks **Run**. The invitation supplies the host's timing and relay settings.
-   Both players still select matching machine settings, ROMs and floppy images
-   locally; desktop invitations do not transfer game files.
+   The host then transfers the machine settings, ROMs and game media. The guest's
+   saved configuration and original files remain unchanged.
 3. The cold machine waits for the peer before running. The connection message
    reports the route; the log records changes between direct and relay paths.
    **F11** cancels setup or disconnects play. Setup times out after 15 minutes.
@@ -171,17 +173,18 @@ Choose **Connection → Direct IP (UDP)** on both computers.
    other player. The other player pastes that code into **Session code**.
    Cmd+V on macOS or Ctrl+V elsewhere replaces the focused address/code box;
    Return commits an edit and Escape cancels it.
-4. Use the same **Input delay** and **Rollback limit**, then click **Run** on
-   both computers. The windows wait for each other before emulation begins.
+4. Player 1 chooses **Input delay** and **Rollback limit**. Click **Run** on
+   both computers. Player 1 sends the setup and files to player 2; both windows
+   wait for verification before emulation begins.
 
 Enabling netplay changes analogue, gamepad-mouse and empty ports to joysticks, turns serial
 and JIT off, disables run-ahead and warp boot, and enables power on. Existing
 mouse/joystick/CD32 ports stay selected. These changes are visible on the other
 configuration pages; Run reapplies them after model or configuration changes.
-ROMs, media and storage selections remain yours to choose;
-Run explains any incompatible device or connection setting. For a two-mouse
-game, select **Mouse** on both controller ports on both computers. For a
-two-joystick game, select **Joystick** on both ports.
+The host chooses ROMs, media, storage and controller devices; Run explains any
+incompatible setting. For a two-mouse game, the host selects **Mouse** on both
+ports; for a two-joystick game, **Joystick** on both ports. Joining temporarily
+replaces the guest's machine while retaining its saved configuration choices.
 
 **F11** disconnects and returns to the Netplay page with the connection details
 intact. A connection failure also returns there, showing its error. Correct the
@@ -195,11 +198,12 @@ endpoint before enabling netplay in the GUI.
 
 ## Start from the command line
 
-Give both players the same ROM, floppy contents, and machine settings. A floppy
-can come from the configuration or `--insert-disk-after 0 df0 PATH`. Paths can
-differ between computers; Copperline checks the loaded contents. Put any
-additional disks in the other configured drives before starting. Media swaps
-are unavailable during a session.
+Give the host the ROM, game files and machine settings. A floppy can come from
+the configuration or `--insert-disk-after 0 df0 PATH`. The guest supplies only
+connection details. The host can also use `--whdload game.lha`, `--run program`,
+directory volumes, or IDE/SCSI/LIDE hard-drive images. Netplay takes a private
+copy of these volumes; in-session writes and saves do not update the original
+game directory or hardfile.
 
 For Internet play, the host writes an invitation to a file:
 
@@ -211,9 +215,7 @@ copperline --factory --model A500 --serial off --port1 joystick --port2 joystick
 The guest copies the code from that file and supplies it as one argument:
 
 ```sh
-copperline --factory --model A500 --serial off --port1 joystick --port2 joystick \
-  --netplay-join 'CLNI1.PASTE_THE_FULL_CODE_HERE' \
-  --insert-disk-after 0 df0 game.adf KICK13.ROM
+copperline --netplay-join 'CLNI1.PASTE_THE_FULL_CODE_HERE'
 ```
 
 The host may add `--netplay-relay https://relay.example.com` for a custom iroh
@@ -230,11 +232,10 @@ copperline --factory --model A500 --serial off --port1 joystick --port2 joystick
   --netplay-player 1 --netplay-session 8b21488dae9544f591adf03e291ce976 \
   --insert-disk-after 0 df0 game.adf KICK13.ROM
 
-# Player 2, on 192.168.1.11:
-copperline --factory --model A500 --serial off --port1 joystick --port2 joystick \
+# Player 2, on 192.168.1.11 (no local ROM or disk required):
+copperline \
   --netplay-bind 0.0.0.0:19732 --netplay-peer 192.168.1.10:19732 \
-  --netplay-player 2 --netplay-session 8b21488dae9544f591adf03e291ce976 \
-  --insert-disk-after 0 df0 game.adf KICK13.ROM
+  --netplay-player 2 --netplay-session 8b21488dae9544f591adf03e291ce976
 ```
 
 Use a fresh 32-digit hexadecimal session ID for each game, shared with your
@@ -242,14 +243,38 @@ peer; `openssl rand -hex 16` generates one. The example ID is illustrative.
 Allow the chosen UDP port through each host's firewall. Across the internet,
 both endpoints must be reachable at the addresses given to the other peer,
 usually through port forwarding or a private VPN. A VPN also supplies transport
-encryption and authentication: the direct UDP transport sends inputs in
+encryption and authentication: the direct UDP transport sends inputs and game files in
 cleartext, and its session ID distinguishes games rather than authenticating a
 person. Connect only to a trusted peer.
 
-Both windows wait until their initial machine fingerprints match. Different
-build versions, ROMs, disk contents, controller devices, RAM, or hardware settings
-stop the connection. A fitted guest clock defaults to 2000-01-01 UTC for netplay;
-use the same `--rtc-time` on both peers to choose another starting time.
+Both windows wait until the transferred setup produces matching initial machine
+fingerprints. Different builds or corrupt transfers stop the connection. A
+fitted guest clock defaults to 2000-01-01 UTC; the host can choose another
+starting time with `--rtc-time`.
+
+### Change desktop floppy disks
+
+The host uses the status bar's load, next-disk and eject buttons for DF0–DF3.
+The load picker can select a playlist; Cmd+D on macOS or Alt+D elsewhere cycles
+it. Dropping floppy images loads a playlist into the first connected drive.
+The guest's media controls are disabled. The host can schedule a replacement
+with `--insert-disk-after SECS dfN PATH` at a nonzero emulated time.
+
+Both peers stop at a confirmed frame, verify and transfer the replacement,
+apply it together, then resume. A bad local file leaves the current game
+running; a failed transfer ends the session. The picker keeps the connection
+alive while the host selects files. Disk changes never write received data over
+the guest's original files.
+
+Desktop setup allows up to 512 MiB of media in total, with a 256 MiB limit per
+hard drive, 16 MiB per floppy (including decompression), and 2 MiB per ROM.
+Machine, expansion and video RAM together are limited to 64 MiB, and the
+rollback snapshot budget may require a smaller machine or prediction window.
+Host filesystem mounts, including WHDLoad and executable boot volumes, become
+OFS images, preserving their volume name and boot priority; normal Amiga
+filesystem filename limits apply. Directory mounts already on IDE, SCSI or LIDE
+keep their configured filesystem. Received ROM and hard-drive files are staged
+in a private temporary directory which is removed at disconnect.
 
 ## Controls
 
@@ -257,10 +282,11 @@ Player 1 controls Amiga port 1; player 2 controls port 2. For joystick/CD32
 ports, a connected gamepad drives the local port. Without a gamepad, the first
 keyboard controller mapping drives it: by default arrows move, right Ctrl fires, and
 left Alt is the second button. The existing saved input mappings apply.
-Either port may be `mouse`, `joystick` or `cd32`, provided both peers use the same
-settings. A mouse port takes that player's host mouse, with keyboard typing
-enabled automatically. For two mice, pass `--port1 mouse --port2 mouse` on both
-computers. Mixed mouse and joystick/CD32 configurations also work on desktop.
+The desktop host chooses `mouse`, `joystick` or `cd32` for each port; the guest
+inherits those choices. A mouse port takes that player's host mouse, with
+keyboard typing enabled automatically. For two mice, pass
+`--port1 mouse --port2 mouse` on the host. Mixed mouse and joystick/CD32
+configurations also work on desktop.
 
 For joystick/CD32 ports, press **F12** to switch between keyboard controller
 mode and typing on the Amiga keyboard. Typing mode sends keys such as Return and the arrows to the guest
@@ -271,8 +297,8 @@ window focus releases local held controls on the next sampled frame.
 The host Quit and Fullscreen shortcuts remain available (Cmd+Q/Cmd+F on macOS,
 Alt+Q/Alt+F elsewhere). Click the display to capture the mouse; Cmd+G on macOS
 or Alt+G elsewhere releases or captures it. Menus, resets, pause, debugger access,
-save states, and media changes are unavailable while connected. Press F11 to
-return to setup, or close the window to end the session; the remaining peer stops
+save states, and media changes other than host floppy swaps are unavailable
+while connected. Press F11 to return to setup, or close the window to end the session; the remaining peer stops
 after its timeout. Scripted mouse and analogue input remain unavailable during
 netplay.
 
@@ -283,7 +309,7 @@ netplay.
 | `--netplay-delay` | 2 | 0–6 frames | Delays local input to reduce corrections |
 | `--netplay-rollback` | 8 | 1–12 frames | Caps prediction while waiting for input |
 
-Both peers must choose the same values. At PAL's nominal 50 Hz, two frames are
+Desktop guests inherit these values from the host. At PAL's nominal 50 Hz, two frames are
 about 40 ms. Zero delay gives immediate local input but can produce more visible
 corrections. Rollback reduces perceived latency; it cannot remove network delay.
 If input or its acknowledgement falls too far behind, emulation waits and resumes
@@ -324,9 +350,11 @@ configurations on both peers, serial off, and rewind/run-ahead disabled. Floppy 
 guest disk writes can be rolled back and do **not** modify the original files.
 Disk changes and in-session saves are not persisted.
 
-Host directory volumes (including `--run` and WHDLoad staging), hard-drive/ATAPI
-images, physical drives, live networking/MIDI/parallel peripherals, CD images,
-persistent NVRAM, debugger traces, and recordings are excluded. These devices or
+Desktop converts host directory volumes (including `--run` and WHDLoad staging)
+to private disks and supports IDE/SCSI/LIDE hardfiles. The `copperhf` asynchronous
+controller, ATAPI images, physical drives, live networking/MIDI/parallel peripherals, CD images,
+persistent NVRAM, debugger traces, and recordings are excluded. Netplay uses
+session-only clock/NVRAM storage. These devices or
 observers have state outside the rollback snapshots. A state file cannot be used
 to bypass these restrictions: this version does not accept `--load-state` or USS
 imports for netplay.
@@ -346,7 +374,7 @@ compares confirmed PNGs and checkpoint logs:
 
 ```sh
 python3 tools/check-netplay.py --binary target/release/copperline
-# Add identical machine options after --, for example:
+# Add the host's machine options after --, for example:
 python3 tools/check-netplay.py --seconds 10 -- --config game.toml
 ```
 

--- a/docs/guide/netplay.md
+++ b/docs/guide/netplay.md
@@ -288,6 +288,9 @@ keyboard typing enabled automatically. For two mice, pass
 `--port1 mouse --port2 mouse` on the host. Mixed mouse and joystick/CD32
 configurations also work on desktop.
 
+Audio output device selection (including Disabled), display preferences and
+host input preferences such as mouse sensitivity remain local to each player.
+
 For joystick/CD32 ports, press **F12** to switch between keyboard controller
 mode and typing on the Amiga keyboard. Typing mode sends keys such as Return and the arrows to the guest
 instead of consuming them as controller bindings. Keyboard input from the two

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -32,6 +32,9 @@ the shared input datagrams. The default `netplay-internet` feature adds iroh to
 native builds. The browser/core build keeps its existing transport boundary.
 
 The host sends a bounded JSON hardware manifest and checksummed media bytes.
+The control channel takes ownership of separate media buffers and copies only
+packet-sized chunks. It releases each buffer as it is queued, and the receiver
+grows its buffer with incoming data up to the validated message length.
 GUI and CLI guests retain local output, display and host input preferences on
 their placeholder machine while ignoring remembered machine and game settings.
 The manifest contains no host file paths, display/output preferences, plugin
@@ -61,7 +64,8 @@ target, allowing the ROM boot driver to discover subsequent IDE/SCSI volumes.
 
 Session hard drives share an immutable base by SHA-256 and serialize only a
 sorted overlay of changed sectors. Local checkpoint deserialization resolves
-the base through a process-local weak registry; it never opens a path. The live
+the base through a process-local weak registry; serialization borrows the
+overlay without cloning dirty sectors. Deserialization never opens a path. The live
 disk keeps its base alive. Read-only volumes reject writes, including writes to
 partition metadata. Persistent hardfiles and ordinary in-memory volumes retain
 their existing storage behavior. This adds the session backing to hard-drive

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -32,6 +32,8 @@ the shared input datagrams. The default `netplay-internet` feature adds iroh to
 native builds. The browser/core build keeps its existing transport boundary.
 
 The host sends a bounded JSON hardware manifest and checksummed media bytes.
+GUI and CLI guests retain local output, display and host input preferences on
+their placeholder machine while ignoring remembered machine and game settings.
 The manifest contains no host file paths, display/output preferences, plugin
 modules or host-device authority. Only generated filenames inside a private
 temporary directory reach the guest's machine builder. Both peers rebuild the

--- a/docs/internals/netplay.md
+++ b/docs/internals/netplay.md
@@ -20,14 +20,57 @@ The implementation follows five steps:
 These steps are implemented in `src/netplay/`, `Emulator::step_netplay_frame`,
 `src/video/window/app_netplay.rs`, `crates/copperline-web/src/netplay.rs` and
 `crates/copperline-web/www/netplay.js`. The feature uses native Rust and does not
-link the GGPO SDK. Public matchmaking, spectators, reconnect, desktop media
-transfers, and transactional host filesystems remain separate work.
+link the GGPO SDK. Public matchmaking, spectators, reconnect and persistent
+host filesystem writes remain separate work.
 
 ## Native Internet transport
 
-`Session` is a `Connection<NativeTransport>`; the adapter selects direct UDP or
-`InternetTransport`. The default `netplay-internet` feature adds iroh to native
-builds. The browser/core build keeps its existing transport boundary.
+`Session` coordinates setup and media around a
+`Connection<Control<NativeTransport>>`; the adapter selects direct UDP or
+`InternetTransport`. `Control` multiplexes reliable setup/media messages with
+the shared input datagrams. The default `netplay-internet` feature adds iroh to
+native builds. The browser/core build keeps its existing transport boundary.
+
+The host sends a bounded JSON hardware manifest and checksummed media bytes.
+The manifest contains no host file paths, display/output preferences, plugin
+modules or host-device authority. Only generated filenames inside a private
+temporary directory reach the guest's machine builder. Both peers rebuild the
+same cold setup, validate their initial fingerprints, then begin the input
+handshake. Guest launcher settings remain local. No remote emulator checkpoint
+is accepted or deserialized.
+
+Setup and disk changes use a 32-packet selective-repeat window with cumulative
+and selective acknowledgements, sequence numbers and a 200 ms retransmission
+timer. Packets fit within the existing datagram bound and use the same peer and
+socket in both connection modes. The emulation thread polls bounded queues;
+file selection uses an asynchronous dialog. Setup expires after 15 minutes and
+a disk change after three minutes.
+
+WHDLoad, executable boot and other host-directory volumes are converted to
+Amiga OFS disk images with their volume names and boot priorities. Available
+motherboard IDE slots are used first, then SCSI slots. Configured IDE/SCSI/LIDE
+images keep their controller. The host exports complete virtual sectors,
+including any synthesized partition metadata, so the receiver never has to
+interpret host directory paths. The asynchronous `copperhf` controller and CD
+backends remain excluded from rollback.
+
+Synthesized RDB headers mark the final LUN without claiming to be the final
+target, allowing the ROM boot driver to discover subsequent IDE/SCSI volumes.
+
+Session hard drives share an immutable base by SHA-256 and serialize only a
+sorted overlay of changed sectors. Local checkpoint deserialization resolves
+the base through a process-local weak registry; it never opens a path. The live
+disk keeps its base alive. Read-only volumes reject writes, including writes to
+partition metadata. Persistent hardfiles and ordinary in-memory volumes retain
+their existing storage behavior. This adds the session backing to hard-drive
+state and bumps save-state format 79 to 80; old save states are rejected.
+
+For a floppy change, the host and guest hold their current frames, agree on the
+greater frame, and catch up while still exchanging inputs. At that fully
+confirmed boundary they compare state digests, transfer and validate the disk,
+apply insertion/ejection, compare again, then resume. Retained predictions
+cannot restore the previous disk. Only the host initiates changes, with one
+transaction outstanding at a time.
 
 Internet setup uses a host-generated Ed25519 endpoint key and an independent
 random 128-bit invitation capability. The bounded `CLNI1.` code contains the
@@ -68,8 +111,7 @@ Network frame zero begins at cold boot. Each network frame ends when Agnus next
 increments the emulated video-frame counter, at the first CPU instruction or
 STOP fast-forward boundary after the wrap. This uses precise CPU stepping and
 cycle accounting, independent of the ordinary frontend's CPU-budget quantum.
-The scheduler state and transport remain outside serialized guest state; the
-save-state version is unchanged.
+The scheduler state and transport remain outside serialized guest state.
 
 An input contains eleven digital controller bits, a 128-key held-state bitmap,
 signed mouse X/Y deltas and three held mouse buttons.

--- a/docs/internals/savestate.md
+++ b/docs/internals/savestate.md
@@ -196,6 +196,12 @@ files are refused with a clear version message instead of failing with a
 confusing decode error (or worse, decoding into nonsense). There is no
 migration machinery; old states are simply invalidated.
 
+Version 80 adds the private netplay hard-drive backing. Its immutable media
+reference is valid only while that disk is alive in the current process;
+rollback checkpoints store changed sectors separately. Normal file-backed and
+in-memory-volume saves retain their existing contents. Netplay does not expose
+file save/load operations or accept checkpoints from the other peer.
+
 ## Snapshot point and atomicity
 
 File saves write through a buffered compressor into a unique sibling temporary

--- a/src/ata.rs
+++ b/src/ata.rs
@@ -164,6 +164,10 @@ impl IdeDrive {
             boot_pri,
             filesystem,
         )?;
+        Ok(Self::from_disk(disk))
+    }
+
+    pub(crate) fn from_disk(disk: HardDriveImage) -> Self {
         // The classic Amiga HDF geometry: 16 surfaces, 32 sectors per track
         // (what HDToolBox/RDB tooling defaults to), so the CHS the host
         // computes from an RDB's physical-drive block agrees with what the
@@ -172,7 +176,7 @@ impl IdeDrive {
         let spt = RDB_SPT as u8;
         let cylinders =
             (disk.total_sectors() / (u64::from(heads) * u64::from(spt))).clamp(1, 65535) as u16;
-        Ok(Self {
+        Self {
             disk,
             default_heads: heads,
             default_spt: spt,
@@ -180,7 +184,7 @@ impl IdeDrive {
             heads,
             spt,
             multiple: 0,
-        })
+        }
     }
 
     /// Open a real host disk as an IDE drive.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1447,9 +1447,7 @@ where
             options.validate()?;
             copperline::netplay::ConnectionOptions::Direct(options)
         };
-        if run.is_some()
-            || whdload.is_some()
-            || load_state.is_some()
+        if load_state.is_some()
             || load_uss.is_some()
             || benchmark_until.is_some()
             || gdb.is_some()
@@ -1469,15 +1467,12 @@ where
             || !mouse_after.is_empty()
             || !mouse_to_after.is_empty()
             || !pot_after.is_empty()
-            || disk_insert_after.iter().any(|d| match d {
-                CliDiskInsert::Explicit(s) => s.secs != 0.0,
-                CliDiskInsert::Configured { secs, .. } => *secs != 0.0,
-            })
+            || (options.settings().player == 1 && !disk_insert_after.is_empty())
             || joy_after
                 .iter()
                 .any(|j| usize::from(j.3) != options.settings().player)
         {
-            bail!("netplay supports cold boot, disks inserted at time 0, local-port --joy-after and keyboard input; state loads, media changes, scripted mouse/analogue input, debugging, warp and recording are unavailable");
+            bail!("netplay supports cold boot, host floppy changes, local-port --joy-after and keyboard input; state loads, guest media changes, scripted mouse/analogue input, debugging, warp and recording are unavailable");
         }
         Some(options)
     } else {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -90,6 +90,12 @@ pub struct WasmBoardConfig {
 #[derive(Debug, Clone)]
 pub struct Config {
     pub rom_path: PathBuf,
+    /// Installed only by netplay preparation, never by a configuration file.
+    /// All hard-drive opens then use private rollback-aware session storage.
+    #[doc(hidden)]
+    pub netplay_storage: bool,
+    #[doc(hidden)]
+    pub netplay_read_only: Vec<PathBuf>,
     pub cpu: CpuModel,
     pub fpu: bool,
     /// CPU clock in MHz. Defaults to the model's stock speed
@@ -2389,6 +2395,8 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             rom_path: PathBuf::from(BUNDLED_AROS_ROM),
+            netplay_storage: false,
+            netplay_read_only: Vec::new(),
             cpu: CpuModel::M68000,
             fpu: CpuModel::M68000.default_fpu(),
             cpu_clock_mhz: CpuModel::M68000.default_clock_mhz(),

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -1235,6 +1235,8 @@ impl TryFrom<RawConfig> for Config {
         Ok(Config {
             host_disks,
             rom_path: raw.rom.map(PathBuf::from).unwrap_or(defaults.rom_path),
+            netplay_storage: false,
+            netplay_read_only: Vec::new(),
             cpu,
             fpu,
             cpu_clock_mhz,

--- a/src/dirfs.rs
+++ b/src/dirfs.rs
@@ -66,6 +66,15 @@ pub fn build_image(
     volume_name: &str,
     filesystem: crate::diskimage::FileSystem,
 ) -> anyhow::Result<Vec<u8>> {
+    build_image_limited(dir, volume_name, filesystem, MAX_IMAGE_BYTES)
+}
+
+pub(crate) fn build_image_limited(
+    dir: &Path,
+    volume_name: &str,
+    filesystem: crate::diskimage::FileSystem,
+    limit: u64,
+) -> anyhow::Result<Vec<u8>> {
     // Only `ffs`/plain-vs-not matters here: Kickstart 1.3 (the reason OFS
     // exists as an option at all) has no intl/dircache/longname support
     // either, so callers are only ever expected to pass FileSystem::OFS or
@@ -91,13 +100,13 @@ pub fn build_image(
         }
         total = rounded;
     }
-    if total * BSIZE as u64 > MAX_IMAGE_BYTES {
+    if total * BSIZE as u64 > limit {
         anyhow::bail!(
             "directory {} needs a {} MiB volume; refusing to build an in-memory \
              image larger than {} MiB",
             dir.display(),
             (total * BSIZE as u64) >> 20,
-            MAX_IMAGE_BYTES >> 20
+            limit >> 20
         );
     }
 

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -3306,6 +3306,89 @@ pub fn build_machine(
     paced: bool,
     rom_optional: bool,
 ) -> Result<Emulator> {
+    build_machine_inner(cfg, audio, paced, rom_optional, cfg.netplay_storage)
+}
+
+/// Build a cold machine whose hard-drive writes belong only to this session.
+/// Callers validate the config and supply local, staged media paths.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn build_netplay_machine(
+    cfg: &Config,
+    audio: Box<dyn AudioSink>,
+    paced: bool,
+) -> Result<Emulator> {
+    build_machine_inner(cfg, audio, paced, false, true)
+}
+
+fn build_machine_inner(
+    cfg: &Config,
+    audio: Box<dyn AudioSink>,
+    paced: bool,
+    rom_optional: bool,
+    netplay: bool,
+) -> Result<Emulator> {
+    let open_disk = |path: &std::path::Path,
+                     name: &str,
+                     bus: &'static str,
+                     volume: Option<&str>,
+                     priority: i8,
+                     filesystem: crate::diskimage::FileSystem| {
+        if netplay {
+            let mut disk = crate::harddrive::HardDriveImage::open_session(
+                path, name, bus, volume, priority, filesystem,
+            )?;
+            disk.set_session_read_only(cfg.netplay_read_only.iter().any(|p| p == path));
+            Ok(disk)
+        } else {
+            crate::harddrive::HardDriveImage::open(path, name, bus, volume, priority, filesystem)
+        }
+    };
+    let open_ide_target = |path: &std::path::Path,
+                           unit: usize,
+                           volume: Option<&str>,
+                           priority: i8,
+                           filesystem: crate::diskimage::FileSystem| {
+        if netplay {
+            anyhow::ensure!(
+                !crate::config::is_cd_image_path(path),
+                "netplay cannot use ATAPI CD images"
+            );
+            let disk = open_disk(
+                path,
+                &format!("DH{unit}"),
+                "ide",
+                volume,
+                priority,
+                filesystem,
+            )?;
+            Ok(crate::ata::AtaDevice::from(
+                crate::ata::IdeDrive::from_disk(disk),
+            ))
+        } else {
+            open_ide_target(path, unit, volume, priority, filesystem)
+        }
+    };
+    let open_scsi_target = |drive: &crate::config::DriveImage, unit| {
+        if netplay {
+            anyhow::ensure!(
+                !crate::config::is_cd_image_path(&drive.path),
+                "netplay cannot use SCSI CD images"
+            );
+            let disk = open_disk(
+                &drive.path,
+                &format!("DH{unit}"),
+                "scsi",
+                drive.volume_name.as_deref(),
+                drive.boot_pri,
+                drive.filesystem,
+            )?;
+            Ok(crate::scsi::ScsiTarget::from(
+                crate::scsi::ScsiDisk::from_disk(disk),
+            ))
+        } else {
+            open_scsi_target(drive, unit)
+        }
+    };
     let mut zorro = cfg.build_zorro_chain()?;
     // Functional Zorro-chain boards. Each board's autoconfig identity goes on
     // the chain (mapping its window to a device slot) while the device object
@@ -3484,7 +3567,7 @@ pub fn build_machine(
         let mut board = crate::copperhf::CopperhfBoard::new();
         for (unit, drive) in cfg.copperhf.units.iter().enumerate() {
             let Some(drive) = drive else { continue };
-            let disk = crate::harddrive::HardDriveImage::open(
+            let disk = open_disk(
                 &drive.path,
                 &format!("DH{unit}"),
                 "copperhf",

--- a/src/harddrive.rs
+++ b/src/harddrive.rs
@@ -78,12 +78,14 @@ pub struct HardDriveImage {
 /// writes survive the round trip. Deserialization reopens file backings,
 /// which makes a missing/moved image a load-time error instead of a later
 /// I/O panic.
+/// Generic fields borrow media for serialization and own it on deserialization,
+/// keeping the same field order without cloning disk contents per checkpoint.
 #[derive(serde::Serialize, serde::Deserialize)]
-struct HardDriveImageState {
-    path: PathBuf,
-    memory: Option<Vec<u8>>,
+struct HardDriveImageState<P = PathBuf, B = Vec<u8>, S = SessionImage> {
+    path: P,
+    memory: Option<B>,
     total_sectors: u64,
-    rdb_overlay: Option<Vec<u8>>,
+    rdb_overlay: Option<B>,
     overlay_write_warned: bool,
     scsi_bus: bool,
     /// The real disk this drive is, if it is one: the identifier a
@@ -95,7 +97,7 @@ struct HardDriveImageState {
     /// sector translation; without the access, a disk attached read-only
     /// would come back writable.
     host_device: Option<HostDiskState>,
-    session: Option<SessionImage>,
+    session: Option<S>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -108,9 +110,9 @@ struct HostDiskState {
 impl serde::Serialize for HardDriveImage {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         HardDriveImageState {
-            path: self.path.clone(),
+            path: &self.path,
             memory: match &self.backing {
-                Backing::Memory(image) => Some(image.clone()),
+                Backing::Memory(image) => Some(image.as_slice()),
                 // A physical disk is not ours to capture: the medium lives
                 // outside the emulator and can be swapped while a state is
                 // saved. What it is gets recorded instead, and resuming
@@ -118,7 +120,7 @@ impl serde::Serialize for HardDriveImage {
                 _ => None,
             },
             total_sectors: self.total_sectors,
-            rdb_overlay: self.rdb_overlay.clone(),
+            rdb_overlay: self.rdb_overlay.as_deref(),
             overlay_write_warned: self.overlay_write_warned,
             scsi_bus: self.bus_name == "scsi",
             host_device: match &self.backing {
@@ -133,7 +135,7 @@ impl serde::Serialize for HardDriveImage {
                 _ => None,
             },
             session: match &self.backing {
-                Backing::Session(image) => Some(image.clone()),
+                Backing::Session(image) => Some(image),
                 _ => None,
             },
         }
@@ -143,7 +145,7 @@ impl serde::Serialize for HardDriveImage {
 
 impl<'de> serde::Deserialize<'de> for HardDriveImage {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let state = HardDriveImageState::deserialize(deserializer)?;
+        let state: HardDriveImageState = HardDriveImageState::deserialize(deserializer)?;
         let bus_name = if state.scsi_bus { "scsi" } else { "ide" };
         if let Some(disk) = state.host_device {
             #[cfg(not(target_arch = "wasm32"))]
@@ -1012,6 +1014,20 @@ mod tests {
         let lba = u64::from(CYL_SECTORS) + 3;
         original.write_sector(lba, &[0xA5; SECTOR_SIZE]).unwrap();
         let encoded = bincode::serialize(&original).unwrap();
+        let owned: HardDriveImageState = HardDriveImageState {
+            path: original.path.clone(),
+            memory: None,
+            total_sectors: original.total_sectors,
+            rdb_overlay: original.rdb_overlay.clone(),
+            overlay_write_warned: original.overlay_write_warned,
+            scsi_bus: false,
+            host_device: None,
+            session: match &original.backing {
+                Backing::Session(image) => Some(image.clone()),
+                _ => unreachable!(),
+            },
+        };
+        assert_eq!(encoded, bincode::serialize(&owned).unwrap());
         original.write_sector(lba, &[0x5A; SECTOR_SIZE]).unwrap();
         original.flush().unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), bytes);
@@ -1211,7 +1227,7 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn serde_defers_physical_disk_acquisition() {
-        let state = HardDriveImageState {
+        let state: HardDriveImageState = HardDriveImageState {
             path: PathBuf::from("/dev/definitely-not-opened"),
             session: None,
             memory: None,

--- a/src/harddrive.rs
+++ b/src/harddrive.rs
@@ -14,6 +14,9 @@ use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
+mod session;
+use session::SessionImage;
+
 pub const SECTOR_SIZE: usize = 512;
 
 /// Largest image a gzip-compressed hardfile may unpack to. Deflate has no
@@ -41,6 +44,7 @@ const RDB_LOCATION_LIMIT: usize = 16;
 enum Backing {
     File(File),
     Memory(Vec<u8>),
+    Session(SessionImage),
     /// A real disk attached to the host. Presents 512-byte sectors like the
     /// others; the block size the media actually uses, and the privilege the
     /// open needed, are the device's own business.
@@ -91,6 +95,7 @@ struct HardDriveImageState {
     /// sector translation; without the access, a disk attached read-only
     /// would come back writable.
     host_device: Option<HostDiskState>,
+    session: Option<SessionImage>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -127,6 +132,10 @@ impl serde::Serialize for HardDriveImage {
                 Backing::PendingDevice(device) => Some(device.clone()),
                 _ => None,
             },
+            session: match &self.backing {
+                Backing::Session(image) => Some(image.clone()),
+                _ => None,
+            },
         }
         .serialize(serializer)
     }
@@ -154,9 +163,13 @@ impl<'de> serde::Deserialize<'de> for HardDriveImage {
                 disk.id
             )));
         }
-        let backing = match state.memory {
-            Some(image) => Backing::Memory(image),
-            None => Backing::File(
+        let backing = match (state.session, state.memory) {
+            (Some(image), None) => Backing::Session(image),
+            (Some(_), Some(_)) => {
+                return Err(serde::de::Error::custom("conflicting disk backings"))
+            }
+            (None, Some(image)) => Backing::Memory(image),
+            (None, None) => Backing::File(
                 OpenOptions::new()
                     .read(true)
                     .write(true)
@@ -285,7 +298,9 @@ fn build_rdsk_block(total_cyls: u32) -> Vec<u8> {
     put_be32(&mut b, 4, 64); // size in longs
     put_be32(&mut b, 12, 7); // host id
     put_be32(&mut b, 16, SECTOR_SIZE as u32);
-    put_be32(&mut b, 20, 0x17); // flags: last disk/LUN/ID
+    // This disk has one LUN, but other targets may follow it. LAST/LASTTID
+    // would tell the boot driver to stop before probing a slave or SCSI unit.
+    put_be32(&mut b, 20, 0x12); // LASTLUN | DISKID
     put_be32(&mut b, 24, !0); // bad-block list: none
     put_be32(&mut b, 28, 1); // partition list at sector 1
     put_be32(&mut b, 32, !0); // filesystem-header list: none
@@ -363,7 +378,7 @@ fn build_part_block(total_cyls: u32, dostype: u32, name: &[u8], boot_pri: i8) ->
 /// route. Deflate cannot be seeked, so a compressed image is read whole here
 /// and served from memory afterwards -- which is also why it is capped at
 /// [`MAX_GZIP_IMAGE_BYTES`].
-fn read_gzip_hardfile(path: &Path, bus_name: &str) -> anyhow::Result<Option<Vec<u8>>> {
+fn read_gzip_hardfile(path: &Path, bus_name: &str, limit: u64) -> anyhow::Result<Option<Vec<u8>>> {
     let mut file = File::open(path)
         .map_err(|e| anyhow::anyhow!("opening {bus_name} image {}: {e}", path.display()))?;
     let mut magic = [0u8; 2];
@@ -384,18 +399,18 @@ fn read_gzip_hardfile(path: &Path, bus_name: &str) -> anyhow::Result<Option<Vec<
     drop(file);
     let packed = std::fs::read(path)
         .map_err(|e| anyhow::anyhow!("reading {bus_name} image {}: {e}", path.display()))?;
-    let image = crate::gzip::inflate_members(&packed, Some(MAX_GZIP_IMAGE_BYTES)).map_err(|e| {
+    let image = crate::gzip::inflate_members(&packed, Some(limit)).map_err(|e| {
         anyhow::anyhow!(
             "decompressing gzip-compressed {bus_name} image {}: {e}",
             path.display()
         )
     })?;
-    if image.len() as u64 > MAX_GZIP_IMAGE_BYTES {
+    if image.len() as u64 > limit {
         anyhow::bail!(
             "gzip-compressed {bus_name} image {} unpacks to more than {} MiB, which does not \
              fit in memory as a whole disk; decompress it to a plain hardfile and attach that",
             path.display(),
-            MAX_GZIP_IMAGE_BYTES / (1 << 20)
+            limit / (1 << 20)
         );
     }
     Ok(Some(image))
@@ -519,13 +534,58 @@ impl HardDriveImage {
         boot_pri: i8,
         filesystem: crate::diskimage::FileSystem,
     ) -> anyhow::Result<Self> {
+        Self::open_inner(
+            path,
+            device_name,
+            bus_name,
+            volume_override,
+            boot_pri,
+            filesystem,
+            false,
+        )
+    }
+
+    /// Read a private session copy. Neither opening nor guest writes modify
+    /// the source. The shared base keeps rollback checkpoints small.
+    pub(crate) fn open_session(
+        path: &Path,
+        device_name: &str,
+        bus_name: &'static str,
+        volume_override: Option<&str>,
+        boot_pri: i8,
+        filesystem: crate::diskimage::FileSystem,
+    ) -> anyhow::Result<Self> {
+        Self::open_inner(
+            path,
+            device_name,
+            bus_name,
+            volume_override,
+            boot_pri,
+            filesystem,
+            true,
+        )
+    }
+
+    fn open_inner(
+        path: &Path,
+        device_name: &str,
+        bus_name: &'static str,
+        volume_override: Option<&str>,
+        boot_pri: i8,
+        filesystem: crate::diskimage::FileSystem,
+        session: bool,
+    ) -> anyhow::Result<Self> {
         let mut backing = if path.is_dir() {
             let volume = volume_override.map(str::to_string).unwrap_or_else(|| {
                 path.file_name()
                     .map(|n| n.to_string_lossy().into_owned())
                     .unwrap_or_default()
             });
-            let image = crate::dirfs::build_image(path, &volume, filesystem)?;
+            let image = if session {
+                crate::dirfs::build_image_limited(path, &volume, filesystem, 256 * 1024 * 1024)?
+            } else {
+                crate::dirfs::build_image(path, &volume, filesystem)?
+            };
             log::warn!(
                 "{bus_name}: {} mounted as an in-memory volume \"{volume}\" built from the \
                  directory; guest writes to it are NOT written back to the host and are lost \
@@ -541,7 +601,15 @@ impl HardDriveImage {
                     path.display()
                 );
             }
-            match read_gzip_hardfile(path, bus_name)? {
+            match read_gzip_hardfile(
+                path,
+                bus_name,
+                if session {
+                    256 * 1024 * 1024
+                } else {
+                    MAX_GZIP_IMAGE_BYTES
+                },
+            )? {
                 Some(image) => {
                     log::warn!(
                         "{bus_name}: {} is a gzip-compressed hardfile, unpacked into memory \
@@ -555,7 +623,7 @@ impl HardDriveImage {
                 None => Backing::File(
                     OpenOptions::new()
                         .read(true)
-                        .write(true)
+                        .write(!session)
                         .open(path)
                         .map_err(|e| {
                             anyhow::anyhow!("opening {bus_name} image {}: {e}", path.display())
@@ -569,6 +637,7 @@ impl HardDriveImage {
                 .map_err(|e| anyhow::anyhow!("stat {bus_name} image {}: {e}", path.display()))?
                 .len(),
             Backing::Memory(image) => image.len() as u64,
+            Backing::Session(_) => unreachable!("session backing is installed after validation"),
             #[cfg(not(target_arch = "wasm32"))]
             Backing::Device(device) => device.total_sectors() * SECTOR_SIZE as u64,
             #[cfg(not(target_arch = "wasm32"))]
@@ -584,6 +653,10 @@ impl HardDriveImage {
                 SECTOR_SIZE
             );
         }
+        anyhow::ensure!(
+            !session || len <= 256 * 1024 * 1024,
+            "netplay hard-drive images are limited to 256 MiB each"
+        );
 
         // Sniff the first sectors: a bare partition hardfile (filesystem boot
         // block at sector 0, no RDSK block in the first 16 sectors) gets a
@@ -596,6 +669,7 @@ impl HardDriveImage {
                 .read_exact(&mut head)
                 .map_err(|e| anyhow::anyhow!("reading {bus_name} image {}: {e}", path.display()))?,
             Backing::Memory(image) => head.copy_from_slice(&image[..sniff_len]),
+            Backing::Session(_) => unreachable!("session backing is installed after validation"),
             #[cfg(not(target_arch = "wasm32"))]
             Backing::Device(device) => {
                 for (lba, sector) in head.chunks_mut(SECTOR_SIZE).enumerate() {
@@ -660,8 +734,25 @@ impl HardDriveImage {
 
         let overlay_sectors = rdb_overlay.as_ref().map_or(0, |_| u64::from(CYL_SECTORS));
         let total_sectors = len / SECTOR_SIZE as u64 + overlay_sectors;
+        if session {
+            let bytes = match backing {
+                Backing::Memory(bytes) => bytes,
+                Backing::File(mut file) => {
+                    file.rewind()?;
+                    let mut bytes = vec![0; len as usize];
+                    file.read_exact(&mut bytes)?;
+                    bytes
+                }
+                _ => unreachable!("only image files and directories are session sources"),
+            };
+            backing = Backing::Session(SessionImage::new(bytes, false));
+        }
         Ok(Self {
-            path: path.to_path_buf(),
+            path: if session {
+                PathBuf::from("netplay-disk")
+            } else {
+                path.to_path_buf()
+            },
             backing,
             total_sectors,
             rdb_overlay,
@@ -672,6 +763,12 @@ impl HardDriveImage {
 
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    pub(crate) fn set_session_read_only(&mut self, read_only: bool) {
+        if let Backing::Session(image) = &mut self.backing {
+            image.set_read_only(read_only);
+        }
     }
 
     /// Whether this drive is a real disk of the host's rather than an image.
@@ -721,6 +818,7 @@ impl HardDriveImage {
                 buf[..SECTOR_SIZE].copy_from_slice(&image[off..off + SECTOR_SIZE]);
                 Ok(())
             }
+            Backing::Session(image) => image.read(file_lba, buf),
             #[cfg(not(target_arch = "wasm32"))]
             Backing::Device(device) => device.read_sector(file_lba, buf),
             #[cfg(not(target_arch = "wasm32"))]
@@ -731,6 +829,12 @@ impl HardDriveImage {
     }
 
     pub fn write_sector(&mut self, lba: u64, buf: &[u8]) -> std::io::Result<()> {
+        if matches!(&self.backing, Backing::Session(image) if image.read_only()) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "session disk is read-only",
+            ));
+        }
         if let Some(overlay) = &mut self.rdb_overlay {
             if lba < u64::from(CYL_SECTORS) {
                 if !self.overlay_write_warned {
@@ -758,6 +862,7 @@ impl HardDriveImage {
                 image[off..off + SECTOR_SIZE].copy_from_slice(&buf[..SECTOR_SIZE]);
                 Ok(())
             }
+            Backing::Session(image) => image.write(file_lba, buf),
             #[cfg(not(target_arch = "wasm32"))]
             Backing::Device(device) => device.write_sector(file_lba, buf),
             #[cfg(not(target_arch = "wasm32"))]
@@ -877,6 +982,47 @@ mod tests {
         assert_eq!(&sector[..4], b"MARK");
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn synthesized_rdb_keeps_later_targets_discoverable() {
+        let rdsk = build_rdsk_block(3);
+        assert_eq!(u32::from_be_bytes(rdsk[20..24].try_into().unwrap()) & 5, 0);
+        assert_eq!(
+            rdsk.chunks_exact(4).fold(0u32, |sum, word| {
+                sum.wrapping_add(u32::from_be_bytes(word.try_into().unwrap()))
+            }),
+            0
+        );
+    }
+
+    #[test]
+    fn session_disk_rolls_back_writes_without_reopening_or_changing_its_source() {
+        let bytes = bare_partition_bytes(2);
+        let path = temp_image("session.hdf", &bytes);
+        let mut original = HardDriveImage::open_session(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
+        let lba = u64::from(CYL_SECTORS) + 3;
+        original.write_sector(lba, &[0xA5; SECTOR_SIZE]).unwrap();
+        let encoded = bincode::serialize(&original).unwrap();
+        original.write_sector(lba, &[0x5A; SECTOR_SIZE]).unwrap();
+        original.flush().unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), bytes);
+        std::fs::remove_file(&path).unwrap();
+        let mut restored: HardDriveImage = bincode::deserialize(&encoded).unwrap();
+        let mut sector = [0; SECTOR_SIZE];
+        restored.read_sector(lba, &mut sector).unwrap();
+        assert_eq!(sector, [0xA5; SECTOR_SIZE]);
+        restored.set_session_read_only(true);
+        assert!(restored.write_sector(0, &[0; SECTOR_SIZE]).is_err());
+        assert!(restored.write_sector(lba, &[0; SECTOR_SIZE]).is_err());
     }
 
     #[test]
@@ -1067,6 +1213,7 @@ mod tests {
     fn serde_defers_physical_disk_acquisition() {
         let state = HardDriveImageState {
             path: PathBuf::from("/dev/definitely-not-opened"),
+            session: None,
             memory: None,
             total_sectors: 1234,
             rdb_overlay: None,

--- a/src/harddrive/session.rs
+++ b/src/harddrive/session.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Session disks share immutable sectors; rollback records only writes.
+//! The base identifier resolves only within this process. These references
+//! are for local rollback checkpoints, never a network media format.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+use serde::{Deserialize, Serialize};
+
+type Bases = BTreeMap<[u8; 32], Weak<Vec<u8>>>;
+
+fn bases() -> &'static Mutex<Bases> {
+    static BASES: OnceLock<Mutex<Bases>> = OnceLock::new();
+    BASES.get_or_init(Mutex::default)
+}
+
+#[derive(Clone)]
+pub(super) struct SessionImage {
+    base: Arc<Vec<u8>>,
+    id: [u8; 32],
+    writes: BTreeMap<u64, Vec<u8>>,
+    read_only: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct State {
+    id: [u8; 32],
+    writes: BTreeMap<u64, Vec<u8>>,
+    read_only: bool,
+}
+
+impl Serialize for SessionImage {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        State {
+            id: self.id,
+            writes: self.writes.clone(),
+            read_only: self.read_only,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SessionImage {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let state = State::deserialize(deserializer)?;
+        let base = bases()
+            .lock()
+            .unwrap()
+            .get(&state.id)
+            .and_then(Weak::upgrade)
+            .ok_or_else(|| {
+                serde::de::Error::custom("netplay disk is no longer available in this process")
+            })?;
+        if state.writes.iter().any(|(&sector, bytes)| {
+            sector >= (base.len() / super::SECTOR_SIZE) as u64 || bytes.len() != super::SECTOR_SIZE
+        }) {
+            return Err(serde::de::Error::custom("invalid netplay disk sector"));
+        }
+        Ok(Self {
+            base,
+            id: state.id,
+            writes: state.writes,
+            read_only: state.read_only,
+        })
+    }
+}
+
+impl SessionImage {
+    pub(super) fn read_only(&self) -> bool {
+        self.read_only
+    }
+    pub(super) fn set_read_only(&mut self, value: bool) {
+        self.read_only = value;
+    }
+    pub(super) fn new(bytes: Vec<u8>, read_only: bool) -> Self {
+        let id = crate::netplay::digest(&bytes);
+        let mut bases = bases().lock().unwrap();
+        bases.retain(|_, base| base.strong_count() != 0);
+        let base = bases
+            .get(&id)
+            .and_then(Weak::upgrade)
+            .unwrap_or_else(|| Arc::new(bytes));
+        bases.insert(id, Arc::downgrade(&base));
+        Self {
+            base,
+            id,
+            writes: BTreeMap::new(),
+            read_only,
+        }
+    }
+
+    pub(super) fn read(&self, sector: u64, out: &mut [u8]) -> std::io::Result<()> {
+        let offset = self.offset(sector)?;
+        let data = self
+            .writes
+            .get(&sector)
+            .map(Vec::as_slice)
+            .unwrap_or(&self.base[offset..offset + super::SECTOR_SIZE]);
+        out[..super::SECTOR_SIZE].copy_from_slice(data);
+        Ok(())
+    }
+
+    pub(super) fn write(&mut self, sector: u64, data: &[u8]) -> std::io::Result<()> {
+        let offset = self.offset(sector)?;
+        if self.read_only {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "session disk is read-only",
+            ));
+        }
+        let data = &data[..super::SECTOR_SIZE];
+        if data == &self.base[offset..offset + super::SECTOR_SIZE] {
+            self.writes.remove(&sector);
+        } else {
+            self.writes.insert(sector, data.to_vec());
+        }
+        Ok(())
+    }
+
+    fn offset(&self, sector: u64) -> std::io::Result<usize> {
+        if sector >= (self.base.len() / super::SECTOR_SIZE) as u64 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "sector outside session disk",
+            ));
+        }
+        Ok(sector as usize * super::SECTOR_SIZE)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checkpoint_restores_writes_without_copying_the_disk() {
+        let mut disk = SessionImage::new(vec![0; 8 * 1024 * 1024], false);
+        disk.write(3, &[7; 512]).unwrap();
+        let checkpoint = bincode::serialize(&disk).unwrap();
+        assert!(checkpoint.len() < 1024);
+        disk.write(3, &[8; 512]).unwrap();
+        let restored: SessionImage = bincode::deserialize(&checkpoint).unwrap();
+        assert!(Arc::ptr_eq(&disk.base, &restored.base));
+        let mut data = [0; 512];
+        restored.read(3, &mut data).unwrap();
+        assert_eq!(data, [7; 512]);
+        disk.read(3, &mut data).unwrap();
+        assert_eq!(data, [8; 512]);
+        disk.write(3, &[0; 512]).unwrap();
+        assert!(disk.writes.is_empty());
+    }
+
+    #[test]
+    fn disk_protection_and_bounds_survive_restore() {
+        let disk = SessionImage::new(vec![1; 512], true);
+        let mut restored: SessionImage =
+            bincode::deserialize(&bincode::serialize(&disk).unwrap()).unwrap();
+        assert!(restored.write(0, &[0; 512]).is_err());
+        assert!(restored.read(u64::MAX, &mut [0; 512]).is_err());
+        assert!(restored.write(u64::MAX, &[0; 512]).is_err());
+    }
+}

--- a/src/harddrive/session.rs
+++ b/src/harddrive/session.rs
@@ -25,9 +25,9 @@ pub(super) struct SessionImage {
 }
 
 #[derive(Serialize, Deserialize)]
-struct State {
+struct State<W = BTreeMap<u64, Vec<u8>>> {
     id: [u8; 32],
-    writes: BTreeMap<u64, Vec<u8>>,
+    writes: W,
     read_only: bool,
 }
 
@@ -35,7 +35,7 @@ impl Serialize for SessionImage {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         State {
             id: self.id,
-            writes: self.writes.clone(),
+            writes: &self.writes,
             read_only: self.read_only,
         }
         .serialize(serializer)
@@ -44,7 +44,7 @@ impl Serialize for SessionImage {
 
 impl<'de> Deserialize<'de> for SessionImage {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let state = State::deserialize(deserializer)?;
+        let state: State = State::deserialize(deserializer)?;
         let base = bases()
             .lock()
             .unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -693,6 +693,9 @@ fn main() -> Result<()> {
         for target in ["iroh", "noq", "netwatch", "tracing::span"] {
             log_builder.filter_module(target, netplay_level);
         }
+        if copperline::envcfg::flag("COPPERLINE_NETPLAY_DEBUG") {
+            log_builder.filter_module("copperline::netplay", log::LevelFilter::Debug);
+        }
     }
     log_builder.init();
 
@@ -785,12 +788,30 @@ fn main() -> Result<()> {
         )?);
     }
 
-    let (cfg, mut raw_cfg) = load_config(cli.config_path.as_deref(), &cli.overrides, cli.factory)?;
+    let netplay_guest = cli
+        .netplay
+        .as_ref()
+        .is_some_and(|options| options.settings().player == 1);
+    let (cfg, mut raw_cfg) = if netplay_guest {
+        (
+            Config::default(),
+            load_raw_config(cli.config_path.as_deref(), &cli.overrides, cli.factory)?,
+        )
+    } else {
+        load_config(cli.config_path.as_deref(), &cli.overrides, cli.factory)?
+    };
     if let Some(p) = &cli.rom_path {
         raw_cfg.rom = Some(p.to_string_lossy().into_owned());
     }
 
-    let mut cfg = cfg.with_rom_override(cli.rom_path.clone());
+    let mut cfg = if netplay_guest {
+        cfg
+    } else {
+        cfg.with_rom_override(cli.rom_path.clone())
+    };
+    if netplay_guest {
+        cfg.serial.mode = copperline::config::SerialMode::Off;
+    }
     let uss = cli
         .load_uss
         .as_ref()
@@ -808,13 +829,19 @@ fn main() -> Result<()> {
     // An explicit --run outranks a game remembered in [whdload]: the two
     // stage competing boot volumes (--run with --whdload itself is already
     // a validation error).
-    let config_game = if (cli.run.is_some() || uss.is_some()) && config_game.is_some() {
-        info!("ignoring the configured [whdload] game for this session");
-        None
-    } else {
-        config_game
-    };
-    if let Some(game) = cli.whdload.clone().or(config_game) {
+    let config_game =
+        if (netplay_guest || cli.run.is_some() || uss.is_some()) && config_game.is_some() {
+            info!("ignoring the configured [whdload] game for this session");
+            None
+        } else {
+            config_game
+        };
+    if let Some(game) = cli
+        .whdload
+        .clone()
+        .or(config_game)
+        .filter(|_| !netplay_guest)
+    {
         let prepared = copperline::whdload::prepare(&game, &whdload_options)?;
         // Derive on a clone: the session keeps the user's own raw config
         // (plus the game itself), so a launcher opened later edits -- and
@@ -825,12 +852,16 @@ fn main() -> Result<()> {
         cfg = Config::try_from(derived)?;
         copperline::whdload::remember_game(&mut raw_cfg, &game);
         info!(
-            "whdload: booting {} ({}) from {}, saves persist in {}",
+            "whdload: booting {} ({}) from {}",
             prepared.slave_rel.display(),
             prepared.slave.name.as_deref().unwrap_or("unnamed slave"),
-            game.display(),
-            prepared.game_dir.display()
+            game.display()
         );
+        if cli.netplay.is_none() {
+            info!("whdload: saves persist in {}", prepared.game_dir.display());
+        } else {
+            info!("whdload: netplay saves last for this session only");
+        }
     }
     // Warp launch: stage the minimal boot volume around the executable and
     // mount its directory. Same derive-on-a-clone discipline as WHDLoad so
@@ -839,7 +870,7 @@ fn main() -> Result<()> {
     // configuration and CLI flags say.
     let mut run_prog_name: Option<String> = None;
     let mut run_warp: Option<copperline::runprog::WarpLaunch> = None;
-    if let Some(program) = &cli.run {
+    if let Some(program) = cli.run.as_ref().filter(|_| !netplay_guest) {
         let prepared = copperline::runprog::prepare_with_options(
             program,
             cli.run_args.as_deref(),
@@ -890,7 +921,10 @@ fn main() -> Result<()> {
              storage-idle heuristic or the fixed timestamp"
         ));
     }
-    if cli.load_state.is_some() {
+    if cli.netplay.is_some() {
+        copperline::netplay::prepare_config(&mut cfg)?;
+    }
+    if cli.load_state.is_some() || netplay_guest {
         // A save state restores the full ROM image, so a Kickstart file is not
         // required to load one. Still resolve the bundled-AROS sentinel when
         // AROS is installed (best effort, so the banner and any post-load reuse
@@ -900,10 +934,11 @@ fn main() -> Result<()> {
     } else {
         config::resolve_bundled_rom(&mut cfg)?;
     }
-    let mut disk_insert_after = resolve_disk_insert_after(&mut cfg, cli.disk_insert_after)?;
-    if cli.netplay.is_some() {
-        copperline::netplay::prepare_config(&mut cfg)?;
-    }
+    let mut disk_insert_after = if netplay_guest {
+        Vec::new()
+    } else {
+        resolve_disk_insert_after(&mut cfg, cli.disk_insert_after)?
+    };
 
     // Name the boot ROM in the banner: a Kickstart image is identified by
     // checksum (src/romdb.rs), so the log says which Kickstart is booting
@@ -994,7 +1029,12 @@ fn main() -> Result<()> {
         info!("emulation timing: paced to wall-clock because a physical floppy drive is attached");
     }
     info!("emulation timing: deterministic core, paced={paced}");
-    let mut emu = emulator::build_machine(&cfg, audio, paced, cli.load_state.is_some())?;
+    let mut emu = emulator::build_machine(
+        &cfg,
+        audio,
+        paced,
+        cli.load_state.is_some() || netplay_guest,
+    )?;
     if let Some(uss) = &uss {
         uss.load(&mut emu)?;
     }
@@ -1110,7 +1150,11 @@ fn main() -> Result<()> {
     // The warp-launch gate belongs to interactive sessions only: a capture
     // run is already unpaced end to end and must never be re-paced when the
     // program loads.
-    let run_warp_target = if headless_capture { None } else { run_warp };
+    let run_warp_target = if headless_capture || cli.netplay.is_some() {
+        None
+    } else {
+        run_warp
+    };
     // The general warp-boot gate: interactive sessions only, same rule as
     // the --run gate above (a capture run is already unpaced end to end).
     let warp_boot_gate = if headless_capture {
@@ -1123,7 +1167,11 @@ fn main() -> Result<()> {
         )
     };
     let netplay = if let Some(options) = cli.netplay {
-        for disk in disk_insert_after.drain(..) {
+        let (boot, later): (Vec<_>, Vec<_>) = std::mem::take(&mut disk_insert_after)
+            .into_iter()
+            .partition(|disk| disk.secs == 0.0);
+        disk_insert_after = later;
+        for disk in boot {
             emu.bus_mut().floppy.insert_disk_image(
                 disk.drive_idx,
                 disk.path,
@@ -2568,6 +2616,29 @@ mod netplay_cli_tests {
     }
 
     #[test]
+    fn netplay_host_accepts_boot_packages_and_scheduled_floppy_swaps() -> Result<()> {
+        for extra in [
+            vec!["--run", "program"],
+            vec!["--whdload", "game.lha"],
+            vec!["--insert-disk-after", "3", "df3", "disk.adf"],
+        ] {
+            args(&extra)?;
+        }
+        for when in ["0", "3"] {
+            assert!(args(&[
+                "--netplay-player",
+                "2",
+                "--insert-disk-after",
+                when,
+                "df0",
+                "disk.adf",
+            ])
+            .is_err());
+        }
+        Ok(())
+    }
+
+    #[test]
     fn netplay_rejects_incomplete_invalid_and_unilateral_operations() {
         assert!(parse_args_from(["--netplay-delay".to_string(), "2".to_string()]).is_err());
         for extra in [
@@ -2579,12 +2650,9 @@ mod netplay_cli_tests {
             vec!["--netplay-session", "bad"],
             vec!["--netplay-peer", "0.0.0.0:19732"],
             vec!["--load-state", "saved.clstate"],
-            vec!["--run", "program"],
-            vec!["--whdload", "game.lha"],
             vec!["--warp-boot"],
             vec!["--control", ":1234"],
             vec!["--audio-wav", "/tmp/netplay.wav"],
-            vec!["--insert-disk-after", "1", "df0", "disk.adf"],
             vec!["--joy-after", "1", "red", "100", "2"],
             vec!["--mouse-after", "1", "3", "4"],
         ] {

--- a/src/main.rs
+++ b/src/main.rs
@@ -793,10 +793,8 @@ fn main() -> Result<()> {
         .as_ref()
         .is_some_and(|options| options.settings().player == 1);
     let (cfg, mut raw_cfg) = if netplay_guest {
-        (
-            Config::default(),
-            load_raw_config(cli.config_path.as_deref(), &cli.overrides, cli.factory)?,
-        )
+        let raw = load_raw_config(cli.config_path.as_deref(), &cli.overrides, cli.factory)?;
+        (copperline::netplay::guest_config(&raw)?, raw)
     } else {
         load_config(cli.config_path.as_deref(), &cli.overrides, cli.factory)?
     };

--- a/src/netplay/control.rs
+++ b/src/netplay/control.rs
@@ -25,7 +25,7 @@ pub(super) struct Control<T> {
     player: usize,
     next_send: u64,
     next_receive: u64,
-    sending: VecDeque<Vec<u8>>,
+    sending: VecDeque<VecDeque<Vec<u8>>>,
     send_offset: usize,
     outgoing: BTreeMap<u64, Outgoing>,
     incoming: BTreeMap<u64, Vec<u8>>,
@@ -57,13 +57,21 @@ impl<T: Transport> Control<T> {
     }
 
     pub fn send_message(&mut self, bytes: Vec<u8>) -> Result<()> {
+        self.send_parts(vec![bytes])
+    }
+
+    /// Take ownership of each media buffer, copying only packet-sized chunks.
+    pub fn send_parts(&mut self, parts: Vec<Vec<u8>>) -> Result<()> {
+        let len = parts
+            .iter()
+            .try_fold(0usize, |len, part| len.checked_add(part.len()))
+            .context("netplay control message length overflow")?;
         ensure!(
-            bytes.len() <= super::setup::MAX_BUNDLE + 1 && self.sending.len() < 4,
+            len > 0 && len <= super::setup::MAX_BUNDLE + 1 && self.sending.len() < 4,
             "netplay control send queue is full"
         );
-        let mut framed = Vec::with_capacity(bytes.len() + 4);
-        framed.extend((bytes.len() as u32).to_le_bytes());
-        framed.extend(bytes);
+        let mut framed = VecDeque::from([(len as u32).to_le_bytes().to_vec()]);
+        framed.extend(parts.into_iter().filter(|part| !part.is_empty()));
         self.sending.push_back(framed);
         Ok(())
     }
@@ -165,11 +173,12 @@ impl<T: Transport> Control<T> {
             .first_key_value()
             .map_or(self.next_send, |(&n, _)| n);
         while self.next_send - base < WINDOW {
-            let Some(message) = self.sending.front() else {
+            let Some(message) = self.sending.front_mut() else {
                 break;
             };
-            let end = (self.send_offset + CHUNK).min(message.len());
-            let chunk = message[self.send_offset..end].to_vec();
+            let part = message.front().unwrap();
+            let end = (self.send_offset + CHUNK).min(part.len());
+            let chunk = part[self.send_offset..end].to_vec();
             self.outgoing.insert(
                 self.next_send,
                 Outgoing {
@@ -182,8 +191,11 @@ impl<T: Transport> Control<T> {
                 .checked_add(1)
                 .context("setup sequence exhausted")?;
             self.send_offset = end;
-            if end == message.len() {
-                self.sending.pop_front();
+            if end == part.len() {
+                message.pop_front();
+                if message.is_empty() {
+                    self.sending.pop_front();
+                }
                 self.send_offset = 0;
             }
         }
@@ -229,6 +241,16 @@ impl<T: Transport> Control<T> {
         while !bytes.is_empty() {
             let target = self.expected.unwrap_or(4);
             let take = (target - self.assembling.len()).min(bytes.len());
+            if self.assembling.len() + take > self.assembling.capacity() {
+                let capacity = self
+                    .assembling
+                    .capacity()
+                    .max(CHUNK)
+                    .saturating_mul(2)
+                    .min(target);
+                self.assembling
+                    .reserve_exact(capacity - self.assembling.len());
+            }
             self.assembling.extend_from_slice(&bytes[..take]);
             bytes = &bytes[take..];
             if self.assembling.len() != target {
@@ -240,6 +262,8 @@ impl<T: Transport> Control<T> {
                     len <= super::setup::MAX_BUNDLE + 1 && len > 0,
                     "invalid setup message length"
                 );
+                // Grow only as data arrives, capped at the validated length.
+                // A near-limit message type byte must not double allocation.
                 self.assembling.clear();
                 self.expected = Some(len);
             } else {
@@ -288,12 +312,38 @@ impl<T: Transport> Transport for Control<T> {
 mod tests {
     use super::*;
     use crate::netplay::PacketQueue;
+
+    #[test]
+    fn receive_allocation_grows_with_data_and_stays_within_message_length() -> Result<()> {
+        let mut control = Control::new(PacketQueue::default(), [3; 16], 0);
+        let limit = (super::super::setup::MAX_BUNDLE + 1) as u32;
+        control.assemble(&limit.to_le_bytes())?;
+        control.assemble(&[1])?;
+        assert!(control.assembling.capacity() <= 2 * CHUNK);
+
+        let mut control = Control::new(PacketQueue::default(), [3; 16], 0);
+        let len = CHUNK * 3 + 1;
+        control.assemble(&(len as u32).to_le_bytes())?;
+        for chunk in vec![7; len].chunks(CHUNK) {
+            control.assemble(chunk)?;
+            assert!(control.assembling.capacity() <= len);
+        }
+        let message = control.take_message().unwrap();
+        assert_eq!(message, vec![7; len]);
+        assert!(message.capacity() <= len);
+        Ok(())
+    }
+
     #[test]
     fn transfer_survives_loss_reordering_duplicates_and_backpressure() -> Result<()> {
         let mut a = Control::new(PacketQueue::default(), [3; 16], 0);
         let mut b = Control::new(PacketQueue::default(), [3; 16], 1);
         let payload: Vec<_> = (0..120_000).map(|n| (n % 251) as u8).collect();
-        a.send_message(payload.clone())?;
+        a.send_parts(vec![
+            payload[..123].to_vec(),
+            vec![],
+            payload[123..].to_vec(),
+        ])?;
         b.send_message(b"reply".to_vec())?;
         let mut now = Instant::now();
         let mut received = None;

--- a/src/netplay/control.rs
+++ b/src/netplay/control.rs
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Bounded reliable messages beside the input datagrams, over either native
+//! transport. Selective repeat uses the same socket and peer as netplay.
+
+use super::{Transport, MAX_PACKET};
+use crate::timebase::{Duration, Instant};
+use anyhow::{ensure, Result};
+use std::collections::{BTreeMap, VecDeque};
+
+const MAGIC: &[u8; 4] = b"CLNC";
+const HEADER: usize = 4 + 1 + 16 + 1 + 8 + 8 + 4 + 1;
+const CHUNK: usize = MAX_PACKET - HEADER;
+const WINDOW: u64 = 32;
+const RESEND: Duration = Duration::from_millis(200);
+
+struct Outgoing {
+    bytes: Vec<u8>,
+    sent: Option<Instant>,
+}
+
+pub(super) struct Control<T> {
+    pub inner: T,
+    session: [u8; 16],
+    player: usize,
+    next_send: u64,
+    next_receive: u64,
+    sending: VecDeque<Vec<u8>>,
+    send_offset: usize,
+    outgoing: BTreeMap<u64, Outgoing>,
+    incoming: BTreeMap<u64, Vec<u8>>,
+    assembling: Vec<u8>,
+    expected: Option<usize>,
+    messages: VecDeque<Vec<u8>>,
+    game: VecDeque<Vec<u8>>,
+    ack_pending: bool,
+}
+
+impl<T: Transport> Control<T> {
+    pub fn new(inner: T, session: [u8; 16], player: usize) -> Self {
+        Self {
+            inner,
+            session,
+            player,
+            next_send: 0,
+            next_receive: 0,
+            sending: VecDeque::new(),
+            send_offset: 0,
+            outgoing: BTreeMap::new(),
+            incoming: BTreeMap::new(),
+            assembling: Vec::new(),
+            expected: None,
+            messages: VecDeque::new(),
+            game: VecDeque::new(),
+            ack_pending: false,
+        }
+    }
+
+    pub fn send_message(&mut self, bytes: Vec<u8>) -> Result<()> {
+        ensure!(
+            bytes.len() <= super::setup::MAX_BUNDLE + 1 && self.sending.len() < 4,
+            "netplay control send queue is full"
+        );
+        let mut framed = Vec::with_capacity(bytes.len() + 4);
+        framed.extend((bytes.len() as u32).to_le_bytes());
+        framed.extend(bytes);
+        self.sending.push_back(framed);
+        Ok(())
+    }
+
+    pub fn take_message(&mut self) -> Option<Vec<u8>> {
+        self.messages.pop_front()
+    }
+    pub fn sending(&self) -> bool {
+        !self.sending.is_empty() || !self.outgoing.is_empty()
+    }
+    pub fn has_game_packets(&self) -> bool {
+        self.game.iter().any(|bytes| {
+            super::wire::Packet::decode(bytes).is_some_and(|packet| packet.session == self.session)
+        })
+    }
+    pub fn received_bytes(&self) -> usize {
+        self.assembling.len()
+    }
+
+    pub fn poll(&mut self) -> Result<()> {
+        self.poll_at(Instant::now())
+    }
+
+    fn poll_at(&mut self, now: Instant) -> Result<()> {
+        if !self.inner.ready()? {
+            return Ok(());
+        }
+        let mut buffer = [0; MAX_PACKET + 1];
+        for _ in 0..128 {
+            let Some(len) = self.inner.receive(&mut buffer)? else {
+                break;
+            };
+            let Some(bytes) = buffer.get(..len) else {
+                continue;
+            };
+            if !bytes.starts_with(MAGIC) {
+                super::wire::Packet::check_version(bytes, &self.session)?;
+                if self.game.len() < 64 && !bytes.is_empty() {
+                    self.game.push_back(bytes.to_vec());
+                }
+                continue;
+            }
+            if bytes.len() < HEADER || bytes.len() > MAX_PACKET || bytes[5..21] != self.session {
+                continue;
+            }
+            ensure!(
+                bytes[4] == 1,
+                "incompatible desktop setup protocol; use the same build"
+            );
+            ensure!(
+                usize::from(bytes[21]) == 1 - self.player,
+                "netplay peers must use opposite player roles"
+            );
+            let seq = u64::from_le_bytes(bytes[22..30].try_into()?);
+            let ack = u64::from_le_bytes(bytes[30..38].try_into()?);
+            let mask = u32::from_le_bytes(bytes[38..42].try_into()?);
+            ensure!(ack <= self.next_send, "peer acknowledged unsent setup data");
+            self.outgoing
+                .retain(|&n, _| n >= ack && (n - ack >= WINDOW || mask & (1 << (n - ack)) == 0));
+            if bytes[42] == 0 {
+                ensure!(bytes.len() == HEADER, "invalid setup acknowledgement");
+                continue;
+            }
+            ensure!(
+                bytes[42] == 1 && bytes.len() > HEADER,
+                "invalid setup data packet"
+            );
+            self.ack_pending = true;
+            if seq < self.next_receive {
+                continue;
+            }
+            ensure!(
+                seq - self.next_receive < WINDOW,
+                "setup data exceeds receive window"
+            );
+            if let Some(previous) = self.incoming.get(&seq) {
+                ensure!(
+                    previous.as_slice() == &bytes[HEADER..],
+                    "peer changed pending setup data"
+                );
+            } else {
+                self.incoming.insert(seq, bytes[HEADER..].to_vec());
+            }
+            while let Some(chunk) = self.incoming.remove(&self.next_receive) {
+                self.next_receive = self
+                    .next_receive
+                    .checked_add(1)
+                    .context("setup sequence exhausted")?;
+                self.assemble(&chunk)?;
+            }
+        }
+        if self.ack_pending && self.inner.send(&self.packet(0, &[]))? {
+            self.ack_pending = false;
+        }
+        // Keep the window anchored at the oldest unacknowledged sequence,
+        // including selectively acknowledged packets after a missing chunk.
+        let base = self
+            .outgoing
+            .first_key_value()
+            .map_or(self.next_send, |(&n, _)| n);
+        while self.next_send - base < WINDOW {
+            let Some(message) = self.sending.front() else {
+                break;
+            };
+            let end = (self.send_offset + CHUNK).min(message.len());
+            let chunk = message[self.send_offset..end].to_vec();
+            self.outgoing.insert(
+                self.next_send,
+                Outgoing {
+                    bytes: chunk,
+                    sent: None,
+                },
+            );
+            self.next_send = self
+                .next_send
+                .checked_add(1)
+                .context("setup sequence exhausted")?;
+            self.send_offset = end;
+            if end == message.len() {
+                self.sending.pop_front();
+                self.send_offset = 0;
+            }
+        }
+        let due: Vec<_> = self
+            .outgoing
+            .iter()
+            .filter(|(_, packet)| {
+                packet
+                    .sent
+                    .is_none_or(|sent| now.duration_since(sent) >= RESEND)
+            })
+            .map(|(&seq, _)| seq)
+            .collect();
+        for seq in due {
+            let packet = self.packet(seq, &self.outgoing[&seq].bytes);
+            if !self.inner.send(&packet)? {
+                break;
+            }
+            self.outgoing.get_mut(&seq).unwrap().sent = Some(now);
+        }
+        Ok(())
+    }
+
+    fn packet(&self, sequence: u64, payload: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(HEADER + payload.len());
+        bytes.extend(MAGIC);
+        bytes.push(1);
+        bytes.extend(self.session);
+        bytes.push(self.player as u8);
+        bytes.extend(sequence.to_le_bytes());
+        bytes.extend(self.next_receive.to_le_bytes());
+        let mask = self
+            .incoming
+            .keys()
+            .fold(0u32, |mask, n| mask | (1 << (n - self.next_receive)));
+        bytes.extend(mask.to_le_bytes());
+        bytes.push(u8::from(!payload.is_empty()));
+        bytes.extend(payload);
+        bytes
+    }
+
+    fn assemble(&mut self, mut bytes: &[u8]) -> Result<()> {
+        while !bytes.is_empty() {
+            let target = self.expected.unwrap_or(4);
+            let take = (target - self.assembling.len()).min(bytes.len());
+            self.assembling.extend_from_slice(&bytes[..take]);
+            bytes = &bytes[take..];
+            if self.assembling.len() != target {
+                continue;
+            }
+            if self.expected.is_none() {
+                let len = u32::from_le_bytes(self.assembling[..4].try_into()?) as usize;
+                ensure!(
+                    len <= super::setup::MAX_BUNDLE + 1 && len > 0,
+                    "invalid setup message length"
+                );
+                self.assembling.clear();
+                self.expected = Some(len);
+            } else {
+                ensure!(
+                    self.messages.len() < 4,
+                    "netplay control receive queue is full"
+                );
+                self.messages
+                    .push_back(std::mem::take(&mut self.assembling));
+                self.expected = None;
+            }
+        }
+        Ok(())
+    }
+}
+
+use anyhow::Context;
+
+impl<T: Transport> Transport for Control<T> {
+    fn route(&self) -> &'static str {
+        self.inner.route()
+    }
+    fn ready(&mut self) -> Result<bool> {
+        // A disconnect can follow the last input/ack in the same poll. Let
+        // the timeline consume those packets before surfacing the close.
+        if self.game.is_empty() {
+            self.inner.ready()
+        } else {
+            Ok(true)
+        }
+    }
+    fn receive(&mut self, buffer: &mut [u8]) -> Result<Option<usize>> {
+        let Some(bytes) = self.game.pop_front() else {
+            return Ok(None);
+        };
+        ensure!(bytes.len() <= buffer.len(), "input packet too large");
+        buffer[..bytes.len()].copy_from_slice(&bytes);
+        Ok(Some(bytes.len()))
+    }
+    fn send(&mut self, packet: &[u8]) -> Result<bool> {
+        self.inner.send(packet)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::netplay::PacketQueue;
+    #[test]
+    fn transfer_survives_loss_reordering_duplicates_and_backpressure() -> Result<()> {
+        let mut a = Control::new(PacketQueue::default(), [3; 16], 0);
+        let mut b = Control::new(PacketQueue::default(), [3; 16], 1);
+        let payload: Vec<_> = (0..120_000).map(|n| (n % 251) as u8).collect();
+        a.send_message(payload.clone())?;
+        b.send_message(b"reply".to_vec())?;
+        let mut now = Instant::now();
+        let mut received = None;
+        let mut reply = None;
+        for tick in 0..500 {
+            a.poll_at(now)?;
+            b.poll_at(now)?;
+            for reverse in [false, true] {
+                let (from, to) = if reverse {
+                    (&mut a.inner, &mut b.inner)
+                } else {
+                    (&mut b.inner, &mut a.inner)
+                };
+                let mut packets = Vec::new();
+                while let Some(packet) = from.pop() {
+                    packets.push(packet);
+                }
+                for (i, packet) in packets.into_iter().rev().enumerate() {
+                    if (tick + i) % 7 != 0 {
+                        to.push(&packet)?;
+                        if i % 5 == 0 {
+                            to.push(&packet)?;
+                        }
+                    }
+                }
+            }
+            if let Some(message) = a.take_message() {
+                ensure!(reply.is_none(), "duplicate delivery");
+                reply = Some(message);
+            }
+            if let Some(message) = b.take_message() {
+                ensure!(received.is_none(), "duplicate delivery");
+                received = Some(message);
+            }
+            now += Duration::from_millis(50);
+            if received.is_some() && reply.is_some() && !a.sending() && !b.sending() {
+                break;
+            }
+        }
+        assert_eq!(received, Some(payload));
+        assert_eq!(reply, Some(b"reply".to_vec()));
+        assert!(!a.sending() && !b.sending());
+        Ok(())
+    }
+}

--- a/src/netplay/desktop.rs
+++ b/src/netplay/desktop.rs
@@ -187,7 +187,7 @@ pub struct Session {
     pub(super) connection: Connection<Control<NativeTransport>>,
     options: ConnectionOptions,
     phase: Phase,
-    bundle: Option<Vec<u8>>,
+    bundle: Option<Vec<Vec<u8>>>,
     directory: Option<tempfile::TempDir>,
     changed_config: Option<Config>,
     started: Instant,
@@ -216,7 +216,7 @@ impl Session {
         // or moving its output sink. The host also uses the transmitted setup.
         let staged = if settings.player == 0 {
             let bundle = Bundle::capture(cfg, emu)?;
-            Some((bundle.stage()?, bundle.encode()?))
+            Some((bundle.stage()?, bundle.into_parts()?))
         } else {
             None
         };
@@ -571,11 +571,13 @@ impl Session {
             }
             if self.phase == Phase::GuestBundle {
                 ensure!(bytes.first() == Some(&2), "expected host setup bundle");
+                let bundle = Bundle::decode(&bytes[1..])?;
+                drop(bytes);
                 let Staged {
                     emu: mut received,
                     cfg,
                     directory,
-                } = Bundle::decode(&bytes[1..])?.stage()?;
+                } = bundle.stage()?;
                 // Reuse the same validation as initial session construction.
                 self.connection.identity =
                     initial_identity(&self.connection.settings, &mut received, &cfg)?;
@@ -615,9 +617,9 @@ impl Session {
                         delay: self.connection.settings.input_delay,
                         window: self.connection.settings.rollback_frames,
                     })?;
-                    let mut bytes = vec![2];
-                    bytes.extend(self.bundle.take().unwrap());
-                    self.connection.transport.send_message(bytes)?;
+                    let mut parts = vec![vec![2]];
+                    parts.extend(self.bundle.take().unwrap());
+                    self.connection.transport.send_parts(parts)?;
                     self.phase = Phase::HostVerified;
                     self.progress = Some("Sending machine configuration and game files...".into());
                 }

--- a/src/netplay/desktop.rs
+++ b/src/netplay/desktop.rs
@@ -1,0 +1,699 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use super::{
+    control::Control,
+    setup::{Bundle, Staged},
+    transport::{NativeTransport, UdpTransport},
+    *,
+};
+use crate::{
+    config::Config,
+    emulator::Emulator,
+    timebase::{Duration, Instant},
+};
+use anyhow::{ensure, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+enum Message {
+    Hello { build: String },
+    Offer { delay: u8, window: u8 },
+    Verified { identity: [u8; 32] },
+    Start,
+    Swap { id: u64, event: SwapMessage },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guest_adopts_host_setup_and_both_peers_commit_insert_and_eject() -> Result<()> {
+        std::thread::Builder::new()
+            .stack_size(32 * 1024 * 1024)
+            .spawn(|| -> Result<()> {
+                let reserve = [
+                    std::net::UdpSocket::bind("127.0.0.1:0")?,
+                    std::net::UdpSocket::bind("127.0.0.1:0")?,
+                ];
+                let addresses = [reserve[0].local_addr()?, reserve[1].local_addr()?];
+                drop(reserve);
+                let mut machines = [
+                    super::super::tests::emulator()?,
+                    super::super::tests::emulator()?,
+                ];
+                let mut cfg = super::super::tests::safe_config()?;
+                cfg.floppy_connected = [true; 4];
+                prepare_config(&mut cfg)?;
+                let mut guest_cfg = cfg.clone();
+                guest_cfg.chip_ram_bytes *= 2;
+                let options = |player| Options {
+                    bind: addresses[player],
+                    peer: addresses[1 - player],
+                    player,
+                    session: [17; 16],
+                    input_delay: 2,
+                    rollback_frames: 8,
+                };
+                let mut peers = [
+                    Session::new(options(0), &mut machines[0], &cfg)?,
+                    Session::new(options(1), &mut machines[1], &guest_cfg)?,
+                ];
+                let deadline = Instant::now() + Duration::from_secs(90);
+                while !peers.iter().all(|p| p.status().connected) {
+                    for n in 0..2 {
+                        peers[n].step(&mut machines[n], Input::default(), false)?;
+                    }
+                    ensure!(Instant::now() < deadline, "setup did not connect");
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                assert_eq!(
+                    peers[1].take_config().unwrap().chip_ram_bytes,
+                    cfg.chip_ram_bytes
+                );
+                assert_eq!(
+                    machines[0].netplay_snapshot()?,
+                    machines[1].netplay_snapshot()?
+                );
+                assert!(!peers[1].can_change_disk());
+                assert!(machines.iter().all(|emu| !emu.paced()));
+                let before = machines[0].netplay_snapshot()?;
+                assert!(peers[0]
+                    .change_disk(&machines[0], 0, vec![1, 2, 3], true)
+                    .is_err());
+                assert_eq!(before, machines[0].netplay_snapshot()?);
+                for (drive, bytes) in
+                    (0..4).flat_map(|drive| [(drive, vec![0; 901_120]), (drive, Vec::new())])
+                {
+                    let inserted = !bytes.is_empty();
+                    peers[0].change_disk(&machines[0], drive, bytes, inserted)?;
+                    while peers.iter().any(|p| p.swap.is_some()) || !peers[0].can_change_disk() {
+                        for n in 0..2 {
+                            peers[n].step(&mut machines[n], Input::default(), true)?;
+                        }
+                        ensure!(Instant::now() < deadline, "disk change did not finish");
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    // Stop both on a common frame before comparing full state.
+                    let target = peers.iter().map(|p| p.status().frame).max().unwrap() + 2;
+                    while !peers
+                        .iter()
+                        .all(|p| p.status().frame == target && p.ready_to_capture())
+                    {
+                        for n in 0..2 {
+                            let advance = peers[n].status().frame < target;
+                            peers[n].step(&mut machines[n], Input::default(), advance)?;
+                        }
+                        ensure!(Instant::now() < deadline, "confirmation did not finish");
+                    }
+                    assert_eq!(machines[0].bus().floppy.disk_inserted(drive), inserted);
+                    assert_eq!(machines[1].bus().floppy.disk_inserted(drive), inserted);
+                    assert_eq!(
+                        machines[0].netplay_snapshot()?,
+                        machines[1].netplay_snapshot()?
+                    );
+                }
+                Ok(())
+            })?
+            .join()
+            .unwrap()
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+enum SwapMessage {
+    Begin {
+        drive: usize,
+        size: usize,
+        hash: [u8; 32],
+        writable: bool,
+    },
+    Held {
+        frame: u64,
+    },
+    Target {
+        frame: u64,
+    },
+    Ready {
+        hash: [u8; 32],
+    },
+    Prepared,
+    Apply,
+    Applied {
+        hash: [u8; 32],
+    },
+    Resume,
+}
+
+#[derive(PartialEq, Eq)]
+enum SwapPhase {
+    HostHeld,
+    HostReady,
+    HostPrepared,
+    HostApplied,
+    GuestTarget,
+    GuestReady,
+    GuestBytes,
+    GuestApply,
+    GuestResume,
+}
+
+struct Swap {
+    phase: SwapPhase,
+    stop: u64,
+    drive: usize,
+    writable: bool,
+    size: usize,
+    hash: [u8; 32],
+    bytes: Option<Vec<u8>>,
+    peer_digest: Option<[u8; 32]>,
+    started: Instant,
+}
+
+#[derive(PartialEq, Eq)]
+enum Phase {
+    HostHello,
+    GuestOffer,
+    GuestBundle,
+    HostVerified,
+    GuestStart,
+    Running,
+}
+
+/// Desktop setup and media coordination around the shared rollback protocol.
+pub struct Session {
+    pub(super) connection: Connection<Control<NativeTransport>>,
+    options: ConnectionOptions,
+    phase: Phase,
+    bundle: Option<Vec<u8>>,
+    directory: Option<tempfile::TempDir>,
+    changed_config: Option<Config>,
+    started: Instant,
+    progress: Option<String>,
+    last_progress: Instant,
+    failure: Option<String>,
+    swap: Option<Swap>,
+    swap_id: u64,
+}
+
+impl Session {
+    pub fn new(
+        options: impl Into<ConnectionOptions>,
+        emu: &mut Emulator,
+        cfg: &Config,
+    ) -> Result<Self> {
+        let options = options.into();
+        let settings = options.settings();
+        settings.validate()?;
+        validate_config(cfg)?;
+        ensure!(
+            emu.bus().emulated_cck() == 0,
+            "netplay must start before the machine runs"
+        );
+        // Finish every fallible preparation before replacing the live machine
+        // or moving its output sink. The host also uses the transmitted setup.
+        let staged = if settings.player == 0 {
+            let bundle = Bundle::capture(cfg, emu)?;
+            Some((bundle.stage()?, bundle.encode()?))
+        } else {
+            None
+        };
+        let transport = match options.clone() {
+            ConnectionOptions::Direct(options) => {
+                options.validate()?;
+                NativeTransport::Udp(UdpTransport::new(options)?)
+            }
+            #[cfg(feature = "netplay-internet")]
+            ConnectionOptions::Internet(options) => {
+                NativeTransport::Internet(Box::new(internet::InternetTransport::new(*options)?))
+            }
+        };
+        let control = Control::new(transport, settings.session, settings.player);
+        let (connection, directory, bundle, changed_config) =
+            if let Some((mut staged, bytes)) = staged {
+                staged.emu.set_paced(emu.paced());
+                let connection = Connection::with_transport(
+                    settings.clone(),
+                    control,
+                    &mut staged.emu,
+                    &staged.cfg,
+                )?;
+                std::mem::swap(
+                    &mut staged.emu.bus_mut().paula.audio,
+                    &mut emu.bus_mut().paula.audio,
+                );
+                *emu = *staged.emu;
+                (
+                    connection,
+                    Some(staged.directory),
+                    Some(bytes),
+                    Some(staged.cfg),
+                )
+            } else {
+                (
+                    Connection::with_transport(settings.clone(), control, emu, cfg)?,
+                    None,
+                    None,
+                    None,
+                )
+            };
+        let now = Instant::now();
+        let mut session = Self {
+            connection,
+            options,
+            phase: if settings.player == 0 {
+                Phase::HostHello
+            } else {
+                Phase::GuestOffer
+            },
+            directory,
+            bundle,
+            changed_config,
+            started: now,
+            progress: Some("Waiting for the other player...".into()),
+            last_progress: now,
+            failure: None,
+            swap: None,
+            swap_id: 0,
+        };
+        if settings.player == 1 {
+            session.send(Message::Hello {
+                build: env!("COPPERLINE_DISPLAY_VERSION").into(),
+            })?;
+        }
+        Ok(session)
+    }
+
+    pub fn options(&self) -> ConnectionOptions {
+        self.options.clone()
+    }
+    pub fn player(&self) -> usize {
+        self.connection.player()
+    }
+    pub fn status(&self) -> Status {
+        self.connection.status()
+    }
+    pub fn route(&self) -> &'static str {
+        self.connection.route()
+    }
+    pub fn confirmed_state_digest(&self, emu: &Emulator) -> Result<[u8; 32]> {
+        self.connection.confirmed_state_digest(emu)
+    }
+    pub fn take_config(&mut self) -> Option<Config> {
+        self.changed_config.take()
+    }
+    pub fn take_progress(&mut self) -> Option<String> {
+        self.progress.take()
+    }
+    pub fn ready_to_capture(&self) -> bool {
+        self.swap.is_none()
+            && !self.connection.transport.sending()
+            && self.status().ready_to_capture()
+    }
+    pub fn can_change_disk(&self) -> bool {
+        self.player() == 0
+            && self.phase == Phase::Running
+            && self.status().connected
+            && self.swap.is_none()
+            && !self.connection.transport.sending()
+    }
+
+    /// Queue one host-controlled insertion or eject. Decode the local image
+    /// before stopping the game, so a bad selection leaves play untouched.
+    pub fn change_disk(
+        &mut self,
+        emu: &Emulator,
+        drive: usize,
+        bytes: Vec<u8>,
+        writable: bool,
+    ) -> Result<()> {
+        ensure!(
+            self.can_change_disk(),
+            "wait for the host's connected, idle netplay session"
+        );
+        Self::validate_disk(emu, drive, &bytes, writable)?;
+        let size = bytes.len();
+        let hash = digest(&bytes);
+        self.swap_id = self
+            .swap_id
+            .checked_add(1)
+            .context("disk change identifier exhausted")?;
+        self.swap = Some(Swap {
+            phase: SwapPhase::HostHeld,
+            stop: self.status().frame,
+            drive,
+            writable,
+            size,
+            hash,
+            bytes: Some(bytes),
+            peer_digest: None,
+            started: Instant::now(),
+        });
+        self.swap_send(SwapMessage::Begin {
+            drive,
+            size,
+            hash,
+            writable,
+        })?;
+        self.progress = Some(format!("Pausing both players for DF{drive}..."));
+        Ok(())
+    }
+
+    fn validate_disk(emu: &Emulator, drive: usize, bytes: &[u8], writable: bool) -> Result<()> {
+        ensure!(
+            drive < 4 && emu.bus().floppy.drive_connected(drive),
+            "floppy drive is not connected"
+        );
+        ensure!(
+            bytes.len() <= setup::FLOPPY_LIMIT && (!bytes.is_empty() || !writable),
+            "invalid replacement disk size or write protection"
+        );
+        if !bytes.is_empty() {
+            crate::floppy::FloppyController::default().insert_memory_disk_image_bytes_with_limit(
+                0,
+                bytes.to_vec(),
+                "replacement".into(),
+                !writable,
+                setup::FLOPPY_LIMIT,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn swap_send(&mut self, event: SwapMessage) -> Result<()> {
+        self.send(Message::Swap {
+            id: self.swap_id,
+            event,
+        })
+    }
+
+    fn swap_message(&mut self, emu: &mut Emulator, id: u64, event: SwapMessage) -> Result<()> {
+        if let SwapMessage::Begin {
+            drive,
+            size,
+            hash,
+            writable,
+        } = event
+        {
+            ensure!(
+                self.player() == 1
+                    && self.status().connected
+                    && self.swap.is_none()
+                    && self.swap_id.checked_add(1) == Some(id),
+                "unexpected disk change request"
+            );
+            ensure!(
+                drive < 4
+                    && emu.bus().floppy.drive_connected(drive)
+                    && size <= setup::FLOPPY_LIMIT
+                    && (size > 0 || !writable),
+                "invalid disk change description"
+            );
+            self.swap_id = id;
+            let frame = self.status().frame;
+            self.swap = Some(Swap {
+                phase: SwapPhase::GuestTarget,
+                stop: frame,
+                drive,
+                size,
+                hash,
+                writable,
+                bytes: None,
+                peer_digest: None,
+                started: Instant::now(),
+            });
+            self.progress = Some(format!("Host is changing DF{drive}..."));
+            return self.swap_send(SwapMessage::Held { frame });
+        }
+        ensure!(id == self.swap_id, "unexpected disk change identifier");
+        let frame = self.status().frame;
+        let swap = self.swap.as_mut().context("no disk change in progress")?;
+        match event {
+            SwapMessage::Held { frame: peer } if swap.phase == SwapPhase::HostHeld => {
+                ensure!(peer.abs_diff(frame) <= 32, "invalid peer disk change frame");
+                let target = peer.max(frame);
+                swap.stop = target;
+                swap.phase = SwapPhase::HostReady;
+                self.swap_send(SwapMessage::Target { frame: target })?;
+            }
+            SwapMessage::Target { frame: target } if swap.phase == SwapPhase::GuestTarget => {
+                ensure!(
+                    target >= frame && target - frame <= 32,
+                    "invalid disk change target"
+                );
+                swap.stop = target;
+                swap.phase = SwapPhase::GuestReady;
+            }
+            SwapMessage::Ready { hash } if swap.phase == SwapPhase::HostReady => {
+                swap.peer_digest = Some(hash);
+            }
+            SwapMessage::Prepared if swap.phase == SwapPhase::HostPrepared => {
+                self.apply_disk(emu)?;
+                self.swap.as_mut().unwrap().phase = SwapPhase::HostApplied;
+                self.swap_send(SwapMessage::Apply)?;
+            }
+            SwapMessage::Apply if swap.phase == SwapPhase::GuestApply => {
+                self.apply_disk(emu)?;
+                self.swap.as_mut().unwrap().phase = SwapPhase::GuestResume;
+                self.swap_send(SwapMessage::Applied {
+                    hash: self.confirmed_state_digest(emu)?,
+                })?;
+            }
+            SwapMessage::Applied { hash } if swap.phase == SwapPhase::HostApplied => {
+                ensure!(
+                    self.confirmed_state_digest(emu)? == hash,
+                    "players differ after the disk change"
+                );
+                self.swap_send(SwapMessage::Resume)?;
+                self.finish_swap();
+            }
+            SwapMessage::Resume if swap.phase == SwapPhase::GuestResume => {
+                self.finish_swap();
+            }
+            _ => anyhow::bail!("unexpected disk change phase"),
+        }
+        Ok(())
+    }
+
+    fn apply_disk(&mut self, emu: &mut Emulator) -> Result<()> {
+        let status = self.status();
+        let swap = self.swap.as_mut().context("no disk change in progress")?;
+        ensure!(
+            status.ready_to_capture() && status.frame == swap.stop,
+            "disk change is not at a confirmed boundary"
+        );
+        let bytes = swap
+            .bytes
+            .take()
+            .context("replacement disk is not verified")?;
+        if bytes.is_empty() {
+            emu.bus_mut().floppy.eject_disk_image(swap.drive)?;
+        } else {
+            emu.bus_mut()
+                .floppy
+                .insert_memory_disk_image_bytes_with_limit(
+                    swap.drive,
+                    bytes,
+                    format!("netplay-df{}", swap.drive).into(),
+                    !swap.writable,
+                    setup::FLOPPY_LIMIT,
+                )?;
+        }
+        Ok(())
+    }
+
+    fn finish_swap(&mut self) {
+        let swap = self.swap.take().unwrap();
+        self.progress = Some(format!(
+            "DF{} {} on both players",
+            swap.drive,
+            if swap.size == 0 {
+                "ejected"
+            } else {
+                "inserted"
+            }
+        ));
+    }
+    pub fn step(&mut self, emu: &mut Emulator, input: Input, advance: bool) -> Result<bool> {
+        self.step_local(emu, &mut input.into(), advance)
+    }
+
+    pub fn step_local(
+        &mut self,
+        emu: &mut Emulator,
+        input: &mut LocalInput,
+        advance: bool,
+    ) -> Result<bool> {
+        if let Some(error) = &self.failure {
+            anyhow::bail!("{error}");
+        }
+        let result = self.step_inner(emu, input, advance);
+        if let Err(error) = &result {
+            self.failure = Some(format!("{error:#}"));
+        }
+        result
+    }
+
+    fn send(&mut self, message: Message) -> Result<()> {
+        let mut bytes = vec![1];
+        bytes.extend(serde_json::to_vec(&message)?);
+        self.connection.transport.send_message(bytes)
+    }
+
+    fn step_inner(
+        &mut self,
+        emu: &mut Emulator,
+        input: &mut LocalInput,
+        advance: bool,
+    ) -> Result<bool> {
+        self.connection.transport.poll()?;
+        ensure!(
+            !matches!(self.phase, Phase::HostHello | Phase::GuestOffer)
+                || !self.connection.transport.has_game_packets(),
+            "peer does not support desktop setup transfer; use the same Copperline build"
+        );
+        while let Some(bytes) = self.connection.transport.take_message() {
+            if bytes.first() == Some(&3) {
+                let swap = self.swap.as_mut().context("unexpected replacement disk")?;
+                ensure!(
+                    swap.phase == SwapPhase::GuestBytes
+                        && bytes.len() == swap.size + 1
+                        && digest(&bytes[1..]) == swap.hash,
+                    "invalid replacement disk transfer"
+                );
+                Self::validate_disk(emu, swap.drive, &bytes[1..], swap.writable)?;
+                swap.bytes = Some(bytes[1..].to_vec());
+                swap.phase = SwapPhase::GuestApply;
+                self.swap_send(SwapMessage::Prepared)?;
+                continue;
+            }
+            if self.phase == Phase::GuestBundle {
+                ensure!(bytes.first() == Some(&2), "expected host setup bundle");
+                let Staged {
+                    emu: mut received,
+                    cfg,
+                    directory,
+                } = Bundle::decode(&bytes[1..])?.stage()?;
+                // Reuse the same validation as initial session construction.
+                self.connection.identity =
+                    initial_identity(&self.connection.settings, &mut received, &cfg)?;
+                self.connection.rollback = Rollback::new(
+                    self.player(),
+                    self.connection.settings.input_delay,
+                    self.connection.settings.rollback_frames,
+                );
+                received.set_paced(emu.paced());
+                std::mem::swap(
+                    &mut received.bus_mut().paula.audio,
+                    &mut emu.bus_mut().paula.audio,
+                );
+                *emu = *received;
+                *input = LocalInput::default();
+                self.directory = Some(directory);
+                self.changed_config = Some(cfg);
+                self.send(Message::Verified {
+                    identity: self.connection.identity,
+                })?;
+                self.phase = Phase::GuestStart;
+                self.progress = Some("Host setup verified; waiting to start...".into());
+                continue;
+            }
+            ensure!(
+                bytes.first() == Some(&1) && bytes.len() <= 2048,
+                "invalid netplay setup message"
+            );
+            let message: Message = serde_json::from_slice(&bytes[1..])?;
+            match message {
+                Message::Hello { build } if self.phase == Phase::HostHello => {
+                    ensure!(
+                        build == env!("COPPERLINE_DISPLAY_VERSION"),
+                        "netplay requires the same Copperline build on both peers"
+                    );
+                    self.send(Message::Offer {
+                        delay: self.connection.settings.input_delay,
+                        window: self.connection.settings.rollback_frames,
+                    })?;
+                    let mut bytes = vec![2];
+                    bytes.extend(self.bundle.take().unwrap());
+                    self.connection.transport.send_message(bytes)?;
+                    self.phase = Phase::HostVerified;
+                    self.progress = Some("Sending machine configuration and game files...".into());
+                }
+                Message::Offer { delay, window } if self.phase == Phase::GuestOffer => {
+                    let mut settings = self.connection.settings.clone();
+                    settings.input_delay = delay;
+                    settings.rollback_frames = window;
+                    settings.validate()?;
+                    self.connection.settings = settings;
+                    self.phase = Phase::GuestBundle;
+                    self.progress =
+                        Some("Receiving machine configuration and game files...".into());
+                }
+                Message::Verified { identity } if self.phase == Phase::HostVerified => {
+                    ensure!(
+                        identity == self.connection.identity,
+                        "received setup produced a different machine"
+                    );
+                    self.send(Message::Start)?;
+                    self.phase = Phase::Running;
+                }
+                Message::Start if self.phase == Phase::GuestStart => {
+                    self.phase = Phase::Running;
+                }
+                Message::Swap { id, event } if self.phase == Phase::Running => {
+                    self.swap_message(emu, id, event)?;
+                }
+                _ => anyhow::bail!("unexpected netplay setup message"),
+            }
+        }
+        if self.phase != Phase::Running {
+            ensure!(
+                self.started.elapsed() < Duration::from_secs(15 * 60),
+                "netplay setup timed out"
+            );
+            self.connection.started = Instant::now();
+            if self.phase == Phase::GuestBundle
+                && self.last_progress.elapsed() > Duration::from_secs(1)
+            {
+                self.progress = Some(format!(
+                    "Receiving game files: {} KiB",
+                    self.connection.transport.received_bytes() / 1024
+                ));
+                self.last_progress = Instant::now();
+            }
+            return Ok(false);
+        }
+        let advance = advance
+            && self
+                .swap
+                .as_ref()
+                .is_none_or(|swap| self.status().frame < swap.stop);
+        let stepped = self.connection.step_local(emu, input, advance)?;
+        let status = self.status();
+        if let Some(swap) = &self.swap {
+            ensure!(
+                swap.started.elapsed() < Duration::from_secs(180),
+                "disk change timed out"
+            );
+            if status.frame == swap.stop && status.ready_to_capture() {
+                let own = self.confirmed_state_digest(emu)?;
+                if swap.phase == SwapPhase::GuestReady {
+                    self.swap.as_mut().unwrap().phase = SwapPhase::GuestBytes;
+                    self.swap_send(SwapMessage::Ready { hash: own })?;
+                } else if swap.phase == SwapPhase::HostReady {
+                    if let Some(peer) = swap.peer_digest {
+                        ensure!(peer == own, "players differ before the disk change");
+                        let swap = self.swap.as_mut().unwrap();
+                        let mut bytes = vec![3];
+                        bytes.extend(swap.bytes.as_ref().unwrap());
+                        swap.phase = SwapPhase::HostPrepared;
+                        self.connection.transport.send_message(bytes)?;
+                    }
+                }
+            }
+        }
+        Ok(stepped)
+    }
+}

--- a/src/netplay/internet.rs
+++ b/src/netplay/internet.rs
@@ -214,21 +214,26 @@ impl Transport for InternetTransport {
     fn ready(&mut self) -> Result<bool> {
         let shared = self.shared.lock().unwrap();
         if let Some(error) = &shared.failure {
+            if shared.packets.has_incoming() {
+                return Ok(shared.ready);
+            }
             bail!("{error}");
         }
         Ok(shared.ready)
     }
 
     fn receive(&mut self, buffer: &mut [u8]) -> Result<Option<usize>> {
-        self.ready()?;
+        // Deliver the final acknowledgement before reporting a peer close.
+        // The next ready() poll surfaces failure after the queue is drained.
         self.shared.lock().unwrap().packets.receive(buffer)
     }
 
     fn send(&mut self, packet: &[u8]) -> Result<bool> {
-        if !self.ready()? {
+        let mut shared = self.shared.lock().unwrap();
+        if !shared.ready || shared.failure.is_some() {
             return Ok(false);
         }
-        self.shared.lock().unwrap().packets.send(packet)
+        shared.packets.send(packet)
     }
 }
 
@@ -346,6 +351,29 @@ async fn establish(endpoint: &Endpoint, options: &Options) -> Result<iroh::endpo
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn queued_final_packets_are_delivered_before_disconnect() -> Result<()> {
+        let mut state = Shared {
+            ready: true,
+            failure: Some("peer closed".into()),
+            ..Default::default()
+        };
+        state.packets.push(&[1, 2, 3])?;
+        let mut transport = InternetTransport {
+            options: Options::host(2, 8, "", false)?,
+            shared: Arc::new(Mutex::new(state)),
+            cancel: None,
+        };
+        assert!(transport.ready()?);
+        assert!(!transport.send(&[4])?);
+        let mut bytes = [0; 16];
+        assert_eq!(transport.receive(&mut bytes)?, Some(3));
+        assert_eq!(&bytes[..3], &[1, 2, 3]);
+        assert_eq!(transport.receive(&mut bytes)?, None);
+        assert!(transport.ready().is_err());
+        Ok(())
+    }
 
     #[test]
     fn invitations_keep_host_keys_private_and_validate_routes_and_settings() -> Result<()> {

--- a/src/netplay/mod.rs
+++ b/src/netplay/mod.rs
@@ -12,6 +12,8 @@ pub mod internet;
 mod rollback;
 #[cfg(not(target_arch = "wasm32"))]
 mod setup;
+#[cfg(not(target_arch = "wasm32"))]
+pub use setup::guest_config;
 #[cfg(test)]
 mod tests;
 mod transport;

--- a/src/netplay/mod.rs
+++ b/src/netplay/mod.rs
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-//! Two-peer GGPO-style netplay. Only inputs and state digests cross the network.
+//! Two-peer GGPO-style netplay. Gameplay exchanges inputs and state digests;
+//! desktop setup and floppy changes also transfer the host's settings and media.
 
+#[cfg(not(target_arch = "wasm32"))]
+mod control;
+#[cfg(not(target_arch = "wasm32"))]
+mod desktop;
 #[cfg(all(feature = "netplay-internet", not(target_arch = "wasm32")))]
 pub mod internet;
 mod rollback;
+#[cfg(not(target_arch = "wasm32"))]
+mod setup;
 #[cfg(test)]
 mod tests;
 mod transport;
@@ -226,9 +233,30 @@ pub(crate) fn digest(bytes: &[u8]) -> [u8; 32] {
 
 /// Validate static host dependencies before building or connecting a machine.
 pub fn validate_config(cfg: &crate::config::Config) -> Result<()> {
-    if let Some(reason) = cfg.runahead_machine_block_reason() {
+    let mut dependencies = cfg.clone();
+    if cfg.netplay_storage {
+        dependencies.ide.master = None;
+        dependencies.ide.slave = None;
+        dependencies.scsi.units.fill(None);
+        dependencies.lide.drives.fill(None);
+    }
+    if let Some(reason) = dependencies.runahead_machine_block_reason() {
         anyhow::bail!("netplay cannot use {reason}");
     }
+    ensure!(
+        cfg.run_program_dir.is_none() && !cfg.emulation.uaelib_files,
+        "netplay cannot use host file commands"
+    );
+    ensure!(cfg.cd_image_path.is_none(), "netplay cannot use CD images");
+    ensure!(
+        [cfg.ide.master.as_ref(), cfg.ide.slave.as_ref()]
+            .into_iter()
+            .chain(cfg.scsi.units.iter().map(Option::as_ref))
+            .chain(cfg.lide.drives.iter().map(Option::as_ref))
+            .flatten()
+            .all(|drive| !crate::config::is_cd_image_path(&drive.path)),
+        "netplay cannot use ATAPI or SCSI CD images"
+    );
     // The sampler attaches in the frontend after session construction; reject
     // it here, before fingerprinting or opening any parallel host device.
     ensure!(
@@ -262,6 +290,8 @@ pub fn validate_config(cfg: &crate::config::Config) -> Result<()> {
 
 /// Apply the deterministic clock default before constructing a netplay machine.
 pub fn prepare_config(cfg: &mut crate::config::Config) -> Result<()> {
+    #[cfg(not(target_arch = "wasm32"))]
+    setup::prepare_sources(cfg)?;
     validate_config(cfg)?;
     if cfg.rtc_present && cfg.rtc_seed_unix.is_none() {
         cfg.rtc_seed_unix = Some(RTC_SEED);
@@ -272,7 +302,7 @@ pub fn prepare_config(cfg: &mut crate::config::Config) -> Result<()> {
 
 /// A session is serviced on the emulation thread; socket I/O never blocks it.
 #[cfg(not(target_arch = "wasm32"))]
-pub type Session = Connection<NativeTransport>;
+pub use desktop::Session;
 
 pub struct Connection<T: Transport> {
     transport: T,
@@ -345,6 +375,46 @@ impl Connection<NativeTransport> {
     }
 }
 
+fn initial_identity(
+    settings: &Settings,
+    emu: &mut Emulator,
+    cfg: &crate::config::Config,
+) -> Result<[u8; 32]> {
+    validate_config(cfg)?;
+    ensure!(
+        emu.bus().emulated_cck() == 0,
+        "netplay must start before the machine runs"
+    );
+    settings.validate()?;
+    // Paths are host metadata; normalize only after adopting the complete
+    // images into memory so replay cannot reopen or overwrite local files.
+    emu.bus_mut().floppy.prepare_netplay_images();
+    if let Some(reason) = emu
+        .bus()
+        .runahead_host_block_reason()
+        .or_else(|| emu.machine.runahead_debug_block_reason())
+    {
+        anyhow::bail!("netplay cannot use {reason}");
+    }
+    ensure!(
+        !emu.time_travel_enabled(),
+        "netplay cannot record reverse history"
+    );
+    ensure!(
+        emu.bus().input.ports.iter().all(|p| matches!(
+            p.device,
+            crate::bus::PortDevice::Mouse
+                | crate::bus::PortDevice::Joystick
+                | crate::bus::PortDevice::Cd32Pad
+        )),
+        "netplay requires mouse, joystick or CD32 controllers on both ports"
+    );
+    let mut identity_hash = Sha256::new();
+    identity_hash.update(env!("COPPERLINE_DISPLAY_VERSION").as_bytes());
+    identity_hash.update(emu.netplay_snapshot()?);
+    Ok(identity_hash.finalize().into())
+}
+
 impl<T: Transport> Connection<T> {
     pub fn route(&self) -> &'static str {
         self.transport.route()
@@ -355,39 +425,7 @@ impl<T: Transport> Connection<T> {
         emu: &mut Emulator,
         cfg: &crate::config::Config,
     ) -> Result<Self> {
-        validate_config(cfg)?;
-        ensure!(
-            emu.bus().emulated_cck() == 0,
-            "netplay must start before the machine runs"
-        );
-        settings.validate()?;
-        // Paths are host metadata; normalize only after adopting the complete
-        // images into memory so replay cannot reopen or overwrite local files.
-        emu.bus_mut().floppy.prepare_netplay_images();
-        if let Some(reason) = emu
-            .bus()
-            .runahead_host_block_reason()
-            .or_else(|| emu.machine.runahead_debug_block_reason())
-        {
-            anyhow::bail!("netplay cannot use {reason}");
-        }
-        ensure!(
-            !emu.time_travel_enabled(),
-            "netplay cannot record reverse history"
-        );
-        ensure!(
-            emu.bus().input.ports.iter().all(|p| matches!(
-                p.device,
-                crate::bus::PortDevice::Mouse
-                    | crate::bus::PortDevice::Joystick
-                    | crate::bus::PortDevice::Cd32Pad
-            )),
-            "netplay requires mouse, joystick or CD32 controllers on both ports"
-        );
-        let mut identity_hash = Sha256::new();
-        identity_hash.update(env!("COPPERLINE_DISPLAY_VERSION").as_bytes());
-        identity_hash.update(emu.netplay_snapshot()?);
-        let identity = identity_hash.finalize().into();
+        let identity = initial_identity(&settings, emu, cfg)?;
         let rollback = Rollback::new(
             settings.player,
             settings.input_delay,

--- a/src/netplay/setup.rs
+++ b/src/netplay/setup.rs
@@ -18,6 +18,29 @@ pub(super) const MAX_BUNDLE: usize = 512 * 1024 * 1024;
 pub(super) const FLOPPY_LIMIT: usize = 16 * 1024 * 1024;
 const MANIFEST_LIMIT: usize = 64 * 1024;
 
+/// The guest waits on a default machine, but its host presentation preferences
+/// still apply before and after receiving the host's emulated hardware.
+pub fn guest_config(local: &RawConfig) -> Result<Config> {
+    let mut raw = RawConfig {
+        display: local.display.clone(),
+        input: RawInput {
+            port1: None,
+            port2: None,
+            ..local.input.clone()
+        },
+        audio: RawAudio {
+            output_enabled: local.audio.output_enabled,
+            output_device: local.audio.output_device.clone(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    raw.emulation.realtime_priority = local.emulation.realtime_priority;
+    raw.emulation.pacing_budget = local.emulation.pacing_budget.clone();
+    raw.serial.mode = Some("off".into());
+    Config::try_from(raw)
+}
+
 /// Turn directory mounts (including staged WHDLoad/--run volumes) into
 /// ordinary Amiga disk volumes. Their names and boot priorities survive;
 /// host-directory services and host file authority do not enter the game.
@@ -607,6 +630,31 @@ fn read_limited(path: &Path, limit: usize) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn guest_keeps_local_output_preferences_without_loading_local_game_settings() -> Result<()> {
+        let mut raw = RawConfig::default();
+        raw.cpu.model = Some("invalid local machine".into());
+        raw.rom = Some("missing-local.rom".into());
+        raw.whdload.game = Some("missing-local-game.lha".into());
+        raw.run_program_dir = Some("local-program-files".into());
+        raw.audio.output_enabled = Some(false);
+        raw.audio.output_device = Some("local output".into());
+        raw.display.full_screen = Some(true);
+        raw.input.mouse_sensitivity = Some(72);
+        raw.input.port1 = Some("analogue".into());
+        let cfg = guest_config(&raw)?;
+        assert!(!cfg.audio.output_enabled);
+        assert_eq!(cfg.audio.output_device.as_deref(), Some("local output"));
+        assert!(cfg.full_screen);
+        assert_eq!(cfg.mouse_sensitivity, 72);
+        assert_eq!(cfg.cpu, Config::default().cpu);
+        assert_eq!(cfg.port_devices, Config::default().port_devices);
+        assert!(cfg.run_program_dir.is_none());
+        assert_eq!(cfg.serial.mode, SerialMode::Off);
+        assert_ne!(cfg.rom_path, Path::new("missing-local.rom"));
+        Ok(())
+    }
 
     #[test]
     fn hardware_profiles_round_trip_without_host_paths() -> Result<()> {

--- a/src/netplay/setup.rs
+++ b/src/netplay/setup.rs
@@ -254,7 +254,9 @@ impl Hardware {
         // of bundled-asset lookup while validating the hardware selection.
         if let Some(controller) = &self.scsi {
             raw.scsi.controller = Some(controller.clone());
-            raw.scsi.rom = Some(String::new());
+            if !controller.eq_ignore_ascii_case("A3000") {
+                raw.scsi.rom = Some(String::new());
+            }
         }
         if let Some(board) = &self.lide {
             raw.lide.board = Some(board.clone());
@@ -474,19 +476,20 @@ impl Bundle {
         Ok(())
     }
 
-    pub fn encode(&self) -> Result<Vec<u8>> {
+    pub fn into_parts(self) -> Result<Vec<Vec<u8>>> {
         let manifest = serde_json::to_vec(&self.manifest)?;
         ensure!(
             manifest.len() <= MANIFEST_LIMIT,
             "netplay manifest too large"
         );
-        let mut bytes = (manifest.len() as u32).to_le_bytes().to_vec();
-        bytes.extend(manifest);
-        for file in &self.files {
-            bytes.extend(file);
-        }
-        ensure!(bytes.len() <= MAX_BUNDLE, "netplay bundle exceeds 512 MiB");
-        Ok(bytes)
+        let len = 4 + manifest.len() + self.files.iter().map(Vec::len).sum::<usize>();
+        ensure!(len <= MAX_BUNDLE, "netplay bundle exceeds 512 MiB");
+        let mut header = Vec::with_capacity(4 + manifest.len());
+        header.extend((manifest.len() as u32).to_le_bytes());
+        header.extend(manifest);
+        let mut parts = vec![header];
+        parts.extend(self.files);
+        Ok(parts)
     }
 
     pub fn decode(bytes: &[u8]) -> Result<Self> {
@@ -721,6 +724,11 @@ mod tests {
             if profile == "A3000" {
                 assert_eq!(cfg.scsi.controller, ScsiController::A3000);
             }
+            let restored = Hardware::capture(&cfg).config()?;
+            assert_eq!(restored.scsi.controller, cfg.scsi.controller);
+            if profile == "A3000" {
+                assert!(restored.scsi.rom.is_none());
+            }
         }
         Ok(())
     }
@@ -750,8 +758,15 @@ mod tests {
                 let emu = super::super::tests::emulator()?;
                 let cfg = super::super::tests::safe_config()?;
                 let bundle = Bundle::capture(&cfg, &emu)?;
-                let bytes = bundle.encode()?;
                 let host = bundle.stage()?;
+                let buffers: Vec<_> = bundle.files.iter().map(Vec::as_ptr).collect();
+                let parts = bundle.into_parts()?;
+                assert_eq!(
+                    parts[1..].iter().map(Vec::as_ptr).collect::<Vec<_>>(),
+                    buffers,
+                    "transfer owns the original media allocations"
+                );
+                let bytes: Vec<_> = parts.into_iter().flatten().collect();
                 let guest = Bundle::decode(&bytes)?.stage()?;
                 assert_eq!(host.emu.netplay_snapshot()?, guest.emu.netplay_snapshot()?);
                 assert_ne!(host.directory.path(), guest.directory.path());

--- a/src/netplay/setup.rs
+++ b/src/netplay/setup.rs
@@ -1,0 +1,720 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Validated machine settings and media, without remote host paths.
+
+use std::{
+    collections::BTreeSet,
+    io::{Read, Write},
+    path::Path,
+};
+
+use anyhow::{ensure, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::chipset::{agnus::AgnusRevision, denise::DeniseRevision};
+use crate::{config::*, emulator::Emulator};
+
+pub(super) const MAX_BUNDLE: usize = 512 * 1024 * 1024;
+pub(super) const FLOPPY_LIMIT: usize = 16 * 1024 * 1024;
+const MANIFEST_LIMIT: usize = 64 * 1024;
+
+/// Turn directory mounts (including staged WHDLoad/--run volumes) into
+/// ordinary Amiga disk volumes. Their names and boot priorities survive;
+/// host-directory services and host file authority do not enter the game.
+pub(super) fn prepare_sources(cfg: &mut Config) -> Result<()> {
+    let mut prepared = cfg.clone();
+    prepared.netplay_storage = true;
+    prepared.run_program_dir = None;
+    prepared.emulation.uaelib_files = false;
+    for mount in std::mem::take(&mut prepared.filesys) {
+        if mount.readonly {
+            prepared.netplay_read_only.push(mount.path.clone());
+        }
+        let drive = DriveImage {
+            path: mount.path,
+            volume_name: Some(mount.volume),
+            boot_pri: mount.boot_pri,
+            filesystem: crate::diskimage::FileSystem::OFS,
+        };
+        if prepared.gate_array.gayle_id().is_some() || prepared.ide_a4000 {
+            if prepared.ide.master.is_none() {
+                prepared.ide.master = Some(drive);
+                prepared.rom_scsi_device_disable = false;
+                continue;
+            }
+            if prepared.ide.slave.is_none() {
+                prepared.ide.slave = Some(drive);
+                prepared.rom_scsi_device_disable = false;
+                continue;
+            }
+        }
+        let slot = prepared
+            .scsi
+            .units
+            .iter_mut()
+            .find(|slot| slot.is_none())
+            .context("no free SCSI unit for a netplay directory volume")?;
+        *slot = Some(drive);
+        if prepared.sdmac && prepared.scsi.rom.is_none() {
+            prepared.scsi.controller = ScsiController::A3000;
+            prepared.rom_scsi_device_disable = false;
+        } else if prepared.scsi.rom.is_none() {
+            prepared.scsi.rom = Some(std::path::PathBuf::from(match prepared.scsi.controller {
+                ScsiController::A4091 => BUNDLED_A4091_ROM,
+                _ => BUNDLED_A2091_ROM,
+            }));
+        }
+    }
+    // Persisted clocks are host resources; netplay starts a deterministic,
+    // session-only clock on both machines.
+    prepared.battmem_path = None;
+    prepared.cd32_nvram_path = None;
+    super::validate_config(&prepared)?;
+    *cfg = prepared;
+    Ok(())
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Hardware {
+    cpu: RawCpu,
+    memory: RawMemory,
+    machine: RawMachine,
+    chipset: RawChipset,
+    audio: RawAudio,
+    identify: bool,
+    uaelib: bool,
+    connected: [bool; 4],
+    speed: u16,
+    ports: [String; 2],
+    rtg: RawRtg,
+    boards: Vec<crate::zorro::BoardSpec>,
+    scsi: Option<String>,
+    lide: Option<String>,
+    cartridge: Option<String>,
+}
+
+impl Hardware {
+    fn capture(cfg: &Config) -> Self {
+        let cpu = format!("{:?}", cfg.cpu);
+        Self {
+            cpu: RawCpu {
+                model: Some(cpu.strip_prefix('M').unwrap_or(&cpu).to_owned()),
+                fpu: Some(cfg.fpu),
+                clock_mhz: Some(cfg.cpu_clock_mhz),
+                icache: Some(cfg.cpu_icache),
+                dcache: Some(cfg.cpu_dcache),
+                unimplemented: (cfg.cpu == CpuModel::M68060)
+                    .then(|| format!("{:?}", cfg.cpu_unimplemented).to_ascii_lowercase()),
+                jit: Some(false),
+            },
+            memory: RawMemory {
+                chip: Some(cfg.chip_ram_bytes.to_string()),
+                fast: Some(cfg.fast_ram_bytes.to_string()),
+                slow: Some(cfg.slow_ram_bytes.to_string()),
+                init: Some(cfg.ram_init.config_value()),
+                motherboard: Some(cfg.mb_ram_bytes.to_string()),
+                accelerator: Some(cfg.accel_ram_bytes.to_string()),
+                z3: Some(cfg.z3_ram_bytes.to_string()),
+            },
+            machine: RawMachine {
+                profile: cfg.machine.map(|m| format!("{m:?}")),
+                rtc: Some(cfg.rtc_present),
+                rtc_chip: cfg.rtc_present.then(|| format!("{:?}", cfg.rtc_chip)),
+                rtc_time: cfg.rtc_seed_unix.map(|t| RawRtcTime::Unix(t as i64)),
+                rtc_frozen: Some(cfg.rtc_frozen),
+                battmem: Some(String::new()),
+                mem_controller: Some(
+                    match cfg.mem_controller {
+                        MemController::None => "none",
+                        MemController::Ramsey4 => "ramsey-04",
+                        MemController::Ramsey7 => "ramsey-07",
+                    }
+                    .into(),
+                ),
+                rom_scsi_device_disable: Some(cfg.rom_scsi_device_disable),
+            },
+            chipset: RawChipset {
+                revision: Some(format!("{:?}", cfg.chipset)),
+                video: Some(format!("{:?}", cfg.video_standard)),
+                agnus: Some(
+                    match cfg.agnus_revision {
+                        AgnusRevision::Ocs => "OCS",
+                        AgnusRevision::Ecs8372Rev4 => "8372A",
+                        AgnusRevision::Ecs8375 => "8375",
+                        AgnusRevision::AgaAlice => "ALICE",
+                    }
+                    .into(),
+                ),
+                denise: Some(
+                    match cfg.denise_revision {
+                        DeniseRevision::Ocs => "OCS",
+                        DeniseRevision::Ecs8373 => "ECS",
+                        DeniseRevision::AgaLisa => "LISA",
+                    }
+                    .into(),
+                ),
+            },
+            audio: RawAudio {
+                floppy_sounds: Some(cfg.audio.floppy_sounds),
+                floppy_sounds_volume: Some(cfg.audio.floppy_sounds_volume.into()),
+                channel_mode: Some(format!("{:?}", cfg.audio.channel_mode)),
+                audio_filter: Some(format!("{:?}", cfg.audio.filter)),
+                stereo_separation: Some(cfg.audio.stereo_separation.into()),
+                ..Default::default()
+            },
+            identify: cfg.identify_board,
+            uaelib: cfg.emulation.uaelib,
+            connected: cfg.floppy_connected,
+            speed: cfg.floppy.speed,
+            ports: cfg.port_devices.map(|p| p.label().to_owned()),
+            rtg: RawRtg {
+                card: Some(format!("{:?}", cfg.rtg)),
+                vram: Some(cfg.rtg_vram_bytes.to_string()),
+            },
+            boards: cfg.zorro_boards.clone(),
+            scsi: cfg
+                .scsi
+                .enabled()
+                .then(|| format!("{:?}", cfg.scsi.controller)),
+            lide: cfg.lide.enabled().then(|| cfg.lide.board.name().to_owned()),
+            cartridge: cfg.cartridge.model.map(|m| format!("{m:?}")),
+        }
+    }
+
+    fn config(&self) -> Result<Config> {
+        // Validate before the ordinary config parser can resolve any paths.
+        ensure!(
+            self.machine.battmem.as_deref().is_none_or(str::is_empty),
+            "remote battery RAM path is forbidden"
+        );
+        ensure!(
+            self.audio.output_device.is_none()
+                && self.audio.output_enabled.is_none()
+                && self.audio.stem_granularity.is_none(),
+            "remote audio output settings are forbidden"
+        );
+        ensure!(
+            self.boards.len() <= 16
+                && self
+                    .boards
+                    .iter()
+                    .all(|b| b.name.len() <= 128 && b.backing == crate::zorro::BoardBacking::Ram),
+            "invalid netplay expansion boards"
+        );
+        let mut raw = RawConfig {
+            cpu: self.cpu.clone(),
+            memory: self.memory.clone(),
+            machine: self.machine.clone(),
+            chipset: self.chipset.clone(),
+            audio: self.audio.clone(),
+            identify: Some(self.identify),
+            rtg: self.rtg.clone(),
+            ..Default::default()
+        };
+        raw.emulation.uaelib = Some(self.uaelib);
+        if raw
+            .machine
+            .profile
+            .as_ref()
+            .is_some_and(|s| s.eq_ignore_ascii_case("CD32"))
+        {
+            raw.fmv_rom = Some(String::new());
+            raw.cd.nvram = Some(String::new());
+        }
+        raw.floppy.speed = Some(self.speed);
+        raw.floppy.drives = Some(0);
+        raw.serial.mode = Some("off".into());
+        raw.input.port1 = Some(self.ports[0].clone());
+        raw.input.port2 = Some(self.ports[1].clone());
+        // Controller ROMs are supplied separately. Empty ROM settings opt out
+        // of bundled-asset lookup while validating the hardware selection.
+        if let Some(controller) = &self.scsi {
+            raw.scsi.controller = Some(controller.clone());
+            raw.scsi.rom = Some(String::new());
+        }
+        if let Some(board) = &self.lide {
+            raw.lide.board = Some(board.clone());
+            raw.lide.rom = Some(String::new());
+            raw.lide.rom_bank2 = Some(String::new());
+        }
+        let mut cfg = Config::try_from(raw)?;
+        cfg.netplay_storage = true;
+        cfg.floppy_connected = self.connected;
+        cfg.battmem_path = None;
+        cfg.cd32_nvram_path = None;
+        cfg.zorro_boards = self.boards.clone();
+        let ram = [
+            cfg.chip_ram_bytes,
+            cfg.fast_ram_bytes,
+            cfg.slow_ram_bytes,
+            cfg.mb_ram_bytes,
+            cfg.accel_ram_bytes,
+            cfg.z3_ram_bytes,
+            cfg.rtg_vram_bytes,
+        ]
+        .into_iter()
+        .chain(cfg.zorro_boards.iter().map(|b| b.size_bytes))
+        .try_fold(0usize, |sum, n| sum.checked_add(n))
+        .context("netplay RAM size overflow")?;
+        ensure!(
+            ram <= 64 * 1024 * 1024,
+            "netplay supports up to 64 MiB of RAM including expansion and video RAM"
+        );
+        cfg.build_zorro_chain()?;
+        super::validate_config(&cfg)?;
+        Ok(cfg)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub(super) enum Kind {
+    Rom,
+    Extended,
+    Fmv,
+    ScsiRom,
+    ScsiOdd,
+    LideRom,
+    LideBank,
+    Cartridge,
+    Floppy(u8),
+    Ide(u8),
+    Scsi(u8),
+    Lide(u8),
+}
+
+impl Kind {
+    fn limit(self) -> Result<usize> {
+        Ok(match self {
+            Self::Floppy(n) => {
+                ensure!(n < 4, "invalid floppy drive");
+                FLOPPY_LIMIT
+            }
+            Self::Ide(n) => {
+                ensure!(n < 2, "invalid IDE drive");
+                256 * 1024 * 1024
+            }
+            Self::Scsi(n) => {
+                ensure!(n < 7, "invalid SCSI drive");
+                256 * 1024 * 1024
+            }
+            Self::Lide(n) => {
+                ensure!(n < 4, "invalid LIDE drive");
+                256 * 1024 * 1024
+            }
+            _ => 2 * 1024 * 1024,
+        })
+    }
+    fn hard_disk(self) -> bool {
+        matches!(self, Self::Ide(_) | Self::Scsi(_) | Self::Lide(_))
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileInfo {
+    kind: Kind,
+    size: usize,
+    hash: [u8; 32],
+    writable: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Manifest {
+    version: u16,
+    build: String,
+    hardware: Hardware,
+    files: Vec<FileInfo>,
+}
+
+pub(super) struct Bundle {
+    manifest: Manifest,
+    files: Vec<Vec<u8>>,
+}
+
+pub(super) struct Staged {
+    pub cfg: Config,
+    pub emu: Box<Emulator>,
+    // Generated files are scoped to the session and never stored in RawConfig.
+    pub directory: tempfile::TempDir,
+}
+
+impl Bundle {
+    pub fn capture(cfg: &Config, emu: &Emulator) -> Result<Self> {
+        let mut bundle = Self {
+            manifest: Manifest {
+                version: 1,
+                build: env!("COPPERLINE_DISPLAY_VERSION").into(),
+                hardware: Hardware::capture(cfg),
+                files: Vec::new(),
+            },
+            files: Vec::new(),
+        };
+        let mut rom = emu.bus().mem.rom.clone();
+        if cfg.machine == Some(MachineModel::A1000) {
+            rom.truncate(crate::memory::A1000_BOOT_ROM_SIZE);
+        }
+        bundle.add(Kind::Rom, rom, false)?;
+        if !emu.bus().mem.extended_rom.is_empty() {
+            bundle.add(Kind::Extended, emu.bus().mem.extended_rom.clone(), false)?;
+        }
+        for (kind, path) in [
+            (Kind::Fmv, cfg.fmv_rom_path.as_ref()),
+            (Kind::ScsiRom, cfg.scsi.rom.as_ref()),
+            (Kind::ScsiOdd, cfg.scsi.rom_odd.as_ref()),
+            (Kind::LideRom, cfg.lide.rom.as_ref()),
+            (Kind::LideBank, cfg.lide.rom_bank2.as_ref()),
+            (Kind::Cartridge, cfg.cartridge.rom.as_ref()),
+        ] {
+            if let Some(path) = path {
+                bundle.add(kind, read_limited(path, kind.limit()?)?, false)?;
+            }
+        }
+        for drive in 0..4 {
+            if let Some(protected) = emu.bus().floppy.disk_image_write_protected(drive) {
+                bundle.add(
+                    Kind::Floppy(drive as u8),
+                    emu.bus().floppy.export_disk_image(drive)?,
+                    !protected,
+                )?;
+            }
+        }
+        for (kind, drive) in [cfg.ide.master.as_ref(), cfg.ide.slave.as_ref()]
+            .into_iter()
+            .enumerate()
+            .map(|(n, d)| (Kind::Ide(n as u8), d))
+            .chain(
+                cfg.scsi
+                    .units
+                    .iter()
+                    .enumerate()
+                    .map(|(n, d)| (Kind::Scsi(n as u8), d.as_ref())),
+            )
+            .chain(
+                cfg.lide
+                    .drives
+                    .iter()
+                    .enumerate()
+                    .map(|(n, d)| (Kind::Lide(n as u8), d.as_ref())),
+            )
+        {
+            if let Some(drive) = drive {
+                let unit = match kind {
+                    Kind::Ide(n) | Kind::Scsi(n) | Kind::Lide(n) => n,
+                    _ => unreachable!(),
+                };
+                let mut disk = crate::harddrive::HardDriveImage::open_session(
+                    &drive.path,
+                    &format!("DH{unit}"),
+                    match kind {
+                        Kind::Ide(_) | Kind::Lide(_) => "ide",
+                        _ => "scsi",
+                    },
+                    drive.volume_name.as_deref(),
+                    drive.boot_pri,
+                    drive.filesystem,
+                )?;
+                let len = usize::try_from(disk.total_sectors())?
+                    .checked_mul(512)
+                    .context("disk size overflow")?;
+                ensure!(
+                    len <= kind.limit()?,
+                    "netplay disk exceeds 256 MiB including partition metadata"
+                );
+                let mut bytes = vec![0; len];
+                for (sector, data) in bytes.chunks_exact_mut(512).enumerate() {
+                    disk.read_sector(sector as u64, data)?;
+                }
+                bundle.add(kind, bytes, !cfg.netplay_read_only.contains(&drive.path))?;
+            }
+        }
+        Ok(bundle)
+    }
+
+    fn add(&mut self, kind: Kind, bytes: Vec<u8>, writable: bool) -> Result<()> {
+        ensure!(
+            !bytes.is_empty() && bytes.len() <= kind.limit()?,
+            "invalid netplay media size"
+        );
+        ensure!(
+            self.files.iter().map(Vec::len).sum::<usize>() + bytes.len() <= MAX_BUNDLE,
+            "netplay media exceeds 512 MiB"
+        );
+        self.manifest.files.push(FileInfo {
+            kind,
+            size: bytes.len(),
+            hash: super::digest(&bytes),
+            writable,
+        });
+        self.files.push(bytes);
+        Ok(())
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>> {
+        let manifest = serde_json::to_vec(&self.manifest)?;
+        ensure!(
+            manifest.len() <= MANIFEST_LIMIT,
+            "netplay manifest too large"
+        );
+        let mut bytes = (manifest.len() as u32).to_le_bytes().to_vec();
+        bytes.extend(manifest);
+        for file in &self.files {
+            bytes.extend(file);
+        }
+        ensure!(bytes.len() <= MAX_BUNDLE, "netplay bundle exceeds 512 MiB");
+        Ok(bytes)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        ensure!(
+            bytes.len() >= 4 && bytes.len() <= MAX_BUNDLE,
+            "invalid netplay bundle length"
+        );
+        let len = u32::from_le_bytes(bytes[..4].try_into()?) as usize;
+        ensure!(
+            len <= MANIFEST_LIMIT && len <= bytes.len() - 4,
+            "invalid netplay manifest length"
+        );
+        let manifest: Manifest = serde_json::from_slice(&bytes[4..4 + len])?;
+        ensure!(
+            manifest.version == 1 && manifest.build == env!("COPPERLINE_DISPLAY_VERSION"),
+            "netplay requires the same Copperline build on both peers"
+        );
+        ensure!(
+            !manifest.files.is_empty() && manifest.files.len() <= 25,
+            "invalid netplay file count"
+        );
+        manifest.hardware.config()?;
+        let mut kinds = BTreeSet::new();
+        let mut offset = 4 + len;
+        let mut files = Vec::new();
+        for file in &manifest.files {
+            ensure!(
+                kinds.insert(file.kind) && file.size > 0 && file.size <= file.kind.limit()?,
+                "invalid or repeated netplay media"
+            );
+            let end = offset
+                .checked_add(file.size)
+                .context("media length overflow")?;
+            let data = bytes.get(offset..end).context("truncated netplay media")?;
+            ensure!(
+                super::digest(data) == file.hash,
+                "netplay media checksum mismatch"
+            );
+            files.push(data.to_vec());
+            offset = end;
+        }
+        ensure!(
+            offset == bytes.len() && kinds.contains(&Kind::Rom),
+            "invalid netplay bundle contents"
+        );
+        Ok(Self { manifest, files })
+    }
+
+    pub fn stage(&self) -> Result<Staged> {
+        let mut cfg = self.manifest.hardware.config()?;
+        let directory = tempfile::Builder::new()
+            .prefix("copperline-netplay-")
+            .tempdir()?;
+        for (index, (info, bytes)) in self.manifest.files.iter().zip(&self.files).enumerate() {
+            let path = directory.path().join(format!(
+                "{index}.{}",
+                if info.kind.hard_disk() { "hdf" } else { "bin" }
+            ));
+            if matches!(info.kind, Kind::Floppy(_)) {
+                continue;
+            }
+            std::fs::File::create(&path)?.write_all(bytes)?;
+            if info.kind.hard_disk() && !info.writable {
+                cfg.netplay_read_only.push(path.clone());
+            }
+            match info.kind {
+                Kind::Rom => cfg.rom_path = path,
+                Kind::Extended => cfg.extended_rom_path = Some(path),
+                Kind::Fmv => cfg.fmv_rom_path = Some(path),
+                Kind::ScsiRom => cfg.scsi.rom = Some(path),
+                Kind::ScsiOdd => cfg.scsi.rom_odd = Some(path),
+                Kind::LideRom => cfg.lide.rom = Some(path),
+                Kind::LideBank => cfg.lide.rom_bank2 = Some(path),
+                Kind::Cartridge => {
+                    cfg.cartridge.model = CartridgeConfig::parse_model(
+                        self.manifest
+                            .hardware
+                            .cartridge
+                            .as_deref()
+                            .context("missing cartridge model")?,
+                    )?;
+                    cfg.cartridge.rom = Some(path);
+                }
+                Kind::Ide(n) | Kind::Scsi(n) | Kind::Lide(n) => {
+                    let drive = Some(DriveImage {
+                        path,
+                        volume_name: None,
+                        boot_pri: HARDFILE_DEFAULT_BOOT_PRI,
+                        filesystem: crate::diskimage::FileSystem::FFS,
+                    });
+                    match info.kind {
+                        Kind::Ide(0) => cfg.ide.master = drive,
+                        Kind::Ide(_) => cfg.ide.slave = drive,
+                        Kind::Scsi(_) => cfg.scsi.units[n as usize] = drive,
+                        Kind::Lide(_) => cfg.lide.drives[n as usize] = drive,
+                        _ => unreachable!(),
+                    }
+                }
+                Kind::Floppy(_) => unreachable!(),
+            }
+        }
+        let mut emu = Box::new(crate::emulator::build_netplay_machine(
+            &cfg,
+            Box::new(crate::audio::NullSink),
+            true,
+        )?);
+        for (info, bytes) in self.manifest.files.iter().zip(&self.files) {
+            if let Kind::Floppy(drive) = info.kind {
+                emu.bus_mut()
+                    .floppy
+                    .insert_memory_disk_image_bytes_with_limit(
+                        drive as usize,
+                        bytes.clone(),
+                        format!("netplay-df{drive}").into(),
+                        !info.writable,
+                        FLOPPY_LIMIT,
+                    )?;
+            }
+        }
+        emu.bus_mut().floppy.prepare_netplay_images();
+        Ok(Staged {
+            cfg,
+            emu,
+            directory,
+        })
+    }
+}
+
+fn read_limited(path: &Path, limit: usize) -> Result<Vec<u8>> {
+    let file = std::fs::File::open(path).with_context(|| format!("reading {}", path.display()))?;
+    ensure!(
+        file.metadata()?.len() <= limit as u64,
+        "netplay media exceeds its size limit"
+    );
+    let mut bytes = Vec::new();
+    file.take(limit as u64 + 1).read_to_end(&mut bytes)?;
+    ensure!(bytes.len() <= limit, "netplay media exceeds its size limit");
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hardware_profiles_round_trip_without_host_paths() -> Result<()> {
+        for profile in [
+            "A500", "A500OCS", "A500Plus", "A600", "A1200", "A3000", "A4000", "CDTV", "CD32",
+            "A1000",
+        ] {
+            let mut raw = RawConfig::default();
+            raw.machine.profile = Some(profile.into());
+            let mut cfg = Config::try_from(raw)?;
+            cfg.serial.mode = SerialMode::Off;
+            super::super::prepare_config(&mut cfg)?;
+            let hardware = Hardware::capture(&cfg);
+            let restored = hardware
+                .config()
+                .with_context(|| format!("round-tripping {profile}"))?;
+            assert_eq!(restored.machine, cfg.machine);
+            assert_eq!(restored.cpu, cfg.cpu);
+            assert_eq!(restored.floppy_connected, cfg.floppy_connected);
+            assert_eq!(restored.rtc_seed_unix, cfg.rtc_seed_unix);
+            assert_eq!(restored.agnus_revision, cfg.agnus_revision);
+            assert_eq!(restored.port_devices, cfg.port_devices);
+            assert!(restored.battmem_path.is_none() && restored.cd32_nvram_path.is_none());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn directory_volumes_keep_names_priorities_and_read_only_access() -> Result<()> {
+        for profile in ["A500", "A1200", "A3000", "A4000"] {
+            let mut raw = RawConfig::default();
+            raw.machine.profile = Some(profile.into());
+            raw.serial.mode = Some("off".into());
+            for n in 0..3 {
+                raw.filesys.push(RawFilesysMount {
+                    path: format!("volume-{n}"),
+                    volume: Some(format!("Volume{n}")),
+                    bootpri: Some(if n == 0 { 6 } else { -128 }),
+                    readonly: Some(n == 1),
+                });
+            }
+            let mut cfg = Config::try_from(raw)?;
+            prepare_sources(&mut cfg)?;
+            assert!(cfg.filesys.is_empty() && cfg.netplay_storage);
+            let drives: Vec<_> = [cfg.ide.master.as_ref(), cfg.ide.slave.as_ref()]
+                .into_iter()
+                .chain(cfg.scsi.units.iter().map(Option::as_ref))
+                .flatten()
+                .collect();
+            assert_eq!(drives.len(), 3);
+            for (n, drive) in drives.iter().enumerate() {
+                assert_eq!(
+                    drive.volume_name.as_deref(),
+                    Some(format!("Volume{n}").as_str())
+                );
+                assert_eq!(drive.boot_pri, if n == 0 { 6 } else { -128 });
+                assert!(!drive.filesystem.ffs);
+                assert_eq!(cfg.netplay_read_only.contains(&drive.path), n == 1);
+            }
+            assert_eq!(
+                cfg.ide.master.is_some(),
+                matches!(profile, "A1200" | "A4000")
+            );
+            if profile == "A3000" {
+                assert_eq!(cfg.scsi.controller, ScsiController::A3000);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn hardware_rejects_host_resources_and_excessive_ram() -> Result<()> {
+        let mut hw = Hardware::capture(&Config::default());
+        hw.machine.battmem = Some("/tmp/not-a-session-file".into());
+        assert!(hw.config().is_err());
+        hw.machine.battmem = None;
+        hw.audio.output_device = Some("remote choice".into());
+        assert!(hw.config().is_err());
+        hw.audio.output_device = None;
+        hw.cpu.jit = Some(true);
+        assert!(hw.config().is_err());
+        hw.cpu.jit = Some(false);
+        hw.memory.chip = Some("1000000000G".into());
+        assert!(hw.config().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn bundle_rebuilds_the_same_cold_machine_and_rejects_corruption() -> Result<()> {
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| -> Result<()> {
+                let emu = super::super::tests::emulator()?;
+                let cfg = super::super::tests::safe_config()?;
+                let bundle = Bundle::capture(&cfg, &emu)?;
+                let bytes = bundle.encode()?;
+                let host = bundle.stage()?;
+                let guest = Bundle::decode(&bytes)?.stage()?;
+                assert_eq!(host.emu.netplay_snapshot()?, guest.emu.netplay_snapshot()?);
+                assert_ne!(host.directory.path(), guest.directory.path());
+                let mut bad = bytes.clone();
+                *bad.last_mut().unwrap() ^= 1;
+                assert!(Bundle::decode(&bad).is_err());
+                assert!(Bundle::decode(&bytes[..bytes.len() - 1]).is_err());
+                assert!(Bundle::decode(&u32::MAX.to_le_bytes()).is_err());
+                Ok(())
+            })?
+            .join()
+            .unwrap()
+    }
+}

--- a/src/netplay/tests.rs
+++ b/src/netplay/tests.rs
@@ -226,7 +226,7 @@ fn wire_round_trip_and_bounded_rejection() {
     }
 }
 
-fn emulator() -> Result<Emulator> {
+pub(super) fn emulator() -> Result<Emulator> {
     use crate::{
         audio::NullSink,
         bus::{Bus, PortDevice},
@@ -372,8 +372,8 @@ fn udp_pair_with_delay(delay: u8, window: u8) -> Result<()> {
         Ok(options)
     };
     let mut sessions = [
-        Session::new(session_options(0)?, &mut machines[0], &safe_config()?)?,
-        Session::new(session_options(1)?, &mut machines[1], &safe_config()?)?,
+        Connection::<NativeTransport>::new(session_options(0)?, &mut machines[0], &safe_config()?)?,
+        Connection::<NativeTransport>::new(session_options(1)?, &mut machines[1], &safe_config()?)?,
     ];
     let destinations = [
         sessions[0].transport.socket().local_addr()?,
@@ -435,7 +435,11 @@ fn udp_pair_with_delay(delay: u8, window: u8) -> Result<()> {
 fn mismatch_desync_and_disconnect_stop_the_session() -> Result<()> {
     let peer = UdpSocket::bind("127.0.0.1:0")?;
     let mut emu = emulator()?;
-    let mut session = Session::new(options(peer.local_addr()?, 0), &mut emu, &safe_config()?)?;
+    let mut session = Connection::<NativeTransport>::new(
+        options(peer.local_addr()?, 0),
+        &mut emu,
+        &safe_config()?,
+    )?;
     let mut packet = wire::Packet {
         session: [42; 16],
         identity: [0; 32],
@@ -455,7 +459,11 @@ fn mismatch_desync_and_disconnect_stop_the_session() -> Result<()> {
         session.step(&mut emu, Input::default(), true).is_err(),
         "failure stays latched"
     );
-    let mut session = Session::new(options(peer.local_addr()?, 0), &mut emu, &safe_config()?)?;
+    let mut session = Connection::<NativeTransport>::new(
+        options(peer.local_addr()?, 0),
+        &mut emu,
+        &safe_config()?,
+    )?;
     packet.identity = session.identity;
     session.connected = true;
     session.rollback.current = 60;
@@ -467,7 +475,11 @@ fn mismatch_desync_and_disconnect_stop_the_session() -> Result<()> {
     assert!(poll_error(&mut session, &mut emu)
         .to_string()
         .contains("desynchronized"));
-    let mut session = Session::new(options(peer.local_addr()?, 0), &mut emu, &safe_config()?)?;
+    let mut session = Connection::<NativeTransport>::new(
+        options(peer.local_addr()?, 0),
+        &mut emu,
+        &safe_config()?,
+    )?;
     session.connected = true;
     session.last_received = Instant::now() - Duration::from_secs(11);
     assert!(session
@@ -478,7 +490,7 @@ fn mismatch_desync_and_disconnect_stop_the_session() -> Result<()> {
     Ok(())
 }
 
-fn safe_config() -> Result<crate::config::Config> {
+pub(super) fn safe_config() -> Result<crate::config::Config> {
     let mut cfg = crate::config::Config::try_from(crate::config::RawConfig::default())?;
     cfg.serial.mode = crate::config::SerialMode::Off;
     Ok(cfg)
@@ -512,7 +524,11 @@ fn capture_waits_for_the_peer_to_acknowledge_retransmitted_local_input() -> Resu
     let peer = UdpSocket::bind("127.0.0.1:0")?;
     peer.set_read_timeout(Some(Duration::from_secs(1)))?;
     let mut emu = emulator()?;
-    let mut session = Session::new(options(peer.local_addr()?, 0), &mut emu, &safe_config()?)?;
+    let mut session = Connection::<NativeTransport>::new(
+        options(peer.local_addr()?, 0),
+        &mut emu,
+        &safe_config()?,
+    )?;
     let mut packet = wire::Packet {
         session: session.settings.session,
         identity: session.identity,
@@ -569,7 +585,7 @@ fn capture_waits_for_the_peer_to_acknowledge_retransmitted_local_input() -> Resu
     Ok(())
 }
 
-fn poll_error(session: &mut Session, emu: &mut Emulator) -> anyhow::Error {
+fn poll_error(session: &mut Connection<NativeTransport>, emu: &mut Emulator) -> anyhow::Error {
     for _ in 0..100 {
         if let Err(error) = session.step(emu, Input::default(), false) {
             return error;
@@ -879,12 +895,12 @@ fn internet_pair(relay_only: bool) -> Result<()> {
     let mut machines = [emulator()?, emulator()?];
     let cfg = safe_config()?;
     let mut sessions = [
-        Session::new(
+        Connection::<NativeTransport>::new(
             ConnectionOptions::Internet(Box::new(host)),
             &mut machines[0],
             &cfg,
         )?,
-        Session::new(
+        Connection::<NativeTransport>::new(
             ConnectionOptions::Internet(Box::new(guest)),
             &mut machines[1],
             &cfg,

--- a/src/netplay/transport.rs
+++ b/src/netplay/transport.rs
@@ -81,6 +81,11 @@ pub struct PacketQueue {
 }
 
 impl PacketQueue {
+    #[cfg(all(feature = "netplay-internet", not(target_arch = "wasm32")))]
+    pub(super) fn has_incoming(&self) -> bool {
+        !self.incoming.is_empty()
+    }
+
     pub fn push(&mut self, packet: &[u8]) -> Result<()> {
         ensure!(packet.len() <= MAX_PACKET, "netplay packet is too large");
         if self.incoming.len() == 64 {

--- a/src/savestate.rs
+++ b/src/savestate.rs
@@ -379,7 +379,9 @@ const STATE_MAGIC: &[u8; 8] = b"CLSSTATE";
 //      between dumps.
 //  79: Expansion-board kind IDs are explicit and feature-independent. Builds
 //      without an optional board reject its kind without renumbering others.
-pub const STATE_VERSION: u32 = 79;
+//  80: Hard-drive state distinguishes private netplay sector overlays from
+//      full in-memory volumes and persistent image files.
+pub const STATE_VERSION: u32 = 80;
 
 /// Default state file name, timestamped like the screenshot/recorder names.
 pub fn auto_filename() -> std::path::PathBuf {

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -940,6 +940,7 @@ pub struct App {
     netplay_input: crate::netplay::LocalInput,
     netplay_keyboard_controller: bool,
     netplay_setup: Option<crate::video::launcher::NetplaySetup>,
+    netplay_disk_picker: Option<(usize, app_netplay::DiskPicker)>,
     // Linux serves clipboard selections from the owning instance.
     host_clipboard: Option<arboard::Clipboard>,
     emu: Emulator,
@@ -2220,6 +2221,7 @@ impl App {
             netplay_input: Default::default(),
             netplay_keyboard_controller: true,
             netplay_setup: None,
+            netplay_disk_picker: None,
             host_clipboard: None,
             run_ahead_frames,
             runahead_machine_block,
@@ -3330,9 +3332,13 @@ impl App {
                 .tt_note_input(crate::inputsched::ReplayAction::Pot { port, x, y });
         }
         let mut disk_inserts = Vec::new();
+        let mut disk_change_available = self.netplay.as_ref().is_none_or(|s| s.can_change_disk());
         self.auto_disk_inserts.retain(|insert| {
-            if emu_secs >= insert.insert_at_emulated_secs {
+            if disk_change_available && emu_secs >= insert.insert_at_emulated_secs {
                 disk_inserts.push(insert.clone());
+                if self.netplay.is_some() {
+                    disk_change_available = false;
+                }
                 false
             } else {
                 true

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -1387,10 +1387,11 @@ impl App {
         // The same validation Run has always used: the raw view through the
         // config pipeline (MachineSetup::build_config is exactly this over
         // its own to_raw()).
-        let mut cfg = Config::try_from(staged)?;
-        if guest {
-            cfg.serial.mode = crate::config::SerialMode::Off;
-        }
+        let mut cfg = if guest {
+            crate::netplay::guest_config(&raw)?
+        } else {
+            Config::try_from(staged)?
+        };
         if options.is_some() {
             crate::netplay::prepare_config(&mut cfg)?;
         }

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -1360,31 +1360,45 @@ impl App {
                 "Netplay requires restarting Copperline without the GDB endpoint"
             );
         }
-        let mut staged = raw.clone();
+        let guest = options
+            .as_ref()
+            .is_some_and(|options| options.settings().player == 1);
+        let mut staged = if guest {
+            RawConfig::default()
+        } else {
+            raw.clone()
+        };
         let (game, opts) = crate::whdload::game_and_options(&staged);
         if let Some(game) = game {
-            anyhow::ensure!(
-                options.is_none(),
-                "Netplay needs a floppy session; clear the WHDLoad game first"
-            );
             let prepared = crate::whdload::prepare(&game, &opts)?;
             crate::whdload::apply_to_raw(&mut staged, &prepared);
             info!(
-                "whdload: booting {} ({}) from {}, saves persist in {}",
+                "whdload: booting {} ({}) from {}",
                 prepared.slave_rel.display(),
                 prepared.slave.name.as_deref().unwrap_or("unnamed slave"),
-                game.display(),
-                prepared.game_dir.display()
+                game.display()
             );
+            if options.is_none() {
+                info!("whdload: saves persist in {}", prepared.game_dir.display());
+            } else {
+                info!("whdload: netplay saves last for this session only");
+            }
         }
         // The same validation Run has always used: the raw view through the
         // config pipeline (MachineSetup::build_config is exactly this over
         // its own to_raw()).
         let mut cfg = Config::try_from(staged)?;
+        if guest {
+            cfg.serial.mode = crate::config::SerialMode::Off;
+        }
         if options.is_some() {
             crate::netplay::prepare_config(&mut cfg)?;
         }
-        crate::config::resolve_bundled_rom(&mut cfg)?;
+        if guest {
+            let _ = crate::config::resolve_bundled_rom(&mut cfg);
+        } else {
+            crate::config::resolve_bundled_rom(&mut cfg)?;
+        }
         self.build_and_run_machine(&cfg, raw, options)
     }
 
@@ -1421,7 +1435,10 @@ impl App {
         self.emu.bus_mut().floppy.release_bridges();
         // This path boots a fresh machine, never a save state, so a real
         // ROM is required here.
-        let built = crate::emulator::build_machine(cfg, audio, true, false).and_then(|mut emu| {
+        let guest = options
+            .as_ref()
+            .is_some_and(|options| options.settings().player == 1);
+        let built = crate::emulator::build_machine(cfg, audio, true, guest).and_then(|mut emu| {
             let session = options
                 .map(|options| crate::netplay::Session::new(options, &mut emu, cfg))
                 .transpose()?;

--- a/src/video/window/app_media.rs
+++ b/src/video/window/app_media.rs
@@ -9,6 +9,23 @@ impl App {
     /// the drive's swap playlist; the first image is inserted right away
     /// and the rest are queued for the swap button / shortcut.
     pub(super) fn load_drive_disks_from_dialog(&mut self, drive_idx: usize) {
+        if let Some(session) = &self.netplay {
+            if !session.can_change_disk() || self.netplay_disk_picker.is_some() {
+                self.show_osd("Only the host can change disks; wait for the session to be ready");
+                return;
+            }
+            // Keep servicing the peer while the native picker is open.
+            self.netplay_disk_picker = Some((
+                drive_idx,
+                Box::pin(
+                    rfd::AsyncFileDialog::new()
+                        .set_title(format!("Netplay: load DF{drive_idx} disk image(s)"))
+                        .add_filter("Amiga disk images", crate::floppy::IMAGE_EXTENSIONS)
+                        .pick_files(),
+                ),
+            ));
+            return;
+        }
         self.suspend_live_audio_for_host_io();
         let picked = rfd::FileDialog::new()
             .set_title(format!("Load DF{drive_idx} disk image(s)"))
@@ -35,10 +52,14 @@ impl App {
             return;
         };
         let count = paths.len();
-        self.disk_playlists[drive_idx] = paths;
-        self.disk_playlist_index[drive_idx] = 0;
+        if self.netplay.is_none() {
+            self.disk_playlists[drive_idx] = paths.clone();
+            self.disk_playlist_index[drive_idx] = 0;
+        }
         let name = display_file_name(&path);
         if self.insert_disk_image(drive_idx, path, self.disk_write_protected[drive_idx]) {
+            self.disk_playlists[drive_idx] = paths;
+            self.disk_playlist_index[drive_idx] = 0;
             if count > 1 {
                 self.show_osd(format!("DF{drive_idx}: {name} (1/{count})"));
             } else {
@@ -73,9 +94,12 @@ impl App {
         let next = (self.disk_playlist_index[drive_idx] + 1) % count;
         let path = self.disk_playlists[drive_idx][next].clone();
         let write_protected = self.disk_write_protected[drive_idx];
-        self.disk_playlist_index[drive_idx] = next;
+        if self.netplay.is_none() {
+            self.disk_playlist_index[drive_idx] = next;
+        }
         let name = display_file_name(&path);
         if self.insert_disk_image(drive_idx, path, write_protected) {
+            self.disk_playlist_index[drive_idx] = next;
             self.show_osd(format!("DF{drive_idx}: {name} ({}/{count})", next + 1));
         } else {
             self.show_osd(format!("DF{drive_idx}: swap failed (see log)"));
@@ -83,6 +107,12 @@ impl App {
     }
 
     pub(super) fn eject_drive_disk(&mut self, drive_idx: usize) {
+        if let Some(session) = &mut self.netplay {
+            if let Err(error) = session.change_disk(&self.emu, drive_idx, Vec::new(), false) {
+                self.show_osd(format!("DF{drive_idx}: {error}"));
+            }
+            return;
+        }
         if !self.emu.bus().floppy.disk_inserted(drive_idx) {
             self.show_osd(format!("DF{drive_idx}: no disk"));
             return;
@@ -147,6 +177,26 @@ impl App {
     /// an explanatory notice. winit reports drops with no cursor position,
     /// so the target drive can only be picked after the fact.
     pub(super) fn handle_dropped_files(&mut self, files: Vec<PathBuf>) {
+        if self.netplay.is_some() {
+            if !self.netplay.as_ref().is_some_and(|s| s.can_change_disk()) {
+                self.show_osd("Only the host can change disks; wait for the session to be ready");
+                return;
+            }
+            if files
+                .iter()
+                .any(|p| classify_dropped_media(p) != DroppedMediaKind::Floppy)
+            {
+                self.show_osd("During netplay, drop replacement floppy images only");
+                return;
+            }
+            if let Some(drive) = (0..4).find(|&drive| self.emu.bus().floppy.drive_connected(drive))
+            {
+                self.insert_disk_playlist(drive, files);
+            } else {
+                self.show_osd("No floppy drive is connected");
+            }
+            return;
+        }
         // The configuration screen runs on a placeholder machine: an insert
         // would target hardware the launcher is about to rebuild, and the
         // chooser would replace the launcher panel and its unsaved state.
@@ -296,6 +346,30 @@ impl App {
         path: PathBuf,
         write_protected: bool,
     ) -> bool {
+        if let Some(session) = &mut self.netplay {
+            let result = (|| -> anyhow::Result<()> {
+                anyhow::ensure!(
+                    session.can_change_disk(),
+                    "only the host can change disks; wait for the session to be ready"
+                );
+                use std::io::Read;
+                let mut bytes = Vec::new();
+                std::fs::File::open(&path)?
+                    .take(16 * 1024 * 1024 + 1)
+                    .read_to_end(&mut bytes)?;
+                anyhow::ensure!(!bytes.is_empty(), "the disk image is empty");
+                session.change_disk(&self.emu, drive_idx, bytes, !write_protected)
+            })();
+            if let Err(error) = result {
+                warn!("netplay disk change: {error:#}");
+                self.show_osd(format!("DF{drive_idx}: {error}"));
+                return false;
+            }
+            self.show_osd(format!(
+                "Sharing replacement DF{drive_idx} with the other player..."
+            ));
+            return true;
+        }
         self.suspend_live_audio_for_host_io();
         let result = match self.emu.bus_mut().floppy.insert_disk_image(
             drive_idx,

--- a/src/video/window/app_netplay.rs
+++ b/src/video/window/app_netplay.rs
@@ -4,6 +4,9 @@
 
 use super::*;
 
+pub(super) type DiskPicker =
+    std::pin::Pin<Box<dyn std::future::Future<Output = Option<Vec<rfd::FileHandle>>>>>;
+
 impl App {
     pub fn attach_netplay(&mut self, session: crate::netplay::Session) {
         self.netplay_setup = Some(crate::video::launcher::NetplaySetup::from(
@@ -66,6 +69,7 @@ impl App {
     }
 
     pub(super) fn leave_netplay(&mut self, error: Option<String>) {
+        self.netplay_disk_picker = None;
         self.set_mouse_captured(false);
         self.netplay = None;
         self.netplay_input = Default::default();
@@ -119,12 +123,50 @@ impl App {
     }
 
     pub(super) fn step_netplay(&mut self) -> Result<bool> {
+        if let Some((drive, picker)) = &mut self.netplay_disk_picker {
+            let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+            if let std::task::Poll::Ready(files) = picker.as_mut().poll(&mut context) {
+                let drive = *drive;
+                self.netplay_disk_picker = None;
+                if let Some(files) = files {
+                    self.insert_disk_playlist(
+                        drive,
+                        files.into_iter().map(|f| f.path().to_path_buf()).collect(),
+                    );
+                }
+            }
+        }
         let session = self.netplay.as_mut().unwrap();
         let before = session.status();
         let connected = before.connected;
         let stepped = session.step_local(&mut self.emu, &mut self.netplay_input, true)?;
         let after = session.status();
         let route = session.route();
+        let config = session.take_config();
+        let progress = session.take_progress();
+        let guest = session.player() == 1;
+        if let Some(cfg) = config {
+            self.netplay_input = Default::default();
+            self.netplay_keyboard_controller = self.mouse_port().is_none();
+            self.keyboard_joy_held = Default::default();
+            self.about_machine_lines = crate::config::about_machine_lines(&cfg);
+            self.disk_write_protected = std::array::from_fn(|drive| {
+                self.emu
+                    .bus()
+                    .floppy
+                    .disk_image_write_protected(drive)
+                    .unwrap_or(true)
+            });
+            if guest {
+                self.disk_playlists = Default::default();
+                self.disk_playlist_index = [0; 4];
+            }
+            self.reset_render_pipeline();
+        }
+        if let Some(progress) = progress {
+            log::debug!(target: "copperline::netplay", "netplay: {progress}");
+            self.show_osd(progress);
+        }
         if after.rollbacks != before.rollbacks {
             self.reset_render_pipeline();
         }
@@ -160,13 +202,17 @@ impl App {
         }
         loop {
             let session = self.netplay.as_mut().unwrap();
+            if session.ready_to_capture() {
+                return Ok(());
+            }
             let before = session.status().rollbacks;
             session.step_local(&mut self.emu, &mut self.netplay_input, false)?;
             let status = session.status();
+            let ready = session.ready_to_capture();
             if status.rollbacks != before {
                 self.reset_render_pipeline();
             }
-            if status.ready_to_capture() {
+            if ready {
                 return Ok(());
             }
             std::thread::sleep(std::time::Duration::from_millis(2));
@@ -202,6 +248,9 @@ impl App {
                     match code {
                         KeyCode::KeyQ => event_loop.exit(),
                         KeyCode::KeyF => self.toggle_fullscreen(),
+                        KeyCode::KeyD if self.netplay.as_ref().is_some_and(|s| s.player() == 0) => {
+                            self.cycle_disk()
+                        }
                         KeyCode::KeyG if self.mouse_port().is_some() => {
                             self.set_mouse_captured(!self.mouse_captured)
                         }
@@ -256,6 +305,7 @@ impl App {
                 true
             }
             WindowEvent::CursorMoved { position, .. } => {
+                let previous_cursor_pos = self.cursor_pos;
                 self.last_cursor_phys = Some(*position);
                 let display_src = self.display_canvas_src();
                 let pos = self
@@ -263,13 +313,20 @@ impl App {
                     .as_ref()
                     .and_then(|r| main_cursor_position(r, display_src, *position));
                 self.cursor_pos = pos;
+                if bar_hover_changed(&bar_layout(&self.media_bar()), previous_cursor_pos, pos) {
+                    self.request_redraw();
+                }
                 if !self.mouse_captured && self.main_window_focused {
                     self.track_uncaptured_cursor_motion(pos);
                 }
                 true
             }
             WindowEvent::CursorLeft { .. } => {
+                let previous_cursor_pos = self.cursor_pos;
                 self.cursor_pos = None;
+                if bar_hover_changed(&bar_layout(&self.media_bar()), previous_cursor_pos, None) {
+                    self.request_redraw();
+                }
                 self.last_display_cursor_pos = None;
                 if !self.mouse_captured {
                     self.release_mouse_buttons();
@@ -277,6 +334,24 @@ impl App {
                 true
             }
             WindowEvent::MouseInput { state, button, .. } => {
+                if *state == ElementState::Pressed
+                    && *button == MouseButton::Left
+                    && !self.mouse_captured
+                    && self.cursor_pos.is_some_and(cursor_in_status_bar)
+                {
+                    if let Some(pos) = self.cursor_pos {
+                        let layout = bar_layout(&self.media_bar());
+                        if let Some(
+                            control @ (BarControl::DriveLoad(_)
+                            | BarControl::DriveSwap(_)
+                            | BarControl::DriveEject(_)),
+                        ) = control_at(pos, &layout)
+                        {
+                            self.activate_bar_control(control);
+                        }
+                    }
+                    return true;
+                }
                 if self.mouse_port().is_some() && self.main_window_focused {
                     let pressed = *state == ElementState::Pressed;
                     let over_display = self.cursor_pos.is_some_and(cursor_in_display);
@@ -309,6 +384,9 @@ impl App {
             | WindowEvent::ScaleFactorChanged { .. }
             | WindowEvent::RedrawRequested
             | WindowEvent::Occluded(_) => false,
+            WindowEvent::HoveredFile(_)
+            | WindowEvent::HoveredFileCancelled
+            | WindowEvent::DroppedFile(_) => false,
             _ => true,
         }
     }

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -11609,48 +11609,56 @@ mod gdb_and_control {
 
 #[test]
 fn netplay_routes_local_inputs_and_blocks_unilateral_menu_actions() -> anyhow::Result<()> {
-    let mut app = test_app();
-    app.emu.bus_mut().rtc.set_seed(Some(946684800), false);
-    app.emu
-        .bus_mut()
-        .input
-        .set_port_device(0, crate::bus::PortDevice::Joystick);
-    app.emu.bus_mut().paula.serial = Box::new(crate::serial::NullSerialSink);
-    let mut cfg = crate::config::Config::try_from(crate::config::RawConfig::default())?;
-    cfg.serial.mode = crate::config::SerialMode::Off;
-    let options = crate::netplay::Options {
-        bind: "127.0.0.1:0".parse()?,
-        peer: "127.0.0.1:19732".parse()?,
-        player: 0,
-        session: [7; 16],
-        input_delay: 0,
-        rollback_frames: 8,
-    };
-    let session = crate::netplay::Session::new(options, &mut app.emu, &cfg)?;
-    app.attach_netplay(session);
-    let before = app.emu.runahead_snapshot()?;
-    app.handle_amiga_key_event(0x40, true);
-    app.auto_joy_held[0].red = true;
-    app.apply_auto_joy_state(0);
-    assert_ne!(app.netplay_input.held.keys[8] & 1, 0);
-    assert_eq!(app.netplay_input.held.buttons, 1 << 4);
-    app.auto_joy_held[1].up = true;
-    app.apply_auto_joy_state(1);
-    assert_eq!(
-        app.netplay_input.held.buttons,
-        1 << 4,
-        "the remote port cannot replace local input"
-    );
-    app.run_menu_action(crate::video::menu::MenuAction::ToggleRewind, None);
-    assert!(!app.rewind_armed);
-    assert_eq!(
-        app.emu.runahead_snapshot()?,
-        before,
-        "only the netplay timeline may touch the machine"
-    );
-    app.handle_amiga_key_event(0x40, false);
-    assert_eq!(app.netplay_input.held.keys[8], 0);
-    Ok(())
+    // Two complete machines plus cold setup exceed the default test stack.
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| -> anyhow::Result<()> {
+            let mut app = test_app();
+            app.emu.bus_mut().rtc.set_seed(Some(946684800), false);
+            app.emu
+                .bus_mut()
+                .input
+                .set_port_device(0, crate::bus::PortDevice::Joystick);
+            app.emu.bus_mut().paula.serial = Box::new(crate::serial::NullSerialSink);
+            let mut cfg = crate::config::Config::try_from(crate::config::RawConfig::default())?;
+            cfg.serial.mode = crate::config::SerialMode::Off;
+            cfg.port_devices[0] = crate::bus::PortDevice::Joystick;
+            let options = crate::netplay::Options {
+                bind: "127.0.0.1:0".parse()?,
+                peer: "127.0.0.1:19732".parse()?,
+                player: 0,
+                session: [7; 16],
+                input_delay: 0,
+                rollback_frames: 8,
+            };
+            let session = crate::netplay::Session::new(options, &mut app.emu, &cfg)?;
+            app.attach_netplay(session);
+            let before = app.emu.runahead_snapshot()?;
+            app.handle_amiga_key_event(0x40, true);
+            app.auto_joy_held[0].red = true;
+            app.apply_auto_joy_state(0);
+            assert_ne!(app.netplay_input.held.keys[8] & 1, 0);
+            assert_eq!(app.netplay_input.held.buttons, 1 << 4);
+            app.auto_joy_held[1].up = true;
+            app.apply_auto_joy_state(1);
+            assert_eq!(
+                app.netplay_input.held.buttons,
+                1 << 4,
+                "the remote port cannot replace local input"
+            );
+            app.run_menu_action(crate::video::menu::MenuAction::ToggleRewind, None);
+            assert!(!app.rewind_armed);
+            assert_eq!(
+                app.emu.runahead_snapshot()?,
+                before,
+                "only the netplay timeline may touch the machine"
+            );
+            app.handle_amiga_key_event(0x40, false);
+            assert_eq!(app.netplay_input.held.keys[8], 0);
+            Ok(())
+        })?
+        .join()
+        .unwrap()
 }
 #[test]
 fn netplay_gui_run_rejects_errors_and_preserves_the_current_machine() {
@@ -11721,138 +11729,156 @@ fn netplay_gui_rejects_an_existing_gdb_endpoint() {
 
 #[test]
 fn netplay_gui_peers_connect_and_can_return_to_setup_and_retry() -> anyhow::Result<()> {
-    use crate::video::launcher::{LauncherField as F, LauncherTab};
-    use std::net::UdpSocket;
-    let reserved = [
-        UdpSocket::bind("127.0.0.1:0")?,
-        UdpSocket::bind("127.0.0.1:0")?,
-    ];
-    let addresses = [reserved[0].local_addr()?, reserved[1].local_addr()?];
-    drop(reserved);
-    let mut apps = [test_app(), test_app()];
-    for (player, app) in apps.iter_mut().enumerate() {
-        app.machine_config.audio.output_enabled = Some(false);
-        app.open_launcher();
-        app.activate_ui_control(UiControl::LauncherToggle(F::NetplayEnabled));
-        let state = app.launcher_state_mut().unwrap();
-        state.netplay.bind = addresses[player].to_string();
-        state.netplay.peer = addresses[1 - player].to_string();
-        state.netplay.player = player;
-        state.netplay.code = "0123456789abcdef0123456789abcdef".into();
-        app.launcher_run();
-        assert!(
-            app.netplay.is_some(),
-            "{:?}",
-            app.launcher_state().and_then(|s| s.status.as_ref())
-        );
-        assert!(app.ui.panel.is_none());
-        assert_eq!(app.emu.bus().emulated_cck(), 0);
-        app.emu.set_paced(false);
-        // The launcher must leave the same frame-zero state as a direct CLI build.
-        let mut cfg = crate::config::Config::try_from(app.machine_config.clone())?;
-        crate::netplay::prepare_config(&mut cfg)?;
-        crate::config::resolve_bundled_rom(&mut cfg)?;
-        let direct = crate::emulator::build_machine(&cfg, Box::new(NullSink), false, false)?;
-        assert_eq!(app.emu.netplay_snapshot()?, direct.netplay_snapshot()?);
-    }
-    for _ in 0..250 {
-        for app in &mut apps {
-            let session = app.netplay.as_mut().unwrap();
-            let advance = session.status().frame < 60;
-            session.step(&mut app.emu, Default::default(), advance)?;
-        }
-        if apps
-            .iter()
-            .all(|app| app.netplay.as_ref().unwrap().status().checked_frame == 60)
-        {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(1));
-    }
-    for app in &apps {
-        assert_eq!(app.netplay.as_ref().unwrap().status().checked_frame, 60);
-    }
-    assert_eq!(
-        apps[0].emu.netplay_snapshot()?,
-        apps[1].emu.netplay_snapshot()?
-    );
-    apps[0].leave_netplay(None);
-    let state = apps[0].launcher_state().unwrap();
-    assert_eq!(state.tab, LauncherTab::Netplay);
-    assert_eq!(state.netplay.peer, addresses[1].to_string());
-    assert!(apps[0].paused);
-    assert!(apps[0].netplay.is_none());
-    apps[1].leave_netplay(Some("peer timed out".into()));
-    assert!(apps[1]
-        .launcher_state()
+    // Two complete machines plus cold setup exceed the default test stack.
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| -> anyhow::Result<()> {
+            use crate::video::launcher::{LauncherField as F, LauncherTab};
+            use std::net::UdpSocket;
+            let reserved = [
+                UdpSocket::bind("127.0.0.1:0")?,
+                UdpSocket::bind("127.0.0.1:0")?,
+            ];
+            let addresses = [reserved[0].local_addr()?, reserved[1].local_addr()?];
+            drop(reserved);
+            let mut apps = [test_app(), test_app()];
+            for (player, app) in apps.iter_mut().enumerate() {
+                app.machine_config.audio.output_enabled = Some(false);
+                app.open_launcher();
+                app.activate_ui_control(UiControl::LauncherToggle(F::NetplayEnabled));
+                let state = app.launcher_state_mut().unwrap();
+                state.netplay.bind = addresses[player].to_string();
+                state.netplay.peer = addresses[1 - player].to_string();
+                state.netplay.player = player;
+                state.netplay.code = "0123456789abcdef0123456789abcdef".into();
+                app.launcher_run();
+                assert!(
+                    app.netplay.is_some(),
+                    "{:?}",
+                    app.launcher_state().and_then(|s| s.status.as_ref())
+                );
+                assert!(app.ui.panel.is_none());
+                assert_eq!(app.emu.bus().emulated_cck(), 0);
+                app.emu.set_paced(false);
+                // The launcher must leave the same frame-zero state as a direct CLI build.
+                let mut cfg = crate::config::Config::try_from(app.machine_config.clone())?;
+                crate::netplay::prepare_config(&mut cfg)?;
+                crate::config::resolve_bundled_rom(&mut cfg)?;
+                let direct =
+                    crate::emulator::build_machine(&cfg, Box::new(NullSink), false, false)?;
+                if player == 0 {
+                    assert_eq!(app.emu.netplay_snapshot()?, direct.netplay_snapshot()?);
+                }
+            }
+            for _ in 0..250 {
+                for app in &mut apps {
+                    let session = app.netplay.as_mut().unwrap();
+                    let advance = session.status().frame < 60;
+                    session.step(&mut app.emu, Default::default(), advance)?;
+                }
+                if apps
+                    .iter()
+                    .all(|app| app.netplay.as_ref().unwrap().status().checked_frame == 60)
+                {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            for app in &apps {
+                assert_eq!(app.netplay.as_ref().unwrap().status().checked_frame, 60);
+            }
+            assert_eq!(
+                apps[0].emu.netplay_snapshot()?,
+                apps[1].emu.netplay_snapshot()?
+            );
+            apps[0].leave_netplay(None);
+            let state = apps[0].launcher_state().unwrap();
+            assert_eq!(state.tab, LauncherTab::Netplay);
+            assert_eq!(state.netplay.peer, addresses[1].to_string());
+            assert!(apps[0].paused);
+            assert!(apps[0].netplay.is_none());
+            apps[1].leave_netplay(Some("peer timed out".into()));
+            assert!(apps[1]
+                .launcher_state()
+                .unwrap()
+                .status
+                .as_ref()
+                .unwrap()
+                .text
+                .contains("timed out"));
+            for app in &mut apps {
+                app.launcher_run();
+                assert!(
+                    app.netplay.is_some(),
+                    "retry must release and rebind the socket"
+                );
+                assert_eq!(app.emu.bus().emulated_cck(), 0);
+                assert!(!app.paused);
+            }
+            Ok(())
+        })?
+        .join()
         .unwrap()
-        .status
-        .as_ref()
-        .unwrap()
-        .text
-        .contains("timed out"));
-    for app in &mut apps {
-        app.launcher_run();
-        assert!(
-            app.netplay.is_some(),
-            "retry must release and rebind the socket"
-        );
-        assert_eq!(app.emu.bus().emulated_cck(), 0);
-        assert!(!app.paused);
-    }
-    Ok(())
 }
 
 #[test]
 fn netplay_host_mouse_owns_only_the_local_mouse_port() -> anyhow::Result<()> {
-    for player in 0..2 {
-        let mut app = test_app();
-        app.emu
-            .bus_mut()
-            .rtc
-            .set_seed(Some(crate::netplay::RTC_SEED), false);
-        app.emu.bus_mut().paula.serial = Box::new(crate::serial::NullSerialSink);
-        for port in 0..2 {
-            app.emu
-                .bus_mut()
-                .input
-                .set_port_device(port, crate::bus::PortDevice::Mouse);
-        }
-        let mut cfg = crate::config::Config::try_from(crate::config::RawConfig::default())?;
-        cfg.serial.mode = crate::config::SerialMode::Off;
-        let session = crate::netplay::Session::new(
-            crate::netplay::Options {
-                bind: "127.0.0.1:0".parse()?,
-                peer: "127.0.0.1:19732".parse()?,
-                player,
-                session: [31; 16],
-                input_delay: 0,
-                rollback_frames: 8,
-            },
-            &mut app.emu,
-            &cfg,
-        )?;
-        app.attach_netplay(session);
-        assert_eq!(app.mouse_port(), Some(player));
-        assert!(!app.netplay_keyboard_controller);
-        let before = app.emu.netplay_snapshot()?;
-        app.add_mouse_delta_i32(15, -23);
-        app.netplay_input.held.set_mouse_button(0, true);
-        app.pump_netplay_input();
-        assert_eq!(
-            (
-                app.netplay_input.mouse_pending.0,
-                app.netplay_input.mouse_pending.1
-            ),
-            (15, -23)
-        );
-        assert_eq!(app.netplay_input.held.mouse_buttons, 1);
-        assert!(app.emu.netplay_snapshot()? == before);
-        app.release_mouse_buttons();
-        assert_eq!(app.netplay_input, Default::default());
-        app.add_mouse_delta_i32(70_000, -90_000);
-        assert_eq!(app.netplay_input.mouse_pending, (70_000, -90_000));
-        assert!(app.emu.netplay_snapshot()? == before);
-    }
-    Ok(())
+    // Two complete machines plus cold setup exceed the default test stack.
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| -> anyhow::Result<()> {
+            for player in 0..2 {
+                let mut app = test_app();
+                app.emu
+                    .bus_mut()
+                    .rtc
+                    .set_seed(Some(crate::netplay::RTC_SEED), false);
+                app.emu.bus_mut().paula.serial = Box::new(crate::serial::NullSerialSink);
+                for port in 0..2 {
+                    app.emu
+                        .bus_mut()
+                        .input
+                        .set_port_device(port, crate::bus::PortDevice::Mouse);
+                }
+                let mut cfg = crate::config::Config::try_from(crate::config::RawConfig::default())?;
+                cfg.serial.mode = crate::config::SerialMode::Off;
+                cfg.port_devices = [crate::bus::PortDevice::Mouse; 2];
+                let session = crate::netplay::Session::new(
+                    crate::netplay::Options {
+                        bind: "127.0.0.1:0".parse()?,
+                        peer: "127.0.0.1:19732".parse()?,
+                        player,
+                        session: [31; 16],
+                        input_delay: 0,
+                        rollback_frames: 8,
+                    },
+                    &mut app.emu,
+                    &cfg,
+                )?;
+                app.attach_netplay(session);
+                assert_eq!(app.mouse_port(), Some(player));
+                assert!(!app.netplay_keyboard_controller);
+                let before = app.emu.netplay_snapshot()?;
+                app.add_mouse_delta_i32(15, -23);
+                app.netplay_input.held.set_mouse_button(0, true);
+                app.pump_netplay_input();
+                assert_eq!(
+                    (
+                        app.netplay_input.mouse_pending.0,
+                        app.netplay_input.mouse_pending.1
+                    ),
+                    (15, -23)
+                );
+                assert_eq!(app.netplay_input.held.mouse_buttons, 1);
+                assert!(app.emu.netplay_snapshot()? == before);
+                app.release_mouse_buttons();
+                assert_eq!(app.netplay_input, Default::default());
+                app.add_mouse_delta_i32(70_000, -90_000);
+                assert_eq!(app.netplay_input.mouse_pending, (70_000, -90_000));
+                assert!(app.emu.netplay_snapshot()? == before);
+            }
+            Ok(())
+        })?
+        .join()
+        .unwrap()
 }

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -11759,6 +11759,7 @@ fn netplay_gui_peers_connect_and_can_return_to_setup_and_retry() -> anyhow::Resu
                 );
                 assert!(app.ui.panel.is_none());
                 assert_eq!(app.emu.bus().emulated_cck(), 0);
+                assert_eq!(app.audio_output, crate::audio::AudioOutput::Disabled);
                 app.emu.set_paced(false);
                 // The launcher must leave the same frame-zero state as a direct CLI build.
                 let mut cfg = crate::config::Config::try_from(app.machine_config.clone())?;

--- a/tools/check-netplay.py
+++ b/tools/check-netplay.py
@@ -56,7 +56,10 @@ def main():
             logs.append(log)
             command = [str(args.binary.resolve()), "--factory", "--model", "A500",
                        "--serial", "off", "--port1", "joystick", "--port2", "joystick"]
-            command += extra
+            # Only the host has game assets/configuration. The guest proves
+            # setup transfer by starting with its bare local defaults.
+            if player == 0:
+                command += extra
             if args.internet:
                 if player == 0:
                     command += ["--netplay-host", str(invitation)]


### PR DESCRIPTION
Desktop netplay guests now receive the host's machine settings, ROMs and game media over either Direct IP UDP or iroh. Guests can join with connection details alone while retaining their own audio output, display and host input preferences. WHDLoad, `--run`, directory volumes and IDE/SCSI/LIDE images use private session disks whose writes participate in rollback without changing the original files.

Hosts can insert, swap and eject DF0–DF3 during play through the existing media controls, playlists, drag and drop, or scheduled CLI events. Both peers pause at a confirmed frame, verify and apply the replacement, then resume together. Setup and disk transfers use a bounded reliable control channel over the selected transport, consuming owned media buffers without making a full concatenated send buffer. Rollback serialization borrows dirty sectors without cloning the overlay.

The change also fixes synthesized RDB flags that stopped boot drivers from discovering later disk targets, and drains queued iroh packets before reporting a disconnect. README, user and internals documentation describe the new flow and limits. CD/ATAPI and asynchronous CopperHF remain unsupported. Session writes are discarded at disconnect. The hard-drive checkpoint layout changes the save-state format from 79 to 80, so older save states are incompatible.

Validation:

- Rust unit tests and golden renders passed on Linux, macOS, Windows x64 and Windows ARM64. Formatting and locked all-target/all-feature Clippy passed; external-asset integration tests remain opt-in.
- Native setup and all four floppy bays covered by regression tests, including insert/eject, invalid media, private writes, rollback and guest restrictions.
- Regression coverage includes local guest output preferences, A3000 motherboard SCSI, bounded receive allocation, and unchanged checkpoint bytes with borrowed storage serialization.
- Release headless runs for Direct IP setup/swaps, WHDLoad and `--run` produced matching confirmed captures on both peers, with game assets supplied only to the host.
- Forced iroh relay setup and a host floppy swap passed using a generated dummy ROM and blank disk; both peers confirmed and checked all 300 frames with identical captures.
- A near-limit synthetic setup of approximately 511 MiB transferred over loopback in 64 seconds, with matching captures and about 1.8 GiB peak resident memory per peer on macOS. A3000 motherboard SCSI transfer also passed with 4 MiB motherboard RAM; larger machines may need less RAM or a smaller rollback window to fit the documented checkpoint budget.
- WASM compile, 32 browser JavaScript tests, core-only storage/setup tests, and strict MyST HTML build passed.
