### PR TITLE
Build the macOS dmg slices on separate runners and move neutral CI jobs to Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ env:
 # Only main saves Rust caches. PRs can restore main's caches, while caches
 # saved on a PR merge ref cannot serve other PRs and evict reusable entries
 # when several of these large build matrices run concurrently.
+#
+# The pool is capped at 10 GB per repository and GitHub evicts the least
+# recently used entries once it is full, so every job that caches a target
+# directory (about 1 GB each for a release-profile build of this crate)
+# competes with the release builds whose cold rebuilds cost the most. Jobs
+# whose cold build is cheap cache only the registry, and platform-neutral
+# checks share one Linux job and one entry rather than one macOS entry each.
 jobs:
   build:
     # Keep the existing check name for branch-protection rules. The ci
@@ -76,25 +83,53 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  lint:
-    name: Rustfmt and clippy
-    # Style and lints need no release build, so this runs alongside the
-    # build job instead of gating it.
-    runs-on: macos-latest
+  checks:
+    name: Rustfmt, clippy, and feature checks
+    # Style, lints, and the check-only feature combinations need no release
+    # build, so this runs alongside the build job instead of gating it. It
+    # is platform-neutral, so it runs on Linux: hosted macOS runners are
+    # limited to five concurrent jobs per organisation and the macOS build,
+    # test, and packaging jobs already queue for them (see the pool note
+    # above for why the check-mode artifacts share one cache entry).
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Install native build dependencies
+        # ALSA (cpal) + udev (gilrs) headers; --all-features pulls in no
+        # further native libraries on Linux.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            . -> target
+            crates/copperline-player -> target
       - name: Formatting
         run: cargo fmt --check
       - name: Clippy
         # Hold the binary, tests, examples, and diagnostic feature gates to
         # the same warning-clean standard used for release checks.
         run: cargo clippy --all-targets --all-features --locked -- -D warnings
+      - name: Frontend without the debug and library features
+        # The feature combination the publisher-kit player builds against
+        # (frontend + cpu-jit; no control, gdb, or game-library).
+        run: cargo check --no-default-features --features frontend,cpu-jit --locked
+      - name: Player crate (example manifest)
+        # Guards the game-manifest baking in crates/copperline-player.
+        # Check-only: the full bundle build belongs to a publisher's own CI
+        # (docs/guide/publishing.md).
+        working-directory: crates/copperline-player
+        run: cargo check --locked
+      - name: Player crate formatting
+        # A standalone workspace, so the root Formatting step never
+        # reaches it.
+        working-directory: crates/copperline-player
+        run: cargo fmt --check
 
   fuzz-build:
     name: Fuzz harnesses build
@@ -147,6 +182,10 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           key: msrv
+          # A cold dev-profile build here finishes well inside the macOS
+          # fan-out's wall time, so its 1 GB target directory is not worth
+          # an entry in the shared cache pool; keep only the registry.
+          cache-targets: false
       - name: Build with MSRV
         run: cargo +"$MSRV" build --locked
       - name: Compile unit tests with MSRV
@@ -196,8 +235,9 @@ jobs:
         # The inline #[cfg(test)] suites in the lib and binaries, prebuilt
         # by the build job (this is everything a root `cargo test` runs
         # besides tests/probe_golden.rs, which has its own job below; the
