### PR TITLE
Fix 68000 disassembler decode collisions and instruction lengths

### DIFF
--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -260,14 +260,15 @@ fn signed_hex(v: i32) -> String {
 }
 
 /// Decode a brief-format extension word index register, e.g. `D3.W*2`.
-fn brief_index(ext: u16) -> String {
+/// Scale factors are 68020+ only; on 68000/010 the scale bits are ignored.
+fn brief_index(ext: u16, show_scale: bool) -> String {
     let reg = ((ext >> 12) & 7) as usize;
     let is_addr = ext & 0x8000 != 0;
     let long = ext & 0x0800 != 0;
-    let scale = (ext >> 9) & 3; // 020+; 0 (==*1) on 68000
+    let scale = (ext >> 9) & 3;
     let name = if is_addr { AN[reg] } else { DN[reg] };
     let size = if long { "L" } else { "W" };
-    if scale == 0 {
+    if !show_scale || scale == 0 {
         format!("{name}.{size}")
     } else {
         format!("{name}.{size}*{}", 1 << scale)
@@ -281,7 +282,12 @@ fn brief_index(ext: u16) -> String {
 fn indexed_ea(base: &str, ext: u16, s: &mut Stream) -> String {
     if ext & 0x0100 == 0 || !s.full_ext {
         let d = ext as i8 as i32;
-        return format!("({},{},{})", signed_hex(d), base, brief_index(ext));
+        return format!(
+            "({},{},{})",
+            signed_hex(d),
+            base,
+            brief_index(ext, s.full_ext)
+        );
     }
     // Full extension word format. Word order after it: base displacement,
     // then outer displacement (matching the execution model in the CPU
@@ -303,7 +309,7 @@ fn indexed_ea(base: &str, ext: u16, s: &mut Stream) -> String {
     } else {
         None
     };
-    let index = (!index_suppress).then(|| brief_index(ext));
+    let index = (!index_suppress).then(|| brief_index(ext, true));
     let mut inner: Vec<String> = Vec::new();
     if let Some(bd) = bd {
         inner.push(signed_hex(bd));
@@ -364,7 +370,7 @@ fn effective_address(mode: u8, reg: u8, size: u8, s: &mut Stream) -> String {
         7 => match reg {
             0 => {
                 let a = s.next_word() as i16 as i32;
-                format!("(${:X}).W", a as u32 & 0xFFFF)
+                format!("(${:X}).W", a as u32)
             }
             1 => {
                 let a = s.next_long();
@@ -400,7 +406,7 @@ pub fn disassemble(read: impl Fn(u32) -> u16, pc: u32, cpu_type: CpuType) -> (St
         full_ext: !matches!(cpu_type, CpuType::M68000 | CpuType::M68010),
     };
     let op = s.next_word();
-    let text = decode(op, &mut s, cpu_type);
+    let text = decode(op, &mut s);
     let text = text.unwrap_or_else(|| {
         // Reset to a single-word DC.W for anything unrecognised.
         format!("DC.W ${op:04X}")
@@ -415,7 +421,7 @@ pub fn disassemble(read: impl Fn(u32) -> u16, pc: u32, cpu_type: CpuType) -> (St
     (text, words * 2)
 }
 
-fn decode(op: u16, s: &mut Stream, _cpu_type: CpuType) -> Option<String> {
+fn decode(op: u16, s: &mut Stream) -> Option<String> {
     match op >> 12 {
         0x0 => decode_0(op, s),
         0x1 => decode_move(op, 0, s),
@@ -447,6 +453,10 @@ fn decode_move(op: u16, size: u8, s: &mut Stream) -> Option<String> {
     let src_reg = (op & 7) as u8;
     let dst_mode = ((op >> 6) & 7) as u8;
     let dst_reg = ((op >> 9) & 7) as u8;
+    // MOVE.B <ea>,An is illegal (no MOVEA.B).
+    if dst_mode == 1 && size == 0 {
+        return None;
+    }
     let src = effective_address(src_mode, src_reg, size, s);
     let dst = effective_address(dst_mode, dst_reg, size, s);
     let mnem = if dst_mode == 1 { "MOVEA" } else { "MOVE" };
@@ -471,8 +481,12 @@ fn decode_0(op: u16, s: &mut Stream) -> Option<String> {
     if op & 0x0100 == 0 {
         if let Some(mnem) = imm_mnem {
             if size != 3 {
-                // ANDI/ORI/EORI #imm,CCR or ,SR
+                // ANDI/ORI/EORI #imm,CCR or ,SR. SUBI/ADDI/CMPI with the
+                // same mode/reg encoding are illegal — emit DC.W.
                 if (op & 0x00FF) == 0x003C || (op & 0x00FF) == 0x007C {
+                    if !matches!(mnem, "ORI" | "ANDI" | "EORI") {
+                        return None;
+                    }
                     let to_sr = (op & 0x0040) != 0;
                     let imm = s.next_word();
                     let dst = if to_sr { "SR" } else { "CCR" };
@@ -523,9 +537,11 @@ fn decode_branch(op: u16, s: &mut Stream) -> String {
     let cc = ((op >> 8) & 0xF) as usize;
     let at = pc_after_opcode(s);
     let disp8 = (op & 0xFF) as i8 as i32;
+    // Low-byte $00 = .W on all CPUs. Low-byte $FF is .L only from 68020;
+    // on 68000/010 it is a valid 8-bit displacement of -1.
     let (disp, suffix) = if (op & 0xFF) == 0x00 {
         (s.next_word() as i16 as i32, ".W")
-    } else if (op & 0xFF) == 0xFF {
+    } else if (op & 0xFF) == 0xFF && s.full_ext {
         (s.next_long() as i32, ".L")
     } else {
         (disp8, ".B")
@@ -586,6 +602,10 @@ fn decode_4(op: u16, s: &mut Stream) -> Option<String> {
             return Some(format!("STOP #${imm:X}"));
         }
         0x4E73 => return Some("RTE".into()),
+        0x4E74 => {
+            let d = s.next_word() as i16 as i32;
+            return Some(format!("RTD #{}", signed_hex(d)));
+        }
         0x4E75 => return Some("RTS".into()),
         0x4E76 => return Some("TRAPV".into()),
         0x4E77 => return Some("RTR".into()),
@@ -615,8 +635,10 @@ fn decode_4(op: u16, s: &mut Stream) -> Option<String> {
         0x4E60 => return Some(format!("MOVE {},USP", AN[reg as usize])),
         0x4E68 => return Some(format!("MOVE USP,{}", AN[reg as usize])),
         0x4840 => return Some(format!("SWAP {}", DN[reg as usize])),
+        0x4848 => return Some(format!("BKPT #{}", op & 7)),
         0x4880 => return Some(format!("EXT.W {}", DN[reg as usize])),
         0x48C0 => return Some(format!("EXT.L {}", DN[reg as usize])),
+        0x49C0 => return Some(format!("EXTB.L {}", DN[reg as usize])),
         _ => {}
     }
     if op & 0xFFF0 == 0x4E40 {
@@ -646,6 +668,16 @@ fn decode_4(op: u16, s: &mut Stream) -> Option<String> {
             return Some(format!("TST{} {ea}", size_suffix(size)));
         }
         _ => {}
+    }
+    // NBCD <ea> (byte)
+    if op & 0xFFC0 == 0x4800 {
+        let ea = effective_address(mode, reg, 0, s);
+        return Some(format!("NBCD {ea}"));
+    }
+    // TAS <ea> (byte)
+    if op & 0xFFC0 == 0x4AC0 {
+        let ea = effective_address(mode, reg, 0, s);
+        return Some(format!("TAS {ea}"));
     }
     // MOVE to/from CCR/SR
     match op & 0xFFC0 {
@@ -908,7 +940,8 @@ pub fn disassemble_copper(ir1: u16, ir2: u16) -> String {
 
 /// Disassemble a Copper list starting at `start`, reading words via `read`,
 /// up to `max` instructions. Stops early at the end-of-list WAIT
-/// ($FFFF,$FFFE). Returns `(address, text)` per instruction.
+/// ($FFFF,$FFFE) or the demoscene end marker ($FFFF,$FFFF).
+/// Returns `(address, text)` per instruction.
 pub fn dump_copper_list(read: impl Fn(u32) -> u16, start: u32, max: usize) -> Vec<(u32, String)> {
     let mut out = Vec::new();
     let mut addr = start & !1;
@@ -917,7 +950,7 @@ pub fn dump_copper_list(read: impl Fn(u32) -> u16, start: u32, max: usize) -> Ve
         let ir2 = read(addr.wrapping_add(2));
         out.push((addr, disassemble_copper(ir1, ir2)));
         addr = addr.wrapping_add(4);
-        if ir1 == 0xFFFF && ir2 == 0xFFFE {
+        if ir1 == 0xFFFF && (ir2 == 0xFFFE || ir2 == 0xFFFF) {
             break;
         }
     }
@@ -1129,6 +1162,73 @@ mod tests {
     #[test]
     fn unknown_is_dc_word() {
         assert_eq!(dis(&[0xA123], 0), ("DC.W $A123".into(), 2));
+    }
+
+    #[test]
+    fn branch_ff_is_byte_on_68000_long_on_020() {
+        // On 68000, low-byte $FF is displacement -1 (BRA to the opcode itself).
+        let (t, n) = dis(&[0x60FF], 0x1000);
+        assert_eq!(t, "BRA.B $1001");
+        assert_eq!(n, 2);
+        // On 68020+, $FF introduces a 32-bit displacement.
+        let (t, n) = dis020(&[0x60FF, 0x0000, 0x0010], 0x1000);
+        assert_eq!(t, "BRA.L $1012");
+        assert_eq!(n, 6);
+    }
+
+    #[test]
+    fn bkpt_not_pea() {
+        assert_eq!(dis(&[0x4848], 0), ("BKPT #0".into(), 2));
+        assert_eq!(dis(&[0x484F], 0), ("BKPT #7".into(), 2));
+        // PEA (A0) still works just past the BKPT range.
+        assert_eq!(dis(&[0x4850], 0), ("PEA (A0)".into(), 2));
+    }
+
+    #[test]
+    fn extb_not_lea() {
+        assert_eq!(dis(&[0x49C0], 0), ("EXTB.L D0".into(), 2));
+        assert_eq!(dis(&[0x49C7], 0), ("EXTB.L D7".into(), 2));
+    }
+
+    #[test]
+    fn imm_to_ccr_sr_only_for_ori_andi_eori() {
+        assert_eq!(dis(&[0x003C, 0x0001], 0), ("ORI #$1,CCR".into(), 4));
+        assert_eq!(dis(&[0x027C, 0x2000], 0), ("ANDI #$2000,SR".into(), 4));
+        assert_eq!(dis(&[0x0A3C, 0x00FF], 0), ("EORI #$FF,CCR".into(), 4));
+        // SUBI/ADDI/CMPI with the CCR/SR encoding are illegal.
+        assert_eq!(dis(&[0x043C, 0x0001], 0), ("DC.W $043C".into(), 2));
+        assert_eq!(dis(&[0x063C, 0x0001], 0), ("DC.W $063C".into(), 2));
+        assert_eq!(dis(&[0x0C3C, 0x0001], 0), ("DC.W $0C3C".into(), 2));
+    }
+
+    #[test]
+    fn movea_byte_is_illegal() {
+        // MOVE.B D0,A0
+        assert_eq!(dis(&[0x1040], 0), ("DC.W $1040".into(), 2));
+    }
+
+    #[test]
+    fn rtd_tas_nbcd() {
+        assert_eq!(dis(&[0x4E74, 0x0008], 0), ("RTD #$8".into(), 4));
+        assert_eq!(dis(&[0x4E74, 0xFFFC], 0), ("RTD #-$4".into(), 4));
+        assert_eq!(dis(&[0x4AC0], 0), ("TAS D0".into(), 2));
+        assert_eq!(dis(&[0x4AD0], 0), ("TAS (A0)".into(), 2));
+        assert_eq!(dis(&[0x4800], 0), ("NBCD D0".into(), 2));
+        assert_eq!(dis(&[0x4810], 0), ("NBCD (A0)".into(), 2));
+    }
+
+    #[test]
+    fn dump_copper_stops_on_ffff_ffff() {
+        let words = [0x0180u16, 0x0123, 0xFFFF, 0xFFFF, 0x0182, 0x0000];
+        let list = dump_copper_list(
+            |addr| words[(addr / 2) as usize],
+            0,
+            10,
+        );
+        assert_eq!(list.len(), 2);
+        assert!(list[0].1.starts_with("MOVE"), "{}", list[0].1);
+        // $FFFF,$FFFF has IR2 bit0 set, so it disassembles as SKIP, not WAIT.
+        assert!(list[1].1.starts_with("SKIP"), "{}", list[1].1);
     }
 
     #[test]

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -195,6 +195,8 @@ struct Stream<'a> {
     /// format (base/outer displacements, memory indirection). The 68000
     /// and 68010 ignore that bit and always use the brief format.
     full_ext: bool,
+    /// MOVE from CCR exists from the 68010 upward (illegal on 68000).
+    move_from_ccr: bool,
 }
 
 impl Stream<'_> {
@@ -404,6 +406,7 @@ pub fn disassemble(read: impl Fn(u32) -> u16, pc: u32, cpu_type: CpuType) -> (St
         base: pc,
         words: 0,
         full_ext: !matches!(cpu_type, CpuType::M68000 | CpuType::M68010),
+        move_from_ccr: !matches!(cpu_type, CpuType::M68000),
     };
     let op = s.next_word();
     let text = decode(op, &mut s);
@@ -455,6 +458,10 @@ fn decode_move(op: u16, size: u8, s: &mut Stream) -> Option<String> {
     let dst_reg = ((op >> 9) & 7) as u8;
     // MOVE.B <ea>,An is illegal (no MOVEA.B).
     if dst_mode == 1 && size == 0 {
+        return None;
+    }
+    // Destinations PC-relative / immediate are illegal for MOVE.
+    if dst_mode == 7 && dst_reg > 1 {
         return None;
     }
     let src = effective_address(src_mode, src_reg, size, s);
@@ -578,7 +585,10 @@ fn decode_5(op: u16, s: &mut Stream) -> Option<String> {
         let ea = effective_address(mode, reg, 0, s);
         return Some(format!("S{} {ea}", CC[cc]));
     }
-    // ADDQ/SUBQ #data,<ea>
+    // ADDQ/SUBQ #data,<ea> (byte to An is illegal).
+    if size == 0 && mode == 1 {
+        return None;
+    }
     let mut data = ((op >> 9) & 7) as u32;
     if data == 0 {
         data = 8;
@@ -634,6 +644,14 @@ fn decode_4(op: u16, s: &mut Stream) -> Option<String> {
         0x4E58 => return Some(format!("UNLK {}", AN[reg as usize])),
         0x4E60 => return Some(format!("MOVE {},USP", AN[reg as usize])),
         0x4E68 => return Some(format!("MOVE USP,{}", AN[reg as usize])),
+        0x4808 => {
+            // LINK.L An,#d32 — 68020+; on 68000/010 the encoding is illegal.
+            if !s.full_ext {
+                return None;
+            }
+            let d = s.next_long() as i32;
+            return Some(format!("LINK.L {},#{}", AN[reg as usize], signed_hex(d)));
+        }
         0x4840 => return Some(format!("SWAP {}", DN[reg as usize])),
         0x4848 => return Some(format!("BKPT #{}", op & 7)),
         0x4880 => return Some(format!("EXT.W {}", DN[reg as usize])),
@@ -669,8 +687,11 @@ fn decode_4(op: u16, s: &mut Stream) -> Option<String> {
         }
         _ => {}
     }
-    // NBCD <ea> (byte)
+    // NBCD <ea> (byte). An direct overlaps LINK.L and is illegal for NBCD.
     if op & 0xFFC0 == 0x4800 {
+        if mode == 1 {
+            return None;
+        }
         let ea = effective_address(mode, reg, 0, s);
         return Some(format!("NBCD {ea}"));
     }
@@ -681,6 +702,10 @@ fn decode_4(op: u16, s: &mut Stream) -> Option<String> {
     }
     // MOVE to/from CCR/SR
     match op & 0xFFC0 {
+        0x42C0 if s.move_from_ccr => {
+            let ea = effective_address(mode, reg, 1, s);
+            return Some(format!("MOVE CCR,{ea}"));
+        }
         0x44C0 => {
             let ea = effective_address(mode, reg, 1, s);
             return Some(format!("MOVE {ea},CCR"));
@@ -877,7 +902,10 @@ fn decode_shift(op: u16, s: &mut Stream) -> Option<String> {
     let size = ((op >> 6) & 3) as u8;
     let names = ["AS", "LS", "ROX", "RO"];
     if size == 3 {
-        // Memory shift by one: <ea>
+        // Memory shift by one: <ea> (Dn/An/immediate/PC-relative illegal).
+        if mode < 2 || (mode == 7 && reg > 1) {
+            return None;
+        }
         let kind = ((op >> 9) & 3) as usize;
         let dir = if op & 0x0100 != 0 { "L" } else { "R" };
         let ea = effective_address(mode, reg, 1, s);
@@ -1043,6 +1071,19 @@ mod tests {
             },
             pc,
             CpuType::M68EC020,
+        )
+    }
+
+    /// Disassemble as a 68010 (MOVE from CCR, no full-format EA / LINK.L).
+    fn dis010(words: &[u16], pc: u32) -> (String, u32) {
+        let mem = words.to_vec();
+        disassemble(
+            move |addr| {
+                let idx = (addr.wrapping_sub(pc) / 2) as usize;
+                mem.get(idx).copied().unwrap_or(0)
+            },
+            pc,
+            CpuType::M68010,
         )
     }
 
@@ -1229,6 +1270,36 @@ mod tests {
         assert!(list[0].1.starts_with("MOVE"), "{}", list[0].1);
         // $FFFF,$FFFF has IR2 bit0 set, so it disassembles as SKIP, not WAIT.
         assert!(list[1].1.starts_with("SKIP"), "{}", list[1].1);
+    }
+
+    #[test]
+    fn link_l_not_nbcd_on_020() {
+        // LINK.L A0,#$12345678 — three words on 68020+.
+        let (t, n) = dis020(&[0x4808, 0x1234, 0x5678], 0);
+        assert_eq!(t, "LINK.L A0,#$12345678");
+        assert_eq!(n, 6);
+        // Same encoding is illegal on 68000 (not NBCD A0).
+        assert_eq!(dis(&[0x4808, 0x1234, 0x5678], 0), ("DC.W $4808".into(), 2));
+        // Real NBCD (A0) still works.
+        assert_eq!(dis020(&[0x4810], 0), ("NBCD (A0)".into(), 2));
+    }
+
+    #[test]
+    fn move_from_ccr_from_68010() {
+        assert_eq!(dis010(&[0x42C0], 0), ("MOVE CCR,D0".into(), 2));
+        assert_eq!(dis010(&[0x42D0], 0), ("MOVE CCR,(A0)".into(), 2));
+        // Illegal on 68000.
+        assert_eq!(dis(&[0x42C0], 0), ("DC.W $42C0".into(), 2));
+    }
+
+    #[test]
+    fn illegal_forms_are_dc_word() {
+        // Memory shift targeting Dn.
+        assert_eq!(dis(&[0xE0C0], 0), ("DC.W $E0C0".into(), 2));
+        // ADDQ.B #1,A0
+        assert_eq!(dis(&[0x5208], 0), ("DC.W $5208".into(), 2));
+        // MOVE.W D0,(d16,PC) — destination PC-relative.
+        assert_eq!(dis(&[0x35C0, 0x0004], 0), ("DC.W $35C0".into(), 2));
     }
 
     #[test]

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -1261,11 +1261,7 @@ mod tests {
     #[test]
     fn dump_copper_stops_on_ffff_ffff() {
         let words = [0x0180u16, 0x0123, 0xFFFF, 0xFFFF, 0x0182, 0x0000];
-        let list = dump_copper_list(
-            |addr| words[(addr / 2) as usize],
-            0,
-            10,
-        );
+        let list = dump_copper_list(|addr| words[(addr / 2) as usize], 0, 10);
         assert_eq!(list.len(), 2);
         assert!(list[0].1.starts_with("MOVE"), "{}", list[0].1);
         // $FFFF,$FFFF has IR2 bit0 set, so it disassembles as SKIP, not WAIT.

--- a/src/disasm.rs
+++ b/src/disasm.rs
@@ -195,8 +195,8 @@ struct Stream<'a> {
     /// format (base/outer displacements, memory indirection). The 68000
     /// and 68010 ignore that bit and always use the brief format.
     full_ext: bool,
-    /// MOVE from CCR exists from the 68010 upward (illegal on 68000).
-    move_from_ccr: bool,
+    /// Instructions introduced on the 68010 (MOVE from CCR, RTD, BKPT).
+    isa_010: bool,
 }
 
 impl Stream<'_> {
@@ -371,8 +371,8 @@ fn effective_address(mode: u8, reg: u8, size: u8, s: &mut Stream) -> String {
         }
         7 => match reg {
             0 => {
-                let a = s.next_word() as i16 as i32;
-                format!("(${:X}).W", a as u32)
+                let a = s.next_word();
+                format!("(${a:X}).W")
             }
             1 => {
                 let a = s.next_long();
@@ -406,7 +406,7 @@ pub fn disassemble(read: impl Fn(u32) -> u16, pc: u32, cpu_type: CpuType) -> (St
         base: pc,
         words: 0,
         full_ext: !matches!(cpu_type, CpuType::M68000 | CpuType::M68010),
-        move_from_ccr: !matches!(cpu_type, CpuType::M68000),
+        isa_010: !matches!(cpu_type, CpuType::M68000),
     };
     let op = s.next_word();
     let text = decode(op, &mut s);
@@ -613,6 +613,10 @@ fn decode_4(op: u16, s: &mut Stream) -> Option<String> {
         }
         0x4E73 => return Some("RTE".into()),
         0x4E74 => {
+            // RTD is 68010+; on 68000 the encoding is illegal.
+            if !s.isa_010 {
+                return None;
+            }
             let d = s.next_word() as i16 as i32;
             return Some(format!("RTD #{}", signed_hex(d)));
         }
@@ -653,10 +657,22 @@ fn decode_4(op: u16, s: &mut Stream) -> Option<String> {
             return Some(format!("LINK.L {},#{}", AN[reg as usize], signed_hex(d)));
         }
         0x4840 => return Some(format!("SWAP {}", DN[reg as usize])),
-        0x4848 => return Some(format!("BKPT #{}", op & 7)),
+        0x4848 => {
+            // BKPT is 68010+; on 68000 fall through to DC.W (not PEA).
+            if !s.isa_010 {
+                return None;
+            }
+            return Some(format!("BKPT #{}", op & 7));
+        }
         0x4880 => return Some(format!("EXT.W {}", DN[reg as usize])),
         0x48C0 => return Some(format!("EXT.L {}", DN[reg as usize])),
-        0x49C0 => return Some(format!("EXTB.L {}", DN[reg as usize])),
+        0x49C0 => {
+            // EXTB.L is 68020+; on 68000/010 fall through to DC.W (not LEA).
+            if !s.full_ext {
+                return None;
+            }
+            return Some(format!("EXTB.L {}", DN[reg as usize]));
+        }
         _ => {}
     }
     if op & 0xFFF0 == 0x4E40 {
@@ -702,7 +718,7 @@ fn decode_4(op: u16, s: &mut Stream) -> Option<String> {
     }
     // MOVE to/from CCR/SR
     match op & 0xFFC0 {
-        0x42C0 if s.move_from_ccr => {
+        0x42C0 if s.isa_010 => {
             let ea = effective_address(mode, reg, 1, s);
             return Some(format!("MOVE CCR,{ea}"));
         }
@@ -1219,16 +1235,23 @@ mod tests {
 
     #[test]
     fn bkpt_not_pea() {
-        assert_eq!(dis(&[0x4848], 0), ("BKPT #0".into(), 2));
-        assert_eq!(dis(&[0x484F], 0), ("BKPT #7".into(), 2));
+        assert_eq!(dis010(&[0x4848], 0), ("BKPT #0".into(), 2));
+        assert_eq!(dis010(&[0x484F], 0), ("BKPT #7".into(), 2));
+        // Illegal on 68000 (must not decode as PEA).
+        assert_eq!(dis(&[0x4848], 0), ("DC.W $4848".into(), 2));
+        assert_eq!(dis(&[0x484F], 0), ("DC.W $484F".into(), 2));
         // PEA (A0) still works just past the BKPT range.
         assert_eq!(dis(&[0x4850], 0), ("PEA (A0)".into(), 2));
+        assert_eq!(dis010(&[0x4850], 0), ("PEA (A0)".into(), 2));
     }
 
     #[test]
     fn extb_not_lea() {
-        assert_eq!(dis(&[0x49C0], 0), ("EXTB.L D0".into(), 2));
-        assert_eq!(dis(&[0x49C7], 0), ("EXTB.L D7".into(), 2));
+        assert_eq!(dis020(&[0x49C0], 0), ("EXTB.L D0".into(), 2));
+        assert_eq!(dis020(&[0x49C7], 0), ("EXTB.L D7".into(), 2));
+        // Illegal on 68000 (must not decode as LEA).
+        assert_eq!(dis(&[0x49C0], 0), ("DC.W $49C0".into(), 2));
+        assert_eq!(dis(&[0x49C7], 0), ("DC.W $49C7".into(), 2));
     }
 
     #[test]
@@ -1250,8 +1273,10 @@ mod tests {
 
     #[test]
     fn rtd_tas_nbcd() {
-        assert_eq!(dis(&[0x4E74, 0x0008], 0), ("RTD #$8".into(), 4));
-        assert_eq!(dis(&[0x4E74, 0xFFFC], 0), ("RTD #-$4".into(), 4));
+        assert_eq!(dis010(&[0x4E74, 0x0008], 0), ("RTD #$8".into(), 4));
+        assert_eq!(dis010(&[0x4E74, 0xFFFC], 0), ("RTD #-$4".into(), 4));
+        // Illegal on 68000 (single-word DC.W; do not consume the displacement).
+        assert_eq!(dis(&[0x4E74, 0x0008], 0), ("DC.W $4E74".into(), 2));
         assert_eq!(dis(&[0x4AC0], 0), ("TAS D0".into(), 2));
         assert_eq!(dis(&[0x4AD0], 0), ("TAS (A0)".into(), 2));
         assert_eq!(dis(&[0x4800], 0), ("NBCD D0".into(), 2));


### PR DESCRIPTION
 - Gate CPU-dependent encodings correctly: `Bcc`/`BRA`/`BSR` `$FF` is `.B` on 68000/010 and `.L` only from 020+; full-format EA/scale  already followed the same rule.
  - Fix misdecodes that broke listings: `BKPT` vs `PEA`, `EXTB.L` vs `LEA`, `LINK.L` vs `NBCD`, illegal `MOVEA.B`, and
  immediate-to-CCR/SR limited to `ORI`/`ANDI`/`EORI`.
  - Add missing mnemonics with correct lengths (`RTD`, `TAS`, `NBCD`, `MOVE CCR,<ea>` from 010+), stop copper dumps on `$FFFF,$FFFF`,  and emit `DC.W` for a few illegal forms (memory shift on Dn/An, `ADDQ.B` to An, MOVE to PC-relative).
