### PR TITLE
Ship copperline-ctl and copperline-import-uae in every release package

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           echo "path=$(ls Copperline-*.AppImage | head -n1)" >> "$GITHUB_OUTPUT"
           echo "helper=$(ls Copperline-*-net-helper.tar.gz | head -n1)" >> "$GITHUB_OUTPUT"
+          echo "tools=$(ls Copperline-*-tools.tar.gz | head -n1)" >> "$GITHUB_OUTPUT"
       - name: Smoke test the AppImage
         # Boot the finished AppImage from an empty directory: the run must
         # find the bundled AROS ROM through the AppDir's
@@ -74,6 +75,12 @@ jobs:
           cd "$smoke"
           "$appimage" --noaudio --screenshot-after 10 smoke.png
           test -s smoke.png
+          # The command-line tools tarball is a release asset of its own;
+          # both tools must be in it and must start.
+          tar -xzf "$GITHUB_WORKSPACE/${{ steps.artifact.outputs.tools }}"
+          tools="$(ls -d Copperline-*-tools)"
+          "$tools/copperline-ctl" --help >/dev/null
+          "$tools/copperline-import-uae" --help >/dev/null
       - uses: actions/upload-artifact@v7
         with:
           name: copperline-appimage
@@ -84,6 +91,11 @@ jobs:
           name: copperline-linux-net-helper
           path: ${{ steps.artifact.outputs.helper }}
           if-no-files-found: error
+      - uses: actions/upload-artifact@v7
+        with:
+          name: copperline-linux-tools
+          path: ${{ steps.artifact.outputs.tools }}
+          if-no-files-found: error
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v3
@@ -91,3 +103,4 @@ jobs:
           files: |
             ${{ steps.artifact.outputs.path }}
             ${{ steps.artifact.outputs.helper }}
+            ${{ steps.artifact.outputs.tools }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -89,10 +89,17 @@ jobs:
       - name: Build release binary
         run: cargo build --release --locked --target ${{ matrix.target }}
       - name: Upload slice for the package job
+        # The emulator plus its two command-line companions (copperline-ctl
+        # and copperline-import-uae are default-feature binaries, so the
+        # build above already produced them); build-dmg.sh lipo-joins each
+        # one into the bundle's Contents/MacOS.
         uses: actions/upload-artifact@v7
         with:
           name: macos-slice-${{ matrix.arch }}
-          path: target/${{ matrix.target }}/release/copperline
+          path: |
+            target/${{ matrix.target }}/release/copperline
+            target/${{ matrix.target }}/release/copperline-ctl
+            target/${{ matrix.target }}/release/copperline-import-uae
           if-no-files-found: error
 
   package:
@@ -118,7 +125,7 @@ jobs:
         # the architecture its directory claims). Artifact zips do not
         # preserve the executable bit, hence the chmod.
         run: |
-          chmod +x prebuilt/*/copperline
+          chmod +x prebuilt/*/copperline prebuilt/*/copperline-ctl prebuilt/*/copperline-import-uae
           PREBUILT_DIR=prebuilt packaging/macos/build-dmg.sh
       - name: Locate artifact
         id: artifact
@@ -160,6 +167,17 @@ jobs:
           sudo softwareupdate --install-rosetta --agree-to-license
           arch -x86_64 "$bin" --noaudio --screenshot-after 10 smoke-x86_64.png
           test -s smoke-x86_64.png
+          # The command-line companions ship beside the emulator inside the
+          # bundle (copperline-ctl launches the copperline next to it), are
+          # universal like it, and start on both architectures.
+          for tool in copperline-ctl copperline-import-uae; do
+            t="$app/Contents/MacOS/$tool"
+            test -x "$t"
+            lipo -archs "$t" | grep -q arm64
+            lipo -archs "$t" | grep -q x86_64
+            "$t" --help >/dev/null
+            arch -x86_64 "$t" --help >/dev/null
+          done
           trap - EXIT
           hdiutil detach "$mnt"
       - name: Upload smoke screenshots

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,8 @@ name: Windows
 # (the zip uses the shipping release profile; tests use the optimized ci
 # profile without fat LTO), then the checks fan out in
 # parallel against those artifacts, mirroring ci.yml: the packaged zip is
-# booted from a clean directory, and the unit suites plus the probe golden
+# booted from a clean directory (and its copperline-ctl / import-uae
+# companions started), and the unit suites plus the probe golden
 # renders (pixel-exact deterministic boots on the bundled AROS ROM) run
 # against the prebuilt test binaries. This is also the only Windows coverage
 # (the main CI runs on macOS and Linux), so the code-path triggers below run
@@ -243,6 +244,15 @@ jobs:
           & $exe.FullName --noaudio --screenshot-after 10 smoke.png
           if ($LASTEXITCODE -ne 0) { throw "packaged emulator exited with $LASTEXITCODE" }
           if ((Get-Item smoke.png).Length -eq 0) { throw "screenshot is empty" }
+          # The command-line companions must ship beside the emulator (the
+          # VS Code extension and MCP clients run copperline-ctl, which
+          # launches the copperline.exe next to it) and must start.
+          foreach ($tool in @("copperline-ctl.exe", "copperline-import-uae.exe")) {
+            $path = Join-Path $exe.DirectoryName $tool
+            if (-not (Test-Path $path)) { throw "$tool missing from the zip" }
+            & $path --help | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw "$tool --help exited with $LASTEXITCODE" }
+          }
 
   unit-tests:
     name: Unit tests (${{ matrix.arch }})