-        # crate has no doctests). Artifact zips do not preserve the
-        # executable bit, hence the chmod.
+        # crate has no doctests). The GDB remote-protocol suite in
+        # src/gdbstub is part of unit-lib: gdb is a default feature.
+        # Artifact zips do not preserve the executable bit, hence the chmod.
         run: |
           chmod +x ci-bins/*
           ./ci-bins/unit-lib
@@ -546,37 +586,13 @@ jobs:
       - run: npx wrangler deploy --env="" --dry-run
         working-directory: services/netplay
 
-  player:
-    name: Publisher-kit player crate
-    # Guards the feature combination the player builds against (frontend +
-    # cpu-jit; no control, gdb, or game-library) and the game-manifest
-    # baking in crates/copperline-player. Check-only: the full bundle build
-    # belongs to a publisher's own CI (docs/guide/publishing.md).
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Frontend without the debug and library features
-        run: cargo check --no-default-features --features frontend,cpu-jit --locked
-      - name: Player crate (example manifest)
-        working-directory: crates/copperline-player
-        run: cargo check --locked
-      - name: Player crate formatting
-        # A standalone workspace, so the root Formatting step never
-        # reaches it.
-        working-directory: crates/copperline-player
-        run: cargo fmt --check
-
   docs:
     name: Docs build (HTML + PDF)
     # Independent of the Rust build: catches MyST/cross-reference breakage
     # (e.g. duplicate labels that only collide in the single-document PDF).
-    runs-on: macos-latest
+    # Nothing here is platform-specific, so it stays off the macOS runner
+    # quota (see the checks job).
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -585,8 +601,9 @@ jobs:
       - name: Install MyST CLI
         run: npm install -g mystmd
       - name: Install Typst (PDF renderer)
-        # MyST shells out to Typst for PDF export; brew matches docs/README.md.
-        run: brew install typst
+        # MyST shells out to Typst for PDF export. Latest release, like the
+        # brew install documented in docs/README.md.
+        uses: typst-community/setup-typst@v5
       - name: Build HTML
         working-directory: docs
         run: myst build --html --ci --strict --check-links
@@ -606,17 +623,3 @@ jobs:
           name: copperline-docs-pdf
           path: docs/_build/exports/copperline.pdf
           if-no-files-found: ignore
-
-  gdb-remote:
-    name: GDB remote protocol tests
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: RSP unit tests
-        # The RSP tests live in the library; selecting it avoids compiling
-        # every integration-test executable just to filter out its tests.
-        run: cargo test --locked --lib gdbstub

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -23,9 +23,9 @@ concurrency:
 jobs:
   pdf:
     name: Build and attach PDF
-    # macos-latest matches the docs job in ci.yml: MyST shells out to Typst,
-    # installed here via brew, exactly as documented in docs/README.md.
-    runs-on: macos-latest
+    # Matches the docs job in ci.yml: MyST shells out to Typst, installed
+    # through setup-typst; the build itself is platform-neutral.
+    runs-on: ubuntu-latest
     # Needed only by the release-attach steps.
     permissions:
       contents: write
@@ -37,7 +37,7 @@ jobs:
       - name: Install MyST CLI
         run: npm install -g mystmd
       - name: Install Typst (PDF renderer)
-        run: brew install typst
+        uses: typst-community/setup-typst@v5
       - name: Build PDF
         working-directory: docs
         # The PDF export merges every chapter into one document; --strict fails

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,6 +8,18 @@ name: macOS
 # under Rosetta, which no other job executes), so it is scoped to the code and
 # packaging surface that affects the bundle.
 #
+# Two stages: a build matrix compiles the release binary for each Apple
+# architecture on its own runner, then the package job lipo-joins the two
+# slices, stages and signs the bundle, lays out the dmg, and smoke-tests it.
+# The shipping profile is fat LTO with one codegen unit, so each slice is a
+# mostly single-threaded compile of roughly twelve minutes on a hosted
+# 3-core runner, and building the two back to back on one runner simply
+# doubled that. One multi-target cargo invocation on one runner is not an
+# option either: the copperline crate alone peaks near 5 GB of resident
+# memory per target, so two concurrent compiles overrun the 7 GB hosted
+# runner and swap. One runner per slice halves the wall time for the same
+# total runner minutes.
+#
 # The image is intentionally unsigned (no Developer ID, no notarization), so it
 # trips Gatekeeper on first launch; the bundled README.txt documents the
 # right-click-Open workaround.
@@ -51,26 +63,63 @@ concurrency:
 
 jobs:
   build:
+    name: Build slice (${{ matrix.arch }})
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            target: aarch64-apple-darwin
+          - arch: x86_64
+            target: x86_64-apple-darwin
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # PRs restore main's cache without uploading a competing copy.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # One entry per slice: an explicit --target build cannot warm
+          # ci.yml's native test build (or the other way round), and the
+          # two architectures share nothing below the registry.
+          key: macos-dmg-${{ matrix.target }}
+      - name: Build release binary
+        run: cargo build --release --locked --target ${{ matrix.target }}
+      - name: Upload slice for the package job
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-slice-${{ matrix.arch }}
+          path: target/${{ matrix.target }}/release/copperline
+          if-no-files-found: error
+
+  package:
     name: Build macOS dmg
+    needs: build
     runs-on: macos-latest
     # Needed only by the release-attach step on v* tags.
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/download-artifact@v8
         with:
-          # Both Apple architectures so build-dmg.sh can lipo a universal binary.
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
-      - uses: Swatinem/rust-cache@v2
+          name: macos-slice-arm64
+          path: prebuilt/aarch64-apple-darwin
+      - uses: actions/download-artifact@v8
         with:
-          # PRs restore main's cache without uploading a competing copy.
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          # Separate explicit architecture builds from ci.yml's native
-          # test build, which otherwise shares this job's default key.
-          key: macos-dmg
+          name: macos-slice-x86_64
+          path: prebuilt/x86_64-apple-darwin
       - name: Build dmg
-        run: packaging/macos/build-dmg.sh
+        # No Rust toolchain here: PREBUILT_DIR makes build-dmg.sh skip its
+        # cargo step and lipo the downloaded slices (it checks each one is
+        # the architecture its directory claims). Artifact zips do not
+        # preserve the executable bit, hence the chmod.
+        run: |
+          chmod +x prebuilt/*/copperline
+          PREBUILT_DIR=prebuilt packaging/macos/build-dmg.sh
       - name: Locate artifact
         id: artifact
         run: echo "path=$(ls Copperline-*-macos-universal.dmg | head -n1)" >> "$GITHUB_OUTPUT"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -180,7 +180,7 @@ attaches `Copperline-X.Y.Z-win-x64.zip` and
 `Copperline-X.Y.Z-win-arm64.zip` to the GitHub Release automatically. The
 same workflow runs the full release build on pull requests that touch the
 code, so it doubles as the Windows build check for both architectures (the
-main CI runs on macOS only).
+main CI runs on macOS and Linux).
 
 The zips are self-contained: the MSVC C runtime is linked statically (see
 `.cargo/config.toml`) so they need no Visual C++ Redistributable, and the
