### PR TITLE
Make CRT strength 0 a true sample no-op

### DIFF
--- a/src/video/window/shaders/crt.wgsl
+++ b/src/video/window/shaders/crt.wgsl
@@ -139,6 +139,11 @@ fn fs_main(in: VOut) -> @location(0) vec4<f32> {
     // the strength-0 no-op.
     let wuv = mix(uv, warp(uv, u.params.w, aspect), strength);
     let base = sample_display(uv);
+    // Face AA softens the rectangle edge even when the bow is flat; skip
+    // the rest of the look so strength 0 stays a true sample no-op.
+    if (strength <= 0.0) {
+        return vec4<f32>(base.rgb, 1.0);
+    }
 
     // Scanlines follow the raster, which is straight.
     let lines = max(u.params.y, 1.0);


### PR DESCRIPTION
## Summary
- Full-CRT face-edge AA darkened viewport border pixels even at strength 0 (`128` → `112`), breaking flat-grey asserts.
- Early-return the display sample when strength is zero so the documented no-op matches Scanlines/Mask.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib` (only pre-existing unknown-lint noise)
- [x] `cargo test --lib 'video::window::crt_shader::' -- --test-threads=1` (23/23)