--- a/docs/debugger/dap.md
+++ b/docs/debugger/dap.md
@@ -29,7 +29,9 @@ type and runs `copperline-ctl --dap` from your PATH. The settings
 `copperline.ctlExecutable` and
 `copperline.emulatorExecutable` name the two executable files when they
 are elsewhere (a source build's `target/release/copperline-ctl` and
-`target/release/copperline`). A launch configuration:
+`target/release/copperline`, or the copies every release package ships;
+see [Command-line tools](../guide/getting-started.md#command-line-tools)
+for where each package puts them). A launch configuration:
 
 ```json
 {

--- a/docs/debugger/vscode.md
+++ b/docs/debugger/vscode.md
@@ -44,6 +44,13 @@ Keep the checkout in place and point VS Code at the executables in
 `target/release`. On Windows they have an `.exe` suffix. Use a release build;
 debug builds are too slow for this workflow.
 
+A release package works instead of a source build once it carries the
+features you need: every package ships `copperline-ctl` next to the
+emulator (Homebrew on PATH, the macOS bundle's `Contents/MacOS`, the Windows
+zip folder, the AppImage's companion tools tarball, or the Flatpak's
+`/app/bin`); [Command-line tools](../guide/getting-started.md#command-line-tools)
+lists the paths to put in the settings below.
+
 The examples boot the bundled open-source AROS ROM, so no Kickstart download
 is needed. If you move the executables out of the checkout, copy
 `assets/aros/` alongside them, preserving the directory name `aros` and its

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -86,6 +86,26 @@ from the [releases page](https://github.com/CopperlineHQ/Copperline/releases),
 matching your Windows architecture. Extract the whole archive and run
 `copperline.exe`; keep the bundled ROMs and other assets alongside it.
 
+(command-line-tools)=
+## Command-line tools
+
+Every package also carries two companion programs: `copperline-ctl`, the
+[control protocol](../debugger/control.md) client whose `--mcp` and `--dap`
+modes serve coding agents and the [VS Code extension](../debugger/vscode.md),
+and `copperline-import-uae`, the [WinUAE/Amiberry/FS-UAE config
+converter](import-uae.md). Where they land depends on the package:
+
+| Package | Location |
+|---|---|
+| Homebrew | On PATH, next to `copperline`. |
+| macOS dmg | Inside the bundle, `Copperline.app/Contents/MacOS/`. Add that directory to PATH or name the files in the VS Code settings. |
+| Windows zip | Next to `copperline.exe` in the extracted folder. Add the folder to PATH or name the `.exe` files in the VS Code settings. |
+| AppImage | The separate `Copperline-X.Y.Z-<arch>-tools.tar.gz` release asset. Unpack it anywhere; set `COPPERLINE_BIN` to the AppImage path so `copperline-ctl` can launch the emulator. |
+| Flatpak | In the sandbox: `flatpak run --command=copperline-ctl dev.copperline.Copperline ...` (and likewise `copperline-import-uae`). |
+
+`copperline-ctl` launches the `copperline` beside it when one is there; the
+[DAP chapter](../debugger/dap.md) lists the full lookup order.
+
 ## Building from source
 
 ```sh

--- a/docs/guide/import-uae.md
+++ b/docs/guide/import-uae.md
@@ -72,10 +72,12 @@ annotates the generated TOML file:
 - **Host-specific settings:** Display window dimensions, host vsync options, and host
   keybindings are not imported.
 