@@ -198,7 +198,8 @@ packaging/windows/build-zip.ps1
 
 The prebuilt macOS download is a disk image (`packaging/macos/`): a
 drag-to-Applications `Copperline.app` wrapped in a `.dmg`. The `macOS` workflow
-builds it on `macos-latest` and, on a `v*` tag, attaches
+builds each architecture's binary on its own `macos-latest` runner, joins them
+into the bundle in a package job, and, on a `v*` tag, attaches
 `Copperline-X.Y.Z-macos-universal.dmg` to the GitHub Release automatically.
 Homebrew (above) remains the build-from-source channel; the disk image is the
 no-compiler alternative.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ The documentation under this directory is written in
   ```sh
   brew install typst        # macOS
   # or: cargo install typst-cli
+  # or a release binary from https://github.com/typst/typst/releases
+  # (CI installs it with typst-community/setup-typst)
   ```
 
   The first PDF build also downloads the MyST Typst template, so it needs

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -6,7 +6,10 @@
 # What it does:
 #   1. Builds the release binary for both Apple architectures with the pinned
 #      dependency graph and lipo-joins them into one universal binary, so a
-#      single download runs natively on Apple Silicon and Intel.
+#      single download runs natively on Apple Silicon and Intel. With
+#      PREBUILT_DIR set the cargo step is skipped and the per-architecture
+#      binaries are taken from that directory instead (the macOS workflow
+#      compiles each slice on its own runner and packages them here).
 #   2. Stages a Copperline.app bundle: the universal binary in Contents/MacOS,
 #      the icon and AROS ROM in Contents/Resources. romsearch.rs probes a
 #      bundle's Contents/Resources/aros first, so the bundled AROS ROM is found
@@ -25,6 +28,8 @@
 #
 # Override knobs (env):
 #   MACOS_UNIVERSAL=0   build only the host architecture (faster local builds)
+#   PREBUILT_DIR=<dir>  skip the cargo build and lipo <dir>/<target>/copperline
+#                       for each target instead
 #   OUTPUT=<path>       final .dmg file name
 set -euo pipefail
 
@@ -49,14 +54,41 @@ else
   targets=(aarch64-apple-darwin x86_64-apple-darwin)
 fi
 
-echo "==> Building release binary (${targets[*]})"
-for target in "${targets[@]}"; do
-  # Idempotent; ensures hand-builds on a fresh checkout have the cross target.
-  if command -v rustup >/dev/null 2>&1; then
-    rustup target add "$target" >/dev/null
-  fi
-  cargo build --release --locked --target "$target"
-done
+# Per-target binaries to join: either built here or supplied prebuilt.
+bins=()
+if [ -n "${PREBUILT_DIR:-}" ]; then
+  echo "==> Using prebuilt binaries from $PREBUILT_DIR (${targets[*]})"
+  for target in "${targets[@]}"; do
+    bin="$PREBUILT_DIR/$target/copperline"
+    if [ ! -f "$bin" ]; then
+      echo "error: no prebuilt binary at $bin" >&2
+      exit 1
+    fi
+    # Catch a slice staged under the wrong target name before lipo would
+    # happily join two copies of the same architecture.
+    case "$target" in
+      aarch64-apple-darwin) want=arm64 ;;
+      x86_64-apple-darwin) want=x86_64 ;;
+      *) want="" ;;
+    esac
+    got="$(lipo -archs "$bin")"
+    if [ -n "$want" ] && [ "$got" != "$want" ]; then
+      echo "error: $bin is $got, expected $want for $target" >&2
+      exit 1
+    fi
+    bins+=("$bin")
+  done
+else
+  echo "==> Building release binary (${targets[*]})"
+  for target in "${targets[@]}"; do
+    # Idempotent; ensures hand-builds on a fresh checkout have the cross target.
+    if command -v rustup >/dev/null 2>&1; then
+      rustup target add "$target" >/dev/null
+    fi
+    cargo build --release --locked --target "$target"
+    bins+=("target/$target/release/copperline")
+  done
+fi
 
 echo "==> Staging $app_name"
 rm -rf "$stage"