-## Building the converter
+## Getting the converter
 
-The import utility is built by default during standard Cargo builds. To build the
-binary standalone:
+Every release package includes `copperline-import-uae` beside the emulator;
+[Command-line tools](getting-started.md#command-line-tools) lists the path
+for each package. The utility is also built by default during standard
+Cargo builds. To build the binary standalone:
 
 ```sh
 cargo build --release --bin copperline-import-uae

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -182,6 +182,7 @@ install -m755 target/release/copperline-ctl "$tools_stage/copperline-ctl"
 install -m755 target/release/copperline-import-uae \
   "$tools_stage/copperline-import-uae"
 install -m644 LICENSE "$tools_stage/LICENSE"
+install -m644 packaging/linux/copperline-tools-README.txt "$tools_stage/README.txt"
 tar -C "$repo_root/target" -czf "$repo_root/$tools_bundle.tar.gz" "$tools_bundle"
 
 echo "==> Built $OUTPUT, $helper_bundle.tar.gz and $tools_bundle.tar.gz"

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -9,6 +9,10 @@
 #      the bundled AROS ROM via <bindir>/../share/copperline/aros.
 #   3. Uses linuxdeploy to pull in the direct shared-library dependencies
 #      (ALSA, udev, X11/Wayland, etc.) and wrap the AppDir into an AppImage.
+#   4. Tars the companions that cannot live inside a single-entry-point
+#      AppImage: the net helper (with its setup/unit files) and the
+#      command-line tools (copperline-ctl, copperline-import-uae), each as
+#      its own release asset.
 #
 # Notes:
 #   - The GPU stack (Mesa/Vulkan/libGL) is deliberately NOT bundled; the
@@ -165,4 +169,19 @@ install -m644 packaging/linux/copperline-net-helper.socket \
   "$helper_stage/copperline-net-helper.socket"
 tar -C "$repo_root/target" -czf "$repo_root/$helper_bundle.tar.gz" "$helper_bundle"
 
-echo "==> Built $OUTPUT and $helper_bundle.tar.gz"
+# Command-line companions: the control-protocol / MCP / DAP client that the
+# VS Code extension and coding agents run, and the WinUAE/Amiberry/FS-UAE
+# config converter. An AppImage has one entry point, so they ship as a
+# separate tarball; copperline-ctl finds the emulator through COPPERLINE_BIN
+# (the AppImage path) or PATH when there is no copperline next to it.
+tools_bundle="Copperline-$VERSION-$arch-tools"
+tools_stage="$repo_root/target/$tools_bundle"
+rm -rf "$tools_stage"
+mkdir -p "$tools_stage"
+install -m755 target/release/copperline-ctl "$tools_stage/copperline-ctl"
+install -m755 target/release/copperline-import-uae \
+  "$tools_stage/copperline-import-uae"
+install -m644 LICENSE "$tools_stage/LICENSE"
+tar -C "$repo_root/target" -czf "$repo_root/$tools_bundle.tar.gz" "$tools_bundle"
+
+echo "==> Built $OUTPUT, $helper_bundle.tar.gz and $tools_bundle.tar.gz"

--- a/packaging/flatpak/dev.copperline.Copperline.yaml
+++ b/packaging/flatpak/dev.copperline.Copperline.yaml
@@ -71,6 +71,14 @@ modules:
       # --locked + --offline reproduce the pinned graph.
       - cargo --offline build --release --locked
       - install -Dm755 target/release/copperline -t ${FLATPAK_DEST}/bin/
+      # Command-line companions (default-feature binaries of the same
+      # build): the control-protocol / MCP / DAP client and the UAE config
+      # converter. Reached with
+      #   flatpak run --command=copperline-ctl dev.copperline.Copperline ...
+      # copperline-ctl launches the copperline beside it in /app/bin, and
+      # --share=network above covers the loopback control socket.
+      - install -Dm755 target/release/copperline-ctl -t ${FLATPAK_DEST}/bin/
+      - install -Dm755 target/release/copperline-import-uae -t ${FLATPAK_DEST}/bin/
       # Bundled AROS open-source Kickstart replacement (the default boot ROM).
       # romsearch.rs resolves it relative to the binary via
       # <prefix>/share/copperline/aros, i.e. /app/share/copperline/aros here.

--- a/packaging/linux/copperline-tools-README.txt
+++ b/packaging/linux/copperline-tools-README.txt
@@ -1,0 +1,27 @@
+Copperline - command-line tools
+================================
+
+Companions to the Copperline AppImage, which as a single-entry-point image
+cannot carry them itself:
+
+  copperline-ctl         Client for the control protocol (scripting and AI
+                         agents), the MCP server mode (--mcp) and the Debug
+                         Adapter Protocol adapter (--dap) used by the VS Code
+                         extension.
+  copperline-import-uae  Converts a WinUAE, Amiberry or FS-UAE config file
+                         into a Copperline TOML config:
+                         copperline-import-uae --from winuae --in game.uae --out game.toml
+
+Put this directory on PATH, or point the VS Code setting
+copperline.ctlExecutable at copperline-ctl.
+
+copperline-ctl launches the emulator when a session needs one. It looks for
+it in this order: an explicit path given to the command, the COPPERLINE_BIN
+environment variable, a copperline next to copperline-ctl, then PATH. With
+the AppImage, set COPPERLINE_BIN to the AppImage's path:
+
+    export COPPERLINE_BIN=/path/to/Copperline-X.Y.Z-x86_64.AppImage
+
+See https://copperline.dev/docs/getting-started/#command-line-tools
+
+Copperline is licensed under GPL-3.0-or-later; see LICENSE.

--- a/packaging/macos/README.txt
+++ b/packaging/macos/README.txt
@@ -43,6 +43,24 @@ own Kickstart ROM and disk/hard-disk images, and launch from a terminal with:
 
 Run that binary with --help for the full command-line surface.
 
+Command-line tools
+------------------
+Two companion programs sit next to the emulator inside the bundle, in
+Copperline.app/Contents/MacOS:
+
+  copperline-ctl         Client for the control protocol (scripting and AI
+                         agents), the MCP server mode (--mcp) and the Debug
+                         Adapter Protocol adapter (--dap) used by the VS Code
+                         extension. It launches the copperline beside it.
+                         Add that directory to PATH, or point the VS Code
+                         setting copperline.ctlExecutable at
+                         /Applications/Copperline.app/Contents/MacOS/copperline-ctl
+  copperline-import-uae  Converts a WinUAE, Amiberry or FS-UAE config file
+                         into a Copperline TOML config:
+                         copperline-import-uae --from winuae --in game.uae --out game.toml
+
+Homebrew installs (brew install copperline) put the same two tools on PATH.
+
 Bridged Ethernet
 ----------------
 User-mode NAT needs no setup. Direct bridged Ethernet uses macOS's system

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -189,10 +189,14 @@ echo "==> Ad-hoc signing $app_name"
 # launch on Apple Silicon; it does not satisfy notarization, so downloads are
 # still Gatekeeper-quarantined (see README.txt).
 cp assets/egui/THIRD_PARTY_FONTS.txt "$app/Contents/Resources/THIRD_PARTY_FONTS.txt"
-# --deep covers the bundle's main executable and nested bundles, but not
-# reliably the extra Mach-O tools beside it in Contents/MacOS, and an
-# unsigned arm64 copperline-ctl would be killed on launch: sign each one.
+# The companion tools first: signing the bundle (or its main executable,
+# which codesign treats as the bundle) verifies every nested code object,
+# and lipo has stripped the per-slice signatures, so an unsigned tool in
+# Contents/MacOS fails that pass. An unsigned arm64 copperline-ctl would
+# also be killed on launch. The bundle-level --deep sign then covers the
+# main executable.
 for name in "${binaries[@]}"; do
+  [ "$name" = copperline ] && continue
   codesign --force --sign - "$app/Contents/MacOS/$name"
 done
 codesign --force --deep --sign - "$app"

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -10,10 +10,13 @@
 #      PREBUILT_DIR set the cargo step is skipped and the per-architecture
 #      binaries are taken from that directory instead (the macOS workflow
 #      compiles each slice on its own runner and packages them here).
-#   2. Stages a Copperline.app bundle: the universal binary in Contents/MacOS,
-#      the icon and AROS ROM in Contents/Resources. romsearch.rs probes a
-#      bundle's Contents/Resources/aros first, so the bundled AROS ROM is found
-#      with no configuration.
+#   2. Stages a Copperline.app bundle: the universal binary in Contents/MacOS
+#      beside the copperline-ctl (control protocol / MCP / DAP client) and
+#      copperline-import-uae (config converter) companions, lipo-joined the
+#      same way; the icon and AROS ROM in Contents/Resources. romsearch.rs
+#      probes a bundle's Contents/Resources/aros first, so the bundled AROS
+#      ROM is found with no configuration, and copperline-ctl launches the
+#      copperline next to it.
 #   3. Ad-hoc code-signs the bundle. lipo strips the per-slice signatures Rust
 #      attaches on macOS, and an unsigned arm64 binary will not launch on Apple
 #      Silicon at all, so a signature is mandatory even when it is ad-hoc.
@@ -28,8 +31,8 @@
 #
 # Override knobs (env):
 #   MACOS_UNIVERSAL=0   build only the host architecture (faster local builds)
-#   PREBUILT_DIR=<dir>  skip the cargo build and lipo <dir>/<target>/copperline
-#                       for each target instead
+#   PREBUILT_DIR=<dir>  skip the cargo build and lipo <dir>/<target>/<binary>
+#                       for each target and shipped binary instead
 #   OUTPUT=<path>       final .dmg file name
 set -euo pipefail
 
@@ -54,16 +57,16 @@ else
   targets=(aarch64-apple-darwin x86_64-apple-darwin)
 fi
 
-# Per-target binaries to join: either built here or supplied prebuilt.
-bins=()
+# Executables that ship in Contents/MacOS: the emulator and its command-line
+# companions (all default-feature binaries of one cargo build).
+binaries=(copperline copperline-ctl copperline-import-uae)
+
+# Per-target build directories holding those binaries: either built here or
+# supplied prebuilt.
+slice_dirs=()
 if [ -n "${PREBUILT_DIR:-}" ]; then
   echo "==> Using prebuilt binaries from $PREBUILT_DIR (${targets[*]})"
   for target in "${targets[@]}"; do
-    bin="$PREBUILT_DIR/$target/copperline"
-    if [ ! -f "$bin" ]; then
-      echo "error: no prebuilt binary at $bin" >&2
-      exit 1
-    fi
     # Catch a slice staged under the wrong target name before lipo would
     # happily join two copies of the same architecture.
     case "$target" in
@@ -71,22 +74,29 @@ if [ -n "${PREBUILT_DIR:-}" ]; then
       x86_64-apple-darwin) want=x86_64 ;;
       *) want="" ;;
     esac
-    got="$(lipo -archs "$bin")"
-    if [ -n "$want" ] && [ "$got" != "$want" ]; then
-      echo "error: $bin is $got, expected $want for $target" >&2
-      exit 1
-    fi
-    bins+=("$bin")
+    for name in "${binaries[@]}"; do
+      bin="$PREBUILT_DIR/$target/$name"
+      if [ ! -f "$bin" ]; then
+        echo "error: no prebuilt binary at $bin" >&2
+        exit 1
+      fi
+      got="$(lipo -archs "$bin")"
+      if [ -n "$want" ] && [ "$got" != "$want" ]; then
+        echo "error: $bin is $got, expected $want for $target" >&2
+        exit 1
+      fi
+    done
+    slice_dirs+=("$PREBUILT_DIR/$target")
   done
 else
-  echo "==> Building release binary (${targets[*]})"
+  echo "==> Building release binaries (${targets[*]})"
   for target in "${targets[@]}"; do
     # Idempotent; ensures hand-builds on a fresh checkout have the cross target.
     if command -v rustup >/dev/null 2>&1; then
       rustup target add "$target" >/dev/null
     fi
     cargo build --release --locked --target "$target"
-    bins+=("target/$target/release/copperline")
+    slice_dirs+=("target/$target/release")
   done
 fi
 
@@ -96,8 +106,16 @@ mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources/aros" \
   "$app/Contents/Resources/a2091" "$app/Contents/Resources/a4091" \
   "$app/Contents/Resources/lide"
 
-# Universal binary from the per-arch slices (a single-arch lipo is a no-op copy).
-lipo -create -output "$app/Contents/MacOS/copperline" "${bins[@]}"
+# Universal binaries from the per-arch slices (a single-arch lipo is a no-op
+# copy). copperline-ctl looks for the emulator next to itself, so all three
+# land in Contents/MacOS together; codesign --deep below signs each of them.
+for name in "${binaries[@]}"; do
+  bins=()
+  for dir in "${slice_dirs[@]}"; do
+    bins+=("$dir/$name")
+  done
+  lipo -create -output "$app/Contents/MacOS/$name" "${bins[@]}"
+done
 
 # Info.plist with the version substituted in; plutil -lint catches a botched
 # substitution before the bundle ships.
@@ -171,6 +189,12 @@ echo "==> Ad-hoc signing $app_name"
 # launch on Apple Silicon; it does not satisfy notarization, so downloads are
 # still Gatekeeper-quarantined (see README.txt).
 cp assets/egui/THIRD_PARTY_FONTS.txt "$app/Contents/Resources/THIRD_PARTY_FONTS.txt"
+# --deep covers the bundle's main executable and nested bundles, but not
+# reliably the extra Mach-O tools beside it in Contents/MacOS, and an
+# unsigned arm64 copperline-ctl would be killed on launch: sign each one.
+for name in "${binaries[@]}"; do
+  codesign --force --sign - "$app/Contents/MacOS/$name"
+done
 codesign --force --deep --sign - "$app"
 
 echo "==> Laying out disk image contents"

--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -34,6 +34,24 @@ own Kickstart ROM and disk/hard-disk images, and launch with:
 
 Run "copperline.exe --help" for the full command-line surface.
 
+Command-line tools
+------------------
+Two companion programs sit next to copperline.exe:
+
+  copperline-ctl.exe         Client for the control protocol (scripting and
+                             AI agents), the MCP server mode (--mcp) and the
+                             Debug Adapter Protocol adapter (--dap) used by
+                             the VS Code extension. It launches the
+                             copperline.exe beside it, so keep them together
+                             or point the copperline.emulatorExecutable
+                             setting at the emulator. Add this folder to
+                             PATH, or set copperline.ctlExecutable to the
+                             full path of copperline-ctl.exe.
+  copperline-import-uae.exe  Converts a WinUAE, Amiberry or FS-UAE config
+                             file into a Copperline TOML config:
+                             copperline-import-uae.exe --from winuae
+                                 --in game.uae --out game.toml
+
 Portable data
 -------------
 By default, quick-save slots and host preferences are kept under

--- a/packaging/windows/build-zip.ps1
+++ b/packaging/windows/build-zip.ps1
@@ -8,10 +8,12 @@
 #      default, ARM64 with -Target aarch64-pc-windows-msvc) with the pinned
 #      dependency graph. The CRT is statically linked (see .cargo/config.toml),
 #      so the bundle needs no Visual C++ Redistributable.
-#   2. Stages a folder holding copperline.exe with a sibling aros\ directory,
-#      which is the first location romsearch.rs probes, so the bundled AROS
-#      ROM is found with no configuration; the other bundled ROM assets
-#      (fmv\, a4091\, a2091\, lide\, hrtmon\) sit beside it the same way.
+#   2. Stages a folder holding copperline.exe, the copperline-ctl.exe
+#      control/debug-adapter client and the copperline-import-uae.exe config
+#      converter, with a sibling aros\ directory, which is the first location
+#      romsearch.rs probes, so the bundled AROS ROM is found with no
+#      configuration; the other bundled ROM assets (fmv\, a4091\, a2091\,
+#      lide\, hrtmon\) sit beside it the same way.
 #   3. Zips the folder into Copperline-<version>-win-<x64|arm64>.zip,
 #      mirroring the AppImage/Homebrew version naming so release assets are
 #      self-describing.
@@ -50,6 +52,14 @@ $arosDir = Join-Path $stage "aros"
 New-Item -ItemType Directory -Force -Path $arosDir | Out-Null
 
 Copy-Item "target\$target\release\copperline.exe" (Join-Path $stage "copperline.exe")
+# Command-line companions built by the same cargo invocation (both are
+# default-feature binaries): the control-protocol / MCP / DAP client that the
+# VS Code extension and coding agents run, and the WinUAE/Amiberry/FS-UAE
+# config converter. copperline-ctl finds the emulator next to itself, so the
+# three must stay siblings.
+foreach ($tool in @("copperline-ctl.exe", "copperline-import-uae.exe")) {
+    Copy-Item "target\$target\release\$tool" (Join-Path $stage $tool)
+}
 Copy-Item "assets\egui\THIRD_PARTY_FONTS.txt" (Join-Path $stage "THIRD_PARTY_FONTS.txt")
 
 # Bundled AROS open-source Kickstart replacement (the default boot ROM).

--- a/src/bin/copperline-ctl.rs
+++ b/src/bin/copperline-ctl.rs
@@ -102,7 +102,6 @@ fn parse_options() -> Result<Options, String> {
             "--dap-listen" => {
                 dap_listen = Some(args.next().ok_or("--dap-listen requires ADDR")?);
             }
-            "-h" | "--help" => return Err(usage().to_string()),
             _ if method.is_none() && !arg.starts_with('-') => method = Some(arg),
             _ if method.is_some() && params.is_null() => {
                 params =
@@ -524,7 +523,6 @@ fn run_profile_report() -> Result<Vec<std::path::PathBuf>, String> {
                     .ok_or("--source-map requires FROM=TO")?;
                 source_map.push((from.to_string(), to.to_string()));
             }
-            "-h" | "--help" => return Err(usage().to_string()),
             other => return Err(format!("unexpected profile-report argument {other:?}")),
         }
     }
@@ -641,9 +639,14 @@ fn run_size_report() -> Result<std::path::PathBuf, String> {
 }
 
 fn main() -> ExitCode {
-    // A help request is not a usage error: the packaging smoke tests (and
-    // anyone probing a fresh install) check the exit status.
-    if matches!(std::env::args().nth(1).as_deref(), Some("-h" | "--help")) {
+    // A help request anywhere on the command line is not a usage error:
+    // the packaging smoke tests (and anyone probing a fresh install) check
+    // the exit status. No mode or subcommand takes "-h"/"--help" as a
+    // value, so the position does not matter.
+    if std::env::args()
+        .skip(1)
+        .any(|arg| arg == "-h" || arg == "--help")
+    {
         println!("{}", usage());
         return ExitCode::SUCCESS;
     }

--- a/src/bin/copperline-ctl.rs
+++ b/src/bin/copperline-ctl.rs
@@ -641,6 +641,12 @@ fn run_size_report() -> Result<std::path::PathBuf, String> {
 }
 
 fn main() -> ExitCode {
+    // A help request is not a usage error: the packaging smoke tests (and
+    // anyone probing a fresh install) check the exit status.
+    if matches!(std::env::args().nth(1).as_deref(), Some("-h" | "--help")) {
+        println!("{}", usage());
+        return ExitCode::SUCCESS;
+    }
     if std::env::args().nth(1).as_deref() == Some("size-report") {
         return match run_size_report() {
             Ok(path) => {

--- a/src/bin/copperline-import-uae.rs
+++ b/src/bin/copperline-import-uae.rs
@@ -231,9 +231,14 @@ const USAGE: &str =
     "usage: copperline-import-uae --from winuae|amiberry|fsuae --in FILE --out FILE";
 
 fn main() -> ExitCode {
-    // A help request is not a usage error: the packaging smoke tests (and
-    // anyone probing a fresh install) check the exit status.
-    if matches!(std::env::args().nth(1).as_deref(), Some("-h" | "--help")) {
+    // A help request anywhere on the command line is not a usage error:
+    // the packaging smoke tests (and anyone probing a fresh install) check
+    // the exit status. No option takes "-h"/"--help" as a value, so the
+    // position does not matter.
+    if std::env::args()
+        .skip(1)
+        .any(|arg| arg == "-h" || arg == "--help")
+    {
         println!("{USAGE}");
         return ExitCode::SUCCESS;
     }

--- a/src/bin/copperline-import-uae.rs
+++ b/src/bin/copperline-import-uae.rs
@@ -53,11 +53,7 @@ fn parse_args() -> Result<Args, String> {
 }
 
 fn run() -> Result<(), String> {
-    let args = parse_args().map_err(|e| {
-        format!(
-            "{e}\n\nusage: copperline-import-uae --from winuae|amiberry|fsuae --in FILE --out FILE"
-        )
-    })?;
+    let args = parse_args().map_err(|e| format!("{e}\n\n{USAGE}"))?;
 
     let text = std::fs::read_to_string(&args.input)
         .map_err(|e| format!("reading {}: {e}", args.input.display()))?;
@@ -231,7 +227,16 @@ fn absent_media(doc: &toml_edit::DocumentMut, source: &std::path::Path) -> Vec<S
         .collect()
 }
 
+const USAGE: &str =
+    "usage: copperline-import-uae --from winuae|amiberry|fsuae --in FILE --out FILE";
+
 fn main() -> ExitCode {
+    // A help request is not a usage error: the packaging smoke tests (and
+    // anyone probing a fresh install) check the exit status.
+    if matches!(std::env::args().nth(1).as_deref(), Some("-h" | "--help")) {
+        println!("{USAGE}");
+        return ExitCode::SUCCESS;
+    }
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {

--- a/tools/vscode-copperline/README.md
+++ b/tools/vscode-copperline/README.md
@@ -20,7 +20,10 @@ without waiting for the upstream pull request.
 
 - A recent Copperline build with the September 2026 debugger additions
   (the guide was tested against commit `3d334a11`). Build from current source
-  until those changes are in your installed release. Put `copperline-ctl`
+  until those changes are in your installed release. Every release
+  package ships `copperline-ctl` next to the emulator (Homebrew on PATH,
+  `Copperline.app/Contents/MacOS` on macOS, the Windows zip folder, the
+  AppImage's companion tools tarball). Put `copperline-ctl`
   on your PATH, or use the
   `copperline.ctlExecutable` setting pointing at the executable file.
   `copperline.emulatorExecutable` names the `copperline` executable file

--- a/tools/vscode-copperline/README.md
+++ b/tools/vscode-copperline/README.md
@@ -23,7 +23,8 @@ without waiting for the upstream pull request.
   until those changes are in your installed release. Every release
   package ships `copperline-ctl` next to the emulator (Homebrew on PATH,
   `Copperline.app/Contents/MacOS` on macOS, the Windows zip folder, the
-  AppImage's companion tools tarball). Put `copperline-ctl`
+  AppImage's companion tools tarball, `/app/bin` inside the Flatpak
+  sandbox). Put `copperline-ctl`
   on your PATH, or use the
   `copperline.ctlExecutable` setting pointing at the executable file.
   `copperline.emulatorExecutable` names the `copperline` executable file


### PR DESCRIPTION
A user reported that `copperline-ctl` is missing from the Windows build. It was wider than Windows: every pre-built package except Homebrew shipped only the `copperline` executable.

## Why

`copperline-ctl` and `copperline-import-uae` are default-feature binaries, so every packaging job already compiled them. The staging steps then copied the emulator alone. Homebrew got them only because `cargo install` installs every default binary. The DAP guide and the VS Code extension tell users to have `copperline-ctl` on PATH, so dmg, zip, AppImage and Flatpak users could not use the debug adapter or the MCP server without a source build, and no document said so.

## Changes

- **Windows zip:** `build-zip.ps1` copies both `.exe` files beside `copperline.exe`. The zip smoke job fails if either is missing or its `--help` exits non-zero. Bundled README gains a "Command-line tools" section.
- **macOS dmg:** the build job uploads all three binaries as its per-architecture slice. `build-dmg.sh` lipo-joins each into `Contents/MacOS`, signs the two tools explicitly before the bundle-level `codesign --deep` (which does not reliably reach extra executables in `Contents/MacOS`), and the smoke job checks both are universal and start natively and under Rosetta. README updated.
- **AppImage:** a single-entry-point image cannot expose a second binary, so the script also produces `Copperline-X.Y.Z-<arch>-tools.tar.gz` holding both tools plus the license. It is uploaded as a workflow artifact, attached to releases alongside the net-helper tarball, and smoke-tested.
- **Flatpak:** both tools are installed into `/app/bin`, reachable via `flatpak run --command=copperline-ctl dev.copperline.Copperline`.
- **`--help` exit status:** both tools returned 1 for `--help`, which the new smoke checks rely on. `-h`/`--help` now print usage to stdout and exit 0; bad arguments still exit 1.
- **Docs:** getting-started gains a "Command-line tools" table listing where each package puts the tools. The DAP chapter, VS Code guide, UAE import guide and the extension README point at it instead of implying a source build is required.

## Validation

- Both binaries rebuilt in release: `--help` exits 0, bad arguments exit 1. `cargo fmt --check` and `cargo clippy` clean on the two binaries.
- Local dry run of `build-dmg.sh` with `PREBUILT_DIR` against host-architecture binaries: the bundle passes `codesign --verify --deep --strict`, both tools are present, signed and run from the mounted image, and the emulator boots the bundled AROS ROM from the read-only volume.
- Shell scripts pass `bash -n`; all four YAML files parse; `actionlint` reports only the pre-existing info notes on `ls` usage.
- The Windows and AppImage paths get their first real run in CI here (no `pwsh` locally, and the tools tarball step only runs on Linux).

## Size note

`copperline-ctl` links the whole emulator library, so it adds about 52 MB per architecture uncompressed to the dmg and zip before compression. The release profile's symbol handling is left alone, since stripping would also affect crash-report backtraces from the main binary.