@@ -64,11 +96,7 @@ mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources/aros" \
   "$app/Contents/Resources/a2091" "$app/Contents/Resources/a4091" \
   "$app/Contents/Resources/lide"
 
-# Universal binary from the per-arch builds (a single-arch lipo is a no-op copy).
-bins=()
-for target in "${targets[@]}"; do
-  bins+=("target/$target/release/copperline")
-done
+# Universal binary from the per-arch slices (a single-arch lipo is a no-op copy).
 lipo -create -output "$app/Contents/MacOS/copperline" "${bins[@]}"
 
 # Info.plist with the version substituted in; plutil -lint catches a botched


### PR DESCRIPTION
The macOS side of CI has been the slowest part of every push. Three things compound, and this addresses the two that do not need a policy decision.

## Where the time went

The `macOS` workflow's dmg job ran two fat-LTO release builds (aarch64, then x86_64) back to back on one 3-core `macos-latest` runner. With one codegen unit each build is essentially single-threaded, so the two took 12.5 + 11.2 minutes on a full cache hit, and 40-48 minutes whenever the cache entry was missing. On top of that, every push spawned ten macOS jobs against the five concurrent macOS jobs the plan allows, so the short test jobs regularly waited 7-9 minutes for a runner after their build had finished.

Building both targets in one cargo invocation on one runner was measured and rejected: it halves wall time locally, but summed rustc memory peaks around 14 GB (the copperline crate alone is about 5 GB per target), which does not fit the 7 GB hosted runner.

## Changes

- `macos.yml`: a build matrix compiles each Apple slice on its own runner, and a `package` job (still named "Build macOS dmg") joins them, signs, images, and runs the unchanged smoke test including the x86_64 slice under Rosetta. Same total runner minutes, about half the wall time.
- `packaging/macos/build-dmg.sh`: new `PREBUILT_DIR` knob that skips the cargo step and lipo-joins supplied slices, checking each one is the architecture its directory claims. Hand builds are unchanged.
- `ci.yml`:
  - `lint` and `player` merge into one Linux job, "Rustfmt, clippy, and feature checks", sharing one cache entry.
  - `docs` moves to Linux with `typst-community/setup-typst`; `docs-release.yml` follows.
  - `gdb-remote` is removed: `gdb` is a default feature, so the RSP suite already runs inside the prebuilt unit-lib binary in the unit-tests job. The only thing lost is a dev-profile (debug-assertions on) pass of those tests.
  - `msrv` caches only the registry.
- macOS jobs per push drop from 10 to 6, and three macOS cache entries (about 2 GB) plus the 1 GB MSRV target cache leave the pool.

## Cache pool

The repository's Actions cache pool was measured at 12.1 GB active against the 10 GB cap, with entries being evicted within the hour (the dmg cache was present at 04:50 and gone by 05:42 on the same day; that is what produced the 48-minute builds). Steady-state demand across all jobs is nearer 14 GB. This PR removes about 3 GB of that; getting under the cap with headroom still needs a call on the fuzz target cache (1.8 GB) or the four Windows entries (4.6 GB), which is left for a follow-up.

## Validation

- `PREBUILT_DIR` packaging path run locally end to end: lipo, codesign, hdiutil, arm64 boot and x86_64 boot under Rosetta; wrong-architecture and missing-slice inputs fail with clear errors.
- Linux `cargo clippy --all-targets --all-features -D warnings` plus the player checks pass in a `rust:latest` container with the same apt packages the job installs.
- Linux MyST HTML (strict, link-checked) and PDF builds pass with a Typst release binary.
- `actionlint` clean apart from a pre-existing info note on an unchanged `ls` line.
