### PR TITLE
Add four-player adapter, light pen, PCMCIA slot, CHD disks and host serial

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,10 +100,11 @@ repeat.
 | `--key-after SECS KEY MS` | Hold a key for exactly MS milliseconds |
 | `--type-after SECS TEXT` | Type TEXT on the US Amiga keyboard from SECS, one key per 100 ms (`\n` Return, `\t` Tab, `\e` Esc) |
 | `--click-after SECS BUTTON MS [PORT]` | Mouse button (`left`/`right`/`middle`) for MS ms (default port 1) |
-| `--joy-after SECS BUTTON MS [PORT]` | Joystick / CD32-pad control (`up`/`down`/`left`/`right`/`red`/`blue`/...) (default port 2) |
+| `--joy-after SECS BUTTON MS [PORT]` | Joystick / CD32-pad control (`up`/`down`/`left`/`right`/`red`/`blue`/...) on port 1-4 (default port 2; 3/4 = parallel-port adapter) |
 | `--mouse-after SECS DX DY [PORT]` | Relative mouse motion (default port 1) |
 | `--mouse-to-after SECS X Y [PORT]` | Steer the pointer to screen pixel (X, Y) via sprite 0 (default port 1) |
 | `--pot-after SECS X Y [PORT]` | Analogue stick/paddle position, 0-255 per axis (default port 2) |
+| `--pen-after SECS X Y [PORT]` | Hold the light pen over screen pixel (X, Y) (`--mouse-to-after` coordinates; negative lifts it off); `--joy-after ... red` is its switch |
 | `--insert-disk-after SECS DFN PATH` | Insert a disk image into `df0`..`df3` |
 | `--insert-cd-after SECS PATH` | Swap the CD image in the machine's CD drive (CDTV/CD32/SCSI CD-ROM) |
 | `--expect-screenshot SECS PATH [TOL]` | Compare the frame at SECS with the PNG at PATH (TOL = fraction or pixel count); mismatch writes `<stem>.actual.png` + `<stem>.diff.png`, exit status 3 at run end |
@@ -115,7 +116,11 @@ digits). A session played by hand under `--record-input` (or Cmd+Shift+R /
 Alt+Shift+R in the window) replays deterministically via `--script`.
 
 Either controller port takes any device -- `[input] port1/port2` in the
-TOML, or `--port1`/`--port2` (`mouse`/`joystick`/`cd32`/`analogue`/`none`;
+TOML, or `--port1`/`--port2` (`mouse`/`joystick`/`cd32`/`analogue`/
+`lightpen`/`none`; a pen only reaches Agnus from port 2 on post-A1000
+boards). `[parallel] device = "joystick-adapter"` (`--parallel
+joystick-adapter`) adds the four-player adapter's ports 3 and 4
+(`--port3`/`--port4`, `joystick`/`none`;
 default mouse + joystick, CD32 pad on the CD32 profile). The scripted-input
 flags' optional trailing `PORT` token (`1` or `2`) aims an event at either
 port; omitted, each flag keeps its traditional port, so existing scripts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
+ "serialport",
  "sha2",
  "smoltcp",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ default = [
     "gdb",
     "dap",
     "netplay-internet",
+    "host-serial",
 ]
 # Native NAT traversal and encrypted relay fallback. The portable/WASM core
 # keeps using its frontend-provided transport.
@@ -166,6 +167,12 @@ dap = ["control", "dep:gimli", "dep:object"]
 # in the build. Off, none of it is built, which is what browser builds
 # (--no-default-features) want.
 fluxbridge = ["dep:fluxbridge"]
+# A real host serial port on Paula's UART (`[serial] mode = "device"`,
+# src/serial/device.rs): the same pure-Rust `serialport` crate FluxBridge
+# talks to a Greaseweazle through. Native-only by construction (threads and
+# tty ioctls), so browser builds (--no-default-features) compile it out and
+# the mode reports itself as unavailable there.
+host-serial = ["dep:serialport"]
 
 [dependencies]
 m68k = { version = "0.12", features = ["serde"] }
@@ -290,6 +297,11 @@ zerocopy = { version = "0.8", features = ["derive"] }
 # line: adding a driver Copperline supports means adding its feature, nothing
 # else.
 fluxbridge = { git = "https://github.com/CopperlineHQ/FluxBridge", branch = "main", default-features = false, features = ["greaseweazle"], optional = true }
+# Host serial ports for `[serial] mode = "device"`. The version FluxBridge
+# already pins, with the same `default-features = false`: the default
+# `libudev` feature would link a C library on Linux for richer USB port
+# descriptions, and the sysfs fallback lists the same ports without it.
+serialport = { version = "4.9", default-features = false, optional = true }
 # CHD (MAME "Compressed Hunks of Data") CD images (src/cdrom/chd.rs). Pure
 # Rust, so it builds for wasm32 browser targets like the rest of the core.
 chd = "0.3"

--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -445,7 +445,9 @@ slow = "512K"
 # autoboots on Kickstart 1.3+, so it does not depend on the Kickstart IDE
 # driver (which only probes the master on stock 3.1). Drive paths accept the
 # same images as [ide]: RDB HDFs, bare partition hardfiles, gzip-compressed
-# hardfiles (.hdz), or host directories. A path ending in .cue, .iso, .nrg, or .chd
+# hardfiles (.hdz), CHD hard-disk images (.chd), or host directories. A path
+# ending in .cue, .iso, .nrg, or a .chd holding a CD (chdman createcd; a
+# createhd one is a hard disk -- the CHD's metadata decides, not its name)
 # attaches a SCSI CD-ROM drive at that ID instead (read-only; mount it in the
 # guest with a CD filesystem pointed at the controller's scsi.device and that
 # unit number). CD audio tracks play through the machine's audio output, and
@@ -499,8 +501,10 @@ slow = "512K"
 # One drive key per slot, in (channel, master/slave) order: drive0/drive1 are
 # channel 0's master/slave, drive2/drive3 are channel 1's (ripple only). Each
 # is independent, so a slot can be left empty without ending the list -- the
-# same shape as [ide]'s master/slave and [scsi]'s unit0..unit6. The older
-# positional `drives = [...]` array is still read for existing configs.
+# same shape as [ide]'s master/slave and [scsi]'s unit0..unit6, taking the
+# same image forms (RDB HDFs, bare partition hardfiles, .hdz, .chd, host
+# directories, CD images). The older positional `drives = [...]` array is
+# still read for existing configs.
 # [lide]
 # board = "ripple"
 # rom = "lide.rom"
@@ -512,10 +516,11 @@ slow = "512K"
 # equivalent of WinUAE's uaehf.device), for a high-performance hard disk with
 # none of a real chip's register timing to model. Up to seven units, same
 # bare-path/table drive form as [ide]/[scsi]/[lide]: RDB HDFs, bare partition
-# hardfiles, gzip-compressed hardfiles (.hdz), and host directories all work
-# the same way, RDB and RDB-less images handled identically to the other
-# controllers. Hard disks only -- a CD image path (.cue/.iso/.nrg/.chd) is
-# rejected; attach CD images to [scsi] or [ide]/[lide] instead. No rom key:
+# hardfiles, gzip-compressed hardfiles (.hdz), CHD hard-disk images (.chd),
+# and host directories all work the same way, RDB and RDB-less images
+# handled identically to the other controllers. Hard disks only -- a CD image
+# path (.cue/.iso/.nrg, or a .chd holding a CD) is rejected; attach CD images
+# to [scsi] or [ide]/[lide] instead. No rom key:
 # the board's boot ROM and device driver are built into Copperline itself
 # (an autoboot DiagArea ROM and RDB mounter -- see COPPERHF-DEVICE-PLAN.md
 # and docs/internals/copperhf.md), not a loadable image.
@@ -553,7 +558,12 @@ video = "PAL"
 # of 256 KiB) work - the latter get a synthesized RDB on the fly. A gzip-
 # compressed hardfile (.hdz, or a gzipped .hdf: it is the content that decides,
 # not the name) is unpacked into memory at open time, so the guest may write to
-# it but nothing goes back to the compressed file. A path may also name a host
+# it but nothing goes back to the compressed file. A CHD hard-disk image (as
+# `chdman createhd -i disk.hdf -o disk.chd` writes, recognised by content too)
+# is decompressed a sector at a time and never written: guest writes go to a
+# copy-on-write overlay beside it, disk.chd.wov, which persists across
+# sessions (delete it to return to the pristine image). If the overlay cannot
+# be created the disk attaches write-protected. A path may also name a host
 # directory, mounted as an in-memory FFS or OFS volume (guest writes are
 # likewise not synced back to the host).
 #
@@ -570,14 +580,31 @@ video = "PAL"
 # own RDB, which keeps its label, priorities, and filesystem recorded inside
 # it.
 #
-# A path ending in .cue, .iso, .nrg, or .chd attaches an ATAPI CD-ROM drive at
-# that slot instead of a hard disk (see [scsi], above, for the read-only
-# SCSI-2 command engine both share).
+# A path ending in .cue, .iso, .nrg, or a .chd holding a CD attaches an ATAPI
+# CD-ROM drive at that slot instead of a hard disk (see [scsi], above, for the
+# read-only SCSI-2 command engine both share).
 # [ide]
 # master = "workbench.hdf"
 # slave = "data.hdf"
 # master = { path = "workbench.hdf", bootpri = 6 }
 # master = { path = "/host/Games", filesystem = "ofs" }
+
+
+# The A600/A1200 PCMCIA (credit-card) slot, wired through Gayle. One card:
+# a CompactFlash card over any image [ide] accepts (the Aminet CF drivers
+# -- compactflash.device, cfd.device, the scsi.device PCMCIA patches --
+# talk to it through the CF register layout; Kickstart's card.resource
+# only detects it), or an SRAM memory card that Kickstart adds as
+# credit-card RAM when present at boot. A real card in a reader goes in
+# with [[host_disk]] attach = "pcmcia" instead. More than 4M of [memory]
+# fast covers the slot's $600000-$9FFFFF window and disables the slot, as
+# on a real A1200 with an 8M Zorro II expansion. --pcmcia-cf PATH and
+# --pcmcia-sram SIZE are the command-line forms.
+# [pcmcia]
+# card = "cf"                # "none" (default), "cf", or "sram"
+# path = "card.hdf"          # cf: the image; sram: optional backing file
+# size = "2M"                # sram only: 64K..1M in 64K steps, or 128K..4M in 128K steps
+# read_only = false          # sram only: the write-protect switch
 
 
 # Direct WHDLoad boot (docs/guide/whdload.md): boot straight into a
@@ -774,12 +801,26 @@ floppy_sounds_volume = 100
 #   "analogue" analogue paddles / proportional stick on the POT pins,
 #              driven by --pot-after scripting or the CCP input.analogue
 #              method (no live host device maps to it yet)
+#   "lightpen" light pen / light gun (alias "lightgun"): follows the host
+#              pointer over the display, a left click is the pen switch /
+#              trigger (POTxX); --pen-after X Y positions it headless. Its
+#              pulses only reach Agnus from the port the board wires to LP:
+#              port 1 on the A1000, port 2 on every later Amiga
 #   "none"     empty port
 # Defaults: port1 = "mouse", port2 = "joystick" ("cd32" on the CD32
 # profile). Also --port1 DEVICE / --port2 DEVICE per run; the runtime menu
 # and the CCP input.set_port method hot-plug a device live.
 # port1 = "mouse"
 # port2 = "joystick"
+#
+# Ports 3 and 4 are the passive parallel-port four-player adapter's sockets
+# (Kick Off 2, Sensible Soccer, Dyna Blaster...): "joystick" or "none".
+# Naming a joystick fits the adapter ([parallel] device =
+# "joystick-adapter"); an adapter named there fills every socket left
+# unset. Also --port3 /
+# --port4, --joy-after ... 3|4, and the CCP input.joy with port 3 or 4.
+# port3 = "joystick"
+# port4 = "joystick"
 
 # Initial host source for the joystick/CD32-pad port:
 #   "gamepad"  (default) only a physical pad drives the port; the keyboard
@@ -849,6 +890,19 @@ floppy_sounds_volume = 100
 #   "pty"     serial in/out is bridged to a host pseudo-terminal (Unix only).
 #             The slave path (/dev/pts/N) is logged at startup; attach a
 #             terminal with e.g. `minicom -D`, `screen`, or `cu -l`.
+#   "device"  serial in/out is wired to a real host serial port, named by
+#             device: a USB adapter's path (/dev/tty.usbserial-1420 on
+#             macOS, /dev/ttyUSB0 on Linux) or a COM name (COM3) on
+#             Windows; --list-serial-ports names them. The guest's DTR/RTS
+#             drive the port's pins and its CTS/DSR/DCD come back on
+#             CIA-B, so a null-modem link to a real Amiga or PC (Amiga
+#             Explorer, ZMODEM) handshakes as it would on real hardware.
+#             The port follows the guest's SERPER rate (nearest standard
+#             rate) and stop bits; host bytes still arrive at the emulated
+#             rate. A pulled adapter reads as an unplugged cable until it
+#             is back. Host-clocked, so outside byte-identical replay, and
+#             reopened rather than restored by a save state. Needs the
+#             host-serial feature (default on).
 #   "modem"   a Hayes/AT-command modem: the guest dials out with
 #             "ATD host:port" rather than the port being wired to a peer at
 #             startup, so there is no connect key here. listen means
@@ -869,10 +923,12 @@ floppy_sounds_volume = 100
 # See docs/guide/modem.md for the full command set and a BBS quick-start.
 # With an AUX: shell on the Amiga side, "tcp"/"pty" give a remote AmigaDOS
 # console. --serial MODE overrides this per run; --serial-connect HOST:PORT
-# implies "tcp-connect"; --serial-session FILE implies "modem"; --midi-out/
-# --midi-in NAME imply "midi".
+# implies "tcp-connect"; --serial-session FILE implies "modem";
+# --serial-device PATH implies "device"; --midi-out/--midi-in NAME imply
+# "midi".
 # mode = "stdout"
 # connect = "bbs.example.com:1337"
+# device = "/dev/tty.usbserial-1420"  # device mode: host serial port (COM3 on Windows)
 # midi_out = "USB MIDI Interface"
 # midi_in = "USB MIDI Interface"
 # listen = "127.0.0.1:1234"
@@ -924,8 +980,15 @@ floppy_sounds_volume = 100
 #              prints; omitted = system default). `sampler_gain` is the preamp
 #              gain in decibels (0 dB = unity; ~ -24 to +24 dB). Needs a build
 #              with the `frontend` feature (it uses cpal, like live audio output).
+#   "joystick-adapter"
+#              the passive four-player joystick adapter: port 3's
+#              directions on D0-D3 (CIA-A PB0-3) and fire on SEL (CIA-B
+#              PA2), port 4's on D4-D7 and BUSY (PA0), second buttons on
+#              POUT (PA1), all switches to ground on pins the guest has
+#              set as inputs. Sockets are [input] port3 / port4.
 # --parallel DEVICE overrides this per run; --sampler-audio-input /
-# --sampler-input-gain imply "sampler".
+# --sampler-input-gain imply "sampler", and [input] port3/port4 =
+# "joystick" implies "joystick-adapter".
 
 [parallel]
 # device = "printer"
@@ -933,6 +996,7 @@ floppy_sounds_volume = 100
 # device = "sampler"
 # sampler_input = "MacBook Air Microphone"
 # sampler_gain = 6.0   # dB
+# device = "joystick-adapter"
 
 
 # Optional floppy drives. Set [floppy] drives to wire 0-4 mechanisms. CDTV

--- a/crates/copperline-player/src/main.rs
+++ b/crates/copperline-player/src/main.rs
@@ -132,6 +132,9 @@ fn main() -> Result<()> {
         Vec::new(),
         Vec::new(),
         Vec::new(),
+        // No scripted light-pen positions: a bundle plays with the
+        // devices its configuration fits, not with a script.
+        Vec::new(),
         Vec::new(),
         Vec::new(),
         // No scripted freeze: a bundle fits no freezer cartridge.

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -368,10 +368,11 @@ events.unsubscribe {"events":["serial"]}
 - `input.type {"text": ..., "at_seconds": ...}`: Type `text` on the US Amiga keyboard as raw key press/release pairs (Shift where needed, newline as Return, tab as Tab, escape as Esc), one key every 100 ms of emulated time from `at_seconds` (default now). Text with characters the US keymap cannot type is rejected. The same conversion backs `--type-after` and the window's Paste as Keystrokes.
 - `input.mouse {"dx": ..., "dy": ..., "left": ..., "right": ..., "middle": ..., "port": 1|2, "at_seconds": ...}`: Inject mouse motion/buttons.
 - `input.mouse_to {"x": ..., "y": ..., "port": 1|2, "tolerance": ..., "max_frames": ...}`: Steer pointer to screen pixel coordinates via sprite 0.
-- `input.joy {"up": ..., "down": ..., "left": ..., "right": ..., "red": ..., "blue": ..., "green": ..., "yellow": ..., "play": ..., "rwd": ..., "ffw": ..., "port": 1|2, "at_seconds": ...}`: Inject joystick / CD32 button state.
+- `input.joy {"up": ..., "down": ..., "left": ..., "right": ..., "red": ..., "blue": ..., "green": ..., "yellow": ..., "play": ..., "rwd": ..., "ffw": ..., "port": 1|2|3|4, "at_seconds": ...}`: Inject joystick / CD32 button state. Ports 3 and 4 are the parallel-port four-player adapter's sockets (driving one fits the adapter); on a light pen `red` is the tip switch / trigger.
 - `input.analogue {"x": ..., "y": ..., "port": 1|2, "at_seconds": ...}`: Set analogue paddle/pot position (0-255).
-- `input.set_port {"port": 1|2, "device": "mouse"|"gamepad-mouse"|"joystick"|"cd32"|"analogue"|"none"}`: Change port device.
-- `input.get_ports`: Query active controller port device assignments.
+- `input.pen {"x": ..., "y": ..., "at_seconds": ...}`: Hold the light pen over presented pixel (x, y) (the `input.mouse_to` coordinates); omit or negate to lift it off the glass.
+- `input.set_port {"port": 1|2|3|4, "device": "mouse"|"gamepad-mouse"|"joystick"|"cd32"|"analogue"|"lightpen"|"none"}`: Change port device (ports 3 and 4 take `joystick` or `none`).
+- `input.get_ports`: Query active controller port device assignments (`port1`-`port4`, `parallel_adapter`, and the light pen's `port`, whether it is `wired` to Agnus LP, and its position).
 
 ### Media management
 - `media.floppy.insert {"drive": 0, "path": "...", "write_protected": true}`: Insert floppy disk image.
@@ -379,6 +380,9 @@ events.unsubscribe {"events":["serial"]}
 - `media.floppy.query`: Query connected floppy drives, mounted disk images, and write-protection status.
 - `media.cd.insert {"path": "..."}`: Insert CD image.
 - `media.cd.eject`: Eject CD image.
+- `pcmcia.insert {"card": "cf"|"sram", "path": "...", "size": "2M", "read_only": false}`: Push a card into the A600/A1200 PCMCIA slot -- a CompactFlash card over the hard-disk image at `path` (the default kind), or an SRAM card of `size` bytes optionally mirrored to `path`. Any card already in the slot is ejected first; Gayle latches the card-detect change, so the guest sees a real insertion (INT6 once card.resource has enabled it). Fails on a machine without the slot.
+- `pcmcia.eject`: Pull the card out of the slot (latches the card-detect change the same way).
+- `pcmcia.query`: Report the slot: `slot` (the machine has one), `enabled` (not disabled by the guest or shadowed by Zorro II fast RAM), `shadowed_by_fast_ram`, `inserted`, `card` (`cf`/`sram`), `description`, `path`, Gayle's sampled `pins`, and its pending `change_latches`. The `media` event stream also reports `{"kind": "pcmcia", "action": "inserted"|"ejected", "name": ...}`.
 - `copperhf.attach {"unit": 0, "path": "...", "volume_name": "...", "boot_pri": 0}`: Hot-attach a `copperhf.device` unit's media (opens `path` exactly like a boot-time `[copperhf]` unit, `volume_name`/`boot_pri` optional). Bumps the unit's change counter and sets its `CHF_CHANGED_MASK` bit. Fails if no `[copperhf]` controller is configured.
 - `copperhf.eject {"unit": 0}`: Hot-eject/detach a `copperhf.device` unit's media. The unit stays present (`CHF_UNIT_PRESENT`); only its media bit (`CHF_UNIT_MEDIA`) clears. Bumps the change counter and sets `CHF_CHANGED_MASK`, the same as the guest's own `TD_EJECT`.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -69,8 +69,9 @@ range checks as the equivalent TOML fields:
 | `--joystick MODE` | `[input] joystick` | `gamepad` (default), `keyboard` |
 | `--mouse-sensitivity N` | `[input] mouse_sensitivity` | `0`-`100` host mouse speed (`50` default = 1:1) |
 | `--mouse-capture MODE` | `[input] mouse_capture` | When the host mouse is grabbed: `click` (default), `auto`, `manual` |
-| `--port1 DEVICE` | `[input] port1` | `mouse` (default), `joystick`, `cd32`, `analogue`, `none` |
+| `--port1 DEVICE` | `[input] port1` | `mouse` (default), `joystick`, `cd32`, `analogue`, `lightpen`, `none` |
 | `--port2 DEVICE` | `[input] port2` | same devices; default `joystick` (`cd32` on the CD32 profile) |
+| `--port3 DEVICE` / `--port4 DEVICE` | `[input] port3` / `port4` | `joystick` or `none` in the parallel-port four-player adapter's sockets (a joystick implies `--parallel joystick-adapter`) |
 | `--autofire HZ` | `[input] autofire_hz` | `0` (off, the default) to `30` |
 | `--run-ahead FRAMES` | `[emulation] run_ahead_frames` | run-ahead latency reduction: `0` (off) to `4` |
 | `--coverage FILE` | (none; needs `--run`) | write lcov line/function coverage of the `--run` program to FILE when it exits or the run ends ([coverage](../debugger/profiling.md#guest-coverage)) |
@@ -86,17 +87,20 @@ range checks as the equivalent TOML fields:
 | `--audio-channel-mode MODE` | `[audio] channel_mode` | `stereo` (default) or `mono` |
 | `--audio-stereo-separation PCT` | `[audio] stereo_separation` | stereo width `0`-`100` (`100` default, `0` = mono) |
 | `--audio-filter MODE` | `[audio] audio_filter` | Paula filter: `auto` (default), `on`, `off` |
-| `--serial MODE` | `[serial] mode` | `off`, `stdout`, `midi`, `tcp`, `tcp-connect`, `pty`, `modem` |
-| `--parallel DEVICE` | `[parallel] device` | `none`, `printer`, `sampler` |
+| `--serial MODE` | `[serial] mode` | `off`, `stdout`, `midi`, `tcp`, `tcp-connect`, `pty`, `modem`, `device` |
+| `--serial-device PATH` | `[serial] device` | host serial port (`/dev/tty...`, `COM3`; implies `--serial device`) |
+| `--parallel DEVICE` | `[parallel] device` | `none`, `printer`, `sampler`, `joystick-adapter` |
 | `--a2065-net BACKEND` | `[a2065] net` | `none`, `loopback`, `nat`, `bridge` |
 | `--a2065-interface NAME` | `[a2065] interface` | bridge adapter name (implies `--a2065-net bridge`) |
 | `--hostsocket-net BACKEND` | `[hostsocket] net` | `none`, `loopback`, `nat`, `bridge`, `host` |
 | `--hostsocket-interface NAME` | `[hostsocket] interface` | bridge adapter name (implies `--hostsocket-net bridge`) |
-| `--host-disk DEVICE [ATTACH]` | `[[host_disk]]` | attach host storage device read-write |
+| `--host-disk DEVICE [ATTACH]` | `[[host_disk]]` | attach host storage device read-write; `ATTACH` includes `pcmcia` |
 | `--host-disk-read-only DEVICE [ATTACH]` | `[[host_disk]]` | attach host storage device read-only (default) |
 | `--type-after SECS TEXT` | (no config key) | type TEXT on the US Amiga keyboard from SECS ([Headless](headless.md#typing-text)) |
 | `--expect-screenshot SECS PATH [TOLERANCE]` | (no config key) | compare the frame at SECS with a PNG; exit status 3 on mismatch ([Headless](headless.md#screenshot-expectations)) |
 | `--exit-on-return` | (no config key) | with `--run`: exit with the program's AmigaDOS return code ([Run](run.md#exit-on-return)) |
+| `--pcmcia-cf PATH` | `[pcmcia] card = "cf"`, `path` | a CompactFlash card over a hard-disk image in the A600/A1200 slot |
+| `--pcmcia-sram SIZE` | `[pcmcia] card = "sram"`, `size` | a session-only SRAM card in the slot, `64K` to `4M` |
 
 For example, to boot a stock A1200 profile but with 8 MB of fast RAM and a
 faster CPU, with no config file at all:
@@ -615,7 +619,9 @@ For a one-off developer run:
   ECS/AGA (also bounded by the selected Agnus revision's address reach).
 - **Fast RAM** is exposed as a Zorro II autoconfig board at `$200000`, so
   it must be a legal Zorro II board size: 64K, 128K, 256K, 512K, 1M, 2M,
-  4M, or 8M.
+  4M, or 8M. On the A600/A1200 more than 4M reaches the PCMCIA slot's
+  common-memory window at `$600000` and disables the slot (see
+  [`[pcmcia]`](#pcmcia----the-a600a1200-credit-card-slot)).
 - **Slow RAM** ($C00000 "ranger" RAM) is arbitrated on the chip bus through
   Agnus exactly like chip RAM -- it is slow in the authentic way.
 - **Motherboard RAM** is the 32-bit local memory Ramsey drives on the
@@ -1177,14 +1183,17 @@ It has no effect without `--audio-stems DIR` on the command line.
 
 ```toml
 [input]
-port1 = "mouse"           # mouse | joystick | cd32 | analogue | none
+port1 = "mouse"           # mouse | joystick | cd32 | analogue | lightpen | none
 port2 = "joystick"        # same values; default "cd32" on the CD32 profile
+# port3 = "joystick"      # parallel-port four-player adapter sockets:
+# port4 = "joystick"      #   joystick | none (see [parallel] joystick-adapter)
 joystick = "gamepad"      # "gamepad" (default) or "keyboard"
 mouse_sensitivity = 50    # host mouse speed 0-100 (50 default = 1:1)
 mouse_capture = "click"   # when to grab the mouse: click | auto | manual
 autofire_hz = 0           # pulse a held fire button at this rate; 0 = off
 ```
 
+(port-devices)=
 ### Port devices
 
 `port1` and `port2` name the controller device plugged into each game port.
@@ -1202,7 +1211,28 @@ Either port accepts any device, exactly as on real hardware:
   the left/right direction lines. No live host device maps to it yet:
   drive it with `--pot-after` scripting or the control protocol's
   `input.analogue` method (positions default to centre).
+- `lightpen` (alias `lightgun`) -- a light pen or light gun. Its
+  photodetector pulls the port's pin 6 (`/FIRx`) low as the beam sweeps
+  past it, and on the board that pin is also Agnus's `LP` input: while
+  `BPLCON0` `LPEN` is set, `VPOSR`/`VHPOSR` then read the latched beam
+  position instead of the live counters (ECS/AGA `BEAMCON0` `LPENDIS`
+  holds the latch off). Only one game port is wired to `LP`: port 1 on
+  the A1000, port 2 on the A500 and every later Amiga -- a pen in the
+  other port has a working switch but its pulses reach nothing, and
+  Copperline logs a warning at start-up. The pen's tip switch (a gun's
+  trigger) is the port's third-button line (`POTxX`, read through
+  `POTGOR`), since `/FIRx` is the pulse line itself. In the window the
+  pen follows the host pointer over the display and a left click presses
+  the switch; headless, `--pen-after SECS X Y` holds it over a screen
+  pixel (in `--mouse-to-after` coordinates) and `--joy-after SECS red MS
+  PORT` or `--click-after SECS left MS PORT` works the switch. The
+  control protocol has `input.pen`.
 - `none` -- an empty port.
+
+`port3` and `port4` are the two sockets of the passive parallel-port
+four-player adapter (see [`[parallel]`](#parallel-port))
+and take only `joystick` or `none`. Naming a joystick there fits the adapter;
+an adapter named in `[parallel]` fills every socket these keys leave unset.
 
 The defaults are today's stock wiring: a mouse in port 1 and a joystick in
 port 2 -- a CD32 pad on the CD32 profile, whose bundled controller the
@@ -1318,11 +1348,12 @@ button.
 
 ```toml
 [serial]
-mode = "stdout"          # off, stdout, midi, tcp, tcp-connect, pty, or modem
+mode = "stdout"          # off, stdout, midi, tcp, tcp-connect, pty, modem, or device
 # midi_out = "FluidSynth"  # midi mode: host destination, "mt32", or "coppersynth"
 # midi_in = "Keystation"   # midi mode: host source, or "mt32"
 # listen = "127.0.0.1:1234"  # tcp mode: bind address; modem mode: incoming-call address
 # connect = "bbs.example.com:1337"  # tcp-connect mode: remote to dial
+# device = "/dev/tty.usbserial-1420"  # device mode: the host serial port (COM3 on Windows)
 # telnet = false           # modem mode: AT*T1 telnet NVT translation, on by default
 # session = "bbs-demo.session"  # modem mode: replay a scripted session instead of TCP
 ```
@@ -1407,6 +1438,38 @@ Paula's serial in/out is connected:
   guarantees. See [the modem chapter](modem.md#scripted-sessions) for the
   file format; `session` cannot be combined with `listen` (the scripted
   transport plays back outbound calls only, with no inbound side).
+- `device` -- serial in/out is wired to a real serial port on the host,
+  named by `device`: a USB serial adapter's path (`/dev/tty.usbserial-1420`
+  on macOS, `/dev/ttyUSB0` or `/dev/ttyACM0` on Linux) or a COM name
+  (`COM3`) on Windows. `--list-serial-ports` prints the host's ports. With
+  a null-modem cable to a real Amiga or PC this is the wiring Amiga
+  Explorer, a term program's ZMODEM transfer, or a serial link between two
+  machines expects, handshake included: the guest's `/DTR` and `/RTS`
+  drive the host port's DTR and RTS pins, and the host port's CTS, DSR and
+  DCD come back on CIA-B, so `serial.device`'s 7-wire handshake works
+  against the far end's real lines (the Amiga has no input for RI; it is
+  logged on the host side when it changes). The host port follows the
+  guest's line settings: the rate `SERPER` works out to is mapped to the
+  nearest standard rate (Paula's divisor never lands exactly on one, so
+  19172 bps becomes 19200 and 114416 becomes 115200; a rate more than 3%
+  from any standard rate -- 110, 300, 600, 1200, 2400, 4800, 9600, 14400,
+  19200, 28800, 31250, 38400, 57600, 76800, 115200, 230400, 460800,
+  921600 -- is passed through as-is for the driver to accept or refuse),
+  and the stop-bit count follows the words the guest writes (one or two).
+  Host UARTs carry eight data bits: a 9-bit word goes out without its
+  ninth bit, and 7-bit-plus-parity framings, which `serial.device` builds
+  in software, cross the wire unchanged. Host bytes still arrive at the
+  emulated rate -- Paula clocks them in at `SERPER`'s bit period, not
+  instantly. A port that cannot be opened (missing, in use by another
+  program, permission denied -- on Linux, the `dialout` or `uucp` group)
+  is a startup error that names the ports the host does have; an adapter
+  pulled mid-run degrades to an unplugged cable (every handshake input
+  high, output dropped) and is reopened, with the guest's settings, when
+  it comes back. The wire is the host's clock, not the emulated one: like
+  the network backends, this mode is outside the byte-identical replay
+  guarantees, and a save state does not carry the port (it is reopened,
+  and the restored machine's DTR/RTS and rate are pushed onto it, on
+  load). Needs a build with the `host-serial` feature (the default).
 
 Every mode also drives the port's RS-232 handshake inputs, which the guest
 reads on CIA-B port A (`/DSR`, `/CTS`, `/CD`) and `serial.device` reports
@@ -1420,20 +1483,27 @@ while a client is connected (or the dial-out is up) -- so a guest BBS sees
 the caller hang up as carrier loss, and a terminal program sees the remote
 drop the same way. `pty` reports a host terminal with the port open (all
 three asserted), since a null-modem cable crosses its DTR and RTS to
-these inputs and the terminal's side cannot be observed from here. The
-guest's own `/DTR` and `/RTS` outputs are the CIA's pins as written.
+these inputs and the terminal's side cannot be observed from here.
+`device` reports the real lines: whatever the far end of the host port's
+cable is driving on CTS, DSR and DCD, sampled continuously. The
+guest's own `/DTR` and `/RTS` outputs are the CIA's pins as written, and
+under `device` they drive the host port's pins too.
 
 With an `AUX:` shell on the Amiga side, `tcp`/`pty` give a remote AmigaDOS
 console. `--serial MODE` overrides the mode per run,
 `--serial-connect HOST:PORT` sets the dial-out target (and implies
 `mode = "tcp-connect"`), `--serial-session FILE` replays a scripted modem
-session (and implies `mode = "modem"`), and `--midi-out NAME`/
+session (and implies `mode = "modem"`), `--serial-device PATH` names the
+host port (and implies `mode = "device"`), and `--midi-out NAME`/
 `--midi-in NAME` imply `mode = "midi"`. The launcher's **I/O Ports** tab
 (Serial Port page) sets all
 of this interactively: **Device / Mode** picks the mode, and the mode brings
 its own address with it -- **Connect** under `tcp-connect` for the
 remote to dial, **Listen** under `tcp` for the local bind address -- as a
-pair of boxes, host and port. A box left empty shows its greyed default
+pair of boxes, host and port, or, under `device` (shown as **Host
+port**), a **Port** picker that steps through the serial ports the host
+has right now (re-read on every step, so a just-plugged adapter appears;
+a saved path the host does not list is kept and marked). A box left empty shows its greyed default
 (host `127.0.0.1` on Listen, port `1234`) and an emptied box reverts to it;
 an IPv6 literal is typed bare or in brackets, and the saved key spells it
 bracketed (`[::1]:1337`). Emptying both boxes unsets the key. The in-window
@@ -1445,15 +1515,17 @@ config-file-only.
 The browser build has its own serial transport (the page bridges the port
 to a WebSocket); see [the browser chapter](browser.md).
 
+(parallel-port)=
 ## `[parallel]` -- Centronics parallel port
 
 ```toml
 [parallel]
-device = "printer"           # none | printer | sampler
+device = "printer"           # none | printer | sampler | joystick-adapter
 output = "printer.raw"       # printer capture path
 # device = "sampler"
 # sampler_input = "MacBook Air Microphone"  # host input; omit for the default
 # sampler_gain = 6.0                          # preamp gain in dB (0 = unity)
+# device = "joystick-adapter"                 # four-player ports 3 and 4
 ```
 
 `device` chooses the peripheral on the parallel port (one at a time). Without
@@ -1489,6 +1561,24 @@ and gain can also be changed live
 from the runtime menu, and the gain with `Cmd/Alt+Shift +/-`. On macOS the CLI
 binary needs microphone permission to capture a real input; routing audio in
 through a loopback device such as BlackHole needs none.
+
+`"joystick-adapter"` is the classic passive four-player adapter (Kick Off 2,
+Sensible Soccer, Dyna Blaster, Gauntlet II, Super Skidmarks and others read
+it): two switch joysticks wired straight to the connector, with no active
+parts. Port 3's directions short the data pins `D0`-`D3` (CIA-A port B bits
+0-3, up/down/left/right) to ground and port 4's short `D4`-`D7`; port 3's
+fire shorts the Centronics `SEL` line (CIA-B `PA2`) and port 4's fire shorts
+`BUSY` (CIA-B `PA0`), all active low, with a second button on either stick
+on the spare `POUT` line (`PA1`). The assignment matches WinUAE's parallel
+joystick model. The switches only pull down pins the guest has programmed as
+inputs (the games clear `DDRB`), so a port a printer driver is driving as
+outputs is left alone. `[input] port3`/`port4` (or `--port3`/`--port4`) say
+which sockets hold a joystick; naming a joystick there fits the adapter by
+itself, and an adapter named here fills every socket left unset. The host
+gamepad and the keyboard mappings reach the sockets through the usual
+routing (see [Controller ports](ui.md#controller-ports)), and `--joy-after
+... 3`/`... 4`, `--script` and the control protocol's `input.joy` drive them
+directly.
 
 ## `[floppy]` and `[floppy.df0]` .. `[floppy.df3]`
 
@@ -1619,6 +1709,28 @@ file, and changes are lost at exit. An image that unpacks to more than
 1 GiB is refused rather than held in host RAM; decompress that one to a
 plain hardfile and attach it instead.
 
+A **CHD hard-disk image** attaches too: MAME's compressed CHD container as
+`chdman createhd -i disk.hdf -o disk.chd` writes it (v5, LZMA/Deflate-
+compressed hunks, `GDDD` geometry metadata; `chdman` ships in MAME's tools,
+`brew install rom-tools` on macOS). It is recognised by content like the
+gzip form, and both kinds of hardfile convert -- an RDB image stays an RDB
+image, a bare partition hardfile still gets its synthesized RDB. Sectors
+are decompressed on demand, so nothing is held in memory and the image can
+be as large as any HDF. The CHD itself is never written: the guest's
+writes go to a copy-on-write **overlay** beside the image, `disk.chd.wov`,
+created the first time the disk attaches and read back every time after,
+so changes persist across sessions while the CHD stays pristine (delete
+the `.wov` to return to the pristine image; `chdman extracthd` gives back
+the original HDF, without the overlay's writes). A converted disk can be
+slightly larger than its hardfile, since chdman pads the last cylinder of
+its own geometry with zero sectors. Where the overlay cannot be created
+(a read-only directory, say) the disk attaches **write-protected** with a
+warning, which the guest sees as a write-protected volume: a cleanly
+unmounted volume still boots, but anything that writes (icon positions,
+WHDLoad saves, a volume needing validation) gets the write-protect error.
+A delta CHD (one made against a parent image) is refused; flatten it with
+chdman first.
+
 A path may also name a **host directory**: its tree is built into an
 in-memory volume at startup (volume name = directory name, files and
 subdirectories included; entries whose names cannot exist on an Amiga
@@ -1683,12 +1795,70 @@ appears in the status bar on IDE machines. On the `A4000` profile the same
 `$DD2020` (no Gayle involved; Kickstart's `scsi.device` drives it the same
 way).
 
-A path ending in `.cue`, `.iso`, `.nrg`, or `.chd` attaches an **ATAPI CD-ROM
-drive** at that slot instead of a hard disk, through the PACKET (0xA0)
+A path ending in `.cue`, `.iso`, `.nrg`, or a `.chd` holding a CD (chdman's
+`createcd`; one holding a hard disk, `createhd`, attaches as the hard disk
+described above -- the CHD's own metadata decides, not its name) attaches
+an **ATAPI CD-ROM drive** at that slot instead of a hard disk, through the
+PACKET (0xA0)
 command -- the same read-only SCSI-2 command engine `[scsi]` CD-ROM units
 use (see below), reached over the ATA task file instead of a WD33C93 SCSI
 bus. It mounts and swaps discs, plays CD audio, and answers `scsi.device`
 filesystems the same way a `[scsi]` CD-ROM unit does.
+
+## `[pcmcia]` -- the A600/A1200 credit-card slot
+
+```toml
+[machine]
+profile = "A1200"            # only the Gayle machines have the slot
+
+[pcmcia]
+card = "cf"                  # "none" (default), "cf", or "sram"
+path = "card.hdf"            # cf: the card's image; sram: optional backing file
+# size = "2M"                # sram only: 64K..4M
+# read_only = false          # sram only: the card's write-protect switch
+```
+
+The A600 and A1200 carry a PCMCIA slot wired through Gayle. Copperline
+fits one of two card types:
+
+- **`card = "cf"`** -- a CompactFlash card, which is a PCMCIA ATA device.
+  `path` is any image the `[ide]` drive backend accepts (an RDB HDF, a bare
+  partition hardfile, a `.hdz`, or a host directory). The card presents the
+  CF register layout: memory-mapped at power-on, then contiguous I/O or
+  PC-style primary/secondary I/O once a driver writes the card's
+  Configuration Option Register -- the layouts the Aminet CF drivers
+  (`compactflash.device`, `cfd.device`, and the `scsi.device` PCMCIA
+  patches) use. Kickstart's `card.resource` sees the card but does not
+  mount it: install one of those drivers. To put a real card from a reader
+  in the slot instead, use `[[host_disk]]` with `attach = "pcmcia"` (see
+  [](host-disks.md)); the slot holds one card, so the two cannot be
+  combined.
+- **`card = "sram"`** -- a static-RAM memory card of `size` bytes (a
+  multiple of 64K up to 1M, or of 128K up to 4M, so its CIS can state the
+  size). With a `path`, the file seeds the card and is written back as the
+  guest changes it (about once a second, on eject, and at exit); without
+  one the card starts blank and lives for the session (and inside save
+  states). `read_only = true` sets the card's write-protect switch. The
+  card's CIS is what Kickstart 2.05/3.x `card.resource` reads: a card
+  present at boot is added to the system as credit-card RAM, and one
+  inserted later can be used through `carddisk.device` (`CC0:`).
+
+Command-line equivalents: `--pcmcia-cf PATH` and `--pcmcia-sram SIZE`.
+
+**Interaction with Zorro II fast RAM.** The slot's common-memory window
+is `$600000`-`$9FFFFF`, inside Zorro II expansion space, and `[memory]
+fast` autoconfigures upward from `$200000`. With more than 4M of fast RAM
+the RAM board covers the window and, as on a real A1200 with an 8M Zorro
+II expansion, Gayle's PCMCIA decode gives way: the slot is disabled, reads
+as empty, and Copperline warns at start-up that the configured card will
+not be seen. Keep `fast = "4M"` or less to use the slot (accelerator,
+motherboard, and Zorro III RAM do not overlap it). The two can never
+claim the same addresses: autoconfigured RAM always answers first.
+
+At run time the window's **PCMCIA Card** menu (offered only on a machine
+with the slot) inserts a CF image or ejects the card, and the control
+protocol's `pcmcia.insert` / `pcmcia.eject` do the same headlessly; both
+raise Gayle's card-detect interrupt exactly as a physical insertion does.
 
 ## `[scsi]` -- SCSI controllers
 
@@ -1740,14 +1910,16 @@ replacement ROM sources and EPROM-pair build outputs live in `a2091-rom/`.
 Each `unitN` accepts everything `[ide]` paths do: RDB images, bare
 partition hardfiles (a synthesized RDB advertises a bootable `DHn`
 partition, named after the SCSI ID), gzip-compressed hardfiles (`.hdz`),
+CHD hard-disk images (`.chd`, writes kept in the `.chd.wov` overlay),
 and host directories built into in-memory FFS/OFS volumes -- including the
 `{ path = "...", name = "...", bootpri = N, filesystem = "..." }` table
 form that overrides a directory mount's volume name, filesystem, and the
 synthesized partition's boot priority. The HDD activity LED covers SCSI
 traffic too.
 
-A `unitN` path ending in `.cue`, `.iso`, `.nrg`, or `.chd` attaches a **SCSI
-CD-ROM drive** at that ID instead of a hard disk: a read-only removable
+A `unitN` path ending in `.cue`, `.iso`, `.nrg`, or a `.chd` holding a CD
+(a hard-disk CHD attaches as a hard disk; the metadata decides) attaches a
+**SCSI CD-ROM drive** at that ID instead of a hard disk: a read-only removable
 SCSI-2 target (INQUIRY device type 5) serving 2048-byte blocks, with the
 full READ TOC / READ CD / mode-page surface CD filesystems expect.
 Cue sheets, NRG, and CHD images may mix data and audio tracks (a cue sheet's
@@ -1791,21 +1963,24 @@ Up to **seven units** (0-6), each taking the same bare-path/table drive form
 as `[ide]`/`[scsi]`/`[lide]`: RDB images, bare partition hardfiles
 (a synthesized RDB advertises a bootable partition, named `DH0`..`DH6` after
 the unit number, from the same virtual-RDB synthesis `[ide]`/`[scsi]`/`[lide]`
-use), gzip-compressed hardfiles (`.hdz`), and host directories built into
+use), gzip-compressed hardfiles (`.hdz`), CHD hard-disk images (`.chd`,
+writes kept in the `.chd.wov` overlay), and host directories built into
 in-memory FFS/OFS volumes -- including the
 `{ path = "...", name = "...", bootpri = N, filesystem = "..." }` table form
 that overrides a directory mount's volume name, filesystem, and the
 synthesized partition's boot priority, exactly as described under `[ide]`
-above. RDB and RDB-less images are handled identically to the other three
+above. A write-protected image (a CHD whose overlay could not be created)
+reports as such through `TD_PROTSTATUS`, and its writes fail with
+`TDERR_WriteProt`. RDB and RDB-less images are handled identically to the other three
 controllers through the same shared hardfile layer, so a unit here behaves
 like the equivalent `[scsi]` unit for anything that isn't specific to the
 register protocol.
 
 **Hard disks only**: unlike `[ide]`/`[scsi]`/`[lide]`, a `unitN` path ending
-in `.cue`, `.iso`, `.nrg`, or `.chd` is rejected at config-parse time rather
-than attaching a CD-ROM drive -- `copperhf.device` has no ATAPI/SCSI-CDROM
-command set behind it. Attach CD images to `[scsi]` or `[ide]`/`[lide]`
-instead.
+in `.cue`, `.iso`, `.nrg`, or a `.chd` holding a CD is rejected at
+config-parse time rather than attaching a CD-ROM drive -- `copperhf.device`
+has no ATAPI/SCSI-CDROM command set behind it. Attach CD images to `[scsi]`
+or `[ide]`/`[lide]` instead. A `.chd` holding a hard disk is welcome.
 
 The guest sees `copperhf.device` with unit numbers 0-6, matching the
 `unitN` key numbering. The board carries a boot ROM (a DiagArea plus a
@@ -1833,8 +2008,9 @@ A built-in Zorro II IDE board compatible with LIV2's actively-maintained
 open-source [lide.device](https://github.com/LIV2/lide.device), giving
 autobooting IDE storage under any Kickstart including 1.3 -- unlike `[ide]`,
 which needs a Gayle or A4000 IDE port, `[lide]` works on **any machine
-model**, the same way `[scsi]`'s Zorro boards do. A `.cue`/`.iso`/`.nrg`/`.chd`
-drive entry attaches an ATAPI CD-ROM drive, exactly as it does on `[ide]`.
+model**, the same way `[scsi]`'s Zorro boards do. A `.cue`/`.iso`/`.nrg` (or
+CD-holding `.chd`) drive entry attaches an ATAPI CD-ROM drive, exactly as
+it does on `[ide]`.
 
 `board` picks the AutoConfig identity: `"ripple"` (the default), LIV2's
 open-hardware Zorro II card with two ATA channels (four drives); `"ride"`,
@@ -1846,7 +2022,7 @@ one channel, no ROM banking. None of the three wire an interrupt line --
 `lide.device` is a purely polling driver.
 
 `drive0`..`drive3` take the same bare-path/table form as `[ide]`/`[scsi]`
-(RDB images, bare partition hardfiles, `.hdz`, host directories, and the
+(RDB images, bare partition hardfiles, `.hdz`, `.chd`, host directories, and the
 `{ path = "...", name = "...", bootpri = N, filesystem = "..." }` table), one
 key per slot in (channel, master/slave) order: `drive0` and `drive1` are
 channel 0's master and slave, `drive2` and `drive3` are channel 1's
@@ -1895,7 +2071,8 @@ as it is, with its own RDB, partitions, and filesystem.
 device = "sdb"                 # last name shown by `--list-disks`
 fingerprint = "v1-..."         # opaque identity written by the launcher
 attach = "ide-master"          # ide-master (default), ide-slave, lide0-master,
-                                # lide0-slave, lide1-master, lide1-slave, or scsi0..scsi6
+                                # lide0-slave, lide1-master, lide1-slave, scsi0..scsi6,
+                                # or pcmcia (a CF card in the A600/A1200 slot)
 read_only = true               # the default; false explicitly allows writes
 ```
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -621,7 +621,7 @@ For a one-off developer run:
   it must be a legal Zorro II board size: 64K, 128K, 256K, 512K, 1M, 2M,
   4M, or 8M. On the A600/A1200 more than 4M reaches the PCMCIA slot's
   common-memory window at `$600000` and disables the slot (see
-  [`[pcmcia]`](#pcmcia----the-a600a1200-credit-card-slot)).
+  [`[pcmcia]`](#pcmcia-config)).
 - **Slow RAM** ($C00000 "ranger" RAM) is arbitrated on the chip bus through
   Agnus exactly like chip RAM -- it is slow in the authentic way.
 - **Motherboard RAM** is the 32-bit local memory Ramsey drives on the
@@ -1805,6 +1805,7 @@ use (see below), reached over the ATA task file instead of a WD33C93 SCSI
 bus. It mounts and swaps discs, plays CD audio, and answers `scsi.device`
 filesystems the same way a `[scsi]` CD-ROM unit does.
 
+(pcmcia-config)=
 ## `[pcmcia]` -- the A600/A1200 credit-card slot
 
 ```toml

--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -144,10 +144,11 @@ You can schedule keyboard, mouse, and joystick inputs at specific emulated times
 | `--key-after SECS KEY MS` | Hold a key for specified duration in milliseconds |
 | `--type-after SECS TEXT` | Type TEXT on the US Amiga keyboard from SECS, one key every 100 ms (below) |
 | `--click-after SECS BTN MS [PORT]` | Click mouse button (`left`, `right`, `middle`) for MS (default port 1) |
-| `--joy-after SECS BTN MS [PORT]` | Trigger joystick/CD32 button (`up`, `down`, `left`, `right`, `red`, `blue`, etc.) (default port 2) |
+| `--joy-after SECS BTN MS [PORT]` | Trigger joystick/CD32 button (`up`, `down`, `left`, `right`, `red`, `blue`, etc.) on port 1-4 (default port 2; 3 and 4 are the parallel-port adapter's sockets) |
 | `--mouse-after SECS DX DY [PORT]` | Move mouse by relative delta (DX, DY) (default port 1) |
 | `--mouse-to-after SECS X Y [PORT]` | Steer sprite 0 pointer to pixel coordinates (X, Y) (default port 1) |
 | `--pot-after SECS X Y [PORT]` | Set analogue paddle/pot position (0-255) (default port 2) |
+| `--pen-after SECS X Y [PORT]` | Hold the light pen over pixel (X, Y), the `--mouse-to-after` coordinates; a negative coordinate lifts it off (default: the port with the pen) |
 | `--insert-disk-after SECS DFN PATH` | Insert a disk image into `df0`..`df3` |
 | `--defer-disk-insert SECS DFN` | Delay insertion of configured disk until SECS |
 | `--insert-cd-after SECS PATH` | Swap CD image (`.cue`, `.iso`, `.nrg`, `.chd`) in CD drive |
@@ -186,6 +187,15 @@ keeps its absolute timestamps under `--load-state`, and is available in
 same typing queue serves the control protocol's `input.type` and the
 window's *Paste as Keystrokes* action (`Cmd+Shift+V` / `Alt+Shift+V`, see
 [](ui.md)).
+
+A light pen (`[input] port1`/`port2 = "lightpen"`) is positioned with
+`--pen-after` and its tip switch / trigger is the port's `red` button in
+`--joy-after` (or `left` in `--click-after`): `--pen-after 5 320 128
+--joy-after 5.5 red 200 2` holds the pen over pixel (320, 128) and presses it
+half a second later. The pulse only reaches Agnus from the port the board
+wires to `LP` (port 2 on every Amiga after the A1000). Joysticks in the
+parallel-port four-player adapter (`--parallel joystick-adapter`) are ports
+`3` and `4` in `--joy-after`'s trailing PORT token.
 
 `--freeze-after` requires an enabled cartridge (`--cartridge hrtmon` or
 `[cartridge] model`, see [Configuration](configuration.md#freezer-cartridge)).

--- a/docs/guide/host-disks.md
+++ b/docs/guide/host-disks.md
@@ -67,6 +67,39 @@ read_only = true               # Default is true for data safety
 | `lide1-master` | `[lide]` expansion board Channel 1 Master (RIPPLE only) |
 | `lide1-slave` | `[lide]` expansion board Channel 1 Slave |
 | `scsi0` .. `scsi6` | SCSI Controller Unit 0 through 6 |
+| `pcmcia` | The A600/A1200 PCMCIA slot, as a CompactFlash card |
+
+### A CompactFlash card from a real Amiga
+
+A CF card that lives in an A600's or A1200's PCMCIA slot carries the
+partitions the Amiga's own CF driver wrote (`compactflash.device`,
+`cfd.device`, or a patched `scsi.device`), and those drivers expect the
+card in the slot, not on the IDE cable. Put the reader's device on the slot
+and the same driver in the guest finds the same card:
+
+```sh
+copperline --model A1200 KICK31.ROM --host-disk-read-only disk4 pcmcia
+```
+
+```toml
+[machine]
+profile = "A1200"
+
+[[host_disk]]
+device = "disk4"
+attach = "pcmcia"
+read_only = true
+```
+
+The card is presented through Gayle's slot windows with the CF register
+layout a real card has (memory-mapped, contiguous I/O, or PC-style I/O,
+whichever the driver configures), so the guest sees a card, not an IDE
+drive; Kickstart's `card.resource` reports the insertion but does not mount
+it by itself. The slot holds one card, so `attach = "pcmcia"` cannot be
+combined with a `[pcmcia]` image, and more than 4M of Zorro II fast RAM
+disables the slot (see [`[pcmcia]`](configuration.md#pcmcia----the-a600a1200-credit-card-slot)).
+A card reader is removable media, so read-write access must be selected
+afresh each session, as for any other removable disk below.
 
 ## Device fingerprints and renaming
 

--- a/docs/guide/host-disks.md
+++ b/docs/guide/host-disks.md
@@ -97,7 +97,7 @@ whichever the driver configures), so the guest sees a card, not an IDE
 drive; Kickstart's `card.resource` reports the insertion but does not mount
 it by itself. The slot holds one card, so `attach = "pcmcia"` cannot be
 combined with a `[pcmcia]` image, and more than 4M of Zorro II fast RAM
-disables the slot (see [`[pcmcia]`](configuration.md#pcmcia----the-a600a1200-credit-card-slot)).
+disables the slot (see [`[pcmcia]`](configuration.md#pcmcia-config)).
 A card reader is removable media, so read-write access must be selected
 afresh each session, as for any other removable disk below.
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -260,6 +260,8 @@ Disk images can be dropped anywhere on the emulator window:
   multi-selection in the disk dialog.
 - **CD images** (`.cue`/`.iso`/`.nrg`/`.chd`) mount in the machine's CD drive
   (CDTV, CD32, or a SCSI CD-ROM unit), with the media-change notification.
+  A `.chd` is read to see what it holds: one made with chdman's `createhd`
+  is a hard-disk image and is treated as such below.
 - **WHDLoad packages** (`.lha`, `.zip`, or a bare `.slave`) reboot the
   machine straight into the game through the [WHDLoad booter](whdload.md),
   keeping any explicit machine choices; dropped on the configuration
@@ -484,6 +486,21 @@ Shown only when something is on the port.
   *Decrease* rows step (also `Cmd/Alt+Shift +/-`). Both change live. See the
   `[parallel]` section of [Configuration](configuration.md).
 
+### PCMCIA Card
+
+Offered only on an A600 or A1200, whose Gayle carries the credit-card
+slot; the category row shows what is in the slot (or *Empty*).
+
+- **Insert CF Card Image...**: pick a hard-disk image (anything `[ide]`
+  accepts) and push it into the slot as a CompactFlash card, ejecting
+  whatever was there. Gayle latches the card-detect change, so a
+  `card.resource` client sees a real insertion.
+- **Eject Card**: pull the card (greyed with an empty slot). An SRAM
+  card's backing file is written back on the way out.
+
+See the `[pcmcia]` section of [Configuration](configuration.md) for
+boot-time cards, SRAM cards, real card readers, and the fast-RAM rule.
+
 ### Emulation Settings
 
 - **Floppy Speed**: the emulated drive speed -- 100% (real speed), 200%,
@@ -686,7 +703,11 @@ The layout is:
   port fields. Leaving a field blank uses the default (host `127.0.0.1` for
   Listen, port `1234`; Connect requires a host/IP). Valid ports are 1-65535;
   on macOS and Linux, binding a Listen port below 1024 requires root
-  privileges (outbound connections have no port restrictions); the
+  privileges (outbound connections have no port restrictions). The
+  **Host port** mode (`device`) shows a **Port** picker instead, stepping
+  through the serial ports the host has at that moment (re-read on every
+  step, so a freshly plugged adapter appears; a saved path the host does
+  not list is kept and marked "not found"); the
   parallel device -- None, Printer, or Sampler -- with, for the printer, its
   capture output file, or for the sampler, its host audio input and input gain;
   and the A2065 Ethernet and HostSocket bsdsocket.library boards, each --
@@ -1045,8 +1066,8 @@ either direction.
 
 An Amiga has two game ports, and either accepts any controller. Copperline
 models that: each port carries a device -- `mouse`, `joystick`, `cd32` pad,
-`analogue` paddles, or `none`, and port 1 additionally `gamepad-mouse` --
-set with `[input] port1`/`port2` in the
+`analogue` paddles, `lightpen`, or `none`, and port 1 additionally
+`gamepad-mouse` -- set with `[input] port1`/`port2` in the
 config (or `--port1`/`--port2`, or the launcher's *Input* tab). The default
 is the stock wiring, a mouse in port 1 and a joystick in port 2 (a CD32 pad
 on the CD32 profile). The runtime menu's **Port 1 Device** / **Port 2
@@ -1092,6 +1113,30 @@ protocol instead, including the red/blue/green/yellow and transport
 buttons, on either port. An `analogue` device presents pot resistances on
 the POTxX/POTxY pins; no live host device maps to it yet -- drive it with
 `--pot-after` scripting or the control protocol's `input.analogue`.
+
+A `lightpen` device (alias `lightgun`) follows the host pointer over the
+display: wherever the pointer is, the pen's photodetector is held against
+that pixel, and Agnus latches the beam position as it sweeps past (readable
+through `VPOSR`/`VHPOSR` while the guest sets `BPLCON0` `LPEN`). A left
+click over the display presses the pen's tip switch -- a light gun's
+trigger -- which the pen puts on the port's third-button line (`POTxX`),
+since pin 6 is the pulse line itself. Leave the mouse uncaptured: a
+captured pointer has no position to follow. The pen only reaches Agnus from
+the port the board wires to its `LP` input, port 1 on the A1000 and port 2
+on every later Amiga; a pen in the other port is logged at start-up. See
+[Port devices](configuration.md#port-devices) for the headless and
+control-protocol forms.
+
+Ports 3 and 4 are the sockets of the passive parallel-port four-player
+adapter (`[parallel] device = "joystick-adapter"`, or simply `[input]
+port3`/`port4 = "joystick"`, or `--port3`/`--port4`), the one Kick Off 2,
+Sensible Soccer, Dyna Blaster and Gauntlet II read. They carry plain switch
+joysticks and join the queue for the host sources behind the game ports:
+the pad and the keyboard mappings fill ports 1 and 2 first and a socket is
+driven only when the game ports have no joystick left for it. One physical
+pad is read; scripted `--joy-after ... 3`/`4` input and the control
+protocol's `input.joy` drive the sockets directly. Netplay and the libretro
+core stay two-player.
 
 A `gamepad-mouse` device is a mouse a gamepad moves as well as the host's
 own; the machine still sees one mouse. The d-pad moves the pointer,

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -306,7 +306,12 @@ snapshot:
 - Live host-directory mounts expose file contents and timestamps. File-backed
   hard disks and physical disks retain writes made after a snapshot.
 - Network, serial, MIDI, and sampler input can depend on external devices
-  or services. Physical floppy drives also require wall-clock pacing.
+  or services. A real host serial port (`[serial] mode = "device"`) is
+  live I/O like networking: its bytes and handshake lines arrive on the
+  host's clock, the port is never part of a save state (a load reopens
+  it and pushes the restored machine's DTR/RTS and line rate onto it),
+  and an adapter pulled mid-run reads as an unplugged cable. Physical
+  floppy drives also require wall-clock pacing.
 
 Use fixed image files and scripted inputs for deterministic regression
 tests. See [save-state boundaries](savestate.md#determinism-boundaries) for

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -66,9 +66,101 @@ complete synchronously within the access. One hardware subtlety worth
 knowing: Gayle byte-swaps the IDE bus, so IDENTIFY data words are
 low-byte-first while sector data passes through untouched -- Kickstart
 3.1 expects exactly this. The absent-slave behaviour follows the
-WinUAE-verified model so device scans terminate correctly. PCMCIA reports
-an empty slot (the status/config registers exist so card.resource
-behaves); credit-card device emulation is a non-goal.
+WinUAE-verified model so device scans terminate correctly.
+
+### Gayle PCMCIA slot (`gayle.rs`, `pcmcia.rs`)
+
+Gayle's PCMCIA side is modelled from the Commodore register map as
+captured by Linux's `amigayle.h` (disassembled from card.resource) and
+WinUAE's `gayle.cpp`; nothing in it is keyed to a driver.
+
+Registers, all on the even byte of their A12 page:
+
+| Address | Register | Model |
+|---|---|---|
+| `$DA8000` | card status | read: the slot pins -- CCDET (bit 6), BVD1/SC (5), BVD2/DA (4), WR (3), BSY/IRQ (2) -- OR-ed with the bits last written, plus live IDE INTRQ on bit 7. An empty socket reads with every pin bit clear. Write: bit 0 DIS disables the slot (the windows unmap and the pins read as an empty socket; both edges latch a card-detect change), bit 1 DAEN, and bits 7-2 read back as written (card.resource's `CardMiscControl` write-protect override lands on bit 3) |
+| `$DA9000` | interrupt change | a latch per pin, set whenever the sampled pin differs from the last value shown (an insertion or removal latches every pin that moved); the IDE bit is the INTRQ edge; BSY/IRQ is also re-latched while the pin stays high, since IREQ# is a level. Write-to-clear with AND semantics, except bits 1:0 (RESET, BERR from the preliminary datasheet) which are set by writing them: both together reset the card's configuration, RESET alone reboots the machine on the next card-detect change (BERR alone is logged, not modelled) |
+| `$DAA000` | interrupt enable | bits 7-2 admit the matching latches; bit 1 BVD_LEV and bit 0 BSY_LEV pick INT6 over INT2 for the battery and busy/IRQ sources |
+| `$DAB000` | config | programming voltage (bits 1-0) and access speed (bits 3-2), stored, four bits readable |
+
+Routing: IDE and WR changes drive INT2 (PORTS); card detect always drives
+INT6 (EXTER); BVD1/BVD2 and BSY/IRQ follow their level bits. Both lines are
+levels into Paula, re-asserted each tick while a latched, enabled source
+stands. The bus re-samples the pins after every insert, eject, and card
+access (`Bus::pcmcia_sync_pins`), which is how a CF card's IREQ# reaches the
+status register.
+
+Address windows, decoded by the CPU after the plain-memory regions so an
+autoconfigured Zorro II RAM board always wins the address:
+
+| Window | Cycle |
+|---|---|
+| `$600000`-`$9FFFFF` | common memory (4 MiB) |
+| `$A00000`-`$A1FFFF` | attribute memory: the CIS on even bytes (odd bytes mirror), a CF card's configuration registers at `$200`-`$206` |
+| `$A20000`-`$A2FFFF` | I/O, 16-bit and even 8-bit registers |
+| `$A30000`-`$A3FFFF` | I/O, odd 8-bit registers (A0 forced high: `$A30000+2n` is register `2n+1`) |
+| `$A40000`-`$A7FFFF` | card reset: a write asserts RESET (a CF card drops its configuration and resets its ATA function), a read releases it |
+
+Gayle cross-wires the byte lanes, so a byte at card address N is the byte at
+CPU address N and a 16-bit register reads with its bytes exchanged -- the
+same convention as the Gayle IDE data port, which is why the CF card drives
+the shared `ata.rs` engine unchanged (IDENTIFY words arrive swapped, sector
+data in natural order).
+
+**The fast-RAM rule.** The common window is Zorro II space. Fast RAM
+autoconfigures from `$200000`, so more than 4 MiB reaches `$600000`;
+`Config::pcmcia_slot_shadowed` decides this at machine build, the emulator
+warns, and `Gayle::set_slot_shadowed` makes the slot read as empty and
+decode nothing, as on a real A1200 with an 8 MiB Zorro II expansion. Other
+Zorro II RAM that lands in the window shadows it at the decode level by
+construction (autoconfig RAM is classified before the slot).
+
+**CompactFlash card** (`pcmcia::CfCard`): one `AtaBus` with the drive in
+slot 0 behind the CF register layout. The Configuration Option Register
+(attribute `$200`) selects it: index 0 (power-on) memory-mapped, with the
+16-byte task-file block at the start of every 2 KiB of common memory and
+`$400`-`$7FF` a window on the data register; index 1 contiguous I/O (A3-A0
+decoded); index 2/3 PC primary/secondary I/O (`$1F0`/`$3F6`, `$170`/`$376`).
+Block offsets 8/9 repeat the data register, `$D` error/feature, `$E`
+alternate status/device control. In an I/O configuration the registers
+leave common memory, and INTRQ (masked by nIEN) drives the BSY/IRQ pin.
+COR bit 7 is a soft reset. The CIS is the CF specification's example
+layout (device, JEDEC, VERS_1, FUNCID fixed disk, FUNCE ATA, CONFIG at
+`$200` with last index 3, one CFTABLE_ENTRY per index). Pins: CCDET, BVD1,
+BVD2 (STSCHG#/SPKR inactive), WR (CF cards are never write-protected).
+
+**SRAM card** (`pcmcia::SramCard`): up to 4 MiB of RAM in the common window
+(undecoded beyond its size), a CIS built the way WinUAE established
+card.resource needs -- CISTPL_DEVICE (DTYPE_SRAM, 100 ns, WPS from the
+switch, the size in the tuple's unit-count/unit-size encoding, hence the
+size rule in the configuration guide), DEVICEGEO, VERS_1, FUNCID memory,
+MANFID -- and pins CCDET, BVD1, BVD2 (battery good), WR from the switch.
+Kickstart adds a card present at boot as credit-card RAM. A backing file
+is written back about once an emulated second when dirty, on eject, and
+on drop; the RAM itself travels inside save states.
+
+The card lives in `Bus::pcmcia` (its own `PCMC` state chunk); Gayle holds
+only the register file, the sampled pins, and the slot flags. Runtime
+insert and eject (`Bus::pcmcia_insert`/`pcmcia_eject`, the window's PCMCIA
+Card menu, the `pcmcia.*` control-protocol methods) go through the same
+pin sampling as a boot-time card, so the guest sees a real card-detect
+change.
+
+Observed on Kickstart 3.1 (40.068, A1200) through the control protocol:
+with a 2 MiB SRAM card present at boot, exec's MemList gains a header at
+`$600200` (card.resource adds the card as credit-card RAM, keeping the
+first `$200` bytes for the card's own header) and card.resource writes
+`$DA9000` with the RESET bit set -- which is why a real A600/A1200 reboots
+when a memory card is pulled, and why `pcmcia.eject` on that machine
+resets it. A CF card hot-inserted afterwards has its four latched changes
+(CCDET/BVD1/BVD2/WR) acknowledged by the ROM's INT6 handler within a
+second, and an empty socket reading all-zero pins boots cleanly. Register
+semantics and CIS layouts were cross-checked against WinUAE's model; tests
+in `gayle.rs` (status/change/enable/config bits,
+INT2/INT6 routing, DIS, RESET/BERR, shadowing), `pcmcia.rs` (window
+decode, CIS, SRAM size encoding, backing file), and `bus/tests.rs` (CF
+task-file mapping per configuration, IREQ# to INT2, reset register,
+eject to INT6, SRAM window, shadowing).
 
 Either drive slot may instead be an ATAPI CD-ROM (a `.cue`/`.iso`/`.nrg`/`.chd`
 image): `ata.rs`'s task-file engine drives the PACKET (0xA0) command,
@@ -176,12 +268,13 @@ no boot ROM to configure.
 
 ### Shared drive backend
 
-All IDE and SCSI drives share the `harddrive.rs` sector backend: raw
-HDF images, bare partition hardfiles wrapped in a synthesized RDB
+All IDE, SCSI, and copperhf drives share the `harddrive.rs` sector backend:
+raw HDF images, bare partition hardfiles wrapped in a synthesized RDB
 (bootable `DHn` named after the unit), gzip-compressed hardfiles (`.hdz`,
 sniffed by gzip magic and unpacked by `gzip.rs` into memory at open time
 because deflate has no random access, which is what makes their writes
-session-only), and host directories built into in-memory FFS or OFS volumes by
+session-only), CHD hard-disk images (below), and host directories built
+into in-memory FFS or OFS volumes by
 `dirfs.rs` (FFS by default; `filesystem = "ofs"` on the drive picks OFS,
 the one every Kickstart from 1.2 onward can read with no guest-side
 setup -- FFS needs a handler loaded from disk or an RDB `FileSystemHeader`
@@ -191,6 +284,78 @@ SCSI-2 target layer in
 `scsi.rs` answers INQUIRY, MODE SENSE pages 3/4, READ CAPACITY,
 READ/WRITE(6)/(10), REQUEST SENSE, and the no-op housekeeping commands,
 with sense state kept per target.
+
+`HardDriveImage::write_protected` says whether the backing refuses writes
+(a CHD with no overlay, a read-only netplay session copy, a host disk
+attached read-only); a refused write comes back `PermissionDenied`, which
+the SCSI target reports as DATA PROTECT / WRITE PROTECTED (and shows as
+the WP bit in the MODE SENSE header), copperhf as `TDERR_WriteProt` with
+`CHF_UNIT_RDONLY`/`TD_PROTSTATUS` set, and the ATA core as an aborted
+command (ATA has no write-protect status). The filesystem turns those into
+its own write-protect error instead of a disk fault.
+
+#### CHD hard-disk images (`harddrive/chd.rs`)
+
+A hard-disk CHD -- MAME's compressed container as `chdman createhd` writes
+it from an HDF: compressed hunks of whole 512-byte sectors and one `GDDD`
+metadata entry, `CYLS:401,HEADS:16,SECS:32,BPS:512.` -- is read through
+the same `chd` crate as the CD backend in `cdrom/chd.rs`, with the same
+raw-header pre-validation (the crate sizes its hunk map and codec buffers
+straight from the header's words with no v5 bounds checks, so a hostile
+124-byte header is refused before it reaches the allocator) and the same
+single-hunk decompression cache; the sector arithmetic is LBA to
+hunk/offset with no track layout. The header's logical size fixes the
+sector count; `GDDD` is parsed only to insist on 512-byte sectors, and CD
+track tags make the open fail with "attach it as a CD image". The
+`MComprHD` magic is sniffed by content like the gzip one, so the file's
+name is irrelevant to the open. Delta CHDs (a parent SHA-1 in the header)
+are refused: nothing about the convert-your-own-HDF use case needs them.
+
+`harddrive::chd::media_kind` classifies a `.chd` for the configuration
+(`config::is_cd_image_path`), the launcher, and the window's drop handler
+by walking only the header and the metadata chain -- never the hunk map --
+so the launcher can ask about a path on every redraw; `is_hard_disk_chd`
+caches the verdict against the file's size and mtime. A `.chd` that cannot
+be read keeps its traditional reading as a CD image, so the open that
+follows reports the real problem.
+
+The `chd` crate is read-only and nothing rewrites compressed hunks in
+place (MAME writes only uncompressed CHDs, which forfeit the compression
+that is the point), so guest writes go to a **copy-on-write overlay
+sidecar**, `<image>.wov`, created beside the image on first attach. A read
+checks the overlay index before decompressing; a write lands in the
+overlay only, and the CHD is never opened for writing. The format:
+
+```text
+offset  size  field
+0       8     magic "CLWOV001"
+8       4     sector size, u32 little-endian (512)
+12      8     image sectors, u64 little-endian (the CHD's logical size / 512)
+20      20    the CHD header's SHA-1, so an overlay is refused on any other image
+40      8     reserved, zero
+48      ...   records: u64 LE LBA, then the sector's 512 bytes, repeated
+```
+
+Records are a log: the first write to a sector appends one, later writes
+to the same sector overwrite it in place, so the file grows only with the
+number of distinct sectors written (a Workbench boot costs a few hundred
+KB) and the index from LBA to record is rebuilt by scanning the log at
+open. Every write reaches the file as it happens (the `File` is
+unbuffered), which is the eject/exit flush; a record cut short by a crash
+is dropped at the next open, and that is the only recovery the format
+needs, since a sector's latest bytes are either in its complete record or
+still in the CHD. An overlay that names another image (SHA-1, sector
+count) or is not one at all is left alone and the disk attaches
+write-protected, as it does when the sidecar cannot be created; deleting
+the `.wov` returns the disk to the pristine image. A netplay session copy
+decompresses the whole image into memory instead and never touches a
+sidecar, like the gzip form.
+
+The overlay is machine state: `HardDriveImageState` carries every
+overlaid sector (`chd_overlay`), and loading a state rewrites the sidecar
+to exactly that set, so a resumed run sees the disk as it was when the
+state was taken -- unlike an HDF, whose file contents are deliberately not
+part of the state (`docs/internals/savestate.md`).
 
 The drive controllers latch read/write activity, which the bus drains to
 light the status-bar HDD LED; the LED holds for a short minimum period so
@@ -211,7 +376,7 @@ whole clone family). All three reuse the front-end-agnostic ATA core in
 drive backend above; the new work is entirely in the board's own address
 decode, since none of the three personalities resemble Gayle's 4-byte task
 file. Drive slots may be ATA hard disks or, since `ata.rs` gained ATAPI
-PACKET support, `.cue`/`.iso`/`.nrg`/`.chd` CD-ROM images.
+PACKET support, `.cue`/`.iso`/`.nrg` (or CD-holding `.chd`) CD-ROM images.
 
 **Register decode.** Each ATA channel occupies a 4K block of the board
 window, with register index `(offset >> 9) & 7` -- ATA A0-A2 are wired to
@@ -776,6 +941,45 @@ call the port-indexed `InputState::set_joystick`
 and `set_cd32_buttons` helpers, so JOY1DAT, /FIR1, POT1Y/POTGOR, and
 the CD32 serial bits remain hardware-derived.
 
+The two game ports are joined by the parallel-port four-player adapter's
+sockets (ports 3 and 4, `InputState::parallel_joysticks`) when
+`[parallel] device = "joystick-adapter"` fits it. The adapter is wiring,
+not a peripheral: each direction switch shorts one CIA-A port-B data pin to
+ground (D0-D3 port 3, D4-D7 port 4), port 3's fire shorts the Centronics
+SEL line (CIA-B PA2), port 4's fire shorts BUSY (PA0) and either second
+button shorts POUT (PA1) -- the assignment WinUAE's
+`handle_parport_joystick` models, which the four-player titles were
+written against. The bus overlays the pull-downs on the CIA reads only
+for pins the guest has left as inputs (DDR bit clear), so a printer driver
+driving the port as outputs is unaffected. The host routing
+(`host_routing_for_ports`) queues the sockets behind the game ports for
+the pad and keyboard mappings; the recorder, `--joy-after`'s PORT token
+and the control protocol address them as ports 3 and 4.
+
+A `lightpen` port device models the pen/gun's two signals. The
+photodetector pulls the port's pin 6 (/FIRx) low as the beam sweeps past
+it, and on the board that pin is Agnus's LP input -- port 1's on the A1000
+(detected by the WCS at $FC0000), port 2's on the A500 and every later
+Amiga -- so `Bus::light_pen_wired_port` decides whether a fitted pen
+reaches the chip at all. The pen's glass position is kept in rendered-field
+coordinates (the space `sprite_framebuffer_origin`, `--mouse-to-after` and
+`input.mouse_to` share); at every frame start the bus maps it back
+through the renderer's comparator origin
+(`bitplane::framebuffer_beam_position`) to the beam line and colour clock
+that paints that pixel and hands Agnus the target, and Agnus fires the
+latch as its counters sweep past that exact clock (`light_pen_sweep`),
+once per field, honouring BPLCON0 LPEN and ECS BEAMCON0 LPENDIS as
+before. The Denise output-pipeline delay is not subtracted -- a real pen
+reads late by the same clocks, and pen software calibrates it away. The
+tip switch / trigger is the port's third-button line (POTxX, read through
+POTGOR), because /FIRx is the pulse line and cannot also hold a switch;
+`set_mouse_button` index 0 and `set_joystick`'s fire both close it on a
+pen port. In the window the pen follows the uncaptured host pointer, traced
+back from the canvas pixel through the display copy
+(`canvas_source_point`) and the field placement
+(`FieldPlacement::field_point`); headless, `--pen-after` and the control
+protocol's `input.pen` set the position directly.
+
 Keyboard joystick emulation is deliberately a host input source, not a
 guest-keyboard behaviour. When active, the winit key handler consumes the
 mapped host keys before rawkey translation: cursor keys drive directions,
@@ -841,6 +1045,39 @@ bidirectional, so an `AUX:` shell on the Amiga side gives a remote
 AmigaDOS console. The browser build swaps in a channel-backed sink that
 the page bridges to a WebSocket.
 
+`DeviceSerialSink` (`serial/device.rs`, `mode = "device"`, behind the
+`host-serial` feature) is a real host serial port on the same trait: the
+`serialport` crate FluxBridge already uses, opened 8N1 with OS flow
+control off, so the guest owns the handshake exactly as on a real machine.
+The sink is written against its own small `HostSerialPort` trait (read
+with a bounded timeout, write, the four line settings, the four modem
+inputs, discard, clone), which the crate backend implements and an
+in-memory fake stands in for under test, so the whole sink -- threads,
+unplug, reopen -- is unit-tested with no hardware. Two background threads
+own the host I/O: a reader blocking on the port with a 20 ms timeout, which
+samples CTS/DSR/DCD/RI after every return (so a line change is seen within
+one timeout) and publishes them as `SerialControlLines` bits in an atomic
+the bus reads on each CIA-B PRA read; and a writer draining a 256-byte
+bounded queue, which the emulation thread blocks on only when it outruns
+the wire (an unthrottled run is paced by the port, as a real machine would
+be). The guest's settings follow it onto the port: `baud_changed` maps
+the SERPER-derived rate onto the nearest standard rate within 3%
+(`host_baud_for`; an off-grid rate is passed through for the driver to
+judge), `write_word` infers one or two stop bits from the SERDAT word's
+bits above the data (Paula has no stop-bit register; the guest writes
+them), and `set_control_outputs` mirrors `/DTR` and `/RTS` onto the pins.
+A 9-bit word loses its ninth bit (host UARTs carry eight); a received
+byte comes back with bit 8 clear. RI is read but has no CIA pin to land
+on, so it is only logged. A read or write error is treated as the adapter
+gone: the sink detaches (lines float high like an unplugged cable, output
+is dropped) and the reader retries the same path every second, reapplying
+the settings and DTR/RTS when it reopens. The sink is a live host boundary
+(see [architecture](architecture.md#determinism-and-the-host-boundary)):
+`reset_after_timeline_jump` drops the host bytes queued on the abandoned
+timeline and keeps the port, and `Bus::adopt_host_resources` then pushes
+the restored CIA-B outputs and, through `Paula::republish_serial_line_rate`,
+the restored SERPER rate onto it.
+
 A `SerialSink` that can *produce* input must override
 `has_pending_input` alongside `read_byte`/`read_word`:
 Paula's per-tick UART step takes an idle fast path that skips the receiver
@@ -863,7 +1100,8 @@ acceptor/reader thread maintains, so the PRA read never touches the
 writer lock); `PtySerialSink` is a null-modem peer with its port open;
 `ChannelSerialSink` starts ready-without-carrier and lets the frontend set
 the lines (`ChannelSerialHandle::set_carrier`, exported to the browser as
-`serial_set_carrier`). The lines are host-side state like the bytes
+`serial_set_carrier`); `DeviceSerialSink` reports the real wire. The lines
+are host-side state like the bytes
 themselves -- never serialized, never part of the deterministic timeline.
 Paula has no framing-error or parity hardware: a received word always
 carries its stop bit(s) set, and `serial.device` computes parity in
@@ -944,6 +1182,12 @@ are CIA-B port A pins 0-2, peripheral-driven inputs with motherboard
 pull-ups. The default null peripheral is an unplugged cable: it neither
 acknowledges nor drives any pin, and the pulled-up status lines read all
 high.
+
+`[parallel] device = "joystick-adapter"` is not a `ParallelPort` peripheral
+at all: the four-player adapter's switches live in the deterministic
+`InputState` (see the Input section above) and the bus overlays them on
+the CIA reads, so save states and reverse replay carry them like any
+other controller.
 
 `[parallel] device = "printer"` captures strobed bytes to the configured
 output file (`FileParallelPort`), holding the status lines at

--- a/docs/internals/peripherals.md
+++ b/docs/internals/peripherals.md
@@ -336,15 +336,18 @@ offset  size  field
 48      ...   records: u64 LE LBA, then the sector's 512 bytes, repeated
 ```
 
-Records are a log: the first write to a sector appends one, later writes
-to the same sector overwrite it in place, so the file grows only with the
-number of distinct sectors written (a Workbench boot costs a few hundred
-KB) and the index from LBA to record is rebuilt by scanning the log at
-open. Every write reaches the file as it happens (the `File` is
-unbuffered), which is the eject/exit flush; a record cut short by a crash
-is dropped at the next open, and that is the only recovery the format
-needs, since a sector's latest bytes are either in its complete record or
-still in the CHD. An overlay that names another image (SHA-1, sector
+Records are an append-only log: every write adds one, and the scan at open
+rebuilds the LBA-to-record index so that the last record for a sector
+wins. Nothing is ever overwritten in place, which is what makes the
+recovery rule hold: a record cut short by a crash is dropped at the next
+open, leaving the sector's previous record (or the CHD itself) in force,
+whereas overwriting a record would leave a full-length one holding half of
+each version that a scan could not tell from a sound one. Rewriting the
+same sector therefore leaves superseded records behind, so an open whose
+live records account for less than half the file rewrites it compacted,
+through the same temporary-file-and-rename the state restore uses. Every
+write reaches the file as it happens (the `File` is unbuffered), which is
+the eject/exit flush. An overlay that names another image (SHA-1, sector
 count) or is not one at all is left alone and the disk attaches
 write-protected, as it does when the sidecar cannot be created; deleting
 the `.wov` returns the disk to the pristine image. A netplay session copy
@@ -353,8 +356,10 @@ sidecar, like the gzip form.
 
 The overlay is machine state: `HardDriveImageState` carries every
 overlaid sector (`chd_overlay`), and loading a state rewrites the sidecar
-to exactly that set, so a resumed run sees the disk as it was when the
-state was taken -- unlike an HDF, whose file contents are deliberately not
+to exactly that set by building a sibling file and renaming it over the
+old one, so a restore that fails partway leaves the previous sidecar
+intact rather than a half-written disk. A resumed run sees the disk as it
+was when the state was taken -- unlike an HDF, whose file contents are deliberately not
 part of the state (`docs/internals/savestate.md`).
 
 The drive controllers latch read/write activity, which the bus drains to

--- a/docs/internals/savestate.md
+++ b/docs/internals/savestate.md
@@ -31,7 +31,7 @@ What is captured:
 | `CpuCore` | registers, SR flags, prefetch queue, pending interrupt/stop state, MMU/CACR state, cycle-timing configuration, `cpu_type` and address mask |
 | `MachineRuntimeState` | the `M68kMachine` fields outside the core: `last_cacr`, `sync_cck_on`, `cpu_clocks_per_cck`, `cpu_clock_carry` |
 | `icache` / `dcache` | the CPU cache models (`Option<Box<CpuCache>>`, `None` when absent or opted out). If a compatible state lacks a cache that the restored CPU configuration requires, load creates it cold with enable bits derived from CACR |
-| `Bus` | chip/slow RAM, ROM and extended ROM, Zorro boards (including their RAM), both CIAs, RTC, Agnus/Copper/Denise/Paula/blitter state, floppy controller with in-memory disk images, Gayle IDE, A2091 SCSI, Akiko/CDTV with NVRAM, beam-event capture buffers, DMA pointers, interrupt latches, and the bus-arbitration counters |
+| `Bus` | chip/slow RAM, ROM and extended ROM, Zorro boards (including their RAM), both CIAs, RTC, Agnus/Copper/Denise/Paula/blitter state, floppy controller with in-memory disk images, Gayle IDE and its PCMCIA card (an SRAM card's contents included), A2091 SCSI, Akiko/CDTV with NVRAM, beam-event capture buffers, DMA pointers, interrupt latches, and the bus-arbitration counters |
 
 Deliberately excluded, with the mechanism in parentheses:
 
@@ -40,7 +40,9 @@ Deliberately excluded, with the mechanism in parentheses:
   (`#[serde(skip)]`; the sink defaults produce inert null devices). On load,
   `Bus::adopt_host_resources` moves the live sinks and tap from the old Bus
   onto the restored one, so output and an active subscription continue
-  uninterrupted.
+  uninterrupted; a sink with a live connection (a host serial port) is
+  told of the timeline jump, drops what it had queued from the abandoned
+  one, and is handed the restored CIA-B `/DTR`/`/RTS` and SERPER rate.
 - **Diagnostic host state**: the `COPPERLINE_TRACE_BLITTER` file handle
   (skipped, moved across like the sinks), the debugger and its
   breakpoints/watchpoints (never serialized; they stay armed across a
@@ -109,13 +111,23 @@ files during deserialization. Missing or moved images cause a load-time error:
 
 - `HardDriveImage` (shared by IDE, SCSI, and copperhf) serializes as
   `HardDriveImageState { path, memory, total_sectors, rdb_overlay,
-  overlay_write_warned, scsi_bus, host_device }`. A file-backed image stores
-  `memory: None` and reopens `path` read/write on load; an in-memory
-  directory-built volume stores the whole image in `memory`, so its
-  session-only writes survive the round trip. The synthesized-RDB
-  overlay for bare hardfiles is embedded either way. Consequence: HDF
-  *file contents* are not part of the state -- guest writes made after
-  the snapshot are still visible after restoring.
+  overlay_write_warned, scsi_bus, host_device, session, chd_overlay }`. A
+  file-backed image stores `memory: None` and reopens `path` read/write on
+  load; an in-memory directory-built volume stores the whole image in
+  `memory`, so its session-only writes survive the round trip. The
+  synthesized-RDB overlay for bare hardfiles is embedded either way.
+  Consequence: HDF *file contents* are not part of the state -- guest
+  writes made after the snapshot are still visible after restoring.
+- A CHD hard-disk image (`harddrive/chd.rs`) is the exception: it reopens
+  by `path` like an HDF (sniffed by its magic), but the guest's writes live
+  in its `.wov` overlay sidecar rather than in the image, and every
+  overlaid sector travels in `chd_overlay` (`#[serde(default)]`, so states
+  from before the field load with `None` and leave the sidecar as found).
+  Loading rewrites the sidecar to exactly the saved set, so a resumed run
+  sees the disk as it was when the state was taken; the field is `None`
+  for every other backing and for a CHD attached write-protected (no
+  overlay), and a saved set that cannot be put back because the overlay
+  cannot be opened fails the load rather than resuming on the wrong disk.
 - `CdImageState::Bin { sources, tracks, extents, total_sectors }` stores
   the source descriptions needed to reopen BIN/WAVE/MP3, ISO, and NRG data.
   `CdImageState::Chd { path }` stores the CHD path and rebuilds the CHD
@@ -187,6 +199,7 @@ before it arrived complete.
 | `FLOP` | bus fields | `floppy` (controller, drives, in-memory disk images) |
 | `RTC ` | bus fields | `rtc`, `rtc_present` |
 | `GAYL` | bus fields | `gayle` |
+| `PCMC` | bus fields | `pcmcia` (the card in Gayle's slot: a CF card's ATA state and configuration registers, or an SRAM card's RAM and backing path); optional, absent from states written before the slot existed, which load with an empty socket |
 | `MOBO` | bus fields | `ramsey`, `gary`, `sdmac`, `ide_a4000` |
 | `UAEL` | bus fields | `uaelib` |
 | `CART` | bus fields | `cartridge` |

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -13,7 +13,7 @@ cd fuzz
 cargo +nightly fuzz run dms            # one target...
 cargo +nightly fuzz run floppy_image   # ADF/extADF/DMS/SCP/IPF/gzip/zip
 cargo +nightly fuzz run cd_image       # CUE/BIN, bare ISO, NRG, and CHD
-cargo +nightly fuzz run hardfile_classification # HDF/RDSK/bare-volume classification
+cargo +nightly fuzz run hardfile_classification # HDF/HDZ/CHD, RDSK/bare-volume classification
 cargo +nightly fuzz run savestate      # .clstate chunked machine images
 ```
 

--- a/fuzz/fuzz_targets/hardfile_classification.rs
+++ b/fuzz/fuzz_targets/hardfile_classification.rs
@@ -1,6 +1,9 @@
 //! Fuzz hardfile opening and classification: `HardDriveImage::open` validates
 //! raw-image sizing, sniffs the first 16 sectors for `RDSK`, and distinguishes
 //! those images from bare DOS volumes that need a synthesized RDB overlay.
+//! The same open sniffs gzip and CHD magic, so a hostile `.hdz` or a CHD
+//! header claiming a petabyte of hunks reaches their parsers here too; the
+//! cheap CHD media classifier the configuration uses gets the bytes as well.
 
 #![no_main]
 
@@ -29,4 +32,7 @@ fuzz_target!(|data: &[u8]| {
         0,
         copperline::diskimage::FileSystem::FFS,
     );
+    // A CHD hard disk opened writable creates its overlay sidecar in the
+    // temporary directory; it goes with the directory.
+    let _kind = copperline::harddrive::chd::media_kind(&path);
 });

--- a/src/ata.rs
+++ b/src/ata.rs
@@ -461,6 +461,22 @@ impl AtaBus {
         self.drives.iter().any(Option::is_some)
     }
 
+    /// The host path behind a slot's hard disk, if the slot holds one.
+    pub fn drive_path(&self, slot: usize) -> Option<&Path> {
+        match self.drives.get(slot)? {
+            Some(AtaDevice::Disk(drive)) => Some(drive.disk.path()),
+            _ => None,
+        }
+    }
+
+    /// A slot's hard-disk capacity in sectors, if the slot holds one.
+    pub fn drive_total_sectors(&self, slot: usize) -> Option<u64> {
+        match self.drives.get(slot)? {
+            Some(AtaDevice::Disk(drive)) => Some(drive.disk.total_sectors()),
+            _ => None,
+        }
+    }
+
     /// The hard disk in a numbered ATA slot, for frontend save persistence.
     pub fn hard_disk_mut(&mut self, slot: usize) -> Option<&mut HardDriveImage> {
         match self.drives.get_mut(slot)?.as_mut()? {

--- a/src/bin/import_uae/map/winuae.rs
+++ b/src/bin/import_uae/map/winuae.rs
@@ -449,8 +449,13 @@ pub fn map(entries: &[Entry], source: &std::path::Path) -> MapOutcome {
                     "joystick",
                     Some("CDTV joystick has no dedicated Copperline device; approximated as joystick"),
                 ),
+                "lightpen" => (
+                    "lightpen",
+                    Some("the pen only reaches Agnus from the port the board wires to LP \
+                          (port 1 on the A1000, port 2 on later Amigas)"),
+                ),
                 _ => {
-                    report.unsupported(&e.key, &e.value, "unrecognized or unsupported port device (e.g. lightpen)");
+                    report.unsupported(&e.key, &e.value, "unrecognized or unsupported port device");
                     ("", None)
                 }
             };
@@ -461,6 +466,42 @@ pub fn map(entries: &[Entry], source: &std::path::Path) -> MapOutcome {
                 }
             }
         }
+    }
+
+    // --- Parallel-port joysticks --------------------------------------
+    // WinUAE's joyport2/joyport3 are the passive four-player adapter's
+    // sockets; any host device bound there means the adapter is fitted
+    // with a joystick in that socket. The binding itself (which host pad
+    // or keyboard layout) is host configuration Copperline keeps in its
+    // own routing, so only the socket's presence carries over.
+    let mut adapter = false;
+    for (uae_key, port) in [("joyport2", "port3"), ("joyport3", "port4")] {
+        if let Some(e) = by_key(uae_key) {
+            seen.insert(&e.key, ());
+            let bound = !matches!(e.value.trim(), "" | "none");
+            set_str(
+                &mut doc,
+                &["input"],
+                port,
+                if bound { "joystick" } else { "none" },
+            );
+            adapter |= bound;
+        }
+    }
+    for uae_key in ["joyport2mode", "joyport3mode"] {
+        if let Some(e) = by_key(uae_key) {
+            seen.insert(&e.key, ());
+            if !matches!(e.value.trim(), "" | "djoy" | "gamepad") {
+                report.unsupported(
+                    &e.key,
+                    &e.value,
+                    "the parallel-port adapter carries switch joysticks only",
+                );
+            }
+        }
+    }
+    if adapter {
+        set_str(&mut doc, &["parallel"], "device", "joystick-adapter");
     }
 
     // --- Autofire -----------------------------------------------------
@@ -636,11 +677,13 @@ pub fn map(entries: &[Entry], source: &std::path::Path) -> MapOutcome {
     }
 
     // --- Serial port ---------------------------------------------------
-    // Amiberry's serial_port is a free-form target string; only the
-    // TCP://host:port form has a clean Copperline equivalent ([serial]
-    // mode = "tcp", listen = the host:port). Real hardware device paths
-    // (e.g. "/dev/ttyUSB0", "COM1") and other schemes have no translation
-    // and are left to the generic unrecognized-key fallback below.
+    // serial_port is a free-form target string. Two forms have a clean
+    // Copperline equivalent: TCP://host:port ([serial] mode = "tcp",
+    // listen = the host:port) and a real host port -- a device path
+    // (Amiberry's "/dev/ttyUSB0") or a Windows COM name (WinUAE's "COM1")
+    // -- which is [serial] mode = "device" with the same spelling. Other
+    // schemes (WinUAE's "TCP:" without a slash pair, "midi", a named
+    // pipe) are left to the generic unrecognized-key fallback below.
     if let Some(e) = by_key("serial_port") {
         let value = e.value.trim();
         if let Some(addr) = value
@@ -650,6 +693,10 @@ pub fn map(entries: &[Entry], source: &std::path::Path) -> MapOutcome {
             seen.insert(&e.key, ());
             set_str(&mut doc, &["serial"], "mode", "tcp");
             set_str(&mut doc, &["serial"], "listen", addr);
+        } else if is_host_serial_port(value) {
+            seen.insert(&e.key, ());
+            set_str(&mut doc, &["serial"], "mode", "device");
+            set_str(&mut doc, &["serial"], "device", value);
         }
     }
 
@@ -1347,9 +1394,47 @@ fn parse_filesystem2(value: &str) -> Option<FilesysMount> {
     })
 }
 
+/// Whether a `serial_port` value names a real host serial port: a device
+/// node under /dev, or a COM port (`COM1`, `com12`, `\\.\COM12`).
+fn is_host_serial_port(value: &str) -> bool {
+    if value.starts_with("/dev/") {
+        return true;
+    }
+    let name = value.strip_prefix("\\\\.\\").unwrap_or(value);
+    let Some(digits) = name
+        .get(..3)
+        .filter(|p| p.eq_ignore_ascii_case("com"))
+        .map(|_| &name[3..])
+    else {
+        return false;
+    };
+    !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn serial_port_device_paths_and_com_names_become_device_mode() {
+        let out = convert("serial_port=/dev/ttyUSB0\n");
+        assert!(out.contains(r#"mode = "device""#), "{out}");
+        assert!(out.contains(r#"device = "/dev/ttyUSB0""#), "{out}");
+        let out = convert("serial_port=COM3\n");
+        assert!(out.contains(r#"mode = "device""#), "{out}");
+        assert!(out.contains(r#"device = "COM3""#), "{out}");
+        // The TCP form keeps its own mapping.
+        let out = convert("serial_port=TCP://127.0.0.1:1234\n");
+        assert!(out.contains(r#"mode = "tcp""#), "{out}");
+        assert!(!out.contains("device ="), "{out}");
+        // Anything else is not a port and is reported, not guessed at.
+        let out = convert("serial_port=midi\n");
+        assert!(!out.contains(r#"mode = "device""#), "{out}");
+        assert!(is_host_serial_port("com12"));
+        assert!(is_host_serial_port("\\\\.\\COM12"));
+        assert!(!is_host_serial_port("COM"));
+        assert!(!is_host_serial_port("COMx"));
+    }
 
     fn convert(text: &str) -> String {
         let entries = crate::parse::parse(text);
@@ -1384,6 +1469,18 @@ mod tests {
         // "n blocks": -1 is 128K and 0 is 256K, neither of them "none".
         assert!(convert("chipmem_size=-1\n").contains(r#"chip = "128K""#));
         assert!(convert("chipmem_size=0\n").contains(r#"chip = "256K""#));
+    }
+
+    #[test]
+    fn light_pen_and_parallel_port_joysticks_map_to_copperline_ports() {
+        let out = convert("joyport1mode=lightpen\njoyport2=joy0\njoyport3=none\n");
+        assert!(out.contains(r#"port2 = "lightpen""#), "{out}");
+        assert!(out.contains(r#"port3 = "joystick""#), "{out}");
+        assert!(out.contains(r#"port4 = "none""#), "{out}");
+        assert!(out.contains(r#"device = "joystick-adapter""#), "{out}");
+        // No socket bound: no adapter.
+        let out = convert("joyport2=none\n");
+        assert!(!out.contains("joystick-adapter"), "{out}");
     }
 
     #[test]

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -759,6 +759,12 @@ pub struct Bus {
     /// Gayle gate array (A600/A1200 machine profiles); None on machines
     /// without one, which leaves $DA0000/$DE1000 floating as before.
     pub gayle: Option<Gayle>,
+    /// The card in Gayle's PCMCIA slot, if one is inserted. Gayle owns the
+    /// slot's registers and pins; the card owns the address windows. Its
+    /// own save-state chunk (`PCMC`) so states written before the slot
+    /// existed load with an empty socket.
+    #[serde(default)]
+    pub pcmcia: Option<crate::pcmcia::PcmciaCard>,
     /// Ramsey memory controller (A3000/A4000 machine profiles). Answers on
     /// the same $DE0000 page Gayle uses, so the two are never both fitted.
     #[serde(default)]
@@ -2814,10 +2820,19 @@ pub enum PortDevice {
     /// click, and no joystick port hears from that pad while it does.
     /// Offered on port 1 alone, which is the port a mouse belongs in.
     ///
-    /// Last on purpose: a save state encodes a variant by its position,
-    /// so a state written before this existed must still read an empty
-    /// port as empty. The pickers order themselves.
+    /// A save state encodes a variant by its position, so a state written
+    /// before this existed must still read an empty port as empty: new
+    /// variants go after it. The pickers order themselves.
     GamepadMouse,
+    /// A light pen or light gun. Its photodetector pulls the port's pin 6
+    /// (/FIRx) low as the beam sweeps past it; on the board that pin is
+    /// also Agnus's LP input (port 1's on the A1000, port 2's on every
+    /// later Amiga), and Agnus latches the beam counters on the pulse
+    /// while BPLCON0.LPEN is set. The pen's tip switch / the gun's
+    /// trigger is the port's third-button line (POTxX, read through
+    /// POTGOR), which is why it can be read with the pen off the glass.
+    /// The JOYxDAT counters hold; the pen has no directions.
+    LightPen,
 }
 
 impl PortDevice {
@@ -2829,6 +2844,7 @@ impl PortDevice {
             PortDevice::Cd32Pad => "cd32",
             PortDevice::Analogue => "analogue",
             PortDevice::GamepadMouse => "gamepad-mouse",
+            PortDevice::LightPen => "lightpen",
             PortDevice::None => "none",
         }
     }
@@ -2851,6 +2867,7 @@ impl PortDevice {
             PortDevice::Cd32Pad => "CD32 Pad",
             PortDevice::Analogue => "Analogue",
             PortDevice::GamepadMouse => "Gamepad Mouse",
+            PortDevice::LightPen => "Light Pen",
             PortDevice::None => "None",
         }
     }
@@ -2863,9 +2880,17 @@ impl PortDevice {
             "cd32" | "cd32pad" | "pad" => Some(PortDevice::Cd32Pad),
             "analogue" | "analog" | "paddle" => Some(PortDevice::Analogue),
             "gamepad-mouse" | "gamepad_mouse" | "padmouse" => Some(PortDevice::GamepadMouse),
+            "lightpen" | "light-pen" | "light_pen" | "pen" | "lightgun" | "light-gun"
+            | "light_gun" | "gun" => Some(PortDevice::LightPen),
             "none" | "off" => Some(PortDevice::None),
             _ => None,
         }
+    }
+
+    /// Whether a device can sit in a parallel-port adapter socket (ports
+    /// 3 and 4): the passive adapter carries switch joysticks only.
+    pub fn fits_parallel_port(self) -> bool {
+        matches!(self, PortDevice::Joystick | PortDevice::None)
     }
 }
 
@@ -2944,9 +2969,10 @@ impl ControllerPort {
     /// The JOYxDAT word this port's device presents.
     pub fn joydat(&self) -> u16 {
         match self.device {
-            PortDevice::Mouse | PortDevice::GamepadMouse | PortDevice::None => {
-                mouse_joydat(self.counter_x, self.counter_y)
-            }
+            PortDevice::Mouse
+            | PortDevice::GamepadMouse
+            | PortDevice::LightPen
+            | PortDevice::None => mouse_joydat(self.counter_x, self.counter_y),
             PortDevice::Joystick | PortDevice::Cd32Pad => {
                 digital_joydat(self.up, self.down, self.left, self.right)
             }
@@ -2982,10 +3008,88 @@ impl ControllerPort {
     }
 }
 
+/// One switch joystick on the passive parallel-port four-player adapter
+/// (ports 3 and 4). The adapter is wiring only, with no active parts: each
+/// direction switch shorts one CIA-A port-B data pin to ground -- D0-D3
+/// are port 3's up/down/left/right, D4-D7 port 4's -- port 3's fire shorts
+/// the Centronics SEL line (CIA-B PA2), port 4's fire shorts BUSY (CIA-B
+/// PA0), and a second button on either joystick shorts POUT (CIA-B PA1).
+/// The assignment is the one WinUAE's `handle_parport_joystick` models
+/// (joystick index 2 = SEL, index 3 = BUSY), which is the adapter the
+/// four-player titles were written against.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ParallelJoystick {
+    /// A joystick is plugged into this adapter socket.
+    pub fitted: bool,
+    pub up: bool,
+    pub down: bool,
+    pub left: bool,
+    pub right: bool,
+    pub fire: bool,
+    pub button2: bool,
+}
+
+impl ParallelJoystick {
+    /// This socket's lines as a game-port shaped view, for code that
+    /// diffs or reports every port through one `ControllerPort` reader
+    /// (the input recorder). The quadrature counters are meaningless
+    /// here and read zero.
+    pub fn as_controller_port(self) -> ControllerPort {
+        ControllerPort {
+            device: if self.fitted {
+                PortDevice::Joystick
+            } else {
+                PortDevice::None
+            },
+            up: self.up,
+            down: self.down,
+            left: self.left,
+            right: self.right,
+            fire: self.fire,
+            button2: self.button2,
+            ..ControllerPort::default()
+        }
+    }
+}
+
+/// Where the light pen's photodetector is held against the glass, in the
+/// rendered field's coordinates: `x` in hi-res-pitch columns (times the
+/// canvas scale of a 35 ns scan), `y` in beam lines from the frame's first
+/// visible line. This is the coordinate space `--mouse-to-after`,
+/// `input.mouse_to` and `sprite_framebuffer_origin` share, so a pen can
+/// be aimed at whatever a screenshot or the pointer sprite reports.
+/// `None` is a pen off the glass (or capped): it sees no light and never
+/// pulses.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LightPenState {
+    pub position: Option<(i32, i32)>,
+}
+
+/// First port index the parallel-port adapter's sockets occupy in the
+/// port-numbered input API: ports 3 and 4 are indices 2 and 3.
+pub const PARALLEL_PORT_FIRST: usize = 2;
+/// Number of joystick sockets the machine can present: two game ports
+/// plus the two adapter sockets.
+pub const PORT_COUNT: usize = 4;
+
 #[derive(Default, Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct InputState {
     /// Index 0 = port 1 (JOY0DAT/POT0/FIR0), 1 = port 2 (JOY1DAT/POT1/FIR1).
     pub ports: [ControllerPort; 2],
+    /// The passive four-player adapter is plugged into the Centronics
+    /// connector. Without it the adapter sockets are absent and the
+    /// parallel pins are left to whatever `[parallel]` peripheral is
+    /// fitted.
+    #[serde(default)]
+    pub parallel_adapter: bool,
+    /// The adapter's two sockets: index 0 = port 3 (D0-D3, SEL), 1 =
+    /// port 4 (D4-D7, BUSY).
+    #[serde(default)]
+    pub parallel_joysticks: [ParallelJoystick; 2],
+    /// The light pen's position on the glass, when a [`PortDevice::LightPen`]
+    /// is fitted to a port.
+    #[serde(default)]
+    pub light_pen: LightPenState,
 }
 
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
@@ -3066,22 +3170,56 @@ impl DeviceClock {
 }
 
 impl InputState {
-    /// Port argument convention across the input API: 0 selects port 1,
-    /// every other value port 2.
+    /// Game-port argument convention across the input API: 0 selects port
+    /// 1, 1 selects port 2. Ports 3 and 4 (indices 2 and 3) are the
+    /// parallel adapter's sockets and are routed by [`Self::parallel_index`];
+    /// the game-port-only entry points fold them onto port 2 as the old
+    /// two-port convention always did with any other value.
     fn port_index(port: usize) -> usize {
         usize::from(port != 0)
     }
 
-    /// The device currently plugged into a port.
+    /// The adapter socket a port number names, if it is one of the two
+    /// parallel-port sockets (port 3 = index 0, port 4 = index 1).
+    fn parallel_index(port: usize) -> Option<usize> {
+        match port {
+            2 => Some(0),
+            3 => Some(1),
+            _ => None,
+        }
+    }
+
+    /// The device currently plugged into a port. An adapter socket reads
+    /// as a joystick only while the adapter is fitted with one in it.
     pub fn device(&self, port: usize) -> PortDevice {
+        if let Some(i) = Self::parallel_index(port) {
+            return if self.parallel_adapter && self.parallel_joysticks[i].fitted {
+                PortDevice::Joystick
+            } else {
+                PortDevice::None
+            };
+        }
         self.ports[Self::port_index(port)].device
     }
 
     /// Change the device plugged into a port. Unplugging releases every line
     /// the old device drove; the JOYxDAT counters are chip-side and hold
     /// their values. A freshly plugged analogue controller presents its pots
-    /// centred: a real paddle always shows some resistance.
+    /// centred: a real paddle always shows some resistance. On an adapter
+    /// socket only a joystick fits (anything else unplugs the socket), and
+    /// plugging one in fits the adapter itself if it was absent.
     pub fn set_port_device(&mut self, port: usize, device: PortDevice) {
+        if let Some(i) = Self::parallel_index(port) {
+            let fitted = device == PortDevice::Joystick;
+            self.parallel_joysticks[i] = ParallelJoystick {
+                fitted,
+                ..ParallelJoystick::default()
+            };
+            if fitted {
+                self.parallel_adapter = true;
+            }
+            return;
+        }
         let p = &mut self.ports[Self::port_index(port)];
         if p.device == device {
             return;
@@ -3099,18 +3237,106 @@ impl InputState {
         }
     }
 
+    /// Plug the passive four-player adapter into (or pull it out of) the
+    /// Centronics connector, with a joystick in each socket `fitted` says
+    /// so for. Pulling the adapter releases every switch it carried.
+    pub fn set_parallel_adapter(&mut self, present: bool, fitted: [bool; 2]) {
+        self.parallel_adapter = present;
+        for (socket, fitted) in self.parallel_joysticks.iter_mut().zip(fitted) {
+            *socket = ParallelJoystick {
+                fitted: present && fitted,
+                ..ParallelJoystick::default()
+            };
+        }
+    }
+
+    /// CIA-A port-B data pins the adapter's direction switches are holding
+    /// at ground right now (bit set = pin pulled low): D0-D3 port 3's
+    /// up/down/left/right, D4-D7 port 4's. Nothing while the adapter is
+    /// absent.
+    pub fn parallel_data_pull_downs(&self) -> u8 {
+        if !self.parallel_adapter {
+            return 0;
+        }
+        let mut v = 0u8;
+        for (i, joy) in self.parallel_joysticks.iter().enumerate() {
+            if !joy.fitted {
+                continue;
+            }
+            let shift = 4 * i as u8;
+            if joy.up {
+                v |= 0x01 << shift;
+            }
+            if joy.down {
+                v |= 0x02 << shift;
+            }
+            if joy.left {
+                v |= 0x04 << shift;
+            }
+            if joy.right {
+                v |= 0x08 << shift;
+            }
+        }
+        v
+    }
+
+    /// CIA-B port-A Centronics status pins the adapter's buttons are
+    /// holding at ground (bit set = pin pulled low): port 3's fire on SEL
+    /// (PA2), port 4's fire on BUSY (PA0), either socket's second button
+    /// on the spare POUT line (PA1).
+    pub fn parallel_status_pull_downs(&self) -> u8 {
+        if !self.parallel_adapter {
+            return 0;
+        }
+        let [joy3, joy4] = self.parallel_joysticks;
+        let mut v = 0u8;
+        if joy3.fitted && joy3.fire {
+            v |= crate::parallel::CTL_SEL;
+        }
+        if joy4.fitted && joy4.fire {
+            v |= crate::parallel::CTL_BUSY;
+        }
+        if (joy3.fitted && joy3.button2) || (joy4.fitted && joy4.button2) {
+            v |= crate::parallel::CTL_POUT;
+        }
+        v
+    }
+
+    /// The game port a light pen is plugged into, if any.
+    pub fn light_pen_port(&self) -> Option<usize> {
+        self.ports
+            .iter()
+            .position(|p| p.device == PortDevice::LightPen)
+    }
+
+    /// Hold the light pen's photodetector at `position` on the glass (see
+    /// [`LightPenState`]), or lift it off with `None`.
+    pub fn set_light_pen_position(&mut self, position: Option<(i32, i32)>) {
+        self.light_pen.position = position;
+    }
+
     /// Accumulate mouse quadrature movement into a port's JOYxDAT counters.
     pub fn add_mouse_delta(&mut self, port: usize, dx: i32, dy: i32) {
+        if Self::parallel_index(port).is_some() {
+            return;
+        }
         let p = &mut self.ports[Self::port_index(port)];
         p.counter_x = p.counter_x.wrapping_add(dx as u8);
         p.counter_y = p.counter_y.wrapping_add(dy as u8);
     }
 
     /// Mouse buttons by index: 0 = left (/FIRx), 1 = right (POTxY),
-    /// 2 = middle (POTxX).
+    /// 2 = middle (POTxX). On a light pen the left button is the tip
+    /// switch / trigger, which the pen puts on POTxX: /FIRx is the LP
+    /// pulse line and cannot also carry a held switch, so index 0 and
+    /// index 2 both close the switch.
     pub fn set_mouse_button(&mut self, port: usize, index: u8, pressed: bool) {
+        if Self::parallel_index(port).is_some() {
+            return;
+        }
         let p = &mut self.ports[Self::port_index(port)];
         match index {
+            0 if p.device == PortDevice::LightPen => p.button3 = pressed,
             0 => p.fire = pressed,
             1 => p.button2 = pressed,
             _ => p.button3 = pressed,
@@ -3121,7 +3347,10 @@ impl InputState {
     /// Mouse or empty port so JOYxDAT reports directions; a CD32 pad or
     /// analogue controller keeps its device and just has its lines driven --
     /// fire is /FIRx, button 2 grounds POTxY, and the direction switch lines
-    /// double as the paddle buttons on an analogue device.
+    /// double as the paddle buttons on an analogue device. A light pen has
+    /// no directions and its `fire` is the tip switch / trigger (POTxX).
+    /// On an adapter socket (port 3 or 4) the lines are the adapter's
+    /// switches, and a socket driven this way is fitted with a joystick.
     pub fn set_joystick(
         &mut self,
         port: usize,
@@ -3132,7 +3361,24 @@ impl InputState {
         fire: bool,
         button2: bool,
     ) {
+        if let Some(i) = Self::parallel_index(port) {
+            self.parallel_adapter = true;
+            self.parallel_joysticks[i] = ParallelJoystick {
+                fitted: true,
+                up,
+                down,
+                left,
+                right,
+                fire,
+                button2,
+            };
+            return;
+        }
         let idx = Self::port_index(port);
+        if self.ports[idx].device == PortDevice::LightPen {
+            self.ports[idx].button3 = fire;
+            return;
+        }
         if self.ports[idx].device.is_mouse() || self.ports[idx].device == PortDevice::None {
             self.set_port_device(port, PortDevice::Joystick);
         }
@@ -3147,7 +3393,8 @@ impl InputState {
 
     /// Set a CD32 joypad's extra buttons. Red and Blue arrive through
     /// `set_joystick` as fire/button2; these five only exist in the pad's
-    /// serial report.
+    /// serial report. The adapter sockets carry plain switch joysticks
+    /// and have none of them.
     pub fn set_cd32_buttons(
         &mut self,
         port: usize,
@@ -3157,6 +3404,9 @@ impl InputState {
         green: bool,
         yellow: bool,
     ) {
+        if Self::parallel_index(port).is_some() {
+            return;
+        }
         let p = &mut self.ports[Self::port_index(port)];
         p.cd32_play = play;
         p.cd32_rwd = rwd;
@@ -3169,6 +3419,9 @@ impl InputState {
     /// the count the port's POTxDAT byte latches after a POTGO scan. Engages
     /// the Analogue device.
     pub fn set_analogue(&mut self, port: usize, x: u8, y: u8) {
+        if Self::parallel_index(port).is_some() {
+            return;
+        }
         let idx = Self::port_index(port);
         if self.ports[idx].device != PortDevice::Analogue {
             self.set_port_device(port, PortDevice::Analogue);
@@ -3182,6 +3435,9 @@ impl InputState {
     /// resistance. Each value is measured from +5 V to the corresponding POT
     /// pin; `None` disconnects that axis. Does not change the port's device.
     pub fn set_paddle_resistance(&mut self, port: usize, x_ohms: Option<u32>, y_ohms: Option<u32>) {
+        if Self::parallel_index(port).is_some() {
+            return;
+        }
         let p = &mut self.ports[Self::port_index(port)];
         p.pot_x_ohms = x_ohms;
         p.pot_y_ohms = y_ohms;
@@ -3206,7 +3462,8 @@ impl InputState {
     /// state), while the chip-side quadrature counters clear, the pad
     /// shifters reload, and the driven lines release -- the host input
     /// path re-asserts anything still physically held on the next
-    /// quantum.
+    /// quantum. The adapter and its joysticks stay plugged in with their
+    /// switches released; the pen stays where the hand holds it.
     pub fn reset_for_machine_reset(&mut self) {
         for p in &mut self.ports {
             *p = ControllerPort {
@@ -3214,6 +3471,12 @@ impl InputState {
                 pot_x_ohms: p.pot_x_ohms,
                 pot_y_ohms: p.pot_y_ohms,
                 ..ControllerPort::default()
+            };
+        }
+        for joy in &mut self.parallel_joysticks {
+            *joy = ParallelJoystick {
+                fitted: joy.fitted,
+                ..ParallelJoystick::default()
             };
         }
     }
@@ -3385,6 +3648,7 @@ impl Bus {
             rtc: Rtc::default(),
             rtc_present: true,
             gayle: None,
+            pcmcia: None,
             ramsey: None,
             gary: None,
             sdmac: None,
@@ -4370,6 +4634,152 @@ impl Bus {
 
     pub fn attach_gayle(&mut self, gayle: Gayle) {
         self.gayle = Some(gayle);
+        self.pcmcia_sync_pins();
+    }
+
+    // ----- PCMCIA slot -------------------------------------------------------
+
+    /// Whether the machine has a PCMCIA slot at all (a Gayle machine).
+    pub fn pcmcia_slot_present(&self) -> bool {
+        self.gayle.is_some()
+    }
+
+    /// The card in the slot, if any.
+    pub fn pcmcia_card(&self) -> Option<&crate::pcmcia::PcmciaCard> {
+        self.pcmcia.as_ref()
+    }
+
+    pub fn pcmcia_card_mut(&mut self) -> Option<&mut crate::pcmcia::PcmciaCard> {
+        self.pcmcia.as_mut()
+    }
+
+    /// Insert a card. Any card already in the socket is ejected first, so
+    /// Gayle latches the detect change for both, as a physical swap does.
+    /// Returns false (card dropped) on a machine with no slot.
+    pub fn pcmcia_insert(&mut self, card: crate::pcmcia::PcmciaCard) -> bool {
+        if self.gayle.is_none() {
+            return false;
+        }
+        if self.pcmcia.is_some() {
+            self.pcmcia_eject();
+        }
+        self.pcmcia = Some(card);
+        self.pcmcia_sync_pins();
+        true
+    }
+
+    /// Pull the card. Its backing file is flushed on the way out.
+    pub fn pcmcia_eject(&mut self) -> Option<crate::pcmcia::PcmciaCard> {
+        let mut card = self.pcmcia.take()?;
+        card.flush();
+        self.pcmcia_sync_pins();
+        Some(card)
+    }
+
+    /// Re-sample the slot pins into Gayle after anything that can move
+    /// them: an insert, an eject, or a card access (a CF card's IREQ#).
+    fn pcmcia_sync_pins(&mut self) {
+        let pins = self.pcmcia.as_ref().map_or(0, |card| card.pins());
+        if let Some(gayle) = self.gayle.as_mut() {
+            gayle.set_card_pins(pins);
+        }
+    }
+
+    /// A CPU read in one of the slot windows. `None` when nothing answers
+    /// (no slot, slot disabled or shadowed, empty socket, or a cycle the
+    /// card does not drive), so the CPU treats the address as unmapped.
+    pub fn pcmcia_read(&mut self, addr: u32, size: usize) -> Option<u32> {
+        use crate::pcmcia::SlotAccess;
+        if !self.gayle.as_ref().is_some_and(Gayle::slot_enabled) {
+            return None;
+        }
+        let access = crate::pcmcia::classify(addr)?;
+        if size == 4 {
+            let hi = self.pcmcia_read(addr, 2)?;
+            let lo = self.pcmcia_read(addr.wrapping_add(2), 2)?;
+            return Some((hi << 16) | lo);
+        }
+        if size == 2 && addr & 1 != 0 {
+            let hi = self.pcmcia_read(addr, 1)?;
+            let lo = self.pcmcia_read(addr.wrapping_add(1), 1)?;
+            return Some((hi << 8) | lo);
+        }
+        let value = if let SlotAccess::Reset = access {
+            // Reading the reset register releases the card's RESET line;
+            // the data bus is not driven.
+            return Some(0);
+        } else {
+            let card = self.pcmcia.as_mut()?;
+            match access {
+                SlotAccess::Common(off) => card.read_common(off, size),
+                SlotAccess::Attribute(off) => {
+                    let hi = u32::from(card.read_attribute(off));
+                    if size == 2 {
+                        (hi << 8) | u32::from(card.read_attribute(off | 1))
+                    } else {
+                        hi
+                    }
+                }
+                SlotAccess::Io(off) => card.read_io(off, size)?,
+                SlotAccess::Reset => unreachable!(),
+            }
+        };
+        self.pcmcia_sync_pins();
+        if crate::envcfg::flag("COPPERLINE_DIAG_GAYLE") {
+            log::info!("pcmcia rd {addr:#08X}/{size} -> {value:#06X}");
+        }
+        Some(value)
+    }
+
+    /// A CPU write in one of the slot windows; false when nothing takes it.
+    pub fn pcmcia_write(&mut self, addr: u32, size: usize, value: u32) -> bool {
+        use crate::pcmcia::SlotAccess;
+        if !self.gayle.as_ref().is_some_and(Gayle::slot_enabled) {
+            return false;
+        }
+        let Some(access) = crate::pcmcia::classify(addr) else {
+            return false;
+        };
+        if size == 4 {
+            let a = self.pcmcia_write(addr, 2, value >> 16);
+            let b = self.pcmcia_write(addr.wrapping_add(2), 2, value & 0xFFFF);
+            return a || b;
+        }
+        if size == 2 && addr & 1 != 0 {
+            let a = self.pcmcia_write(addr, 1, (value >> 8) & 0xFF);
+            let b = self.pcmcia_write(addr.wrapping_add(1), 1, value & 0xFF);
+            return a || b;
+        }
+        if crate::envcfg::flag("COPPERLINE_DIAG_GAYLE") {
+            log::info!("pcmcia wr {addr:#08X}/{size} <- {value:#06X}");
+        }
+        let Some(card) = self.pcmcia.as_mut() else {
+            // An empty socket still takes the reset-register cycle.
+            return matches!(access, SlotAccess::Reset);
+        };
+        match access {
+            SlotAccess::Common(off) => card.write_common(off, size, value),
+            SlotAccess::Attribute(off) => {
+                if size == 2 {
+                    card.write_attribute(off, (value >> 8) as u8);
+                    card.write_attribute(off | 1, value as u8);
+                } else {
+                    card.write_attribute(off, value as u8);
+                }
+            }
+            SlotAccess::Io(off) => card.write_io(off, size, value),
+            // Writing the reset register asserts the card's RESET line.
+            SlotAccess::Reset => card.reset(),
+        }
+        self.pcmcia_sync_pins();
+        true
+    }
+
+    /// Drain the card's activity latch, for the HDD LED.
+    pub fn take_pcmcia_activity(&mut self) -> bool {
+        self.pcmcia
+            .as_mut()
+            .is_some_and(crate::pcmcia::PcmciaCard::take_activity)
     }
 
     pub fn attach_uaelib(&mut self, uaelib: crate::uaelib::UaeLib) {
@@ -4578,12 +4988,50 @@ impl Bus {
                 && self.agnus.beamcon0() & BEAMCON0_HARDDIS != 0)
     }
 
-    /// External light-pen pulse at the current beam position. No input
-    /// device is wired to this yet; tests (and future controller-port
-    /// plumbing) call it directly.
+    /// External light-pen pulse at the current beam position: the LP pin
+    /// pulled low by hand. The fitted [`PortDevice::LightPen`] does not go
+    /// through here -- it hands Agnus the beam position its detector sees
+    /// (`arm_light_pen_for_frame`) and the pulse fires as the counters
+    /// sweep past it -- so this is for tests that want a pulse at an
+    /// arbitrary moment.
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn light_pen_pulse(&mut self) {
         self.agnus.trigger_light_pen();
+    }
+
+    /// The game port whose pin 6 (/FIRx) is wired to Agnus's LP input:
+    /// port 1 on the A1000 (the machine with the WCS at $FC0000), port 2
+    /// on the A500 and everything after it (the A2000 moved the trace,
+    /// and every later board followed). A pen in the other port has a
+    /// working tip switch but its pulses reach nothing.
+    pub fn light_pen_wired_port(&self) -> usize {
+        if self.mem.wcs.is_empty() {
+            1
+        } else {
+            0
+        }
+    }
+
+    /// Beam position (`vpos`, `hpos`) the fitted light pen's detector sees
+    /// this frame: the pen's glass position mapped through the renderer's
+    /// own comparator geometry, or `None` with no pen on the LP-wired port
+    /// or the pen off the glass.
+    pub fn light_pen_beam_target(&self) -> Option<(u32, u32)> {
+        let port = self.input.light_pen_port()?;
+        if port != self.light_pen_wired_port() {
+            return None;
+        }
+        let (x, y) = self.input.light_pen.position?;
+        crate::video::bitplane::framebuffer_beam_position(self, x, y)
+    }
+
+    /// Hand Agnus the pen's beam position for the frame about to be
+    /// scanned. Called at every frame start, after the frame geometry has
+    /// been promoted, so the mapping is the one the frame just rendered
+    /// used -- which is what a screenshot's coordinates refer to.
+    pub(crate) fn arm_light_pen_for_frame(&mut self) {
+        let target = self.light_pen_beam_target();
+        self.agnus.set_light_pen_target(target);
     }
 
     /// Queue an Amiga raw key press (a 7-bit raw scan code).
@@ -4666,6 +5114,12 @@ impl Bus {
         if let Some(gayle) = self.gayle.as_mut() {
             gayle.reset();
         }
+        // The system reset line reaches the card's RESET pin through
+        // Gayle, and the pins are sampled afresh afterwards.
+        if let Some(card) = self.pcmcia.as_mut() {
+            card.reset();
+        }
+        self.pcmcia_sync_pins();
         if let Some(gary) = self.gary.as_mut() {
             gary.reset();
         }
@@ -4880,6 +5334,9 @@ impl Bus {
         if let Some(gayle) = self.gayle.as_mut() {
             released += gayle.release_host_disks();
         }
+        if let Some(card) = self.pcmcia.as_mut() {
+            released += card.release_host_disks();
+        }
         if let Some(ide) = self.ide_a4000.as_mut() {
             released += ide.release_host_disks();
         }
@@ -5025,6 +5482,34 @@ impl Bus {
                             log::warn!(
                                 "scsi: unit {unit} asked for host disk {}, which is not \
                                  available: {error}",
+                                disk.device
+                            );
+                            false
+                        }
+                    }
+                }
+                crate::config::HostDiskAttach::Pcmcia => {
+                    if self.gayle.is_none() {
+                        continue;
+                    }
+                    match crate::ata::IdeDrive::open_host_disk(
+                        &disk.device,
+                        disk.fingerprint.as_deref(),
+                        disk.identity_confirmed,
+                        disk.writable,
+                    ) {
+                        Ok(drive) => {
+                            // A fresh card goes in: power-off released the
+                            // old one's medium, and a re-insert is what a
+                            // real slot sees at power-on anyway.
+                            self.pcmcia_insert(crate::pcmcia::PcmciaCard::cf(
+                                crate::pcmcia::CfCard::new(drive),
+                            ));
+                            true
+                        }
+                        Err(error) => {
+                            log::warn!(
+                                "pcmcia: asked for host disk {}, which is not available: {error}",
                                 disk.device
                             );
                             false
@@ -5316,6 +5801,9 @@ impl Bus {
         self.paula
             .serial
             .set_control_outputs(pra & 0x80 == 0, pra & 0x40 == 0);
+        // Likewise the line rate: a host serial port is kept at the guest's
+        // SERPER rate, and this machine's SERPER was restored, not written.
+        self.paula.republish_serial_line_rate();
         std::mem::swap(
             &mut self.paula.serial_observer,
             &mut live.paula.serial_observer,
@@ -5414,6 +5902,9 @@ impl Bus {
         if let Some(gayle) = &self.gayle {
             gayle.pending_host_disks(&mut pending);
         }
+        if let Some(card) = &self.pcmcia {
+            card.pending_host_disks(&mut pending);
+        }
         if let Some(ide) = &self.ide_a4000 {
             ide.pending_host_disks(&mut pending);
         }
@@ -5442,6 +5933,9 @@ impl Bus {
         let result = (|| {
             if let Some(gayle) = &mut self.gayle {
                 gayle.materialize_host_disks()?;
+            }
+            if let Some(card) = &mut self.pcmcia {
+                card.materialize_host_disks()?;
             }
             if let Some(ide) = &mut self.ide_a4000 {
                 ide.materialize_host_disks()?;
@@ -7080,14 +7574,50 @@ impl Bus {
             self.pending_vbi = 1;
         }
 
-        // Gayle drives INT2 (PORTS) as a level; Paula's INTREQ latch keeps
-        // getting set while the line is asserted.
+        // Gayle drives INT2 (PORTS) and INT6 (EXTER) as levels; Paula's
+        // INTREQ latch keeps getting set while a line is asserted.
         if self
             .gayle
             .as_ref()
             .is_some_and(crate::gayle::Gayle::int2_line)
         {
             self.paula.intreq |= INT_PORTS;
+        }
+        if self
+            .gayle
+            .as_ref()
+            .is_some_and(crate::gayle::Gayle::int6_line)
+        {
+            self.paula.intreq |= INT_EXTER;
+        }
+        // A $DA9000 RESET+BERR write resets the card's configuration; a
+        // card-detect change with RESET armed reboots the machine.
+        let (card_reset, machine_reset) = self.gayle.as_mut().map_or((false, false), |gayle| {
+            (
+                gayle.take_card_reset_request(),
+                gayle.take_machine_reset_request(),
+            )
+        });
+        if card_reset {
+            if let Some(card) = self.pcmcia.as_mut() {
+                card.reset();
+            }
+            self.pcmcia_sync_pins();
+        }
+        if machine_reset {
+            // Kickstart 3.x card.resource arms this bit, which is why a
+            // real A600/A1200 reboots when a memory card is pulled.
+            log::info!("gayle: card-detect change with RESET armed, resetting the machine");
+            self.keyboard_system_reset_pending = true;
+            self.slice_preempted = true;
+        }
+        // An SRAM card used as RAM takes millions of writes; its backing
+        // file is written back about once an emulated second, not per
+        // access (the emulated result does not depend on it).
+        if agnus_tick.new_frames > 0 && self.emulated_frames.is_multiple_of(50) {
+            if let Some(card) = self.pcmcia.as_mut() {
+                card.flush();
+            }
         }
 
         // The A4000's IDE has no interrupt latch of its own: the drive's INTRQ
@@ -8358,6 +8888,14 @@ impl Bus {
             if let Some(byte) = self.parallel_port.read_data(self.emulated_cck) {
                 v = byte;
             }
+            // The four-player adapter's direction switches short data pins
+            // to ground. A pin the guest has switched to an output stays
+            // CIA-driven; the games program the port as inputs (DDRB = 0)
+            // and read the switches through the pull-ups.
+            let pulls = self.input.parallel_data_pull_downs();
+            if pulls != 0 {
+                v &= !(pulls & !self.cia_a.port_b_ddr());
+            }
         }
         trace!("cia_a R reg={:X} sz={} val={:02X}", reg, size, v);
         self.poll_stats.tick_read("cia_a", reg);
@@ -8471,6 +9009,13 @@ impl Bus {
             if let Some(lines) = self.parallel_port.control_lines() {
                 let inputs = !ddr & 0x07;
                 v = (v & !inputs) | (lines & inputs);
+            }
+            // The four-player adapter's fire buttons short SEL (port 3)
+            // and BUSY (port 4) to ground, and a second button POUT; the
+            // same input-only overlay as the data pins.
+            let pulls = self.input.parallel_status_pull_downs();
+            if pulls != 0 {
+                v &= !(pulls & !ddr & 0x07);
             }
             // CIA-B PA3-5 are the RS-232 handshake inputs /DSR, /CTS, and
             // /CD, arriving through the motherboard's inverting 1489

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -5848,6 +5848,12 @@ impl Bus {
         {
             return Some("persistent CD32 NVRAM");
         }
+        if self.pcmcia.is_some() {
+            // A card inserted from the menu after start-up never passed
+            // through the configuration's check, and its image or backing
+            // file takes writes the same way.
+            return Some("PCMCIA card in the slot");
+        }
         if self.rtc_present && !self.rtc.runahead_safe() {
             return Some("live or persistent real-time clock");
         }

--- a/src/bus/frame_capture.rs
+++ b/src/bus/frame_capture.rs
@@ -35,6 +35,9 @@ impl Bus {
             self.last_frame_render_events.clear();
             self.current_frame_render_events.clear();
         }
+        // The light pen sees this frame's beam through the geometry the
+        // frame just promoted: aim it now, before the first line scans.
+        self.arm_light_pen_for_frame();
         self.current_frame_collision_events.clear();
         self.current_frame_collision_control_events.clear();
         self.current_frame_collision_bpldat_events.clear();

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -2158,6 +2158,35 @@ fn serper_write_pushes_baud_to_serial_sink() {
 }
 
 #[test]
+fn state_adoption_republishes_serper_rate_to_the_serial_sink() {
+    // A host sink moved onto a restored machine never saw that machine's
+    // SERPER written; a sink that keeps a real port at the guest's rate
+    // (mode = "device") needs the restored rate pushed, the way the
+    // restored /DTR and /RTS are.
+    struct RecordBaud(Arc<Mutex<Vec<u32>>>);
+    impl SerialSink for RecordBaud {
+        fn write_byte(&mut self, _b: u8, _at_cck: u64) {}
+        fn flush(&mut self) {}
+        fn baud_changed(&mut self, bps: u32) {
+            self.0.lock().unwrap().push(bps);
+        }
+    }
+    let mut live = empty_bus();
+    let rates = Arc::new(Mutex::new(Vec::new()));
+    live.paula.serial = Box::new(RecordBaud(Arc::clone(&rates)));
+    // The live machine was at 9600; the restored one had programmed
+    // 19200 (divisor 184).
+    let _ = live.write_custom_word_from(0x032, 372, BeamWriteSource::Cpu);
+    let mut restored = empty_bus();
+    restored.paula.serper = 184;
+    restored.adopt_host_resources(&mut live).unwrap();
+    assert_eq!(
+        *rates.lock().unwrap(),
+        vec![PAULA_CLOCK_HZ / 373, PAULA_CLOCK_HZ / 185]
+    );
+}
+
+#[test]
 fn serial_device_drives_cia_b_handshake_inputs() {
     use crate::serial::{SerialControlLines, CIAB_PA_CD, CIAB_PA_CTS, CIAB_PA_DSR};
 
@@ -13228,6 +13257,206 @@ fn hhposr_reads_hhposw_latch_on_ecs_agnus_only() {
     assert_eq!(ecs.custom_read(0x1DA, 2), 0x0155);
 }
 
+fn pcmcia_test_image(sectors: usize) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    let image = std::env::temp_dir().join(format!(
+        "copperline-bus-pcmcia-{}-{}.hdf",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::write(&image, vec![0u8; 512 * sectors]).unwrap();
+    image
+}
+
+/// A CF card in the slot: the CIS reads from attribute memory at even
+/// addresses, the power-on memory-mapped layout puts the task file at the
+/// start of common memory, a Configuration Option Register write moves it
+/// to the I/O windows (with the odd-byte window reaching the odd
+/// registers), and the reset register drops the configuration again.
+#[test]
+fn pcmcia_cf_card_maps_the_ata_task_file_by_configuration() {
+    use crate::ata::{ST_DRDY, ST_DRQ, ST_DSC};
+    use crate::gayle::Gayle;
+    use crate::pcmcia::{CfCard, PcmciaCard, PIN_CCDET, PIN_WR};
+
+    let image = pcmcia_test_image(64);
+    let mut bus = empty_bus();
+    // No slot yet: the window is unmapped.
+    assert_eq!(bus.pcmcia_read(0x00A0_0000, 1), None);
+    bus.attach_gayle(Gayle::new(0xD1));
+    // Empty socket: the reset register answers, nothing else does.
+    assert_eq!(bus.pcmcia_read(0x00A0_0000, 1), None);
+    assert_eq!(bus.pcmcia_read(0x0060_0000, 2), None);
+    assert!(bus.pcmcia_write(0x00A4_0000, 1, 0));
+
+    bus.pcmcia_insert(PcmciaCard::cf(CfCard::open(&image).unwrap()));
+    let g = bus.gayle.as_ref().unwrap();
+    assert_eq!(g.card_pins() & (PIN_CCDET | PIN_WR), PIN_CCDET | PIN_WR);
+
+    // Attribute memory: CISTPL_DEVICE at $A00000, one CIS byte per even
+    // address, odd bytes mirroring; a word read pairs them.
+    assert_eq!(bus.pcmcia_read(0x00A0_0000, 1), Some(0x01));
+    assert_eq!(bus.pcmcia_read(0x00A0_0002, 1), Some(0x04));
+    assert_eq!(bus.pcmcia_read(0x00A0_0001, 1), Some(0x01));
+    assert_eq!(bus.pcmcia_read(0x00A0_0000, 2), Some(0x0101));
+    assert_eq!(bus.pcmcia_read(0x00A0_0000, 4), Some(0x0101_0404));
+    // COR reads zero at power-on: memory-mapped configuration.
+    assert_eq!(bus.pcmcia_read(0x00A0_0200, 1), Some(0));
+
+    // Memory-mapped: status at common +7, alternate status at +$E; the
+    // I/O windows do not answer.
+    assert_eq!(
+        bus.pcmcia_read(0x0060_0007, 1).map(|v| v as u8),
+        Some(ST_DRDY | ST_DSC)
+    );
+    assert_eq!(
+        bus.pcmcia_read(0x0060_000E, 1).map(|v| v as u8),
+        Some(ST_DRDY | ST_DSC)
+    );
+    assert_eq!(bus.pcmcia_read(0x00A2_0007, 1), None);
+    // The block repeats every 2 KiB (A10-A0 decode).
+    assert_eq!(
+        bus.pcmcia_read(0x0060_0807, 1).map(|v| v as u8),
+        Some(ST_DRDY | ST_DSC)
+    );
+    // IDENTIFY through the memory-mapped block: drive/head at +6,
+    // command at +7, data words through the $400 window.
+    bus.pcmcia_write(0x0060_0006, 1, 0xA0);
+    bus.pcmcia_write(0x0060_0007, 1, 0xEC);
+    assert_eq!(
+        bus.pcmcia_read(0x0060_000E, 1).map(|v| v as u8),
+        Some(ST_DRDY | ST_DSC | ST_DRQ)
+    );
+    let word0 = bus.pcmcia_read(0x0060_0400, 2).unwrap() as u16;
+    assert_eq!(word0.swap_bytes(), 0x045A, "IDENTIFY word 0, lane-swapped");
+    for _ in 1..256 {
+        bus.pcmcia_read(0x0060_0400, 2);
+    }
+    assert_eq!(
+        bus.pcmcia_read(0x0060_0007, 1).map(|v| v as u8),
+        Some(ST_DRDY | ST_DSC)
+    );
+
+    // Configure contiguous I/O (index 1) through the COR at attribute $200.
+    bus.pcmcia_write(0x00A0_0200, 1, 0x01);
+    assert_eq!(bus.pcmcia_read(0x00A0_0200, 1), Some(0x01));
+    assert_eq!(
+        bus.pcmcia_read(0x0060_0007, 1),
+        Some(0),
+        "registers left common memory"
+    );
+    assert_eq!(
+        bus.pcmcia_read(0x00A2_0007, 1).map(|v| v as u8),
+        Some(ST_DRDY | ST_DSC)
+    );
+    // The odd-byte window: $A30006 is I/O register 7 (status).
+    assert_eq!(
+        bus.pcmcia_read(0x00A3_0006, 1).map(|v| v as u8),
+        Some(ST_DRDY | ST_DSC)
+    );
+    // A word read of registers 6/7 lands drive/head high, status low.
+    assert_eq!(
+        bus.pcmcia_read(0x00A2_0006, 2).map(|v| v as u16),
+        Some(0xA000 | u16::from(ST_DRDY | ST_DSC))
+    );
+    // Read a sector through the I/O data port and check the interrupt
+    // reaches Gayle's busy/IRQ pin as a level, on INT2 by default.
+    bus.gayle.as_mut().unwrap().write(0x00DA_A000, 1, 0xEC);
+    bus.gayle.as_mut().unwrap().write(0x00DA_9000, 1, 0);
+    bus.pcmcia_write(0x00A2_0006, 1, 0x40); // LBA, drive 0
+    bus.pcmcia_write(0x00A2_0003, 1, 0);
+    bus.pcmcia_write(0x00A2_0004, 1, 0);
+    bus.pcmcia_write(0x00A2_0005, 1, 0);
+    bus.pcmcia_write(0x00A2_0002, 1, 1);
+    bus.pcmcia_write(0x00A2_0007, 1, 0x20); // READ SECTORS
+    assert!(bus.gayle.as_ref().unwrap().int2_line(), "IREQ# on INT2");
+    bus.advance_devices(4);
+    assert_ne!(bus.paula.intreq & INT_PORTS, 0);
+    for _ in 0..256 {
+        bus.pcmcia_read(0x00A2_0000, 2);
+    }
+    // The status read dropped INTRQ; acknowledging at Gayle clears the line.
+    bus.pcmcia_read(0x00A2_0007, 1);
+    bus.gayle.as_mut().unwrap().write(0x00DA_9000, 1, 0);
+    assert!(!bus.gayle.as_ref().unwrap().int2_line());
+
+    // PC-style primary I/O (index 2): $1F7 and $3F6.
+    bus.pcmcia_write(0x00A0_0200, 1, 0x02);
+    assert_eq!(bus.pcmcia_read(0x00A2_0007, 1), Some(0));
+    assert_eq!(
+        bus.pcmcia_read(0x00A2_01F7, 1).map(|v| v as u8),
+        Some(ST_DRDY | ST_DSC)
+    );
+    assert_eq!(
+        bus.pcmcia_read(0x00A2_03F6, 1).map(|v| v as u8),
+        Some(ST_DRDY | ST_DSC)
+    );
+    // Card reset: a write to $A40000 drops the COR back to memory mode.
+    assert!(bus.pcmcia_write(0x00A4_0000, 1, 0));
+    assert_eq!(bus.pcmcia_read(0x00A0_0200, 1), Some(0));
+    assert_eq!(
+        bus.pcmcia_read(0x0060_0007, 1).map(|v| v as u8),
+        Some(ST_DRDY | ST_DSC)
+    );
+    assert_eq!(bus.pcmcia_read(0x00A4_0000, 1), Some(0), "reset release");
+
+    // Ejecting latches the detect change on INT6 and empties the window.
+    bus.gayle.as_mut().unwrap().write(0x00DA_9000, 1, 0);
+    assert!(bus.pcmcia_eject().is_some());
+    assert!(bus.gayle.as_ref().unwrap().int6_line());
+    bus.advance_devices(4);
+    assert_ne!(bus.paula.intreq & INT_EXTER, 0);
+    assert_eq!(bus.pcmcia_read(0x00A0_0000, 1), None);
+    std::fs::remove_file(image).ok();
+}
+
+/// An SRAM card: its CIS in attribute memory, its RAM through the common
+/// window (reads past its size undecoded), the write-protect switch on
+/// the WR pin, and the slot going dark when fast RAM shadows it.
+#[test]
+fn pcmcia_sram_card_common_memory_and_fast_ram_shadowing() {
+    use crate::gayle::Gayle;
+    use crate::pcmcia::{PcmciaCard, SramCard, PIN_CCDET, PIN_WR};
+
+    let mut bus = empty_bus();
+    bus.attach_gayle(Gayle::new(0xD0));
+    bus.pcmcia_insert(PcmciaCard::Sram(
+        SramCard::new(512 * 1024, None, false).unwrap(),
+    ));
+    // CISTPL_DEVICE: SRAM, 100 ns; 512 KiB is one 512 KiB unit (code 5).
+    assert_eq!(bus.pcmcia_read(0x00A0_0004, 1), Some(0x64));
+    assert_eq!(bus.pcmcia_read(0x00A0_0006, 1), Some(0x05));
+    assert!(bus.pcmcia_write(0x0060_1000, 2, 0xCAFE));
+    assert!(bus.pcmcia_write(0x0060_1002, 4, 0x1234_5678));
+    assert_eq!(bus.pcmcia_read(0x0060_1000, 4), Some(0xCAFE_1234));
+    assert_eq!(bus.pcmcia_read(0x0060_1004, 2), Some(0x5678));
+    assert_eq!(bus.pcmcia_read(0x0060_1001, 1), Some(0xFE));
+    assert_eq!(bus.pcmcia_read(0x0068_0000, 2), Some(0), "past the card");
+    // An I/O cycle to a memory card floats.
+    assert_eq!(bus.pcmcia_read(0x00A2_0000, 2), None);
+    let g = bus.gayle.as_ref().unwrap();
+    assert_eq!(g.card_pins() & (PIN_CCDET | PIN_WR), PIN_CCDET | PIN_WR);
+
+    // Guest-disabled slot ($DA8000 DIS): the window goes away, the card
+    // stays in the socket, and re-enabling brings it back untouched.
+    bus.gayle.as_mut().unwrap().write(0x00DA_8000, 1, 0x01);
+    assert_eq!(bus.pcmcia_read(0x0060_1000, 2), None);
+    bus.gayle.as_mut().unwrap().write(0x00DA_8000, 1, 0x00);
+    assert_eq!(bus.pcmcia_read(0x0060_1000, 2), Some(0xCAFE));
+
+    // The fast-RAM rule: with the slot shadowed nothing decodes and Gayle
+    // reports an empty socket.
+    bus.gayle.as_mut().unwrap().set_slot_shadowed(true);
+    assert_eq!(bus.pcmcia_read(0x0060_1000, 2), None);
+    assert_eq!(bus.pcmcia_read(0x00A0_0000, 1), None);
+    assert_eq!(
+        bus.gayle.as_mut().unwrap().read(0x00DA_8000, 1) as u8 & PIN_CCDET,
+        0
+    );
+    assert!(bus.pcmcia_card().is_some(), "the card is still inserted");
+}
+
 #[test]
 fn gayle_int2_level_keeps_setting_paula_ports_intreq() {
     use crate::gayle::{Gayle, IdeDrive};
@@ -14165,4 +14394,115 @@ fn cartridge_shadows_follow_custom_and_cia_writes_into_the_bank_on_a_freeze() {
     assert_eq!(bank[HRTMON_CIAA_SHADOW + 0x02 * 0x100 + 1], 0x03);
     assert_eq!(bank[HRTMON_CIAB_SHADOW + 0x100], 0x7F);
     assert_eq!(&bus.mem.chip_ram[0x7C..0x80], &0x00A1_000Cu32.to_be_bytes());
+}
+
+#[test]
+fn parallel_joystick_adapter_grounds_input_pins_by_socket() {
+    const CIA_A_PRB: u64 = 0x00BF_E101;
+    const CIA_A_DDRB: u64 = 0x00BF_E301;
+    const CIA_B_PRA: u64 = 0x00BF_D000;
+    let mut bus = empty_bus();
+    bus.input.set_parallel_adapter(true, [true, true]);
+    // The four-player titles read the port as inputs (DDRB = 0): the
+    // pull-ups read every data pin high with the sticks centred, and the
+    // Centronics status lines all high with nothing pressed.
+    assert_eq!(bus.cia_a_read(CIA_A_PRB, 1), 0xFF);
+    assert_eq!(bus.cia_b_read(CIA_B_PRA, 1) as u8 & 0x07, 0x07);
+
+    // Port 3 up + left + fire, port 4 down + right + button 2: D0/D2 and
+    // D5/D7 grounded; SEL (PA2) low for port 3's fire, POUT (PA1) low for
+    // the second button, BUSY (PA0) still high.
+    bus.input
+        .set_joystick(2, true, false, true, false, true, false);
+    bus.input
+        .set_joystick(3, false, true, false, true, false, true);
+    assert_eq!(
+        bus.cia_a_read(CIA_A_PRB, 1),
+        0xFF & !(0x01 | 0x04 | 0x20 | 0x80)
+    );
+    assert_eq!(bus.cia_b_read(CIA_B_PRA, 1) as u8 & 0x07, 0x01);
+    // Port 4 fire is BUSY (PA0); its second button released frees POUT.
+    bus.input
+        .set_joystick(3, false, false, false, false, true, false);
+    assert_eq!(bus.cia_b_read(CIA_B_PRA, 1) as u8 & 0x07, 0x02);
+
+    // Pins the guest drives as outputs are the CIA's, whatever the switches
+    // do: with D0-D3 switched to outputs and written high, port 3's held
+    // directions vanish while port 4's still ground D5/D7.
+    let _ = bus.cia_a_write(CIA_A_PRB, 1, 0xFF);
+    let _ = bus.cia_a_write(CIA_A_DDRB, 1, 0x0F);
+    bus.input
+        .set_joystick(3, false, true, false, true, false, false);
+    assert_eq!(bus.cia_a_read(CIA_A_PRB, 1), 0x5F);
+
+    // Pulling the adapter releases every switch.
+    bus.input.set_parallel_adapter(false, [false, false]);
+    assert_eq!(bus.cia_a_read(CIA_A_PRB, 1), 0xFF);
+    assert_eq!(bus.cia_b_read(CIA_B_PRA, 1) as u8 & 0x07, 0x07);
+}
+
+#[test]
+fn light_pen_device_latches_the_beam_where_the_pen_is_held() {
+    let mut bus = empty_bus();
+    // An A500-class board (no WCS): Agnus LP is port 2's pin 6.
+    assert_eq!(bus.light_pen_wired_port(), 1);
+    bus.input.set_port_device(1, PortDevice::LightPen);
+    bus.input.set_light_pen_position(Some((320, 100)));
+    assert!(!bus.custom_write(0x100, 2, 0x0008)); // BPLCON0 LPEN
+    let (target_v, target_h) = bus.light_pen_beam_target().expect("pen on the glass");
+    assert_eq!(target_v, bus.frame_geometry().visible_start_vpos + 100);
+    assert!(target_h < 227, "beam column {target_h}");
+
+    // The pen is aimed at each frame start and latches as the beam sweeps
+    // past it; read the latch back on the field after, from line 0.
+    let field = bus.frame_lines() * 227;
+    bus.advance_chipset(2 * field + 10);
+    let expect = (((target_v & 0xFF) << 8) | (target_h & 0xFF)) as u64;
+    assert_eq!(bus.custom_read(0x006, 2), expect, "VHPOSR");
+    assert_eq!(
+        bus.custom_read(0x004, 2) & 0x0001,
+        ((target_v >> 8) & 1) as u64,
+        "VPOSR V8"
+    );
+
+    // Lifted off the glass the pen sees no beam: the field ends with the
+    // end-of-field default in the latch instead.
+    bus.input.set_light_pen_position(None);
+    bus.advance_chipset(2 * field);
+    assert_ne!(bus.custom_read(0x006, 2), expect);
+
+    // A pen in the port the board does not wire to LP never reaches Agnus.
+    bus.input.set_port_device(1, PortDevice::Joystick);
+    bus.input.set_port_device(0, PortDevice::LightPen);
+    bus.input.set_light_pen_position(Some((320, 100)));
+    assert_eq!(bus.light_pen_beam_target(), None);
+    bus.advance_chipset(2 * field);
+    assert_ne!(bus.custom_read(0x006, 2), expect);
+
+    // The A1000 (identified by its WCS) wires port 1 instead.
+    let mut a1000 = empty_bus();
+    a1000.mem.wcs = vec![0u8; crate::memory::WCS_SIZE];
+    assert_eq!(a1000.light_pen_wired_port(), 0);
+    a1000.input.set_port_device(0, PortDevice::LightPen);
+    a1000.input.set_light_pen_position(Some((320, 100)));
+    assert!(a1000.light_pen_beam_target().is_some());
+}
+
+#[test]
+fn light_pen_switch_reads_on_the_third_button_line_not_fire() {
+    let mut bus = empty_bus();
+    bus.input.set_port_device(1, PortDevice::LightPen);
+    // The left "click" is the pen's tip switch: POT1X grounded, /FIR1
+    // untouched (that pin is the pulse line).
+    bus.input.set_mouse_button(1, 0, true);
+    assert!(!bus.input.ports[1].fir_asserted());
+    assert!(!bus.input.ports[1].pot_x_released());
+    // A joystick-style fire on the pen port is the same switch, and the
+    // pen keeps its device rather than turning into a joystick.
+    bus.input.set_mouse_button(1, 0, false);
+    bus.input
+        .set_joystick(1, true, false, false, false, true, false);
+    assert_eq!(bus.input.device(1), PortDevice::LightPen);
+    assert!(!bus.input.ports[1].pot_x_released());
+    assert!(!bus.input.ports[1].up, "a pen has no directions");
 }

--- a/src/chipset/agnus.rs
+++ b/src/chipset/agnus.rs
@@ -224,6 +224,11 @@ pub struct Agnus {
     /// Whether a pen pulse latched during the current field; re-armed at
     /// every field wrap.
     lpen_triggered_this_field: bool,
+    /// Beam position a fitted light pen sees the beam at (see
+    /// [`Self::set_light_pen_target`]); the pulse fires as the counters
+    /// sweep past it.
+    #[serde(default)]
+    lpen_target: Option<(u32, u32)>,
     /// HHPOSW latch (ECS). The UHRES dual-mode horizontal counter itself is
     /// not emulated (BEAMCON0.DUAL logs a one-time warning), so HHPOSR reads
     /// back the last written value.
@@ -731,6 +736,7 @@ impl Agnus {
             lpen_enabled: false,
             lpen_latch: None,
             lpen_triggered_this_field: false,
+            lpen_target: None,
             hhpos: 0,
             fmode: 0,
         }
@@ -1069,6 +1075,7 @@ impl Agnus {
             let line_cck = self.current_line_cck();
             let remaining_line = line_cck.saturating_sub(self.hpos).max(1);
             if cck < remaining_line {
+                self.light_pen_sweep(self.hpos, self.hpos + cck);
                 self.hpos += cck;
                 if self.hpos >= 2 {
                     self.vpos_read_delay = None;
@@ -1077,11 +1084,17 @@ impl Agnus {
             }
 
             cck -= remaining_line;
+            self.light_pen_sweep(self.hpos, line_cck);
             self.hpos = 0;
             let previous_vpos = self.vpos;
             self.vpos += 1;
             self.advance_long_line_state();
             self.pending_tick.new_lines += 1;
+            // The pen sitting at the very start of the new line: the
+            // sweeps above cover (from, to], never colour clock 0.
+            if self.lpen_target == Some((self.vpos, 0)) {
+                self.trigger_light_pen_at(self.vpos, 0);
+            }
             if self.vpos >= self.current_frame_lines() {
                 self.vpos = 0;
                 self.pending_tick.new_frames += 1;
@@ -1233,13 +1246,43 @@ impl Agnus {
     /// A light-pen pulse at the current beam position. The first pulse of a
     /// field wins; later pulses in the same field are ignored, matching the
     /// latch staying frozen until it is re-armed at the field wrap.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub fn trigger_light_pen(&mut self) {
+        self.trigger_light_pen_at(self.vpos, self.hpos);
+    }
+
+    /// The LP pin's falling edge at beam position (`vpos`, `hpos`): latch
+    /// it unless the pen is disabled, ECS LPENDIS holds the latch off, or
+    /// this field already latched a pulse.
+    fn trigger_light_pen_at(&mut self, vpos: u32, hpos: u32) {
         if !self.lpen_enabled || self.lpen_latch_disabled() || self.lpen_triggered_this_field {
             return;
         }
-        self.lpen_latch = Some((self.vpos, self.hpos));
+        self.lpen_latch = Some((vpos, hpos));
         self.lpen_triggered_this_field = true;
+    }
+
+    /// Where a light pen's photodetector is held against the glass, as the
+    /// beam position (`vpos`, `hpos`) whose light it sees, or `None` for a
+    /// pen off the glass. The pen pulls the LP pin low as the beam sweeps
+    /// past it, so the latch fires the moment the beam counters reach the
+    /// position, once per field. The bus sets this from the fitted pen
+    /// device at every frame start; the position is external stimulus,
+    /// not chip state, and the chip only ever sees the pulse.
+    pub fn set_light_pen_target(&mut self, target: Option<(u32, u32)>) {
+        self.lpen_target = target;
+    }
+
+    /// The beam advancing from `from` to `to` (exclusive of `from`,
+    /// inclusive of `to`) on the current line: fire the pen's pulse if its
+    /// position lies in the sweep. The latch takes the pen's own colour
+    /// clock, not the end of the advance, so the value software reads is
+    /// independent of how the emulation chunks the line.
+    fn light_pen_sweep(&mut self, from: u32, to: u32) {
+        if let Some((vpos, hpos)) = self.lpen_target {
+            if vpos == self.vpos && from < hpos && hpos <= to {
+                self.trigger_light_pen_at(vpos, hpos);
+            }
+        }
     }
 
     pub fn hhpos(&self) -> u16 {
@@ -2414,5 +2457,45 @@ mod tests {
             Agnus::with_video_standard_and_revision(VideoStandard::Pal, AgnusRevision::Ecs8372Rev4);
         ecs.write_hhposw(0x3123);
         assert_eq!(ecs.hhpos(), 0x0123, "9-bit horizontal latch");
+    }
+
+    #[test]
+    fn light_pen_target_latches_at_the_pen_colour_clock_whatever_the_advance_chunk() {
+        let mut agnus = Agnus::with_video_standard(VideoStandard::Pal);
+        agnus.set_lpen(true);
+        agnus.set_light_pen_target(Some((50, 0x60)));
+        // Awkward chunks across the target line: the latch takes the pen's
+        // own colour clock, not the end of whichever chunk crossed it.
+        while agnus.vpos < 52 {
+            agnus.advance_by_cck(37);
+        }
+        assert_eq!(agnus.read_vhposr(), (50 << 8) | 0x60);
+        // One latch per field: moving the pen later in the same field does
+        // not re-latch until the next field sweeps past it.
+        agnus.set_light_pen_target(Some((60, 0x10)));
+        while agnus.vpos < 62 {
+            agnus.advance_by_cck(37);
+        }
+        assert_eq!(agnus.read_vhposr(), (50 << 8) | 0x60);
+        agnus.advance_by_cck(PAL_LINES * COLORCLOCKS_PER_LINE);
+        assert_eq!(agnus.read_vhposr(), (60 << 8) | 0x10);
+        // Lifting the pen: the field it latched in keeps its latch, and the
+        // first field with no pulse ends with the end-of-field default.
+        agnus.set_light_pen_target(None);
+        agnus.advance_by_cck(PAL_LINES * COLORCLOCKS_PER_LINE);
+        assert_eq!(agnus.read_vhposr(), (60 << 8) | 0x10);
+        agnus.advance_by_cck(PAL_LINES * COLORCLOCKS_PER_LINE);
+        let expect_v = ((PAL_LINES - 1) & 0xFF) as u16;
+        let expect_h = (COLORCLOCKS_PER_LINE - 1) as u16 & 0xFF;
+        assert_eq!(agnus.read_vhposr(), (expect_v << 8) | expect_h);
+    }
+
+    #[test]
+    fn light_pen_target_at_the_start_of_a_line_latches_colour_clock_zero() {
+        let mut agnus = Agnus::with_video_standard(VideoStandard::Pal);
+        agnus.set_lpen(true);
+        agnus.set_light_pen_target(Some((20, 0)));
+        agnus.advance_by_cck(25 * COLORCLOCKS_PER_LINE + 3);
+        assert_eq!(agnus.read_vhposr(), 20 << 8);
     }
 }

--- a/src/chipset/cia.rs
+++ b/src/chipset/cia.rs
@@ -457,6 +457,13 @@ impl Cia {
         self.regs[REG_DDRA]
     }
 
+    /// Port-B data direction register (1 = output), for board wiring that
+    /// overlays external pull-downs on the input pins only (the
+    /// parallel-port joystick adapter's switches on CIA-A PB0-7).
+    pub fn port_b_ddr(&self) -> u8 {
+        self.regs[REG_DDRB]
+    }
+
     /// Port-A pin levels as contributed by the CIA itself: outputs at their
     /// programmed level, inputs released (open-drain, pulled high). External
     /// peripherals are not overlaid here, so a pin an attached device drives

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -1038,6 +1038,16 @@ impl Paula {
         self.serial.baud_changed(PAULA_CLOCK_HZ / divisor);
     }
 
+    /// Tell the sink the line rate the current SERPER works out to, as
+    /// [`write_serper`](Self::write_serper) does on a write. For a sink
+    /// that has just been moved onto a restored machine (save-state load,
+    /// rewind), whose SERPER it never saw written: a host port follows the
+    /// rate, and must follow the restored one.
+    pub fn republish_serial_line_rate(&mut self) {
+        let divisor = self.serial_bit_cck();
+        self.serial.baud_changed(PAULA_CLOCK_HZ / divisor);
+    }
+
     /// INTENA writes use SET/CLR semantics on bit 15.
     pub fn write_intena(&mut self, val: u16) {
         let bits = val & 0x7FFF;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -141,6 +141,12 @@ pub struct CliArgs {
     /// analogue controller's stick/paddle position (each axis 0-255, the
     /// count POTxDAT latches). PORT defaults to 2 (carried 0-based).
     pub pot_after: Vec<(f32, u8, u8, u8)>,
+    /// `--pen-after SECS X Y [PORT]`: at SECS emulated seconds, hold the
+    /// light pen over presented pixel (X, Y) -- the `--mouse-to-after`
+    /// coordinates -- or lift it off the glass with a negative
+    /// coordinate. PORT (carried 0-based) names the port the pen must be
+    /// in; `None` means whichever port has the pen.
+    pub pen_after: Vec<(f32, i32, i32, Option<u8>)>,
     /// `--record-input PATH`: record every input event that reaches the
     /// emulated machine for the whole run and write the scripted-input
     /// file to PATH on exit (the windowed toggle is the host shortcut
@@ -183,6 +189,8 @@ pub struct CliArgs {
     pub calibrate_gamepad: bool,
     /// `--list-midi`: print the host MIDI endpoints and exit.
     pub list_midi: bool,
+    /// `--list-serial-ports`: print the host serial ports and exit.
+    pub list_serial_ports: bool,
     /// `--list-audio-devices`: print the host audio output devices and exit.
     pub list_audio_devices: bool,
     /// `--list-net-interfaces`: print adapters usable for bridging and exit.
@@ -229,7 +237,7 @@ pub fn parse_args() -> Result<CliArgs> {
 /// the flag names (without the leading dashes) whose effects accumulate;
 /// anything else in a script is an error so a typo cannot silently change
 /// emulator configuration.
-const SCRIPT_DIRECTIVES: [&str; 15] = [
+const SCRIPT_DIRECTIVES: [&str; 16] = [
     "press-after",
     "key-after",
     "type",
@@ -241,6 +249,7 @@ const SCRIPT_DIRECTIVES: [&str; 15] = [
     "mouse-after",
     "mouse-to-after",
     "pot-after",
+    "pen-after",
     "insert-disk-after",
     "defer-disk-insert",
     "insert-cd-after",
@@ -356,17 +365,27 @@ fn take_port_token(
     args: &mut std::iter::Peekable<impl Iterator<Item = String>>,
     default_port: u8,
 ) -> u8 {
-    match args.peek().map(String::as_str) {
-        Some("1") => {
-            args.next();
-            0
-        }
-        Some("2") => {
-            args.next();
-            1
-        }
-        _ => default_port - 1,
-    }
+    take_port_token_upto(args, 2).unwrap_or(default_port - 1)
+}
+
+/// Consume an optional trailing PORT token naming one of the first
+/// `max_port` ports (1-based on the command line, returned 0-based), or
+/// leave the argument stream alone when the next token is not one. The
+/// game ports are 1 and 2; the parallel-port adapter's sockets are 3 and 4,
+/// which only the joystick directive can address.
+fn take_port_token_upto(
+    args: &mut std::iter::Peekable<impl Iterator<Item = String>>,
+    max_port: u8,
+) -> Option<u8> {
+    let port = match args.peek().map(String::as_str) {
+        Some("1") => 0,
+        Some("2") => 1,
+        Some("3") if max_port >= 3 => 2,
+        Some("4") if max_port >= 4 => 3,
+        _ => return None,
+    };
+    args.next();
+    Some(port)
 }
 
 pub fn parse_args_from<I>(args: I) -> Result<CliArgs>
@@ -418,6 +437,7 @@ where
     let mut mouse_after: Vec<(f32, i32, i32, u8)> = Vec::new();
     let mut mouse_to_after: Vec<(f32, i32, i32, u8)> = Vec::new();
     let mut pot_after: Vec<(f32, u8, u8, u8)> = Vec::new();
+    let mut pen_after: Vec<(f32, i32, i32, Option<u8>)> = Vec::new();
     let mut record_input: Option<PathBuf> = None;
     let mut wave_path: Option<PathBuf> = None;
     let mut wave_trigger: Option<copperline::waveform::Trigger> = None;
@@ -436,6 +456,7 @@ where
     let mut live_audio_profile_secs: Option<f32> = None;
     let mut calibrate_gamepad = false;
     let mut list_midi = false;
+    let mut list_serial_ports = false;
     let mut list_audio_devices = false;
     let mut list_net_interfaces = false;
     let mut list_disks = false;
@@ -451,6 +472,9 @@ where
         match a.as_str() {
             "--calibrate-gamepad" => {
                 calibrate_gamepad = true;
+            }
+            "--list-serial-ports" => {
+                list_serial_ports = true;
             }
             "--list-midi" => {
                 list_midi = true;
@@ -479,6 +503,18 @@ where
                     ));
                 }
                 host_disk_broker = Some(rest);
+            }
+            "--pcmcia-cf" => {
+                let path = args
+                    .next()
+                    .ok_or_else(|| anyhow!("--pcmcia-cf requires PATH (a hard-disk image)"))?;
+                overrides.pcmcia_cf = Some(path);
+            }
+            "--pcmcia-sram" => {
+                let size = args
+                    .next()
+                    .ok_or_else(|| anyhow!("--pcmcia-sram requires SIZE (64K..4M)"))?;
+                overrides.pcmcia_sram = Some(size);
             }
             "--host-disk" | "--host-disk-read-only" => {
                 let read_only = a == "--host-disk-read-only";
@@ -802,8 +838,22 @@ where
             }
             "--port2" => {
                 overrides.port2 = Some(args.next().ok_or_else(|| {
-                    anyhow!("--port2 requires a device (mouse/joystick/cd32/analogue/none)")
+                    anyhow!(
+                        "--port2 requires a device (mouse/joystick/cd32/analogue/lightpen/none)"
+                    )
                 })?);
+            }
+            "--port3" => {
+                overrides.port3 = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow!("--port3 requires a device (joystick/none)"))?,
+                );
+            }
+            "--port4" => {
+                overrides.port4 = Some(
+                    args.next()
+                        .ok_or_else(|| anyhow!("--port4 requires a device (joystick/none)"))?,
+                );
             }
             "--autofire" => {
                 let value = args
@@ -889,7 +939,15 @@ where
             }
             "--serial" => {
                 overrides.serial = Some(args.next().ok_or_else(|| {
-                    anyhow!("--serial requires a mode (off/stdout/midi/tcp/tcp-connect/pty/modem)")
+                    anyhow!(
+                        "--serial requires a mode \
+                         (off/stdout/midi/tcp/tcp-connect/pty/modem/device)"
+                    )
+                })?);
+            }
+            "--serial-device" => {
+                overrides.serial_device = Some(args.next().ok_or_else(|| {
+                    anyhow!("--serial-device requires a host serial port (/dev/tty... or COMn)")
                 })?);
             }
             "--serial-connect" => {
@@ -940,7 +998,7 @@ where
             }
             "--parallel" => {
                 overrides.parallel = Some(args.next().ok_or_else(|| {
-                    anyhow!("--parallel requires a device (none/printer/sampler)")
+                    anyhow!("--parallel requires a device (none/printer/sampler/joystick-adapter)")
                 })?);
             }
             "--sampler-audio-input" => {
@@ -1028,8 +1086,16 @@ where
                 })?;
                 let dur_ms: u32 =
                     next_arg(&mut args, USAGE, "--joy-after DURATION_MS must be a number")?;
-                let port = take_port_token(&mut args, 2);
+                let port = take_port_token_upto(&mut args, 4).unwrap_or(1);
                 joy_after.push((secs, button, dur_ms, port));
+            }
+            "--pen-after" => {
+                const USAGE: &str = "--pen-after requires SECS X Y";
+                let secs: f32 = next_arg(&mut args, USAGE, "--pen-after SECS must be a number")?;
+                let x: i32 = next_arg(&mut args, USAGE, "--pen-after X must be an integer")?;
+                let y: i32 = next_arg(&mut args, USAGE, "--pen-after Y must be an integer")?;
+                let port = take_port_token_upto(&mut args, 2);
+                pen_after.push((secs, x, y, port));
             }
             "--mouse-to-after" => {
                 const USAGE: &str = "--mouse-to-after requires SECS X Y";
@@ -1605,6 +1671,7 @@ where
         mouse_after,
         mouse_to_after,
         pot_after,
+        pen_after,
         record_input,
         disk_insert_after,
         cd_insert_after,
@@ -1617,6 +1684,7 @@ where
         live_audio_profile_secs,
         calibrate_gamepad,
         list_midi,
+        list_serial_ports,
         list_audio_devices,
         list_net_interfaces,
         list_disks,
@@ -1732,9 +1800,13 @@ fn print_help() {
          --floppy-speed PERCENT         drive speed: 100, 200, 400, 800, or 0 (turbo)\n  \
          {floppy_bridge}--host-disk DEVICE [ATTACH]    give the machine one of the host's own disks\n  \
          \x20                            (--list-disks names them); ATTACH is ide-master\n  \
-         \x20                            (default), ide-slave, or scsi0..scsi6\n  \
+         \x20                            (default), ide-slave, scsi0..scsi6, or pcmcia\n  \
          --host-disk-read-only DEVICE [ATTACH]\n  \
          \x20                            the same, but the guest cannot write to the disk\n  \
+         --pcmcia-cf PATH               a CompactFlash card in the A600/A1200 PCMCIA slot,\n  \
+         \x20                            over a hard-disk image ([pcmcia] card = \"cf\")\n  \
+         --pcmcia-sram SIZE             an SRAM card in the PCMCIA slot, 64K..4M, session-only\n  \
+         \x20                            ([pcmcia] card = \"sram\")\n  \
          --rtc-time TIME                seed the battery clock (implies fitting one) with\n  \
          \x20                            Unix seconds or \"YYYY-MM-DD HH:MM[:SS]\"; it then\n  \
          \x20                            ticks in emulated time, so runs are deterministic\n  \
@@ -1744,9 +1816,13 @@ fn print_help() {
          --mouse-sensitivity N          host mouse sensitivity 0-100 (50 default = 1:1)\n  \
          --mouse-capture MODE           when to grab the host mouse: click (default), auto, manual\n  \
          --port1 DEVICE                 controller in port 1: mouse (default), joystick,\n  \
-         \x20                            cd32, analogue, or none\n  \
+         \x20                            cd32, analogue, lightpen, or none\n  \
          --port2 DEVICE                 controller in port 2 (default: joystick;\n  \
          \x20                            cd32 on the CD32 profile)\n  \
+         --port3 DEVICE                 joystick or none in the parallel-port four-player\n  \
+         \x20                            adapter's first socket (implies --parallel\n  \
+         \x20                            joystick-adapter)\n  \
+         --port4 DEVICE                 joystick or none in the adapter's second socket\n  \
          --autofire HZ                  pulse a held fire button at HZ (0 = off, the default)\n  \
          --netplay-host PATH            host Internet netplay; write invitation to PATH\n  \
          --netplay-join CODE            join a desktop Internet invitation\n  \
@@ -1807,7 +1883,11 @@ fn print_help() {
          \x20                            release MS ms later, on PORT (default 1)\n  \
          --joy-after SECS BTN MS [PORT] press joystick/CD32-pad BTN (up/down/left/right/\n  \
          \x20                            red|fire/blue/green/yellow/play/rwd/ffw) at SECS,\n  \
-         \x20                            release MS ms later, on PORT (default 2)\n  \
+         \x20                            release MS ms later, on PORT 1-4 (default 2;\n  \
+         \x20                            3 and 4 are the parallel-port adapter's sockets)\n  \
+         --pen-after SECS X Y [PORT]    hold the light pen over screen pixel (X, Y) from\n  \
+         \x20                            SECS (the --mouse-to-after coordinates; -1 -1\n  \
+         \x20                            lifts it off), on PORT (default: the pen's port)\n  \
          --mouse-after SECS DX DY [PORT]\n  \
          \x20                            apply a relative mouse motion at SECS on PORT\n  \
          \x20                            (default 1)\n  \
@@ -1862,9 +1942,13 @@ fn print_help() {
          --mt32-pcm-rom PATH            MT-32 PCM ROM\n  \
          --mt32-panel                   show the MT-32 front panel\n  \
          --serial MODE                  Paula serial port: off, stdout, midi, tcp,\n  \
-         \x20                            tcp-connect, pty, or modem\n  \
+         \x20                            tcp-connect, pty, modem, or device\n  \
          --serial-connect HOST:PORT     dial a remote TCP service (a telnet BBS) with the\n  \
          \x20                            serial port (implies --serial tcp-connect)\n  \
+         --serial-device PATH           wire the serial port to a real host serial port\n  \
+         \x20                            (/dev/tty.usbserial-XXXX, /dev/ttyUSB0, COM3;\n  \
+         \x20                            implies --serial device)\n  \
+         --list-serial-ports            list host serial ports and exit\n  \
          --serial-session FILE          modem mode: replay a scripted session from FILE\n  \
          \x20                            instead of dialing out over TCP (implies\n  \
          \x20                            --serial modem); see docs/guide/modem.md\n  \
@@ -1876,7 +1960,8 @@ fn print_help() {
          \x20                            to real host OS sockets, bypassing the emulated\n  \
          \x20                            stack entirely)\n  \
          --hostsocket-interface NAME    bridge adapter; implies --hostsocket-net bridge\n  \
-         --parallel DEVICE              parallel port: none, printer, or sampler\n  \
+         --parallel DEVICE              parallel port: none, printer, sampler, or\n  \
+         \x20                            joystick-adapter (four-player ports 3 and 4)\n  \
          --sampler-audio-input NAME     sampler host capture device (implies --parallel sampler)\n  \
          --sampler-input-gain DB        sampler input gain in dB (implies --parallel sampler)\n  \
          --sampler-list-audio-inputs    list host audio input devices and exit\n  \

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2617,6 +2617,12 @@ impl Config {
         {
             return Some("hard-drive or ATAPI image");
         }
+        if !matches!(self.pcmcia.card, crate::config::PcmciaCardConfig::None) {
+            // A CF card is a hard-disk image by another name, and an SRAM
+            // card with a backing file persists too: speculative writes
+            // that are then rolled back would still reach the host.
+            return Some("PCMCIA card");
+        }
         if self.a2065_net.is_some() {
             return Some("A2065 network board");
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -256,6 +256,8 @@ pub struct Config {
     /// Gayle IDE drive images (raw flat HDF, RDB inside), opened
     /// read/write. Only valid on machines with a Gayle gate array.
     pub ide: IdeConfig,
+    /// `[pcmcia]`: the card in the Gayle machines' credit-card slot.
+    pub pcmcia: PcmciaConfig,
     /// SCSI controller (`[scsi]`): the `controller` selects an A2091 (Zorro II),
     /// an A4091 (Zorro III), or the A3000's motherboard SCSI, plus up to seven
     /// drive images on SCSI IDs 0-6. The Zorro boards autoconfig on the chain
@@ -426,6 +428,12 @@ pub struct Config {
     /// `input.set_port`) changes the live machine without affecting this
     /// start-up value.
     pub port_devices: [PortDevice; 2],
+    /// Whether a joystick sits in each socket of the parallel-port
+    /// four-player adapter (`[input] port3` / `port4`, `--port3` /
+    /// `--port4`); index 0 = port 3. Only meaningful with
+    /// `[parallel] device = "joystick-adapter"`, which naming a joystick
+    /// here implies.
+    pub parallel_joysticks: [bool; 2],
     /// Host wiring for Paula's serial port (`[serial]` / `--serial`).
     /// Defaults to [`SerialMode::Stdout`], preserving the historical
     /// terminal-diagnostics behaviour.
@@ -896,6 +904,12 @@ pub enum SerialMode {
     /// [`Tcp`]: SerialMode::Tcp
     /// [`TcpConnect`]: SerialMode::TcpConnect
     Modem,
+    /// Serial in/out is wired to a real host serial port (the path in
+    /// [`SerialConfig::device`]): a USB adapter on a null-modem cable to
+    /// a real Amiga or PC. The host port follows the guest's SERPER rate
+    /// and stop bits, DTR/RTS drive the port's pins, and CTS/DSR/DCD come
+    /// back on CIA-B. Needs a build with the `host-serial` feature.
+    Device,
 }
 
 impl SerialMode {
@@ -909,6 +923,7 @@ impl SerialMode {
             Self::TcpConnect => "tcp-connect",
             Self::Pty => "pty",
             Self::Modem => "modem",
+            Self::Device => "device",
         }
     }
 }
@@ -946,6 +961,11 @@ pub struct SerialConfig {
     /// Remote `host:port` for [`SerialMode::TcpConnect`]. Required in that
     /// mode (there is no sensible default host to dial).
     pub connect: Option<String>,
+    /// Host serial port for [`SerialMode::Device`]: a device path
+    /// (`/dev/tty.usbserial-XXXX`, `/dev/ttyUSB0`) or a Windows COM name
+    /// (`COM3`). Required in that mode; carried through the others so the
+    /// configuration screen round-trips it.
+    pub device: Option<String>,
     /// `AT*T1`/`AT*T0` default at power-on: telnet NVT translation on by
     /// default. [`SerialMode::Modem`] only. Tri-state on purpose: `None` is
     /// "the config never said", which defers to a stored `AT&W` profile's
@@ -1074,6 +1094,10 @@ pub enum ParallelDevice {
     /// An 8-bit audio sampler (digitizer) on the data lines, fed from a host
     /// capture device. Needs a build with the `frontend` feature (cpal).
     Sampler,
+    /// The passive four-player joystick adapter (ports 3 and 4): switch
+    /// joysticks on the data lines and the Centronics status lines, as
+    /// Kick Off 2, Sensible Soccer, Dyna Blaster and the like read them.
+    JoystickAdapter,
 }
 
 impl ParallelDevice {
@@ -1083,6 +1107,7 @@ impl ParallelDevice {
             Self::None => "none",
             Self::Printer => "printer",
             Self::Sampler => "sampler",
+            Self::JoystickAdapter => "joystick-adapter",
         }
     }
 }
@@ -1156,22 +1181,71 @@ pub const HARDFILE_DEFAULT_BOOT_PRI: i8 = 0;
 pub const BOOT_PRI_NEVER: i8 = -128;
 
 /// Whether a drive-image path names a CD image (a cue sheet, a bare ISO,
-/// a Nero NRG, or a CHD). On the SCSI bus such an entry attaches a CD-ROM drive
-/// instead of a hard disk; the file extension is the format signal,
-/// exactly as it is for the hard-drive back ends (HDF vs. directory).
+/// a Nero NRG, or a CD-ROM CHD). On the SCSI bus such an entry attaches a
+/// CD-ROM drive instead of a hard disk; the file extension is the format
+/// signal, exactly as it is for the hard-drive back ends (HDF vs.
+/// directory) -- except for `.chd`, which chdman writes for hard disks
+/// (`createhd`) as well as CDs (`createcd`). A `.chd` is read to see which
+/// it holds; one that cannot be read (not there yet, say) keeps counting
+/// as a CD, so the open that follows reports the real problem.
 pub fn is_cd_image_path(path: &std::path::Path) -> bool {
-    path.extension().and_then(|e| e.to_str()).is_some_and(|e| {
-        e.eq_ignore_ascii_case("cue")
-            || e.eq_ignore_ascii_case("iso")
-            || e.eq_ignore_ascii_case("nrg")
-            || e.eq_ignore_ascii_case("chd")
-    })
+    let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+        return false;
+    };
+    if ext.eq_ignore_ascii_case("chd") {
+        return !crate::harddrive::chd::is_hard_disk_chd(path);
+    }
+    ext.eq_ignore_ascii_case("cue")
+        || ext.eq_ignore_ascii_case("iso")
+        || ext.eq_ignore_ascii_case("nrg")
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct IdeConfig {
     pub master: Option<DriveImage>,
     pub slave: Option<DriveImage>,
+}
+
+/// The card `[pcmcia]` puts in the A600/A1200 slot.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum PcmciaCardConfig {
+    /// An empty socket.
+    #[default]
+    None,
+    /// A CompactFlash (PCMCIA ATA) card over a hard-disk image: anything
+    /// the `[ide]` drive backend opens.
+    Cf { path: PathBuf },
+    /// An SRAM memory card of `size` bytes, optionally mirrored to a host
+    /// file, with its write-protect switch set by `read_only`.
+    Sram {
+        size: usize,
+        path: Option<PathBuf>,
+        read_only: bool,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PcmciaConfig {
+    pub card: PcmciaCardConfig,
+}
+
+impl PcmciaConfig {
+    /// Whether a card is configured at all.
+    pub fn is_present(&self) -> bool {
+        self.card != PcmciaCardConfig::None
+    }
+
+    /// One line for logs.
+    pub fn describe(&self) -> String {
+        match &self.card {
+            PcmciaCardConfig::None => "empty".to_string(),
+            PcmciaCardConfig::Cf { path } => format!("CF card {}", path.display()),
+            PcmciaCardConfig::Sram { size, path, .. } => match path {
+                Some(p) => format!("SRAM card {} KiB ({})", size / 1024, p.display()),
+                None => format!("SRAM card {} KiB", size / 1024),
+            },
+        }
+    }
 }
 
 /// Which RTG graphics card the `[rtg]` section fits. A machine has at most
@@ -1698,6 +1772,9 @@ pub enum HostDiskAttach {
     LideSlave(u8),
     /// A unit on whichever SCSI controller the machine has fitted.
     Scsi(u8),
+    /// The A600/A1200 PCMCIA slot, as a CompactFlash card: the card a real
+    /// Amiga's owner carries in a reader goes straight in.
+    Pcmcia,
 }
 
 /// SCSI units a controller addresses. Unit 7 is the controller itself.
@@ -1712,6 +1789,7 @@ impl HostDiskAttach {
             Self::LideMaster(ch) => format!("lide{ch}-master"),
             Self::LideSlave(ch) => format!("lide{ch}-slave"),
             Self::Scsi(unit) => format!("scsi{unit}"),
+            Self::Pcmcia => "pcmcia".to_string(),
         }
     }
 
@@ -1723,7 +1801,13 @@ impl HostDiskAttach {
             Self::LideMaster(ch) => format!("Lide {ch} Master"),
             Self::LideSlave(ch) => format!("Lide {ch} Slave"),
             Self::Scsi(unit) => format!("SCSI Unit {unit}"),
+            Self::Pcmcia => "PCMCIA Slot".to_string(),
         }
+    }
+
+    /// Whether this is the PCMCIA slot.
+    pub fn is_pcmcia(self) -> bool {
+        self == Self::Pcmcia
     }
 
     /// What a machine with no way to attach a host disk at all is missing.
@@ -1740,6 +1824,7 @@ impl HostDiskAttach {
             Self::IdeMaster | Self::IdeSlave => "Attach to IDE requires an A600, A1200 or A4000",
             Self::LideMaster(_) | Self::LideSlave(_) => "Attach to Lide requires a [lide] board",
             Self::Scsi(_) => "Attach to SCSI requires a SCSI controller",
+            Self::Pcmcia => "Attach to PCMCIA requires an A600 or A1200",
         }
     }
 
@@ -1759,6 +1844,7 @@ impl HostDiskAttach {
             Self::LideSlave(1),
         ];
         all.extend((0..SCSI_UNITS).map(Self::Scsi));
+        all.push(Self::Pcmcia);
         all
     }
 
@@ -2467,6 +2553,7 @@ impl Default for Config {
             video_standard: VideoStandard::Pal,
             audio: AudioConfig::default(),
             ide: IdeConfig::default(),
+            pcmcia: PcmciaConfig::default(),
             scsi: ScsiConfig::default(),
             copperhf: CopperhfConfig::default(),
             lide: LideConfig::default(),
@@ -2502,6 +2589,7 @@ impl Default for Config {
             mouse_capture: MouseCapture::Click,
             autofire_hz: 0,
             port_devices: [PortDevice::Mouse, PortDevice::Joystick],
+            parallel_joysticks: [false; 2],
             serial: SerialConfig::default(),
             parallel: ParallelConfig::default(),
             paths: crate::pathconf::Paths::default(),
@@ -2593,6 +2681,16 @@ impl Config {
         }
     }
 
+    /// Whether Zorro II fast RAM shadows the PCMCIA slot: the slot's common
+    /// memory window is `$600000`-`$9FFFFF`, and fast RAM configures upward
+    /// from `$200000`, so more than 4 MiB of it reaches into the window and
+    /// Gayle's PCMCIA decode gives way to the RAM board. Only meaningful on
+    /// a machine with a slot.
+    pub fn pcmcia_slot_shadowed(&self) -> bool {
+        self.gate_array.gayle_id().is_some()
+            && self.fast_ram_bytes > crate::pcmcia::MAX_FAST_RAM_WITH_SLOT
+    }
+
     /// Build the Zorro autoconfig chain this config asks for: the built-in
     /// Zorro II fast RAM board, the built-in Zorro III RAM board, any
     /// `[[zorro]]` metadata boards in file order, and finally (unless
@@ -2657,6 +2755,12 @@ pub struct ConfigOverrides {
     pub chip: Option<String>,
     pub fast: Option<String>,
     pub slow: Option<String>,
+    /// A CompactFlash card in the PCMCIA slot (`--pcmcia-cf PATH`): sets
+    /// `[pcmcia] card = "cf"` with that image.
+    pub pcmcia_cf: Option<String>,
+    /// An SRAM card in the PCMCIA slot (`--pcmcia-sram SIZE`): sets
+    /// `[pcmcia] card = "sram"` with that size, session-only.
+    pub pcmcia_sram: Option<String>,
     /// RAM power-on policy (`--ram-init`). Same syntax as `[memory] init`.
     pub ram_init: Option<String>,
     /// Ramsey motherboard fast RAM size (`--motherboard`). Same parser as
@@ -2684,6 +2788,11 @@ pub struct ConfigOverrides {
     pub port1: Option<String>,
     /// Device in game port 2 (`--port2`). Same parser as `[input] port2`.
     pub port2: Option<String>,
+    /// Joystick in the parallel-port adapter's sockets (`--port3` /
+    /// `--port4`): "joystick" or "none". Same parser as `[input] port3` /
+    /// `port4`.
+    pub port3: Option<String>,
+    pub port4: Option<String>,
     /// Autofire rate in Hz (`--autofire`), 0 for off. Same validation as
     /// `[input] autofire_hz`.
     pub autofire_hz: Option<u8>,
@@ -2691,13 +2800,16 @@ pub struct ConfigOverrides {
     /// `[emulation] run_ahead_frames`.
     pub run_ahead_frames: Option<u8>,
     /// Serial port wiring (`--serial`): "off", "stdout", "midi", "tcp",
-    /// "tcp-connect", or "pty" ("none" and "terminal" parse as
-    /// compatibility aliases of the first two). Same parser as
+    /// "tcp-connect", "pty", "modem", or "device" ("none" and "terminal"
+    /// parse as compatibility aliases of the first two). Same parser as
     /// `[serial] mode`.
     pub serial: Option<String>,
     /// Remote host:port the serial port dials (`--serial-connect`),
     /// implying `--serial tcp-connect`.
     pub serial_connect: Option<String>,
+    /// Host serial port to wire the serial port to (`--serial-device`),
+    /// implying `--serial device`. Same as `[serial] device`.
+    pub serial_device: Option<String>,
     /// A scripted session file to replay (`--serial-session`), implying
     /// `--serial modem`. Same as `[serial] session`.
     pub serial_session: Option<String>,
@@ -2825,6 +2937,8 @@ impl ConfigOverrides {
             && self.mouse_capture.is_none()
             && self.port1.is_none()
             && self.port2.is_none()
+            && self.port3.is_none()
+            && self.port4.is_none()
             && self.autofire_hz.is_none()
             && self.run_ahead_frames.is_none()
             && self.serial.is_none()
@@ -2902,6 +3016,20 @@ impl ConfigOverrides {
         }
         if let Some(speed) = self.floppy_speed {
             raw.floppy.speed = Some(speed);
+        }
+        if let Some(path) = &self.pcmcia_cf {
+            raw.pcmcia = RawPcmcia {
+                card: Some("cf".to_string()),
+                path: Some(path.clone()),
+                ..RawPcmcia::default()
+            };
+        }
+        if let Some(size) = &self.pcmcia_sram {
+            raw.pcmcia = RawPcmcia {
+                card: Some("sram".to_string()),
+                size: Some(size.clone()),
+                ..RawPcmcia::default()
+            };
         }
         // Real host disks named on the command line are added to whatever the
         // file already asked for; the parser is what refuses two disks, or a
@@ -2984,6 +3112,12 @@ impl ConfigOverrides {
         if let Some(port2) = &self.port2 {
             raw.input.port2 = Some(port2.clone());
         }
+        if let Some(port3) = &self.port3 {
+            raw.input.port3 = Some(port3.clone());
+        }
+        if let Some(port4) = &self.port4 {
+            raw.input.port4 = Some(port4.clone());
+        }
         if let Some(hz) = self.autofire_hz {
             raw.input.autofire_hz = Some(hz);
         }
@@ -2998,6 +3132,9 @@ impl ConfigOverrides {
         }
         if let Some(path) = &self.serial_session {
             raw.serial.session = Some(path.clone());
+        }
+        if let Some(device) = &self.serial_device {
+            raw.serial.device = Some(device.clone());
         }
         if let Some(out) = &self.midi_out {
             raw.serial.midi_out = Some(out.clone());
@@ -3024,6 +3161,15 @@ impl ConfigOverrides {
             && self.serial_session.is_some()
         {
             raw.serial.mode = Some(SerialMode::Modem.label().to_string());
+        }
+        if self.serial.is_none()
+            && self.midi_out.is_none()
+            && self.midi_in.is_none()
+            && self.serial_connect.is_none()
+            && self.serial_session.is_none()
+            && self.serial_device.is_some()
+        {
+            raw.serial.mode = Some(SerialMode::Device.label().to_string());
         }
         if let Some(device) = &self.parallel {
             raw.parallel.device = Some(device.clone());

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -76,6 +76,8 @@ pub struct RawConfig {
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) ide: RawIde,
     #[serde(default, skip_serializing_if = "is_default")]
+    pub(crate) pcmcia: RawPcmcia,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) scsi: RawScsi,
     #[serde(default, skip_serializing_if = "is_default")]
     pub(crate) copperhf: RawCopperhf,
@@ -272,6 +274,8 @@ impl RawConfig {
         take(&mut self.display.full_screen, &overlay.display.full_screen);
         take(&mut self.input.port1, &overlay.input.port1);
         take(&mut self.input.port2, &overlay.input.port2);
+        take(&mut self.input.port3, &overlay.input.port3);
+        take(&mut self.input.port4, &overlay.input.port4);
         take(&mut self.input.joystick, &overlay.input.joystick);
         take(&mut self.input.autofire_hz, &overlay.input.autofire_hz);
         take(&mut self.audio.output_device, &overlay.audio.output_device);
@@ -533,6 +537,15 @@ pub(crate) struct RawInput {
     /// ("cd32" on the CD32 profile).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) port2: Option<String>,
+    /// Joystick in the parallel-port four-player adapter's first socket:
+    /// "joystick" or "none". Naming one fits the adapter
+    /// (`[parallel] device = "joystick-adapter"`); an adapter named there
+    /// fills every socket these keys leave unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) port3: Option<String>,
+    /// Joystick in the adapter's second socket: same values.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) port4: Option<String>,
     /// Host mouse sensitivity, 0-100 (default 50).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) mouse_sensitivity: Option<u16>,
@@ -549,7 +562,8 @@ pub(crate) struct RawInput {
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawSerial {
-    /// "stdout" (default), "off", "midi", "tcp", "tcp-connect", or "pty".
+    /// "stdout" (default), "off", "midi", "tcp", "tcp-connect", "pty",
+    /// "modem", or "device".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) mode: Option<String>,
     /// Host MIDI output endpoint name (substring match); MIDI mode only.
@@ -588,6 +602,10 @@ pub(crate) struct RawSerial {
     /// Remote host:port to dial; tcp-connect mode only, and required there.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) connect: Option<String>,
+    /// Host serial port path (or Windows COM name); device mode only, and
+    /// required there.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) device: Option<String>,
     /// AT*T1/AT*T0 default at power-on: telnet NVT translation (the
     /// WiModem extra) on by default. Modem mode only. Defaults to false.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -767,6 +785,26 @@ pub(crate) struct RawIde {
     pub(crate) master: Option<RawDrive>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) slave: Option<RawDrive>,
+}
+
+/// `[pcmcia]`: the card in the A600/A1200 credit-card slot.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RawPcmcia {
+    /// "none" (the default), "cf" (a CompactFlash/ATA card over a hard-disk
+    /// image), or "sram" (a static-RAM memory card).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) card: Option<String>,
+    /// CF: the image (anything `[ide]` accepts). SRAM: an optional file the
+    /// card's contents are read from and written back to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) path: Option<String>,
+    /// SRAM: the card's size, up to 4M.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) size: Option<String>,
+    /// SRAM: the card's write-protect switch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) read_only: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5562,6 +5562,21 @@ fn runahead_machine_gate_rejects_host_coupled_storage() -> Result<()> {
         cfg.runahead_machine_block_reason(),
         Some("hard-drive or ATAPI image")
     );
+
+    // A card in the PCMCIA slot is host-coupled storage too: a CF card is
+    // a hard-disk image, and an SRAM card with a backing file persists.
+    for body in [
+        "[pcmcia]\ncard = \"cf\"\npath = \"card.hdf\"",
+        "[pcmcia]\ncard = \"sram\"\nsize = \"1M\"\npath = \"sram.bin\"",
+        "[pcmcia]\ncard = \"sram\"\nsize = \"1M\"",
+    ] {
+        let cfg = parse_config(&format!("[machine]\nprofile = \"A1200\"\n{body}\n"))?;
+        assert_eq!(
+            cfg.runahead_machine_block_reason(),
+            Some("PCMCIA card"),
+            "for {body}"
+        );
+    }
     Ok(())
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -2757,6 +2757,70 @@ fn cd_images_fit_scsi_units_and_the_ide_port() -> Result<()> {
     Ok(())
 }
 
+/// A `.chd` is a CD image or a hard disk depending on what chdman put in
+/// it: the metadata tag decides, not the extension. A hard-disk CHD is
+/// therefore welcome on `[copperhf]`, which takes hard disks only, while a
+/// CD one is still refused there.
+#[test]
+fn chd_images_classify_by_their_metadata_not_their_extension() -> Result<()> {
+    use crate::harddrive::chd::tests::{write_chd_v5, write_hard_disk};
+    let dir = std::env::temp_dir().join(format!(
+        "copperline-config-chd-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir)?;
+    let hd = dir.join("disk.chd");
+    write_hard_disk(&hd, 8, [1; 20]);
+    let cd = dir.join("game.chd");
+    write_chd_v5(
+        &cd,
+        2448 * 2,
+        2448,
+        &[0u8; 2448 * 4],
+        &[(
+            *b"CHT2",
+            b"TRACK:1 TYPE:MODE1 SUBTYPE:NONE FRAMES:4\0".to_vec(),
+        )],
+        [2; 20],
+    );
+
+    assert!(!is_cd_image_path(&hd), "GDDD metadata makes it a hard disk");
+    assert!(is_cd_image_path(&cd), "CD track metadata makes it a CD");
+    assert!(
+        is_cd_image_path(&dir.join("missing.chd")),
+        "an unreadable .chd keeps its traditional reading"
+    );
+
+    let toml_path = |p: &Path| p.to_string_lossy().replace('\\', "\\\\");
+    let cfg = parse_config(&format!(
+        r#"
+            [copperhf]
+            unit0 = "{}"
+            "#,
+        toml_path(&hd)
+    ))?;
+    assert_eq!(
+        cfg.copperhf.units[0].as_ref().map(|d| d.path.clone()),
+        Some(hd.clone())
+    );
+    let err = parse_config(&format!(
+        r#"
+            [copperhf]
+            unit0 = "{}"
+            "#,
+        toml_path(&cd)
+    ))
+    .unwrap_err();
+    assert!(err.to_string().contains("hard disks only"), "{err:#}");
+
+    let _ = fs::remove_dir_all(&dir);
+    Ok(())
+}
+
 /// The A3000's SCSI is motherboard silicon: its drives need no boot ROM,
 /// they are the default on that machine, and they fit nowhere else.
 #[test]
@@ -5498,5 +5562,294 @@ fn runahead_machine_gate_rejects_host_coupled_storage() -> Result<()> {
         cfg.runahead_machine_block_reason(),
         Some("hard-drive or ATAPI image")
     );
+    Ok(())
+}
+
+#[test]
+fn parallel_adapter_sockets_and_the_light_pen_parse() -> Result<()> {
+    // The adapter alone fills both sockets.
+    let cfg = parse_config("[parallel]\ndevice = \"joystick-adapter\"\n")?;
+    assert_eq!(cfg.parallel.device, ParallelDevice::JoystickAdapter);
+    assert_eq!(cfg.parallel_joysticks, [true, true]);
+    // A socket named implies the adapter; an unnamed socket stays empty.
+    let cfg = parse_config("[input]\nport3 = \"joystick\"\n")?;
+    assert_eq!(cfg.parallel.device, ParallelDevice::JoystickAdapter);
+    assert_eq!(cfg.parallel_joysticks, [true, false]);
+    let cfg =
+        parse_config("[parallel]\ndevice = \"joystick-adapter\"\n[input]\nport4 = \"none\"\n")?;
+    assert_eq!(cfg.parallel_joysticks, [true, false]);
+    assert_eq!(parse_config("")?.parallel_joysticks, [false, false]);
+    // A joystick on a connector another peripheral owns is a conflict.
+    let err = parse_config(
+        "[parallel]\ndevice = \"printer\"\noutput = \"p.raw\"\n[input]\nport3 = \"joystick\"\n",
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("port3"), "{err}");
+    // Only switch joysticks fit the adapter.
+    let err = parse_config("[input]\nport4 = \"cd32\"\n").unwrap_err();
+    assert!(err.to_string().contains("port4"), "{err}");
+    // The pen, by any of its names, in either game port.
+    for text in ["lightpen", "lightgun", "light-pen"] {
+        let cfg = parse_config(&format!("[input]\nport2 = {text:?}\n"))?;
+        assert_eq!(cfg.port_devices[1], PortDevice::LightPen, "for {text:?}");
+    }
+    assert_eq!(
+        parse_config("[input]\nport1 = \"lightpen\"\n")?.port_devices[0],
+        PortDevice::LightPen
+    );
+    // The CLI overrides reach the same keys.
+    let overrides = ConfigOverrides {
+        port3: Some("joystick".to_string()),
+        port4: Some("joystick".to_string()),
+        ..ConfigOverrides::default()
+    };
+    assert!(!overrides.is_empty());
+    let cfg = load_overrides(&overrides)?;
+    assert_eq!(cfg.parallel.device, ParallelDevice::JoystickAdapter);
+    assert_eq!(cfg.parallel_joysticks, [true, true]);
+    Ok(())
+}
+
+/// `[pcmcia]` needs the Gayle machines' slot, names its card properly, and
+/// the SRAM size must fit the common window and the CIS size encoding.
+#[test]
+fn pcmcia_section_parses_cf_and_sram_cards_and_needs_a_slot() {
+    let err = parse_config(
+        r#"
+            [pcmcia]
+            card = "cf"
+            path = "card.hdf"
+            "#,
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("PCMCIA slot"), "{err:#}");
+
+    let cfg = parse_config(
+        r#"
+            [machine]
+            profile = "A1200"
+            [pcmcia]
+            card = "cf"
+            path = "card.hdf"
+            "#,
+    )
+    .unwrap();
+    assert_eq!(
+        cfg.pcmcia.card,
+        PcmciaCardConfig::Cf {
+            path: PathBuf::from("card.hdf")
+        }
+    );
+    assert!(!cfg.pcmcia_slot_shadowed(), "2M fast RAM leaves the slot");
+
+    let cfg = parse_config(
+        r#"
+            [machine]
+            profile = "A600"
+            [pcmcia]
+            card = "sram"
+            size = "2M"
+            path = "sram.bin"
+            read_only = true
+            "#,
+    )
+    .unwrap();
+    assert_eq!(
+        cfg.pcmcia.card,
+        PcmciaCardConfig::Sram {
+            size: 2 * 1024 * 1024,
+            path: Some(PathBuf::from("sram.bin")),
+            read_only: true,
+        }
+    );
+
+    for (body, needle) in [
+        ("card = \"cf\"", "needs path"),
+        ("card = \"sram\"", "needs size"),
+        ("card = \"sram\"\nsize = \"8M\"", "between 64K and 4M"),
+        ("card = \"sram\"\nsize = \"1088K\"", "CIS"),
+        ("card = \"flash\"", "not known"),
+        ("path = \"x.hdf\"", "names no card type"),
+        (
+            "card = \"cf\"\npath = \"x.hdf\"\nsize = \"1M\"",
+            "SRAM card",
+        ),
+    ] {
+        let err = parse_config(&format!(
+            "[machine]\nprofile = \"A1200\"\n[pcmcia]\n{body}\n"
+        ))
+        .unwrap_err();
+        assert!(err.to_string().contains(needle), "{body}: {err:#}");
+    }
+}
+
+/// The Zorro II fast-RAM rule: more than 4M reaches the slot's common
+/// memory window, and the slot is reported shadowed; the configuration is
+/// still accepted (the machine warns at build time).
+#[test]
+fn pcmcia_slot_is_shadowed_by_more_than_4m_of_fast_ram() {
+    let cfg = parse_config(
+        r#"
+            [machine]
+            profile = "A1200"
+            [memory]
+            fast = "8M"
+            [pcmcia]
+            card = "sram"
+            size = "4M"
+            "#,
+    )
+    .unwrap();
+    assert!(cfg.pcmcia_slot_shadowed());
+    let cfg = parse_config(
+        r#"
+            [machine]
+            profile = "A1200"
+            [memory]
+            fast = "4M"
+            "#,
+    )
+    .unwrap();
+    assert!(!cfg.pcmcia_slot_shadowed());
+    // Not a Gayle machine: no slot to shadow.
+    let cfg = parse_config("[machine]\nprofile = \"A500\"\n[memory]\nfast = \"8M\"\n").unwrap();
+    assert!(!cfg.pcmcia_slot_shadowed());
+}
+
+/// A real disk on the slot needs the slot, and cannot share it with a
+/// `[pcmcia]` card; it does not count as a drive on the IDE port for the
+/// ROM scsi.device default.
+#[test]
+fn host_disk_on_the_pcmcia_slot_needs_a_free_slot() {
+    let err = parse_config(
+        r#"
+            [[host_disk]]
+            device = "sdb"
+            attach = "pcmcia"
+            "#,
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("A600 or A1200"), "{err:#}");
+
+    let err = parse_config(
+        r#"
+            [machine]
+            profile = "A1200"
+            [pcmcia]
+            card = "sram"
+            size = "1M"
+            [[host_disk]]
+            device = "sdb"
+            attach = "pcmcia"
+            "#,
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("one card"), "{err:#}");
+
+    let cfg = parse_config(
+        r#"
+            [machine]
+            profile = "A1200"
+            [[host_disk]]
+            device = "sdb"
+            attach = "pcmcia"
+            "#,
+    )
+    .unwrap();
+    assert_eq!(cfg.host_disks[0].attach, HostDiskAttach::Pcmcia);
+    assert!(
+        cfg.rom_scsi_device_disable,
+        "a card in the slot is not scsi.device's drive"
+    );
+    assert_eq!(
+        HostDiskAttach::from_token("PCMCIA"),
+        Some(HostDiskAttach::Pcmcia)
+    );
+}
+
+/// `--pcmcia-cf` and `--pcmcia-sram` write the `[pcmcia]` section.
+#[test]
+fn pcmcia_command_line_overrides_fill_the_section() -> Result<()> {
+    let cfg = load_overrides(&ConfigOverrides {
+        model: Some("A1200".to_string()),
+        pcmcia_cf: Some("cf.hdf".to_string()),
+        ..ConfigOverrides::default()
+    })?;
+    assert_eq!(
+        cfg.pcmcia.card,
+        PcmciaCardConfig::Cf {
+            path: PathBuf::from("cf.hdf")
+        }
+    );
+    let cfg = load_overrides(&ConfigOverrides {
+        model: Some("A600".to_string()),
+        pcmcia_sram: Some("512K".to_string()),
+        ..ConfigOverrides::default()
+    })?;
+    assert_eq!(
+        cfg.pcmcia.card,
+        PcmciaCardConfig::Sram {
+            size: 512 * 1024,
+            path: None,
+            read_only: false,
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn serial_section_selects_device_mode_and_port() -> Result<()> {
+    let cfg = parse_config("[serial]\nmode = \"device\"\ndevice = \"/dev/tty.usbserial-1420\"\n")?;
+    assert_eq!(cfg.serial.mode, SerialMode::Device);
+    assert_eq!(
+        cfg.serial.device.as_deref(),
+        Some("/dev/tty.usbserial-1420")
+    );
+    // A Windows COM name is a plain string too, and whitespace around a
+    // path is not part of it. An empty one is no port at all.
+    let cfg = parse_config("[serial]\nmode = \"device\"\ndevice = \" COM3 \"\n")?;
+    assert_eq!(cfg.serial.device.as_deref(), Some("COM3"));
+    let cfg = parse_config("[serial]\nmode = \"device\"\ndevice = \"\"\n")?;
+    assert_eq!(cfg.serial.device, None);
+    // The path is carried in the other modes (the launcher round-trips
+    // it) and only opened in this one.
+    let cfg = parse_config("[serial]\nmode = \"stdout\"\ndevice = \"COM3\"\n")?;
+    assert_eq!(cfg.serial.mode, SerialMode::Stdout);
+    assert_eq!(cfg.serial.device.as_deref(), Some("COM3"));
+    // The mode list in the rejection names it.
+    let err = parse_config("[serial]\nmode = \"usb\"\n").unwrap_err();
+    assert!(err.to_string().contains("\"device\""), "{err:#}");
+    Ok(())
+}
+
+#[test]
+fn cli_serial_device_implies_device_mode() -> Result<()> {
+    // Like --serial-connect implying tcp-connect: naming a host port is
+    // enough, unless --serial explicitly chose another mode.
+    let overrides = ConfigOverrides {
+        serial_device: Some("/dev/ttyUSB0".to_string()),
+        ..Default::default()
+    };
+    let cfg = load_overrides(&overrides)?;
+    assert_eq!(cfg.serial.mode, SerialMode::Device);
+    assert_eq!(cfg.serial.device.as_deref(), Some("/dev/ttyUSB0"));
+
+    let overrides = ConfigOverrides {
+        serial: Some("off".to_string()),
+        serial_device: Some("/dev/ttyUSB0".to_string()),
+        ..Default::default()
+    };
+    let cfg = load_overrides(&overrides)?;
+    assert_eq!(cfg.serial.mode, SerialMode::Off);
+    assert_eq!(cfg.serial.device.as_deref(), Some("/dev/ttyUSB0"));
+
+    // The other implying flags outrank it, as they do each other.
+    let overrides = ConfigOverrides {
+        serial_connect: Some("bbs.example.com:1337".to_string()),
+        serial_device: Some("/dev/ttyUSB0".to_string()),
+        ..Default::default()
+    };
+    let cfg = load_overrides(&overrides)?;
+    assert_eq!(cfg.serial.mode, SerialMode::TcpConnect);
     Ok(())
 }

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -455,6 +455,22 @@ impl TryFrom<RawConfig> for Config {
                 Some(s) => parse_port_device(s, "port2")?,
             },
         ];
+        let adapter_named = raw.parallel.device.is_some();
+        let parallel = resolve_parallel(raw.parallel, &raw.input)?;
+        let parallel_joysticks = [
+            parse_parallel_socket(
+                raw.input.port3.as_deref(),
+                "port3",
+                parallel.device,
+                adapter_named,
+            )?,
+            parse_parallel_socket(
+                raw.input.port4.as_deref(),
+                "port4",
+                parallel.device,
+                adapter_named,
+            )?,
+        ];
         let serial = SerialConfig {
             mode: match raw.serial.mode.as_deref() {
                 None => defaults.serial.mode,
@@ -477,6 +493,13 @@ impl TryFrom<RawConfig> for Config {
                 .unwrap_or(defaults.serial.coppersynth_panel),
             listen: raw.serial.listen.clone(),
             connect: raw.serial.connect.clone(),
+            device: raw
+                .serial
+                .device
+                .as_deref()
+                .map(str::trim)
+                .filter(|d| !d.is_empty())
+                .map(str::to_string),
             telnet: raw.serial.telnet.or(defaults.serial.telnet),
             phonebook: raw
                 .serial
@@ -576,6 +599,15 @@ impl TryFrom<RawConfig> for Config {
                  (or A1200, or A4000)"
             ));
         }
+        // Only the Gayle machines have the credit-card slot.
+        let has_pcmcia_slot = defaults.gate_array.gayle_id().is_some();
+        let pcmcia = match parse_pcmcia(&raw.pcmcia, has_pcmcia_slot) {
+            Ok(pcmcia) => pcmcia,
+            Err(e) => {
+                errors.push(e);
+                PcmciaConfig::default()
+            }
+        };
         let scsi_controller_named = raw.scsi.controller.is_some();
         let scsi_controller = match raw.scsi.controller.as_deref() {
             // A machine with a Super DMAC already has a SCSI bus, so drives go
@@ -1222,18 +1254,23 @@ impl TryFrom<RawConfig> for Config {
             || (defaults.sdmac && scsi.controller == ScsiController::A3000);
         let host_disks =
             parse_host_disks(&raw.host_disk, &ide, &scsi, &lide, has_ide_port, has_scsi)?;
+        check_pcmcia_host_disks(&host_disks, &pcmcia, has_pcmcia_slot)?;
         // A real host disk is a drive on the port just as an image is, and
         // the ROM's driver is what finds it and mounts what its RDB
         // describes. Counting only images would cull that driver out from
         // under a machine whose only drive is a real one -- which opens
-        // perfectly and is then never looked at.
-        let host_disk_on_ide = host_disks.iter().any(|disk| !disk.attach.is_scsi());
+        // perfectly and is then never looked at. A card in the PCMCIA slot
+        // is not scsi.device's to find: the Aminet CF drivers do that.
+        let host_disk_on_ide = host_disks
+            .iter()
+            .any(|disk| !disk.attach.is_scsi() && !disk.attach.is_pcmcia());
         let host_disk_on_scsi = host_disks.iter().any(|disk| disk.attach.is_scsi());
         if raw.fmv_rom.is_some() && !defaults.akiko {
             anyhow::bail!("fmv_rom is only valid for a CD32 machine profile");
         }
         Ok(Config {
             host_disks,
+            pcmcia,
             rom_path: raw.rom.map(PathBuf::from).unwrap_or(defaults.rom_path),
             netplay_storage: false,
             netplay_read_only: Vec::new(),
@@ -1361,8 +1398,9 @@ impl TryFrom<RawConfig> for Config {
             mouse_capture,
             autofire_hz,
             port_devices,
+            parallel_joysticks,
             serial,
-            parallel: resolve_parallel(raw.parallel)?,
+            parallel,
             paths: raw.paths,
         })
     }
@@ -1370,13 +1408,19 @@ impl TryFrom<RawConfig> for Config {
 
 /// Resolve `[parallel]` into a [`ParallelConfig`]. An explicit `device` selects
 /// the peripheral; with none set, a bare `output` path implies a printer
-/// (back-compat with the original `[parallel] output = "..."`) and otherwise the
-/// port is empty. Rejects a printer with no capture path and an out-of-range
-/// sampler gain.
-fn resolve_parallel(raw: RawParallel) -> Result<ParallelConfig> {
+/// (back-compat with the original `[parallel] output = "..."`), a joystick
+/// named in `[input] port3`/`port4` implies the four-player adapter, and
+/// otherwise the port is empty. Rejects a printer with no capture path and
+/// an out-of-range sampler gain.
+fn resolve_parallel(raw: RawParallel, input: &RawInput) -> Result<ParallelConfig> {
+    let socket_named = [input.port3.as_deref(), input.port4.as_deref()]
+        .into_iter()
+        .flatten()
+        .any(|s| PortDevice::parse(s) == Some(PortDevice::Joystick));
     let device = match raw.device.as_deref() {
         Some(s) => parse_parallel_device(s)?,
         None if raw.output.is_some() => ParallelDevice::Printer,
+        None if socket_named => ParallelDevice::JoystickAdapter,
         None => ParallelDevice::None,
     };
     if device == ParallelDevice::Printer && raw.output.is_none() {
@@ -1406,10 +1450,50 @@ pub(crate) fn parse_parallel_device(s: &str) -> Result<ParallelDevice> {
         "none" | "off" => Ok(ParallelDevice::None),
         "printer" => Ok(ParallelDevice::Printer),
         "sampler" => Ok(ParallelDevice::Sampler),
+        "joystick-adapter" | "joystick_adapter" | "joysticks" | "four-player" | "4-player" => {
+            Ok(ParallelDevice::JoystickAdapter)
+        }
         other => bail!(
-            "[parallel] device must be \"none\", \"printer\", or \"sampler\", got \"{other}\""
+            "[parallel] device must be \"none\", \"printer\", \"sampler\", or \
+             \"joystick-adapter\", got \"{other}\""
         ),
     }
+}
+
+/// Resolve one of the four-player adapter's sockets (`[input] port3` /
+/// `port4`): a joystick or nothing. An adapter named in `[parallel]`
+/// (`adapter_named`) fills every socket the config does not mention -- an
+/// adapter with nothing in it is not worth naming -- while an adapter only
+/// implied by the other socket's joystick leaves an unset socket empty. A
+/// joystick named while another peripheral owns the connector is a wiring
+/// conflict, reported rather than guessed at.
+fn parse_parallel_socket(
+    raw: Option<&str>,
+    key: &str,
+    device: ParallelDevice,
+    adapter_named: bool,
+) -> Result<bool> {
+    let adapter = device == ParallelDevice::JoystickAdapter;
+    let Some(s) = raw else {
+        return Ok(adapter && adapter_named);
+    };
+    let socket = PortDevice::parse(s)
+        .filter(|d| d.fits_parallel_port())
+        .ok_or_else(|| {
+            anyhow!(
+                "[input] {key} must be \"joystick\" or \"none\" (the parallel-port adapter \
+                 carries switch joysticks only), got {s:?}"
+            )
+        })?;
+    let fitted = socket == PortDevice::Joystick;
+    if fitted && !adapter {
+        bail!(
+            "[input] {key} = \"joystick\" needs the four-player adapter on the parallel port, \
+             but [parallel] device is \"{}\"",
+            device.label()
+        );
+    }
+    Ok(fitted)
 }
 
 pub(crate) fn parse_overscan(s: &str) -> Result<Overscan> {
@@ -1500,7 +1584,7 @@ pub(crate) fn parse_port_device(s: &str, key: &str) -> Result<PortDevice> {
     let device = PortDevice::parse(s).ok_or_else(|| {
         anyhow!(
             "[input] {key} must be \"mouse\", \"gamepad-mouse\", \"joystick\", \
-             \"cd32\", \"analogue\", or \"none\", got {s:?}"
+             \"cd32\", \"analogue\", \"lightpen\", or \"none\", got {s:?}"
         )
     })?;
     // A mouse belongs in port 1, and a gamepad driving one is still a
@@ -1561,9 +1645,10 @@ pub(crate) fn parse_serial_mode(s: &str) -> Result<SerialMode> {
         "tcp-connect" => Ok(SerialMode::TcpConnect),
         "pty" => Ok(SerialMode::Pty),
         "modem" => Ok(SerialMode::Modem),
+        "device" => Ok(SerialMode::Device),
         _ => Err(anyhow!(
             "unknown [serial] mode {:?}: expected \"off\", \"stdout\", \"midi\", \"tcp\", \
-             \"tcp-connect\", \"pty\", or \"modem\"",
+             \"tcp-connect\", \"pty\", \"modem\", or \"device\"",
             s
         )),
     }
@@ -2505,6 +2590,9 @@ pub(super) fn parse_host_disks(
         let fitted = match attach {
             HostDiskAttach::IdeMaster | HostDiskAttach::IdeSlave => has_ide_port,
             HostDiskAttach::Scsi(_) => has_scsi,
+            // The slot is checked against `[pcmcia]` and the machine by
+            // `check_pcmcia_host_disks`, once the card section is parsed.
+            HostDiskAttach::Pcmcia => true,
             HostDiskAttach::LideMaster(ch) | HostDiskAttach::LideSlave(ch) => {
                 lide.enabled() && usize::from(ch) < lide.board.channels()
             }
@@ -2547,6 +2635,8 @@ pub(super) fn parse_host_disks(
                 .is_some_and(Option::is_some),
             HostDiskAttach::LideMaster(ch) => lide.drives[usize::from(ch) * 2].is_some(),
             HostDiskAttach::LideSlave(ch) => lide.drives[usize::from(ch) * 2 + 1].is_some(),
+            // Checked against `[pcmcia]` by `check_pcmcia_host_disks`.
+            HostDiskAttach::Pcmcia => false,
         };
         if taken {
             bail!(
@@ -2564,6 +2654,101 @@ pub(super) fn parse_host_disks(
         });
     }
     Ok(disks)
+}
+
+/// A host disk on the PCMCIA slot needs the slot to exist and to be free:
+/// `[pcmcia]` and `[[host_disk]] attach = "pcmcia"` fill the same socket.
+/// Separate from `parse_host_disks` because the slot is not a drive port:
+/// what sits in it is a card, configured by its own section.
+fn check_pcmcia_host_disks(
+    disks: &[HostDiskConfig],
+    pcmcia: &PcmciaConfig,
+    has_slot: bool,
+) -> Result<()> {
+    for (index, disk) in disks.iter().enumerate() {
+        if !disk.attach.is_pcmcia() {
+            continue;
+        }
+        if !has_slot {
+            bail!("host_disk[{index}]: {}", disk.attach.requirement());
+        }
+        if pcmcia.is_present() {
+            bail!(
+                "host_disk[{index}] is attached to the PCMCIA slot, which [pcmcia] already \
+                 fills; the slot holds one card"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Parse `[pcmcia]`: which card sits in the A600/A1200 slot.
+pub(super) fn parse_pcmcia(raw: &RawPcmcia, has_slot: bool) -> Result<PcmciaConfig> {
+    let kind = raw.card.as_deref().map(|c| c.trim().to_ascii_lowercase());
+    let card = match kind.as_deref() {
+        None | Some("none") | Some("") => {
+            if raw.path.is_some() || raw.size.is_some() || raw.read_only.is_some() {
+                bail!("[pcmcia] describes a card but names no card type: set card = \"cf\" or \"sram\"");
+            }
+            PcmciaCardConfig::None
+        }
+        Some("cf") => {
+            let Some(path) = raw.path.as_deref().filter(|p| !p.trim().is_empty()) else {
+                bail!("[pcmcia] card = \"cf\" needs path = the card's hard-disk image");
+            };
+            if raw.size.is_some() {
+                bail!("[pcmcia] size applies to an SRAM card; a CF card takes its size from the image");
+            }
+            if raw.read_only.is_some() {
+                bail!(
+                    "[pcmcia] read_only is an SRAM card's write-protect switch; a CF card has none \
+                     (a real card reader's access is set on its [[host_disk]] entry)"
+                );
+            }
+            PcmciaCardConfig::Cf {
+                path: PathBuf::from(path),
+            }
+        }
+        Some("sram") => {
+            let Some(size) = raw.size.as_deref() else {
+                bail!("[pcmcia] card = \"sram\" needs size = the card's capacity (up to 4M)");
+            };
+            let size = parse_size(size, "[pcmcia] SRAM card")?;
+            if size == 0 || size > crate::pcmcia::MAX_SRAM_BYTES {
+                bail!(
+                    "[pcmcia] SRAM card size {} bytes must be between 64K and 4M (the common \
+                     memory window)",
+                    size
+                );
+            }
+            if crate::pcmcia::sram_device_size_byte(size).is_none() {
+                bail!(
+                    "[pcmcia] SRAM card size {} bytes cannot be described by the card's CIS: use a \
+                     multiple of 64K up to 1M, or of 128K up to 4M",
+                    size
+                );
+            }
+            PcmciaCardConfig::Sram {
+                size,
+                path: raw
+                    .path
+                    .as_deref()
+                    .filter(|p| !p.trim().is_empty())
+                    .map(PathBuf::from),
+                read_only: raw.read_only.unwrap_or(false),
+            }
+        }
+        Some(other) => {
+            bail!("[pcmcia] card = {other:?} is not known (expected \"none\", \"cf\", or \"sram\")")
+        }
+    };
+    if card != PcmciaCardConfig::None && !has_slot {
+        bail!(
+            "[pcmcia] needs a machine with a PCMCIA slot: set [machine] profile = \"A600\" or \
+             \"A1200\""
+        );
+    }
+    Ok(PcmciaConfig { card })
 }
 
 fn validate_floppy_image_path(idx: usize, path: &Path) -> Result<()> {

--- a/src/control/catalogue.rs
+++ b/src/control/catalogue.rs
@@ -116,6 +116,12 @@ fn port(desc: &str) -> Value {
     json!({"type": "integer", "enum": [1, 2], "description": desc})
 }
 
+/// A joystick port: the two game ports or the parallel-port four-player
+/// adapter's sockets (3 and 4).
+fn joystick_port(desc: &str) -> Value {
+    json!({"type": "integer", "enum": [1, 2, 3, 4], "description": desc})
+}
+
 fn at_seconds() -> Value {
     number(
         "Emulated time (absolute seconds) at which to apply the input; absent or in the past \
@@ -1164,11 +1170,13 @@ fn build() -> Vec<ToolDef> {
         ),
         entry(
             "input.joy",
-            "Set the joystick or CD32 pad state on `port` (default 2): each of `up`, \
-             `down`, `left`, `right`, `red` (fire), `blue`, `green`, `yellow`, `play`, \
-             `rwd`, `ffw` is true for held, absent or false for released. The state \
-             persists until the next input.joy, so send a second call with the buttons \
-             cleared to release them.",
+            "Set the joystick or CD32 pad state on `port` (default 2; 3 and 4 are the \
+             parallel-port four-player adapter's sockets, fitted on first use): each of \
+             `up`, `down`, `left`, `right`, `red` (fire), `blue`, `green`, `yellow`, \
+             `play`, `rwd`, `ffw` is true for held, absent or false for released. The \
+             state persists until the next input.joy, so send a second call with the \
+             buttons cleared to release them. On a light pen `red` is the tip switch / \
+             trigger.",
             object(
                 vec![
                     ("up", boolean("Direction up held")),
@@ -1182,12 +1190,29 @@ fn build() -> Vec<ToolDef> {
                     ("play", boolean("CD32 play/pause held")),
                     ("rwd", boolean("CD32 reverse shoulder held")),
                     ("ffw", boolean("CD32 forward shoulder held")),
-                    ("port", port("Controller port (default 2)")),
+                    ("port", joystick_port("Controller port 1-4 (default 2)")),
                     ("at_seconds", at_seconds()),
                 ],
                 &[],
             ),
             json!({"red": true}),
+        ),
+        entry(
+            "input.pen",
+            "Hold the light pen (`[input] port1/port2 = \"lightpen\"`) over presented pixel \
+             (`x`, `y`) -- the coordinates of input.mouse_to and capture.screenshot -- so \
+             Agnus latches the beam there while BPLCON0 LPEN is set. Omit both (or pass a \
+             negative value) to lift the pen off the glass. The pen's switch / trigger is \
+             `red` in input.joy or `left` in input.mouse on the pen's port.",
+            object(
+                vec![
+                    ("x", int("Column, or absent/negative to lift the pen", None, None)),
+                    ("y", int("Row, or absent/negative to lift the pen", None, None)),
+                    ("at_seconds", at_seconds()),
+                ],
+                &[],
+            ),
+            json!({"x": 160, "y": 100}),
         ),
         entry(
             "input.analogue",
@@ -1207,16 +1232,26 @@ fn build() -> Vec<ToolDef> {
         entry(
             "input.set_port",
             "Hot-plug a controller device into `port` 1 or 2: mouse, gamepad-mouse (port \
-             1 only), joystick, cd32, analogue, or none. Releases every line the previous \
-             device drove.",
+             1 only), joystick, cd32, analogue, lightpen, or none; ports 3 and 4 are the \
+             parallel-port four-player adapter's sockets and take joystick or none (a \
+             joystick there fits the adapter). Releases every line the previous device \
+             drove.",
             object(
                 vec![
-                    ("port", port("Controller port")),
+                    ("port", joystick_port("Controller port 1-4")),
                     (
                         "device",
                         enumeration(
                             "Device to fit",
-                            &["mouse", "gamepad-mouse", "joystick", "cd32", "analogue", "none"],
+                            &[
+                                "mouse",
+                                "gamepad-mouse",
+                                "joystick",
+                                "cd32",
+                                "analogue",
+                                "lightpen",
+                                "none",
+                            ],
                         ),
                     ),
                 ],
@@ -1226,7 +1261,8 @@ fn build() -> Vec<ToolDef> {
         ),
         entry(
             "input.get_ports",
-            "Report which device is fitted to each controller port.",
+            "Report which device is fitted to each controller port (1-4), whether the \
+             parallel-port adapter is fitted, and the light pen's port and position.",
             no_params(),
             json!({}),
         ),
@@ -1269,6 +1305,38 @@ fn build() -> Vec<ToolDef> {
         entry(
             "media.cd.eject",
             "Eject the CD image from the machine's CD drive.",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "pcmcia.insert",
+            "Push a card into the A600/A1200 PCMCIA slot: `card` \"cf\" (default) wraps the \
+             hard-disk image at `path` as a CompactFlash/ATA card; \"sram\" makes an SRAM \
+             memory card of `size` bytes (64K..4M), optionally mirrored to `path`, with \
+             `read_only` as its write-protect switch. A card already in the slot is ejected \
+             first. Gayle latches the card-detect change, so the guest sees a real insertion.",
+            object(
+                vec![
+                    ("card", string("\"cf\" or \"sram\" (default \"cf\")")),
+                    ("path", string("CF: the image; SRAM: optional backing file")),
+                    ("size", string("SRAM card size, e.g. \"2M\"")),
+                    ("read_only", boolean("SRAM write-protect switch (default false)")),
+                ],
+                &[],
+            ),
+            json!({"card": "cf", "path": "/path/to/card.hdf"}),
+        ),
+        entry(
+            "pcmcia.eject",
+            "Pull the card out of the PCMCIA slot (Gayle latches the card-detect change).",
+            no_params(),
+            json!({}),
+        ),
+        entry(
+            "pcmcia.query",
+            "Report the PCMCIA slot: whether the machine has one, whether it is enabled or \
+             shadowed by Zorro II fast RAM, the card in it, Gayle's sampled card pins, and \
+             its pending change latches.",
             no_params(),
             json!({}),
         ),

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -183,6 +183,8 @@ pub enum CoreOp {
     BreakList,
     BreakClear,
     FloppyQuery,
+    /// What is in the PCMCIA slot, and whether the machine has one.
+    PcmciaQuery,
     EventsSubscribe {
         events: Vec<EventKind>,
         frame_interval: Option<u64>,
@@ -279,6 +281,7 @@ impl CoreOp {
                 | CoreOp::SegmentsList
                 | CoreOp::BreakList
                 | CoreOp::FloppyQuery
+                | CoreOp::PcmciaQuery
                 | CoreOp::EventsList
                 | CoreOp::TraceStatus
                 | CoreOp::WaveformStatus
@@ -300,6 +303,52 @@ pub enum MemDigestScope {
     All,
     /// One address span through the CPU's memory map.
     Range { addr: u32, len: usize },
+}
+
+/// The `pcmcia.query` reply: whether the machine has a slot, whether it is
+/// enabled (not shadowed by Zorro II RAM or disabled by the guest), and
+/// the card in it.
+pub fn pcmcia_query(emu: &Emulator) -> Value {
+    let bus = emu.bus();
+    let gayle = bus.gayle.as_ref();
+    json!({
+        "slot": gayle.is_some(),
+        "enabled": gayle.is_some_and(crate::gayle::Gayle::slot_enabled),
+        "shadowed_by_fast_ram": gayle.is_some_and(crate::gayle::Gayle::slot_shadowed),
+        "inserted": bus.pcmcia_card().is_some(),
+        "card": bus.pcmcia_card().map(|c| c.kind().token()),
+        "description": bus.pcmcia_card().map(crate::pcmcia::PcmciaCard::describe),
+        "path": bus.pcmcia_card().and_then(|c| c.path().map(|p| p.display().to_string())),
+        "pins": gayle.map(crate::gayle::Gayle::card_pins),
+        "change_latches": gayle.map(crate::gayle::Gayle::change_latches),
+    })
+}
+
+/// Build the card a `pcmcia.insert` request describes and push it into the
+/// slot. Shared by the headless and windowed control servers.
+pub fn pcmcia_insert(
+    emu: &mut Emulator,
+    kind: crate::pcmcia::CardKind,
+    path: Option<&std::path::Path>,
+    size: usize,
+    read_only: bool,
+) -> Result<String, CtlError> {
+    use crate::pcmcia::{CardKind, CfCard, PcmciaCard, SramCard};
+    if !emu.bus().pcmcia_slot_present() {
+        return Err(CtlError::unsupported("no PCMCIA slot on this machine"));
+    }
+    let card = match kind {
+        CardKind::Cf => {
+            let path = path.ok_or_else(|| CtlError::invalid_params("a CF card needs a path"))?;
+            PcmciaCard::cf(CfCard::open(path).map_err(|e| CtlError::io(format!("{e:#}")))?)
+        }
+        CardKind::Sram => PcmciaCard::Sram(
+            SramCard::new(size, path, read_only).map_err(|e| CtlError::io(format!("{e:#}")))?,
+        ),
+    };
+    let description = card.describe();
+    emu.bus_mut().pcmcia_insert(card);
+    Ok(description)
 }
 
 /// Optional diagnostic layers painted onto a side-effect-free screenshot.
@@ -615,6 +664,18 @@ pub enum HostOp {
         path: PathBuf,
     },
     CdEject,
+    /// Push a card into the A600/A1200 PCMCIA slot: a CF card over a
+    /// hard-disk image, or an SRAM card of `size` bytes (optionally backed
+    /// by `path`). Gayle latches the card-detect change, so a listening
+    /// card.resource sees a real insertion.
+    PcmciaInsert {
+        kind: crate::pcmcia::CardKind,
+        path: Option<PathBuf>,
+        size: usize,
+        read_only: bool,
+    },
+    /// Pull the card out of the slot.
+    PcmciaEject,
     /// Hot-attach a copperhf.device unit's media at runtime (`[copperhf]`'s
     /// own boot-time attach path, driven from a live session): opens
     /// `path` exactly like a configured `[copperhf]` unit and replaces
@@ -762,6 +823,11 @@ pub enum InputCmd {
         y: u8,
         at_seconds: Option<f64>,
     },
+    /// Light-pen position (`None` lifts the pen off the glass).
+    Pen {
+        position: Option<(i32, i32)>,
+        at_seconds: Option<f64>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -888,6 +954,12 @@ impl InputCmd {
                     );
                 }
             }
+}
+
+            InputCmd::Pen {
+                position,
+                at_seconds,
+            } => emit(at_seconds, InputAction::Pen { position }),
         }
         (now, later)
     }
@@ -917,11 +989,25 @@ fn parse_port_param(p: &ParamReader, default: u32) -> Result<u8, CtlError> {
     Ok((port - 1) as u8)
 }
 
-/// Parse a required 1-based `port` param into the 0-based port index.
+/// Parse the optional 1-based `port` param of a joystick method, which
+/// may also name the parallel-port adapter's sockets (3 and 4).
+fn parse_joystick_port_param(p: &ParamReader, default: u32) -> Result<u8, CtlError> {
+    let port = p.u32_or("port", default)?;
+    if !(1..=crate::bus::PORT_COUNT as u32).contains(&port) {
+        return Err(CtlError::invalid_params(
+            "port must be 1-4 (3 and 4 are the parallel-port adapter's sockets)",
+        ));
+    }
+    Ok((port - 1) as u8)
+}
+
+/// Parse a required 1-based `port` param (1-4) into the 0-based port index.
 fn parse_port_req(p: &ParamReader) -> Result<u8, CtlError> {
     let port = p.u32_req("port")?;
-    if !(1..=2).contains(&port) {
-        return Err(CtlError::invalid_params("port must be 1 or 2"));
+    if !(1..=crate::bus::PORT_COUNT as u32).contains(&port) {
+        return Err(CtlError::invalid_params(
+            "port must be 1-4 (3 and 4 are the parallel-port adapter's sockets)",
+        ));
     }
     Ok((port - 1) as u8)
 }
@@ -1278,7 +1364,7 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
                 .clamp(1, crate::pointer::FRAME_LIMIT),
         }),
         "input.joy" => host(HostOp::Input(InputCmd::Joy {
-            port: parse_port_param(&p, 2)?,
+            port: parse_joystick_port_param(&p, 2)?,
             state: JoyState {
                 up: p.bool_or("up", false)?,
                 down: p.bool_or("down", false)?,
@@ -1306,11 +1392,19 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
                 at_seconds: parse_at_seconds(&p)?,
             }))
         }
+        "input.pen" => {
+            let (x, y) = (p.i32_or("x", -1)?, p.i32_or("y", -1)?);
+            host(HostOp::Input(InputCmd::Pen {
+                position: (x >= 0 && y >= 0).then_some((x, y)),
+                at_seconds: parse_at_seconds(&p)?,
+            }))
+        }
         "input.set_port" => {
             let device = p.str_req("device")?;
             let device = crate::bus::PortDevice::parse(&device).ok_or_else(|| {
                 CtlError::invalid_params(format!(
-                    "device must be mouse|gamepad-mouse|joystick|cd32|analogue|none, got {device}"
+                    "device must be mouse|gamepad-mouse|joystick|cd32|analogue|lightpen|none, \
+                     got {device}"
                 ))
             })?;
             let port = parse_port_req(&p)?;
@@ -1321,6 +1415,12 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             if device == crate::bus::PortDevice::GamepadMouse && port != 0 {
                 return Err(CtlError::invalid_params(
                     "gamepad-mouse is port 1 only".to_string(),
+                ));
+            }
+            // The adapter sockets are passive wiring for switch joysticks.
+            if port as usize >= crate::bus::PARALLEL_PORT_FIRST && !device.fits_parallel_port() {
+                return Err(CtlError::invalid_params(
+                    "ports 3 and 4 (the parallel-port adapter) take joystick or none".to_string(),
                 ));
             }
             host(HostOp::SetPortDevice { port, device })
@@ -1339,6 +1439,45 @@ pub fn parse_method(method: &str, params: &Value) -> Result<Request, CtlError> {
             path: PathBuf::from(p.str_req("path")?),
         }),
         "media.cd.eject" => host(HostOp::CdEject),
+        "pcmcia.insert" => {
+            let kind = match p
+                .str_opt("card")?
+                .unwrap_or_else(|| "cf".to_string())
+                .to_ascii_lowercase()
+                .as_str()
+            {
+                "cf" => crate::pcmcia::CardKind::Cf,
+                "sram" => crate::pcmcia::CardKind::Sram,
+                other => {
+                    return Err(CtlError::invalid_params(format!(
+                        "card must be \"cf\" or \"sram\", not {other:?}"
+                    )))
+                }
+            };
+            let path = p.str_opt("path")?.map(PathBuf::from);
+            let size = match p.str_opt("size")? {
+                Some(size) => crate::config::parse_size(&size, "PCMCIA SRAM card")
+                    .map_err(|e| CtlError::invalid_params(format!("{e:#}")))?,
+                None => 0,
+            };
+            match kind {
+                crate::pcmcia::CardKind::Cf if path.is_none() => {
+                    return Err(CtlError::invalid_params("a CF card needs a path"))
+                }
+                crate::pcmcia::CardKind::Sram if size == 0 => {
+                    return Err(CtlError::invalid_params("an SRAM card needs a size"))
+                }
+                _ => {}
+            }
+            host(HostOp::PcmciaInsert {
+                kind,
+                path,
+                size,
+                read_only: p.bool_or("read_only", false)?,
+            })
+        }
+        "pcmcia.eject" => host(HostOp::PcmciaEject),
+        "pcmcia.query" => core(CoreOp::PcmciaQuery),
         "copperhf.attach" => {
             let unit = p.usize_req("unit")?;
             if unit >= crate::copperhf::NUM_UNITS {
@@ -2461,9 +2600,21 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
         }
         CoreOp::InputPortsGet => {
             let input = &emu.bus().input;
+            let light_pen = input.light_pen_port().map(|port| {
+                json!({
+                    "port": port + 1,
+                    "wired": port == emu.bus().light_pen_wired_port(),
+                    "x": input.light_pen.position.map(|p| p.0),
+                    "y": input.light_pen.position.map(|p| p.1),
+                })
+            });
             Ok(json!({
                 "port1": input.ports[0].device.label(),
                 "port2": input.ports[1].device.label(),
+                "port3": input.device(2).label(),
+                "port4": input.device(3).label(),
+                "parallel_adapter": input.parallel_adapter,
+                "light_pen": light_pen,
             }))
         }
         CoreOp::DebugResources => {
@@ -2708,6 +2859,7 @@ pub fn exec_core(emu: &mut Emulator, ctx: &mut SessionCtx, op: &CoreOp) -> Resul
                 .collect();
             Ok(json!({"drives": drives}))
         }
+        CoreOp::PcmciaQuery => Ok(pcmcia_query(emu)),
         CoreOp::EventsSubscribe {
             events,
             frame_interval,

--- a/src/control/exec.rs
+++ b/src/control/exec.rs
@@ -954,8 +954,6 @@ impl InputCmd {
                     );
                 }
             }
-}
-
             InputCmd::Pen {
                 position,
                 at_seconds,

--- a/src/control/headless.rs
+++ b/src/control/headless.rs
@@ -517,6 +517,38 @@ impl Session {
                 self.write(&reply)?;
                 Ok(None)
             }
+            HostOp::PcmciaInsert {
+                kind,
+                path,
+                size,
+                read_only,
+            } => {
+                let reply = match exec::pcmcia_insert(
+                    &mut self.emu,
+                    kind,
+                    path.as_deref(),
+                    size,
+                    read_only,
+                ) {
+                    Ok(description) => proto::ok_line(&id, json!({"card": description})),
+                    Err(e) => proto::err_line(&id, &e),
+                };
+                self.write(&reply)?;
+                Ok(None)
+            }
+            HostOp::PcmciaEject => {
+                let reply = if !self.emu.bus().pcmcia_slot_present() {
+                    proto::err_line(
+                        &id,
+                        &CtlError::unsupported("no PCMCIA slot on this machine"),
+                    )
+                } else {
+                    let ejected = self.emu.bus_mut().pcmcia_eject().is_some();
+                    proto::ok_line(&id, json!({"ejected": ejected}))
+                };
+                self.write(&reply)?;
+                Ok(None)
+            }
             HostOp::CopperhfAttach {
                 unit,
                 path,
@@ -993,6 +1025,8 @@ impl Session {
                     | HostOp::FloppyEject { .. }
                     | HostOp::CdInsert { .. }
                     | HostOp::CdEject
+                    | HostOp::PcmciaInsert { .. }
+                    | HostOp::PcmciaEject
                     | HostOp::CopperhfAttach { .. }
                     | HostOp::CopperhfEject { .. }
                     | HostOp::SetPortDevice { .. }
@@ -1781,15 +1815,49 @@ mod tests {
             let ports = c.result("input.get_ports", json!({}));
             assert_eq!(ports["port1"], "cd32");
 
-            // input.joy/analogue take an optional port; port 3 is refused.
+            // input.joy/analogue take an optional port; the mouse and
+            // analogue methods stop at the two game ports.
             c.result("input.joy", json!({"port": 1, "up": true, "red": true}));
             c.result("input.analogue", json!({"port": 2, "x": 50, "y": 200}));
             let ports = c.result("input.get_ports", json!({}));
             assert_eq!(ports["port2"], "analogue");
+            assert_eq!(ports["port3"], "none");
+            assert_eq!(ports["parallel_adapter"], false);
             let bad = c.call("input.mouse", json!({"port": 3, "dx": 1}));
+            assert_eq!(bad["error"]["code"], proto::INVALID_PARAMS);
+            let bad = c.call("input.analogue", json!({"port": 3, "x": 1, "y": 1}));
             assert_eq!(bad["error"]["code"], proto::INVALID_PARAMS);
             let bad = c.call("input.set_port", json!({"port": 1, "device": "trackball"}));
             assert_eq!(bad["error"]["code"], proto::INVALID_PARAMS);
+
+            // Ports 3 and 4 are the parallel-port adapter's sockets: a
+            // joystick fitted there fits the adapter, and input.joy
+            // drives it; nothing but a joystick fits.
+            let set = c.result("input.set_port", json!({"port": 3, "device": "joystick"}));
+            assert_eq!(set["port"], 3);
+            let ports = c.result("input.get_ports", json!({}));
+            assert_eq!(ports["port3"], "joystick");
+            assert_eq!(ports["port4"], "none");
+            assert_eq!(ports["parallel_adapter"], true);
+            c.result("input.joy", json!({"port": 4, "left": true}));
+            let ports = c.result("input.get_ports", json!({}));
+            assert_eq!(ports["port4"], "joystick");
+            let bad = c.call("input.set_port", json!({"port": 4, "device": "cd32"}));
+            assert_eq!(bad["error"]["code"], proto::INVALID_PARAMS);
+            let bad = c.call("input.joy", json!({"port": 5, "up": true}));
+            assert_eq!(bad["error"]["code"], proto::INVALID_PARAMS);
+
+            // A light pen reports its port, whether the board wires it
+            // to Agnus, and where it is held.
+            c.result("input.set_port", json!({"port": 2, "device": "lightpen"}));
+            c.result("input.pen", json!({"x": 300, "y": 100}));
+            let ports = c.result("input.get_ports", json!({}));
+            assert_eq!(ports["port2"], "lightpen");
+            assert_eq!(ports["light_pen"]["port"], 2);
+            assert_eq!(ports["light_pen"]["x"], 300);
+            c.result("input.pen", json!({}));
+            let ports = c.result("input.get_ports", json!({}));
+            assert!(ports["light_pen"]["x"].is_null());
         });
     }
 

--- a/src/control/observe.rs
+++ b/src/control/observe.rs
@@ -91,6 +91,8 @@ struct InterruptState {
 struct MediaState {
     floppy: [Option<String>; 4],
     cd_inserted: bool,
+    /// The PCMCIA card's description, when one is in the slot.
+    pcmcia: Option<String>,
 }
 
 /// Subscription and sampling state for one authenticated connection.
@@ -320,6 +322,18 @@ impl Observer {
                         }),
                     ));
                 }
+                if previous.pcmcia != current.pcmcia {
+                    events.push(proto::event_line(
+                        "event.media",
+                        json!({
+                            "position": position(emu),
+                            "kind": "pcmcia",
+                            "action": if current.pcmcia.is_some() { "inserted" } else { "ejected" },
+                            "name": current.pcmcia.clone(),
+                            "dropped_notifications": self.dropped_notifications,
+                        }),
+                    ));
+                }
             }
             self.last_media = Some(current);
         }
@@ -406,6 +420,7 @@ fn media_state(emu: &Emulator) -> MediaState {
     MediaState {
         floppy: std::array::from_fn(|drive| bus.floppy.inserted_disk_name(drive)),
         cd_inserted: bus.cd_disc_inserted(),
+        pcmcia: bus.pcmcia_card().map(crate::pcmcia::PcmciaCard::describe),
     }
 }
 

--- a/src/control/session.rs
+++ b/src/control/session.rs
@@ -79,6 +79,10 @@ pub enum InputAction {
         x: u8,
         y: u8,
     },
+    /// The light pen's position on the glass (`None` lifts it off).
+    Pen {
+        position: Option<(i32, i32)>,
+    },
 }
 
 /// An input action deferred to an emulated-time boundary (`at_seconds`
@@ -496,6 +500,11 @@ pub fn inject_input(
         InputAction::Pot { port, x, y } => {
             emu.bus_mut().input.set_analogue(port as usize, x, y);
             emu.tt_note_input(ReplayAction::Pot { port, x, y });
+            observe_recorder(emu, recorder, secs);
+        }
+        InputAction::Pen { position } => {
+            emu.bus_mut().input.set_light_pen_position(position);
+            emu.tt_note_input(ReplayAction::Pen { position });
             observe_recorder(emu, recorder, secs);
         }
     }

--- a/src/copperhf.rs
+++ b/src/copperhf.rs
@@ -199,6 +199,10 @@ const IOERR_BADADDRESS: i8 = -5;
 // TDERR_DiskChanged is a plain positive io_Error value, not part of the
 // IOERR_* family above.
 const TDERR_DISK_CHANGED: i8 = 29;
+/// `TDERR_WriteProt`: the medium refuses writes, which is what a
+/// write-protected image (a CHD with no write overlay, a read-only host
+/// disk) comes back with.
+const TDERR_WRITE_PROT: i8 = 28;
 // devices/scsidisk.h: HD_SCSICMD's io_Error when the target returned a
 // non-GOOD scsi_Status (the request itself was delivered and answered).
 const HFERR_BAD_STATUS: i8 = 45;
@@ -317,6 +321,9 @@ enum WorkerResult {
         read_data: Option<Vec<u8>>,
     },
     RwFailed,
+    /// The unit's image refused the write as write-protected: reported to
+    /// the guest as `TDERR_WriteProt`, distinct from a plain I/O failure.
+    WriteProtected,
     UpdateOk,
     /// The unit's `flush()` returned an error: distinct from `UpdateOk` so
     /// the guest is told CMD_UPDATE failed rather than being lied to about
@@ -534,6 +541,9 @@ fn execute_job(units: &UnitsShared, job: WorkerJob) -> WorkerResult {
                     };
                     if let Err(e) = disk.disk.write_sector(start_lba + i, chunk) {
                         log::warn!("copperhf: unit {unit}: write_sector failed: {e}");
+                        if e.kind() == std::io::ErrorKind::PermissionDenied {
+                            return WorkerResult::WriteProtected;
+                        }
                         return WorkerResult::RwFailed;
                     }
                 }
@@ -623,6 +633,11 @@ pub struct CopperhfBoard {
     /// unit-table lock. Updated at attach/eject time (both only reachable
     /// while quiesced) and at drain time for a guest `TD_EJECT`.
     media: [bool; NUM_UNITS],
+    /// Board-cached "the unit's image refuses writes" per unit, from
+    /// [`HardDriveImage::write_protected`] at attach time, so
+    /// `CHF_UNIT_RDONLY`/`TD_PROTSTATUS` answer without taking the
+    /// unit-table lock. Cleared with `media` at eject.
+    rdonly: [bool; NUM_UNITS],
     /// Board-cached `total_sectors` per unit, valid while `media[unit]` (and
     /// left stale-but-harmless after an eject -- range checks against a
     /// media-absent unit are answered by the worker's own authoritative
@@ -672,6 +687,7 @@ impl CopperhfBoard {
             units,
             present: [false; NUM_UNITS],
             media: [false; NUM_UNITS],
+            rdonly: [false; NUM_UNITS],
             unit_sectors: [0; NUM_UNITS],
             change_count: [0; NUM_UNITS],
             changed_mask: 0,
@@ -717,6 +733,7 @@ impl CopperhfBoard {
             "copperhf: attach_unit called with requests in flight -- quiesce first"
         );
         let total_sectors = image.total_sectors();
+        self.rdonly[unit] = image.write_protected();
         self.units.lock().unwrap()[unit] = Some(ScsiDisk::from_disk(image));
         self.present[unit] = true;
         self.media[unit] = true;
@@ -760,6 +777,7 @@ impl CopperhfBoard {
         );
         let image = self.units.lock().unwrap()[unit].take();
         self.media[unit] = false;
+        self.rdonly[unit] = false;
         self.change_count[unit] = self.change_count[unit].wrapping_add(1);
         self.changed_mask |= 1 << unit;
         image.map(|d| d.disk)
@@ -797,17 +815,17 @@ impl CopperhfBoard {
         mask
     }
 
-    /// Always reports every attached unit as writable, through M4/M5.
-    ///
-    /// Deviation from the milestone note: there is no per-image read-only
-    /// flag anywhere in the shared `HardDriveImage` layer today (see
-    /// COPPERHF-DEVICE-PLAN.md's "Deferred" section) -- not even for a host
-    /// disk, which exposes `is_host_disk()` but no writability query. Wiring
-    /// `CHF_UNIT_RDONLY`/`TD_PROTSTATUS` up to something real is therefore a
-    /// shared-layer follow-up, not something this board can honestly report
-    /// on its own.
+    /// `CHF_UNIT_RDONLY`: bit *n* set = unit *n*'s image refuses writes
+    /// (`HardDriveImage::write_protected`: a CHD with no write overlay, a
+    /// read-only host disk). An ordinary image file is always writable, so
+    /// this reads 0 for every unit a typical configuration attaches.
     fn rdonly_bitmask(&self) -> u16 {
-        0
+        self.rdonly
+            .iter()
+            .enumerate()
+            .filter(|(_, &rdonly)| rdonly)
+            .map(|(unit, _)| 1u16 << unit)
+            .sum()
     }
 
     fn selected_unit(&self) -> Option<usize> {
@@ -1208,9 +1226,6 @@ impl CopperhfBoard {
                 None => (IOERR_OPENFAIL, 0),
             },
             TD_PROTSTATUS => match self.valid_unit(header.unit) {
-                // rdonly_bitmask() is always 0 today (see its own doc
-                // comment); mirrored here rather than hard-coded so the two
-                // stay in lockstep if that ever changes.
                 Some(unit) => (0, u32::from(self.rdonly_bitmask() & (1 << unit) != 0)),
                 None => (IOERR_OPENFAIL, 0),
             },
@@ -1323,6 +1338,7 @@ impl CopperhfBoard {
                 match self.worker.recv() {
                     Some(WorkerResult::Ejected) => {
                         self.media[unit] = false;
+                        self.rdonly[unit] = false;
                         self.change_count[unit] = self.change_count[unit].wrapping_add(1);
                         self.changed_mask |= 1 << unit;
                         self.complete(ptr, flags, 0, 0, host);
@@ -1365,6 +1381,7 @@ impl CopperhfBoard {
                 (0, header.length)
             }
             (IoDrainKind::Rw { .. }, WorkerResult::RwFailed) => (IOERR_BADADDRESS, 0),
+            (IoDrainKind::Rw { .. }, WorkerResult::WriteProtected) => (TDERR_WRITE_PROT, 0),
             (IoDrainKind::Update, WorkerResult::UpdateOk) => (0, 0),
             (IoDrainKind::Update, WorkerResult::UpdateFailed) => (IOERR_BADADDRESS, 0),
             (
@@ -1453,6 +1470,7 @@ impl CopperhfBoard {
                 PendingRequest::Eject { unit, .. } => {
                     if matches!(self.worker.recv(), Some(WorkerResult::Ejected)) {
                         self.media[unit] = false;
+                        self.rdonly[unit] = false;
                         self.change_count[unit] = self.change_count[unit].wrapping_add(1);
                         self.changed_mask |= 1 << unit;
                     }
@@ -1545,12 +1563,18 @@ impl<'de> serde::Deserialize<'de> for CopperhfBoard {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let state = CopperhfBoardState::deserialize(deserializer)?;
         let media = std::array::from_fn(|i| state.units[i].is_some());
+        let rdonly = std::array::from_fn(|i| {
+            state.units[i]
+                .as_ref()
+                .is_some_and(|disk| disk.disk.write_protected())
+        });
         let units: UnitsShared = Arc::new(Mutex::new(state.units));
         let worker = Worker::spawn(Arc::clone(&units));
         Ok(Self {
             units,
             present: state.present,
             media,
+            rdonly,
             unit_sectors: state.unit_sectors,
             change_count: state.change_count,
             changed_mask: state.changed_mask,
@@ -2659,6 +2683,61 @@ mod tests {
         ring_doorbell_long(&mut board, &mut host, ptr3);
         assert_eq!(io_error(&mem, ptr3), 0);
         assert_eq!(io_actual(&mem, ptr3), 0, "writable");
+    }
+
+    #[test]
+    fn write_protected_unit_reports_rdonly_and_fails_writes_with_writeprot() {
+        let (image, path) = crate::harddrive::chd::tests::write_protected_image("chf-wp", 16);
+        let mut board = CopperhfBoard::new();
+        board.attach_unit(0, open_image("chf-rw", 16));
+        board.attach_unit(1, image);
+        let mut mem = memory();
+        let mut host = DeviceHost::new(&mut mem);
+        assert_eq!(
+            board.read(CHF_UNIT_RDONLY, 2, &mut host),
+            0b10,
+            "only the write-protected unit is flagged"
+        );
+
+        // TD_PROTSTATUS answers per unit from the same cache.
+        let ptr = 0x1000u32;
+        write_request(&mut mem, ptr, 1, TD_PROTSTATUS, 0, 0, 0, 0);
+        let mut host = DeviceHost::new(&mut mem);
+        ring_doorbell_long(&mut board, &mut host, ptr);
+        assert_eq!(io_error(&mem, ptr), 0);
+        assert_eq!(io_actual(&mem, ptr), 1, "write-protected");
+        let ptr = 0x1100u32;
+        write_request(&mut mem, ptr, 0, TD_PROTSTATUS, 0, 0, 0, 0);
+        let mut host = DeviceHost::new(&mut mem);
+        ring_doorbell_long(&mut board, &mut host, ptr);
+        assert_eq!(io_actual(&mem, ptr), 0, "the ordinary image is writable");
+
+        // A write is refused as TDERR_WriteProt, the trackdisk error a
+        // filesystem turns into its own write-protect requester.
+        let ptr = 0x1200u32;
+        let data_addr = 0x2000u32;
+        write_request(&mut mem, ptr, 1, CMD_WRITE, 0, 512, data_addr, 512);
+        let mut host = DeviceHost::new(&mut mem);
+        ring_doorbell_long(&mut board, &mut host, ptr);
+        assert_eq!(io_error(&mem, ptr), TDERR_WRITE_PROT);
+
+        // Reads are unaffected: sector 3 of the fixture carries its LBA.
+        let ptr = 0x1300u32;
+        let readback = 0x3000u32;
+        write_request(&mut mem, ptr, 1, CMD_READ, 0, 512, readback, 3 * 512);
+        let mut host = DeviceHost::new(&mut mem);
+        ring_doorbell_long(&mut board, &mut host, ptr);
+        assert_eq!(io_error(&mem, ptr), 0);
+        assert_eq!(
+            &mem.chip_ram[readback as usize..readback as usize + 4],
+            &3u32.to_be_bytes()
+        );
+
+        // Ejecting clears the flag with the media.
+        board.eject_unit(1);
+        let mut host = DeviceHost::new(&mut mem);
+        assert_eq!(board.read(CHF_UNIT_RDONLY, 2, &mut host), 0);
+        crate::harddrive::chd::tests::remove_write_protected_image(&path);
     }
 
     #[test]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -4177,6 +4177,19 @@ impl CpuBus {
                 return value;
             }
         }
+        // Gayle's PCMCIA slot windows. Zorro II RAM configured over the
+        // common window has already been claimed above (`classify_plain_
+        // memory`), so the card never answers an address a board owns; an
+        // empty or disabled socket leaves the address unmapped.
+        if self.bus.gayle.is_some() && crate::pcmcia::decodes(addr) {
+            if let Some(value) = self.bus.pcmcia_read(addr, size) {
+                self.bus.cpu_slow_external_access(Self::access_words(size));
+                if self.bus.take_pcmcia_activity() {
+                    self.bus.note_hdd_activity();
+                }
+                return value;
+            }
+        }
         if self.bus.uaelib.is_some() && crate::uaelib::UaeLib::decodes(addr) {
             // The uaelib trap stub (crate::uaelib): ROM-like memory (WinUAE's
             // rtarea is a plain ROM bank) the CPU also fetches instructions
@@ -4525,6 +4538,16 @@ impl CpuBus {
                 if gayle.take_activity() {
                     self.bus.note_hdd_activity();
                 }
+            }
+            return;
+        }
+        if self.bus.gayle.is_some()
+            && crate::pcmcia::decodes(addr)
+            && self.bus.pcmcia_write(addr, size, value)
+        {
+            self.bus.cpu_slow_external_access(Self::access_words(size));
+            if self.bus.take_pcmcia_activity() {
+                self.bus.note_hdd_activity();
             }
             return;
         }

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -3189,10 +3189,10 @@ fn build_serial_sink(cfg: &Config) -> Result<Box<dyn crate::serial::SerialSink>>
 /// that slot empty, as it would if the drive had been unplugged. Only a disk
 /// that is present is opened, so a missing one never raises the host's
 /// permission prompt.
-#[cfg(not(target_arch = "wasm32"))]
 /// The card `[pcmcia]` (or a `[[host_disk]]` on the slot) puts in the
 /// socket at power-on. A missing real disk is reported and skipped, as
 /// the IDE ports do; a missing image is an error, as `[ide]`'s is.
+#[cfg(not(target_arch = "wasm32"))]
 fn open_pcmcia_card(cfg: &Config) -> Result<Option<crate::pcmcia::PcmciaCard>> {
     use crate::config::PcmciaCardConfig;
     use crate::pcmcia::{CfCard, PcmciaCard, SramCard};
@@ -3241,6 +3241,7 @@ fn open_pcmcia_card(cfg: &Config) -> Result<Option<crate::pcmcia::PcmciaCard>> {
     Ok(None)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn attach_ide_host_disks(cfg: &Config, mut attach: impl FnMut(usize, crate::ata::IdeDrive)) {
     for disk in &cfg.host_disks {
         // SCSI units, lide positions, and the PCMCIA slot are attached
@@ -4114,7 +4115,10 @@ fn build_machine_inner(
         let shadowed = cfg.pcmcia_slot_shadowed();
         gayle.set_slot_shadowed(shadowed);
         bus.attach_gayle(gayle);
+        #[cfg(not(target_arch = "wasm32"))]
         let card = open_pcmcia_card(cfg)?;
+        #[cfg(target_arch = "wasm32")]
+        let card: Option<crate::pcmcia::PcmciaCard> = None;
         if shadowed {
             if card.is_some() || cfg.host_disks.iter().any(|d| d.attach.is_pcmcia()) {
                 warn!(

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -3147,6 +3147,24 @@ fn build_serial_sink(cfg: &Config) -> Result<Box<dyn crate::serial::SerialSink>>
         SerialMode::Pty => Err(anyhow!(
             "[serial] mode = \"pty\" is only available on Unix hosts"
         )),
+        #[cfg(feature = "host-serial")]
+        SerialMode::Device => {
+            let path = cfg.serial.device.as_deref().ok_or_else(|| {
+                anyhow!(
+                    "[serial] mode = \"device\" needs a host serial port: set [serial] \
+                     device = \"/dev/tty...\" (or \"COMn\"), pass --serial-device, or pick \
+                     one in the launcher's I/O Ports > Serial > Port row \
+                     (--list-serial-ports names them)"
+                )
+            })?;
+            Ok(Box::new(crate::serial::device::DeviceSerialSink::open(
+                path,
+            )?))
+        }
+        #[cfg(not(feature = "host-serial"))]
+        SerialMode::Device => Err(anyhow!(
+            "[serial] mode = \"device\" needs a build with --features host-serial"
+        )),
         SerialMode::Modem => {
             let options = crate::modem::ModemOptions {
                 listen: cfg.serial.listen.clone(),
@@ -3172,15 +3190,68 @@ fn build_serial_sink(cfg: &Config) -> Result<Box<dyn crate::serial::SerialSink>>
 /// that is present is opened, so a missing one never raises the host's
 /// permission prompt.
 #[cfg(not(target_arch = "wasm32"))]
+/// The card `[pcmcia]` (or a `[[host_disk]]` on the slot) puts in the
+/// socket at power-on. A missing real disk is reported and skipped, as
+/// the IDE ports do; a missing image is an error, as `[ide]`'s is.
+fn open_pcmcia_card(cfg: &Config) -> Result<Option<crate::pcmcia::PcmciaCard>> {
+    use crate::config::PcmciaCardConfig;
+    use crate::pcmcia::{CfCard, PcmciaCard, SramCard};
+    match &cfg.pcmcia.card {
+        PcmciaCardConfig::Cf { path } => {
+            let card = CfCard::open(path)
+                .with_context(|| format!("[pcmcia] CF card image {}", path.display()))?;
+            return Ok(Some(PcmciaCard::cf(card)));
+        }
+        PcmciaCardConfig::Sram {
+            size,
+            path,
+            read_only,
+        } => {
+            let card = SramCard::new(*size, path.as_deref(), *read_only)?;
+            return Ok(Some(PcmciaCard::Sram(card)));
+        }
+        PcmciaCardConfig::None => {}
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(disk) = cfg.host_disks.iter().find(|d| d.attach.is_pcmcia()) {
+        match crate::ata::IdeDrive::open_host_disk(
+            &disk.device,
+            disk.fingerprint.as_deref(),
+            disk.identity_confirmed,
+            disk.writable,
+        ) {
+            Ok(drive) => {
+                info!(
+                    "pcmcia: CF card is host disk {}{}",
+                    disk.device,
+                    if disk.writable {
+                        " (WRITABLE)"
+                    } else {
+                        " (read-only)"
+                    }
+                );
+                return Ok(Some(PcmciaCard::cf(CfCard::new(drive))));
+            }
+            Err(error) => warn!(
+                "pcmcia: asked for host disk {}, which is not available: {error}",
+                disk.device
+            ),
+        }
+    }
+    Ok(None)
+}
+
 fn attach_ide_host_disks(cfg: &Config, mut attach: impl FnMut(usize, crate::ata::IdeDrive)) {
     for disk in &cfg.host_disks {
-        // SCSI units and lide positions are attached elsewhere.
+        // SCSI units, lide positions, and the PCMCIA slot are attached
+        // elsewhere.
         let slot = match disk.attach {
             crate::config::HostDiskAttach::IdeMaster => 0,
             crate::config::HostDiskAttach::IdeSlave => 1,
             crate::config::HostDiskAttach::LideMaster(_)
             | crate::config::HostDiskAttach::LideSlave(_)
-            | crate::config::HostDiskAttach::Scsi(_) => continue,
+            | crate::config::HostDiskAttach::Scsi(_)
+            | crate::config::HostDiskAttach::Pcmcia => continue,
         };
         match crate::ata::IdeDrive::open_host_disk(
             &disk.device,
@@ -4036,7 +4107,34 @@ fn build_machine_inner(
         // refused by configuration validation rather than silently replaced.
         #[cfg(not(target_arch = "wasm32"))]
         attach_ide_host_disks(cfg, |slot, drive| gayle.attach_drive(slot, drive));
+        // The PCMCIA common-memory window ($600000-$9FFFFF) is Zorro II
+        // space: with more than 4 MiB of fast RAM configured there Gayle's
+        // slot decode gives way to the RAM board, as on a real A1200 where
+        // an 8 MiB Zorro II expansion kills the slot.
+        let shadowed = cfg.pcmcia_slot_shadowed();
+        gayle.set_slot_shadowed(shadowed);
         bus.attach_gayle(gayle);
+        let card = open_pcmcia_card(cfg)?;
+        if shadowed {
+            if card.is_some() || cfg.host_disks.iter().any(|d| d.attach.is_pcmcia()) {
+                warn!(
+                    "pcmcia: {} of Zorro II fast RAM covers the slot's common memory window \
+                     ($600000-$9FFFFF); the PCMCIA slot is disabled and the card ({}) will not \
+                     be seen. Use fast = \"4M\" or less to keep the slot",
+                    crate::config::format_size(cfg.fast_ram_bytes),
+                    cfg.pcmcia.describe()
+                );
+            } else {
+                info!(
+                    "pcmcia: slot disabled ({} of Zorro II fast RAM covers its window)",
+                    crate::config::format_size(cfg.fast_ram_bytes)
+                );
+            }
+        }
+        if let Some(card) = card {
+            info!("pcmcia: {}", card.describe());
+            bus.pcmcia_insert(card);
+        }
     }
     if cfg.ide_a4000 {
         let mut ide = crate::ide_a4000::IdeA4000::new();
@@ -4168,6 +4266,32 @@ fn build_machine_inner(
         cfg.port_devices[0].label(),
         cfg.port_devices[1].label()
     );
+    // The four-player adapter is wiring on the Centronics connector, not a
+    // host peripheral: it lives in the deterministic input state.
+    let adapter = cfg.parallel.device == crate::config::ParallelDevice::JoystickAdapter;
+    bus.input
+        .set_parallel_adapter(adapter, cfg.parallel_joysticks);
+    if adapter {
+        info!(
+            "parallel: four-player joystick adapter, port 3 = {}, port 4 = {}",
+            bus.input.device(2).label(),
+            bus.input.device(3).label()
+        );
+    }
+    if let Some(port) = bus.input.light_pen_port() {
+        let wired = bus.light_pen_wired_port();
+        if port == wired {
+            info!("input: light pen in port {} drives Agnus LP", port + 1);
+        } else {
+            warn!(
+                "input: light pen in port {} but this board wires Agnus LP to port {}'s pin 6 \
+                 (port 1 on the A1000, port 2 on later Amigas); the pen's switch works, its \
+                 pulses reach nothing",
+                port + 1,
+                wired + 1
+            );
+        }
+    }
     if cfg.akiko {
         let mut akiko = crate::akiko::Akiko::new();
         if let Some(path) = &cfg.cd32_nvram_path {

--- a/src/gayle.rs
+++ b/src/gayle.rs
@@ -1,42 +1,111 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 //! Gayle gate array (A600/A1200): the ID register at $DE1000, the IDE
-//! interface at $DA0000, the Gayle status/interrupt/config registers at
-//! $DA8000-$DAA000, and empty-slot PCMCIA status.
+//! interface at $DA0000, and the PCMCIA status/change/enable/config
+//! registers at $DA8000-$DAB000.
 //!
 //! Decode and register layout follow the Commodore schematics as captured by
-//! the Linux `gayle.c` IDE driver and the ROM scsi.device: the IDE task
-//! file lives at $DA2000 with a 4-byte stride (byte registers on the odd
-//! word half, offset base+4*reg+2), and the control block register at
-//! base+$101A. None of this is on the chip bus; the CPU reaches it through
+//! the Linux `gayle.c` IDE driver, the `amigayle.h` header (disassembled
+//! from card.resource), and WinUAE's `gayle.cpp`: the IDE task file lives at
+//! $DA2000 with a 4-byte stride (byte registers on the odd word half, offset
+//! base+4*reg+2), and the control block register at base+$101A. None of
+//! this is on the chip bus; the CPU reaches it through
 //! `cpu_external_access`.
+//!
+//! The PCMCIA side: Gayle samples the slot's CD, BVD1, BVD2, WP, and
+//! READY/IREQ pins into the status register at $DA8000, latches every
+//! change of them into $DA9000 (write-to-clear, AND semantics), and drives
+//! INT2 or INT6 for the latched sources the $DAA000 enable register admits
+//! -- card detect always on INT6, write-enable and IDE on INT2, battery and
+//! busy/interrupt on whichever of the two the enable register's level bits
+//! pick. $DAB000 holds the programming-voltage and access-speed
+//! configuration. The slot's address windows ($600000 common memory,
+//! $A00000 attribute, $A20000/$A30000 I/O, $A40000 reset) are decoded by
+//! the bus with the card in [`crate::pcmcia`]; Gayle only says whether the
+//! slot is enabled.
 //!
 //! The drives, the task file, and the command engine are the shared ATA core
 //! in [`crate::ata`]; Gayle is the front-end that decodes for it and adds its
 //! own ID, interrupt, and PCMCIA registers.
 
 use crate::ata::{task_file_reg, AtaBus, AtaDevice, IdeReg};
+use crate::pcmcia::{PIN_BSY_IRQ, PIN_BVD1, PIN_BVD2, PIN_CCDET, PIN_WR};
 
 pub use crate::ata::{AtapiDrive, IdeDrive, MAX_MULTIPLE, SECTOR_SIZE};
 
 // Gayle interrupt/status bit layout (shared by the status, interrupt
 // change, and interrupt enable registers).
 pub const GAYLE_IRQ_IDE: u8 = 0x80;
-// PCMCIA bits (CCDET/BVD1/BVD2/WR/BSY) stay clear: no card inserted.
+/// Card detect changed ($DA9000) / card-detect interrupt enable ($DAA000).
+pub const GAYLE_IRQ_CCDET: u8 = PIN_CCDET;
+/// Battery voltage 1 / status change.
+pub const GAYLE_IRQ_BVD1: u8 = PIN_BVD1;
+/// Battery voltage 2 / digital audio.
+pub const GAYLE_IRQ_BVD2: u8 = PIN_BVD2;
+/// Write enable changed.
+pub const GAYLE_IRQ_WR: u8 = PIN_WR;
+/// Busy / card interrupt request.
+pub const GAYLE_IRQ_BSY: u8 = PIN_BSY_IRQ;
+/// The pin-change latches: every status bit that is a slot pin.
+pub const GAYLE_PIN_MASK: u8 = PIN_CCDET | PIN_BVD1 | PIN_BVD2 | PIN_WR | PIN_BSY_IRQ;
+/// $DA9000 bit 1: reset the machine when card detect changes (preliminary
+/// Gayle datasheet; WinUAE `GAYLE_IRQ_RESET`).
+pub const GAYLE_IRQ_RESET: u8 = 0x02;
+/// $DA9000 bit 0: bus-error the access when card detect changes (WinUAE
+/// `GAYLE_IRQ_BERR`). Both bits written together reset the card's
+/// configuration instead.
+pub const GAYLE_IRQ_BERR: u8 = 0x01;
+/// $DAA000 bit 1: battery-voltage interrupts on INT6 instead of INT2.
+pub const GAYLE_INT_BVD_LEV: u8 = 0x02;
+/// $DAA000 bit 0: busy/IRQ interrupts on INT6 instead of INT2.
+pub const GAYLE_INT_BSY_LEV: u8 = 0x01;
+/// $DA8000 write bit 1: enable the card's digital-audio output.
+pub const GAYLE_CS_DAEN: u8 = 0x02;
+/// $DA8000 write bit 0: disable the slot (windows unmapped, pins read as an
+/// empty socket).
+pub const GAYLE_CS_DIS: u8 = 0x01;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Gayle {
     /// $DE1000 ID shifted out MSB-first on D7: $D0 (A600) / $D1 (A1200).
     id: u8,
     id_bit: u8,
-    /// $DA9000 latched interrupt-change bits (write-to-clear with AND).
+    /// $DA9000 latched interrupt-change bits (write-to-clear with AND),
+    /// plus the RESET/BERR control bits in 1:0.
     intreq: u8,
-    /// $DA9800 interrupt enable.
+    /// $DAA000 interrupt enable, plus the BVD/BSY level-select bits in 1:0.
     intena: u8,
-    /// $DAA000 config (PCMCIA voltage/resistor config; stored only).
+    /// $DAB000 config (PCMCIA programming voltage, access speed).
     config: u8,
     /// The IDE cable behind the gate array.
     ata: AtaBus,
+    /// The slot pins as the card drives them, in status-register layout
+    /// (zero for an empty socket). The bus refreshes this whenever the card
+    /// changes or is accessed.
+    #[serde(default)]
+    raw_pins: u8,
+    /// The pins as the status register last showed them: `raw_pins` while
+    /// the slot is enabled, an empty socket otherwise. The change latches
+    /// are the difference between successive values.
+    #[serde(default)]
+    pins: u8,
+    /// $DA8000 as written: bits 1:0 are the DAEN/DIS controls, bits 7:2 read
+    /// back OR-ed into the status (card.resource's CardMiscControl writes
+    /// the write-protect-override bit there).
+    #[serde(default)]
+    status_control: u8,
+    /// The slot windows overlap Zorro II space: with more than 4 MiB of
+    /// fast RAM configured there, Gayle's PCMCIA decode gives way and the
+    /// slot behaves as empty.
+    #[serde(default)]
+    slot_shadowed: bool,
+    /// A write to $DA9000 with RESET and BERR both set asks for the card's
+    /// configuration to be reset; the bus drains this to reach the card.
+    #[serde(default)]
+    card_reset_request: bool,
+    /// Card detect changed with $DA9000's RESET bit set: reset the machine.
+    #[serde(default)]
+    machine_reset_request: bool,
 }
 
 impl Gayle {
@@ -48,6 +117,12 @@ impl Gayle {
             intena: 0,
             config: 0,
             ata: AtaBus::new(),
+            raw_pins: 0,
+            pins: 0,
+            status_control: 0,
+            slot_shadowed: false,
+            card_reset_request: false,
+            machine_reset_request: false,
         }
     }
 
@@ -97,21 +172,137 @@ impl Gayle {
     }
 
     /// System reset: clear the register file and any in-flight transfer but
-    /// keep the mounted drives.
+    /// keep the mounted drives. The card stays in its socket: its pins are
+    /// sampled afresh with no change latched, as on a real power-on.
     pub fn reset(&mut self) {
         self.id_bit = 0;
         self.intreq = 0;
         self.intena = 0;
         self.config = 0;
+        self.status_control = 0;
+        self.card_reset_request = false;
+        self.machine_reset_request = false;
+        self.pins = self.effective_pins();
         self.ata.reset();
     }
 
-    /// The INT2 line into Paula (PORTS): the latched interrupt-change bits
-    /// gated by the $DAA000 enable register (the ROM writes $EC there:
-    /// IDE plus the PCMCIA detect/change sources). Paula's INTREQ latch is
-    /// level-fed, so the bus re-asserts INTREQ.PORTS while this stays true.
+    // ----- PCMCIA slot state -----------------------------------------------
+
+    /// Whether the slot's address windows are decoded: not shadowed by
+    /// Zorro II RAM, and not disabled through the status register.
+    pub fn slot_enabled(&self) -> bool {
+        !self.slot_shadowed && self.status_control & GAYLE_CS_DIS == 0
+    }
+
+    pub fn slot_shadowed(&self) -> bool {
+        self.slot_shadowed
+    }
+
+    /// Decide the fast-RAM conflict rule at machine build: with more than
+    /// 4 MiB of Zorro II fast RAM the common window is RAM and the whole
+    /// slot goes dark.
+    pub fn set_slot_shadowed(&mut self, shadowed: bool) {
+        self.slot_shadowed = shadowed;
+        self.sync_pins();
+    }
+
+    /// The card's pins as the bus last sampled them.
+    pub fn card_pins(&self) -> u8 {
+        self.raw_pins
+    }
+
+    /// Report the pins the card in the socket drives (zero for an empty
+    /// socket). Any bit that differs from what the status register showed
+    /// is latched into $DA9000; a high busy/IRQ pin is latched for as long
+    /// as it stays high (it is a level, as the IDE bit is).
+    pub fn set_card_pins(&mut self, raw: u8) {
+        self.raw_pins = raw & GAYLE_PIN_MASK;
+        self.sync_pins();
+    }
+
+    fn effective_pins(&self) -> u8 {
+        if self.slot_enabled() {
+            self.raw_pins
+        } else {
+            0
+        }
+    }
+
+    fn sync_pins(&mut self) {
+        let now = self.effective_pins();
+        let changed = now ^ self.pins;
+        self.pins = now;
+        self.intreq |= changed;
+        if now & PIN_BSY_IRQ != 0 {
+            self.intreq |= GAYLE_IRQ_BSY;
+        }
+        if changed & PIN_CCDET != 0 {
+            // The preliminary datasheet's card-change actions, as WinUAE
+            // reads them: RESET alone reboots the machine, BERR alone would
+            // bus-error the access (TODO: not modelled; it needs a
+            // deferred bus-error injection into the running instruction),
+            // both together mean neither.
+            match self.intreq & (GAYLE_IRQ_RESET | GAYLE_IRQ_BERR) {
+                GAYLE_IRQ_RESET => self.machine_reset_request = true,
+                GAYLE_IRQ_BERR => {
+                    log::warn!("gayle: card-detect change with BERR armed is not modelled")
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Drain the request a $DA9000 RESET+BERR write made to reset the
+    /// card's configuration.
+    pub fn take_card_reset_request(&mut self) -> bool {
+        std::mem::take(&mut self.card_reset_request)
+    }
+
+    /// Drain the request a card-detect change made to reset the machine.
+    pub fn take_machine_reset_request(&mut self) -> bool {
+        std::mem::take(&mut self.machine_reset_request)
+    }
+
+    /// The bits of $DA9000 currently latched.
+    pub fn change_latches(&self) -> u8 {
+        self.intreq
+    }
+
+    // ----- interrupt lines ------------------------------------------------
+
+    /// The latched sources the enable register admits.
+    fn enabled_sources(&self) -> u8 {
+        self.intreq & self.intena & (GAYLE_IRQ_IDE | GAYLE_PIN_MASK)
+    }
+
+    /// The INT2 line into Paula (PORTS): IDE and write-enable changes, plus
+    /// battery and busy/IRQ changes unless their level bits send them to
+    /// INT6. Paula's INTREQ latch is level-fed, so the bus re-asserts
+    /// INTREQ.PORTS while this stays true.
     pub fn int2_line(&self) -> bool {
-        self.intreq & self.intena != 0
+        let sources = self.enabled_sources();
+        let mut mask = GAYLE_IRQ_IDE | GAYLE_IRQ_WR;
+        if self.intena & GAYLE_INT_BVD_LEV == 0 {
+            mask |= GAYLE_IRQ_BVD1 | GAYLE_IRQ_BVD2;
+        }
+        if self.intena & GAYLE_INT_BSY_LEV == 0 {
+            mask |= GAYLE_IRQ_BSY;
+        }
+        sources & mask != 0
+    }
+
+    /// The INT6 line into Paula (EXTER): card detect always, battery and
+    /// busy/IRQ when their level bits say so.
+    pub fn int6_line(&self) -> bool {
+        let sources = self.enabled_sources();
+        let mut mask = GAYLE_IRQ_CCDET;
+        if self.intena & GAYLE_INT_BVD_LEV != 0 {
+            mask |= GAYLE_IRQ_BVD1 | GAYLE_IRQ_BVD2;
+        }
+        if self.intena & GAYLE_INT_BSY_LEV != 0 {
+            mask |= GAYLE_IRQ_BSY;
+        }
+        sources & mask != 0
     }
 
     /// Latch an IDE interrupt the cable raised during this access. Unlike the
@@ -213,21 +404,18 @@ impl Gayle {
     fn register_read(&mut self, addr: u32) -> u8 {
         match addr & 0xFFFF_F000 {
             0x00DA_8000 => {
-                // Status: live IDE INTRQ on bit 7. The PCMCIA pins are
-                // active-low and pulled up, so an EMPTY slot reads with the
-                // card-detect/battery/write/busy bits SET (0x7C); all-zero
-                // would tell card.resource a card is inserted and wedge boot
-                // waiting for it to become ready.
-                let pcmcia_empty = 0x7C;
+                // Status: the slot pins (all clear for an empty socket, so
+                // card.resource sees no card), the control bits as written,
+                // and live IDE INTRQ on bit 7.
+                let mut v = self.pins | self.status_control;
                 if self.ata.irq_level() {
-                    GAYLE_IRQ_IDE | pcmcia_empty
-                } else {
-                    pcmcia_empty
+                    v |= GAYLE_IRQ_IDE;
                 }
+                v
             }
             0x00DA_9000 => self.intreq,
             0x00DA_A000 => self.intena,
-            0x00DA_B000 => self.config,
+            0x00DA_B000 => self.config & 0x0F,
             _ => 0,
         }
     }
@@ -235,13 +423,26 @@ impl Gayle {
     fn register_write(&mut self, addr: u32, value: u8) {
         match addr & 0xFFFF_F000 {
             0x00DA_8000 => {
-                // Status register writes only touch the PCMCIA control bits;
-                // nothing modeled behind them with an empty slot.
+                let was_disabled = self.status_control & GAYLE_CS_DIS;
+                self.status_control = value;
+                if was_disabled != value & GAYLE_CS_DIS {
+                    // Disabling the slot pulls the pins to the empty-socket
+                    // state and enabling it samples the card again, so both
+                    // edges latch a card-detect change.
+                    self.sync_pins();
+                }
             }
             0x00DA_9000 => {
                 // Interrupt change: write-to-clear. Bits written as 1 are
-                // kept, bits written as 0 are cleared.
-                self.intreq &= value;
+                // kept, bits written as 0 are cleared; the two control bits
+                // are set by writing them, and both together reset the
+                // card's configuration.
+                self.intreq = (self.intreq & value) | (value & (GAYLE_IRQ_RESET | GAYLE_IRQ_BERR));
+                if self.intreq & (GAYLE_IRQ_RESET | GAYLE_IRQ_BERR)
+                    == GAYLE_IRQ_RESET | GAYLE_IRQ_BERR
+                {
+                    self.card_reset_request = true;
+                }
             }
             0x00DA_A000 => self.intena = value,
             0x00DA_B000 => self.config = value,
@@ -267,6 +468,7 @@ mod tests {
     use super::*;
     use crate::ata::{DH_LBA, ERR_ABRT, ST_DRDY, ST_DRQ, ST_DSC, ST_ERR};
     use crate::harddrive::{CYL_SECTORS, RDB_HEADS, RDB_SPT};
+    use crate::pcmcia::{PIN_BSY_IRQ, PIN_BVD1, PIN_BVD2, PIN_CCDET, PIN_WR};
     use std::path::PathBuf;
 
     fn temp_image(sectors: u64) -> PathBuf {
@@ -622,6 +824,181 @@ mod tests {
             "no phantom IDENTIFY: status stays at the pair-present pattern"
         );
         std::fs::remove_file(path).ok();
+    }
+
+    const GAYLE_CONFIG_REG: u32 = 0x00DA_B000;
+    const CARD_PINS: u8 = PIN_CCDET | PIN_BVD1 | PIN_BVD2 | PIN_WR;
+
+    /// An empty socket reads with every pin bit clear (card.resource sees
+    /// no card); inserting a card raises the pins it drives and latches
+    /// each as a change, and card detect goes out on INT6 once enabled.
+    #[test]
+    fn card_insert_sets_status_pins_latches_changes_and_raises_int6() {
+        let mut g = Gayle::new(0xD1);
+        assert_eq!(g.read(GAYLE_STATUS_REG, 1) as u8 & GAYLE_PIN_MASK, 0);
+        assert_eq!(g.read(GAYLE_INTREQ, 1) as u8 & GAYLE_PIN_MASK, 0);
+
+        g.set_card_pins(CARD_PINS);
+        assert_eq!(
+            g.read(GAYLE_STATUS_REG, 1) as u8 & GAYLE_PIN_MASK,
+            CARD_PINS
+        );
+        assert_eq!(g.read(GAYLE_INTREQ, 1) as u8 & GAYLE_PIN_MASK, CARD_PINS);
+        // Nothing enabled: nothing on either line.
+        assert!(!g.int2_line());
+        assert!(!g.int6_line());
+
+        // card.resource's enable word: IDE plus every card source.
+        g.write(GAYLE_INTENA, 1, 0xEC);
+        assert!(g.int6_line(), "card detect is an INT6 source");
+        assert!(g.int2_line(), "WR change is an INT2 source");
+
+        // Write-to-clear: dropping the detect and write-enable latches
+        // while keeping the rest.
+        g.write(
+            GAYLE_INTREQ,
+            1,
+            u32::from(!(GAYLE_IRQ_CCDET | GAYLE_IRQ_WR)),
+        );
+        assert_eq!(
+            g.read(GAYLE_INTREQ, 1) as u8 & GAYLE_PIN_MASK,
+            PIN_BVD1 | PIN_BVD2
+        );
+        assert!(!g.int6_line());
+        // BVD changes default to INT2 (level bit clear).
+        assert!(g.int2_line());
+        g.write(GAYLE_INTREQ, 1, 0);
+        assert!(!g.int2_line());
+
+        // Removing the card latches every pin again.
+        g.set_card_pins(0);
+        assert_eq!(g.read(GAYLE_STATUS_REG, 1) as u8 & GAYLE_PIN_MASK, 0);
+        assert_eq!(g.read(GAYLE_INTREQ, 1) as u8 & GAYLE_PIN_MASK, CARD_PINS);
+        assert!(g.int6_line());
+    }
+
+    /// The $DAA000 level bits steer the battery and busy/IRQ sources
+    /// between INT2 and INT6; card detect stays on INT6 regardless.
+    #[test]
+    fn enable_register_level_bits_route_bvd_and_bsy_between_int2_and_int6() {
+        let mut g = Gayle::new(0xD1);
+        g.set_card_pins(CARD_PINS);
+        g.write(GAYLE_INTREQ, 1, 0); // drop the insertion latches
+        g.write(GAYLE_INTENA, 1, u32::from(GAYLE_IRQ_BVD1 | GAYLE_IRQ_BSY));
+
+        // Battery pin drops: INT2 by default, INT6 with BVD_LEV.
+        g.set_card_pins(CARD_PINS & !PIN_BVD1);
+        assert!(g.int2_line());
+        assert!(!g.int6_line());
+        g.write(
+            GAYLE_INTENA,
+            1,
+            u32::from(GAYLE_IRQ_BVD1 | GAYLE_IRQ_BSY | GAYLE_INT_BVD_LEV),
+        );
+        assert!(!g.int2_line());
+        assert!(g.int6_line());
+        g.write(GAYLE_INTREQ, 1, u32::from(!GAYLE_IRQ_BVD1));
+
+        // A card interrupt (IREQ#) is a level: it stays latched while the
+        // pin is high even after a clear, and follows BSY_LEV.
+        g.set_card_pins(CARD_PINS & !PIN_BVD1 | PIN_BSY_IRQ);
+        assert!(g.int2_line(), "BSY_LEV clear: INT2");
+        g.write(GAYLE_INTREQ, 1, u32::from(!GAYLE_IRQ_BSY));
+        assert_eq!(g.read(GAYLE_INTREQ, 1) as u8 & GAYLE_IRQ_BSY, 0);
+        g.set_card_pins(CARD_PINS & !PIN_BVD1 | PIN_BSY_IRQ);
+        assert_ne!(
+            g.read(GAYLE_INTREQ, 1) as u8 & GAYLE_IRQ_BSY,
+            0,
+            "a high IRQ pin re-latches on the next sample"
+        );
+        g.write(
+            GAYLE_INTENA,
+            1,
+            u32::from(GAYLE_IRQ_BVD1 | GAYLE_IRQ_BSY | GAYLE_INT_BSY_LEV),
+        );
+        assert!(!g.int2_line());
+        assert!(g.int6_line(), "BSY_LEV set: INT6");
+        // Card detect always rides INT6, whatever the level bits say.
+        g.write(GAYLE_INTENA, 1, u32::from(GAYLE_IRQ_CCDET));
+        g.set_card_pins(0);
+        assert!(g.int6_line());
+        assert!(!g.int2_line());
+    }
+
+    /// $DA8000 writes: DIS pulls the socket to empty (latching the detect
+    /// change) and re-enabling samples the card again; the other written
+    /// bits read back OR-ed into the status (CardMiscControl's
+    /// write-protect override); $DAB000 keeps only its four config bits.
+    #[test]
+    fn status_control_bits_disable_the_slot_and_read_back() {
+        let mut g = Gayle::new(0xD1);
+        g.set_card_pins(CARD_PINS & !PIN_WR); // write-protected card
+        g.write(GAYLE_INTREQ, 1, 0);
+        assert!(g.slot_enabled());
+
+        g.write(GAYLE_STATUS_REG, 1, u32::from(GAYLE_CS_DIS));
+        assert!(!g.slot_enabled());
+        assert_eq!(g.read(GAYLE_STATUS_REG, 1) as u8 & GAYLE_PIN_MASK, 0);
+        assert_ne!(g.read(GAYLE_INTREQ, 1) as u8 & GAYLE_IRQ_CCDET, 0);
+        assert_ne!(g.read(GAYLE_STATUS_REG, 1) as u8 & GAYLE_CS_DIS, 0);
+        g.write(GAYLE_INTREQ, 1, 0);
+
+        // Write-protect override: bit 3 written reads back set.
+        g.write(GAYLE_STATUS_REG, 1, u32::from(PIN_WR | GAYLE_CS_DAEN));
+        assert!(g.slot_enabled());
+        assert_eq!(
+            g.read(GAYLE_STATUS_REG, 1) as u8 & (GAYLE_PIN_MASK | GAYLE_CS_DAEN),
+            CARD_PINS | GAYLE_CS_DAEN
+        );
+        assert_ne!(g.read(GAYLE_INTREQ, 1) as u8 & GAYLE_IRQ_CCDET, 0);
+
+        g.write(GAYLE_CONFIG_REG, 1, 0xF9);
+        assert_eq!(g.read(GAYLE_CONFIG_REG, 1), 0x09, "voltage/speed bits only");
+        // A word write lands on the even byte.
+        g.write(GAYLE_CONFIG_REG, 2, 0x0500);
+        assert_eq!(g.read(GAYLE_CONFIG_REG, 2), 0x0500);
+    }
+
+    /// $DA9000 bits 1:0 are set by writing them: both together ask for a
+    /// card configuration reset, RESET alone reboots the machine on the
+    /// next card-detect change.
+    #[test]
+    fn change_register_control_bits_request_card_and_machine_resets() {
+        let mut g = Gayle::new(0xD1);
+        g.write(GAYLE_INTREQ, 1, u32::from(GAYLE_IRQ_RESET | GAYLE_IRQ_BERR));
+        assert_eq!(
+            g.read(GAYLE_INTREQ, 1) as u8 & 3,
+            GAYLE_IRQ_RESET | GAYLE_IRQ_BERR
+        );
+        assert!(g.take_card_reset_request());
+        assert!(!g.take_card_reset_request(), "drained");
+        assert!(!g.take_machine_reset_request());
+
+        g.write(GAYLE_INTREQ, 1, u32::from(GAYLE_IRQ_RESET));
+        assert!(!g.take_card_reset_request());
+        g.set_card_pins(CARD_PINS);
+        assert!(g.take_machine_reset_request());
+        // A system reset clears every latch and control bit but keeps the
+        // card visible, with no change pending.
+        g.reset();
+        assert_eq!(g.read(GAYLE_INTREQ, 1), 0);
+        assert_eq!(
+            g.read(GAYLE_STATUS_REG, 1) as u8 & GAYLE_PIN_MASK,
+            CARD_PINS
+        );
+    }
+
+    /// More than 4 MiB of Zorro II fast RAM covers the slot's window: the
+    /// socket reads empty whatever is in it, and nothing is latched.
+    #[test]
+    fn fast_ram_shadowing_makes_the_slot_read_empty() {
+        let mut g = Gayle::new(0xD1);
+        g.set_slot_shadowed(true);
+        g.set_card_pins(CARD_PINS);
+        assert!(!g.slot_enabled());
+        assert_eq!(g.read(GAYLE_STATUS_REG, 1) as u8 & GAYLE_PIN_MASK, 0);
+        assert_eq!(g.read(GAYLE_INTREQ, 1), 0);
+        assert!(g.card_pins() == CARD_PINS, "the card is still there");
     }
 
     /// A `.iso` path attaches as an ATAPI drive rather than being rejected:

--- a/src/harddrive.rs
+++ b/src/harddrive.rs
@@ -4,17 +4,22 @@
 //! IDE drives and the A2091 SCSI targets.
 //!
 //! A unit opens from a raw HDF image file, from a gzip-compressed one (the
-//! `.hdz` convention), or from a host directory (built into an in-memory
-//! FFS or OFS volume at open time, caller's choice; see `dirfs.rs`). Bare
-//! partition hardfiles (a filesystem boot block at sector 0, no RDSK) get a
+//! `.hdz` convention), from a MAME CHD hard-disk image (`chd.rs`, read
+//! through the `chd` crate with guest writes kept in a copy-on-write
+//! sidecar), or from a host directory (built into an in-memory FFS or OFS
+//! volume at open time, caller's choice; see `dirfs.rs`). Bare partition
+//! hardfiles (a filesystem boot block at sector 0, no RDSK) get a
 //! synthesized RDB cylinder prepended so the ROM boot driver can mount them
 //! without pre-conversion.
 
+use std::collections::BTreeMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
+pub mod chd;
 mod session;
+use chd::ChdHardDisk;
 use session::SessionImage;
 
 pub const SECTOR_SIZE: usize = 512;
@@ -45,6 +50,9 @@ enum Backing {
     File(File),
     Memory(Vec<u8>),
     Session(SessionImage),
+    /// A CHD hard-disk image: sectors decompressed on demand, writes in
+    /// the overlay sidecar beside it (or refused, when there is none).
+    Chd(Box<ChdHardDisk>),
     /// A real disk attached to the host. Presents 512-byte sectors like the
     /// others; the block size the media actually uses, and the privilege the
     /// open needed, are the device's own business.
@@ -98,6 +106,14 @@ struct HardDriveImageState<P = PathBuf, B = Vec<u8>, S = SessionImage> {
     /// would come back writable.
     host_device: Option<HostDiskState>,
     session: Option<S>,
+    /// Every sector a CHD image's write overlay holds, when the image is
+    /// one and writable. The CHD itself reopens by `path` like an HDF, but
+    /// the overlay is where the guest's writes live, so it travels with
+    /// the state and is put back on load: a resumed machine sees the disk
+    /// exactly as it was when the state was taken. `None` for every other
+    /// backing, and for a write-protected CHD.
+    #[serde(default)]
+    chd_overlay: Option<BTreeMap<u64, Vec<u8>>>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -138,6 +154,15 @@ impl serde::Serialize for HardDriveImage {
                 Backing::Session(image) => Some(image),
                 _ => None,
             },
+            chd_overlay: match &self.backing {
+                Backing::Chd(disk) => disk.overlay_contents().map_err(|e| {
+                    serde::ser::Error::custom(format!(
+                        "reading the write overlay of {}: {e}",
+                        self.path.display()
+                    ))
+                })?,
+                _ => None,
+            },
         }
         .serialize(serializer)
     }
@@ -171,18 +196,35 @@ impl<'de> serde::Deserialize<'de> for HardDriveImage {
                 return Err(serde::de::Error::custom("conflicting disk backings"))
             }
             (None, Some(image)) => Backing::Memory(image),
-            (None, None) => Backing::File(
-                OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .open(&state.path)
-                    .map_err(|e| {
-                        serde::de::Error::custom(format!(
-                            "reopening hard-drive image {}: {e}",
-                            state.path.display()
-                        ))
-                    })?,
-            ),
+            (None, None) => {
+                let reopen_error = |e: &dyn std::fmt::Display| {
+                    serde::de::Error::custom(format!(
+                        "reopening hard-drive image {}: {e}",
+                        state.path.display()
+                    ))
+                };
+                if is_chd_file(&state.path).map_err(|e| reopen_error(&e))? {
+                    let mut disk = ChdHardDisk::open(&state.path, bus_name, true)
+                        .map_err(|e| reopen_error(&format!("{e:#}")))?;
+                    if let Some(overlay) = &state.chd_overlay {
+                        disk.restore_overlay(overlay).map_err(|e| {
+                            serde::de::Error::custom(format!(
+                                "restoring the write overlay of {}: {e}",
+                                state.path.display()
+                            ))
+                        })?;
+                    }
+                    Backing::Chd(Box::new(disk))
+                } else {
+                    Backing::File(
+                        OpenOptions::new()
+                            .read(true)
+                            .write(true)
+                            .open(&state.path)
+                            .map_err(|e| reopen_error(&e))?,
+                    )
+                }
+            }
         };
         Ok(Self {
             path: state.path,
@@ -418,6 +460,19 @@ fn read_gzip_hardfile(path: &Path, bus_name: &str, limit: u64) -> anyhow::Result
     Ok(Some(image))
 }
 
+/// Whether the file at `path` opens with the CHD magic. Like the gzip
+/// sniff, this goes by content: a CHD called `.hdf` is still a CHD. A file
+/// too short to hold the magic is simply not one.
+fn is_chd_file(path: &Path) -> std::io::Result<bool> {
+    let mut file = File::open(path)?;
+    let mut head = [0u8; 8];
+    match file.read_exact(&mut head) {
+        Ok(()) => Ok(chd::is_chd(&head)),
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
 impl HardDriveImage {
     /// Whether the image carries its own Rigid Disk Block, rather than
     /// being a bare single-partition hardfile this had to synthesize one
@@ -622,6 +677,14 @@ impl HardDriveImage {
                     );
                     Backing::Memory(image)
                 }
+                None if is_chd_file(path).map_err(|e| {
+                    anyhow::anyhow!("reading {bus_name} image {}: {e}", path.display())
+                })? =>
+                {
+                    // A session copy is decompressed whole below; only a
+                    // persistent drive gets (or creates) the overlay sidecar.
+                    Backing::Chd(Box::new(ChdHardDisk::open(path, bus_name, !session)?))
+                }
                 None => Backing::File(
                     OpenOptions::new()
                         .read(true)
@@ -639,6 +702,7 @@ impl HardDriveImage {
                 .map_err(|e| anyhow::anyhow!("stat {bus_name} image {}: {e}", path.display()))?
                 .len(),
             Backing::Memory(image) => image.len() as u64,
+            Backing::Chd(disk) => disk.total_sectors() * SECTOR_SIZE as u64,
             Backing::Session(_) => unreachable!("session backing is installed after validation"),
             #[cfg(not(target_arch = "wasm32"))]
             Backing::Device(device) => device.total_sectors() * SECTOR_SIZE as u64,
@@ -671,6 +735,13 @@ impl HardDriveImage {
                 .read_exact(&mut head)
                 .map_err(|e| anyhow::anyhow!("reading {bus_name} image {}: {e}", path.display()))?,
             Backing::Memory(image) => head.copy_from_slice(&image[..sniff_len]),
+            Backing::Chd(disk) => {
+                for (lba, sector) in head.chunks_mut(SECTOR_SIZE).enumerate() {
+                    disk.read_sector(lba as u64, sector).map_err(|e| {
+                        anyhow::anyhow!("reading {bus_name} image {}: {e}", path.display())
+                    })?;
+                }
+            }
             Backing::Session(_) => unreachable!("session backing is installed after validation"),
             #[cfg(not(target_arch = "wasm32"))]
             Backing::Device(device) => {
@@ -745,6 +816,17 @@ impl HardDriveImage {
                     file.read_exact(&mut bytes)?;
                     bytes
                 }
+                // Decompressed whole: the session copy takes its writes in
+                // memory, and the CHD is never opened for a sidecar.
+                Backing::Chd(mut disk) => {
+                    let mut bytes = vec![0; len as usize];
+                    for (lba, sector) in bytes.chunks_mut(SECTOR_SIZE).enumerate() {
+                        disk.read_sector(lba as u64, sector).map_err(|e| {
+                            anyhow::anyhow!("reading {bus_name} image {}: {e}", path.display())
+                        })?;
+                    }
+                    bytes
+                }
                 _ => unreachable!("only image files and directories are session sources"),
             };
             backing = Backing::Session(SessionImage::new(bytes, false));
@@ -809,6 +891,22 @@ impl HardDriveImage {
         self.total_sectors
     }
 
+    /// Whether the guest's writes are refused: a CHD with no write overlay,
+    /// a read-only session copy, or a physical disk attached read-only.
+    /// Writes to such a drive fail with `PermissionDenied`, which the
+    /// controllers report to the guest as a write-protected medium.
+    pub fn write_protected(&self) -> bool {
+        match &self.backing {
+            Backing::Chd(disk) => disk.write_protected(),
+            Backing::Session(image) => image.read_only(),
+            #[cfg(not(target_arch = "wasm32"))]
+            Backing::Device(device) => !device.writable(),
+            #[cfg(not(target_arch = "wasm32"))]
+            Backing::PendingDevice(saved) => !saved.writable,
+            Backing::File(_) | Backing::Memory(_) => false,
+        }
+    }
+
     /// Sectors served from the synthesized RDB overlay; file LBAs shift down
     /// by this much.
     fn overlay_sectors(&self) -> u64 {
@@ -837,6 +935,7 @@ impl HardDriveImage {
                 Ok(())
             }
             Backing::Session(image) => image.read(file_lba, buf),
+            Backing::Chd(disk) => disk.read_sector(file_lba, buf),
             #[cfg(not(target_arch = "wasm32"))]
             Backing::Device(device) => device.read_sector(file_lba, buf),
             #[cfg(not(target_arch = "wasm32"))]
@@ -881,6 +980,7 @@ impl HardDriveImage {
                 Ok(())
             }
             Backing::Session(image) => image.write(file_lba, buf),
+            Backing::Chd(disk) => disk.write_sector(file_lba, buf),
             #[cfg(not(target_arch = "wasm32"))]
             Backing::Device(device) => device.write_sector(file_lba, buf),
             #[cfg(not(target_arch = "wasm32"))]
@@ -897,10 +997,11 @@ impl HardDriveImage {
         if let Backing::Device(device) = &mut self.backing {
             return device.flush();
         }
-        if let Backing::File(file) = &mut self.backing {
-            return file.flush();
+        match &mut self.backing {
+            Backing::File(file) => file.flush(),
+            Backing::Chd(disk) => disk.flush(),
+            _ => Ok(()),
         }
-        Ok(())
     }
 }
 
@@ -1042,6 +1143,7 @@ mod tests {
                 Backing::Session(image) => Some(image.clone()),
                 _ => unreachable!(),
             },
+            chd_overlay: None,
         };
         assert_eq!(encoded, bincode::serialize(&owned).unwrap());
         original.write_sector(lba, &[0x5A; SECTOR_SIZE]).unwrap();
@@ -1256,6 +1358,7 @@ mod tests {
                 fingerprint: "v1-saved".to_string(),
                 writable: false,
             }),
+            chd_overlay: None,
         };
         let bytes = bincode::serialize(&state).unwrap();
         let image: HardDriveImage = bincode::deserialize(&bytes).unwrap();

--- a/src/harddrive/chd.rs
+++ b/src/harddrive/chd.rs
@@ -580,6 +580,8 @@ struct Overlay {
     index: BTreeMap<u64, u64>,
     /// Length of the file as this handle knows it; the next record goes here.
     len: u64,
+    /// The CHD's SHA-1, as the header records it, for rewriting the file.
+    sha1: [u8; 20],
 }
 
 /// The sidecar path for `image`.
@@ -608,6 +610,7 @@ impl Overlay {
             path,
             index: BTreeMap::new(),
             len,
+            sha1,
         };
         if len == 0 {
             overlay.write_header(total_sectors, sha1)?;
@@ -664,6 +667,7 @@ impl Overlay {
             pos += RECORD_BYTES;
         }
         drop(reader);
+        let live_records = overlay.index.len() as u64;
         if pos < len {
             log::warn!(
                 "overlay {}: dropping {} trailing bytes of an incomplete record",
@@ -672,6 +676,29 @@ impl Overlay {
             );
             overlay.file.set_len(pos)?;
             overlay.len = pos;
+        }
+        // Records are appended, never overwritten, so a volume that keeps
+        // rewriting the same sectors leaves superseded copies behind. Fold
+        // them away when they have come to outweigh the live ones, which
+        // is a whole-file rewrite and so belongs here rather than in the
+        // middle of a session.
+        let live_bytes = OVERLAY_HEADER_BYTES + live_records * RECORD_BYTES;
+        if live_records > 0 && overlay.len > 2 * live_bytes {
+            let sectors = overlay.contents()?;
+            let sha1 = overlay.sha1;
+            match overlay.rewrite_atomically(&sectors, total_sectors, sha1) {
+                Ok(()) => log::info!(
+                    "overlay {}: compacted {} superseded record(s)",
+                    overlay.path.display(),
+                    (len - live_bytes) / RECORD_BYTES
+                ),
+                // A compaction that cannot be written changes nothing: the
+                // log it failed to replace is still complete and correct.
+                Err(e) => log::warn!(
+                    "overlay {}: leaving it uncompacted: {e}",
+                    overlay.path.display()
+                ),
+            }
         }
         Ok(overlay)
     }
@@ -701,22 +728,24 @@ impl Overlay {
         Ok(true)
     }
 
+    /// Append the sector's new contents as a fresh record.
+    ///
+    /// Rewriting the sector's existing record in place would be smaller,
+    /// but a write torn by a crash or a full disk would leave a
+    /// full-length record holding a mix of old and new bytes, and a scan
+    /// cannot tell that from a record that was written whole. A new record
+    /// at the end is either complete or dropped as a torn tail, leaving the
+    /// previous contents in force. The scan takes the last record for an
+    /// LBA, so the newest one wins; [`Overlay::open`] compacts the file
+    /// when the superseded records come to outweigh the live ones.
     fn write(&mut self, lba: u64, buf: &[u8]) -> std::io::Result<()> {
-        match self.index.get(&lba) {
-            Some(&offset) => {
-                self.file.seek(SeekFrom::Start(offset))?;
-                self.file.write_all(&buf[..SECTOR_SIZE])
-            }
-            None => {
-                let record = self.len;
-                self.file.seek(SeekFrom::Start(record))?;
-                self.file.write_all(&lba.to_le_bytes())?;
-                self.file.write_all(&buf[..SECTOR_SIZE])?;
-                self.index.insert(lba, record + 8);
-                self.len = record + RECORD_BYTES;
-                Ok(())
-            }
-        }
+        let record = self.len;
+        self.file.seek(SeekFrom::Start(record))?;
+        self.file.write_all(&lba.to_le_bytes())?;
+        self.file.write_all(&buf[..SECTOR_SIZE])?;
+        self.index.insert(lba, record + 8);
+        self.len = record + RECORD_BYTES;
+        Ok(())
     }
 
     fn contents(&self) -> std::io::Result<BTreeMap<u64, Vec<u8>>> {
@@ -746,12 +775,63 @@ impl Overlay {
                 format!("state carries an invalid overlay record for sector {lba}"),
             ));
         }
-        self.file.set_len(OVERLAY_HEADER_BYTES)?;
-        self.len = OVERLAY_HEADER_BYTES;
-        self.index.clear();
-        for (&lba, data) in sectors {
-            self.write(lba, data)?;
+        // Build the replacement beside the sidecar and swap it in once it
+        // is whole: truncating first would destroy the overlay a failed
+        // restore has to leave intact.
+        let sha1 = self.sha1;
+        self.rewrite_atomically(sectors, total_sectors, sha1)
+    }
+
+    /// Replace the sidecar's contents with `sectors`, one record each, by
+    /// writing a sibling file and renaming it over the old one. On any
+    /// failure the old sidecar is untouched and the temporary is removed.
+    fn rewrite_atomically(
+        &mut self,
+        sectors: &BTreeMap<u64, Vec<u8>>,
+        total_sectors: u64,
+        sha1: [u8; 20],
+    ) -> std::io::Result<()> {
+        let mut temp_name = self.path.as_os_str().to_owned();
+        temp_name.push(".new");
+        let temp_path = PathBuf::from(temp_name);
+        let outcome = (|| -> std::io::Result<(File, BTreeMap<u64, u64>, u64)> {
+            let mut temp = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&temp_path)?;
+            let mut header = [0u8; OVERLAY_HEADER_BYTES as usize];
+            header[..8].copy_from_slice(OVERLAY_MAGIC);
+            header[8..12].copy_from_slice(&(SECTOR_SIZE as u32).to_le_bytes());
+            header[12..20].copy_from_slice(&total_sectors.to_le_bytes());
+            header[20..40].copy_from_slice(&sha1);
+            temp.write_all(&header)?;
+            let mut index = BTreeMap::new();
+            let mut len = OVERLAY_HEADER_BYTES;
+            for (&lba, data) in sectors {
+                temp.write_all(&lba.to_le_bytes())?;
+                temp.write_all(&data[..SECTOR_SIZE])?;
+                index.insert(lba, len + 8);
+                len += RECORD_BYTES;
+            }
+            temp.sync_all()?;
+            Ok((temp, index, len))
+        })();
+        let (temp, index, len) = match outcome {
+            Ok(built) => built,
+            Err(e) => {
+                let _ = std::fs::remove_file(&temp_path);
+                return Err(e);
+            }
+        };
+        if let Err(e) = std::fs::rename(&temp_path, &self.path) {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(e);
         }
+        self.file = temp;
+        self.index = index;
+        self.len = len;
         Ok(())
     }
 }
@@ -1029,7 +1109,7 @@ pub(crate) mod tests {
             let sector = vec![0xA5; SECTOR_SIZE];
             drive.write_sector(3, &sector).unwrap();
             drive.write_sector(8, &sector).unwrap();
-            // A second write to the same sector overwrites its record.
+            // A second write to the same sector appends a new record.
             let again = vec![0x5A; SECTOR_SIZE];
             drive.write_sector(3, &again).unwrap();
             drive.flush().unwrap();
@@ -1045,7 +1125,7 @@ pub(crate) mod tests {
             "the CHD is untouched"
         );
         let overlay = std::fs::metadata(overlay_path(&path)).unwrap().len();
-        assert_eq!(overlay, OVERLAY_HEADER_BYTES + 2 * RECORD_BYTES);
+        assert_eq!(overlay, OVERLAY_HEADER_BYTES + 3 * RECORD_BYTES);
 
         let mut drive = open(&path);
         let mut back = vec![0u8; SECTOR_SIZE];
@@ -1055,6 +1135,81 @@ pub(crate) mod tests {
         assert!(back.iter().all(|&b| b == 0xA5));
         drive.read_sector(2, &mut back).unwrap();
         assert_eq!(&back[..], &data[2 * SECTOR_SIZE..3 * SECTOR_SIZE]);
+        cleanup(&path);
+    }
+
+    /// A rewrite that is cut short leaves the sector's previous contents
+    /// in force. Records are appended rather than overwritten precisely so
+    /// that a torn write cannot produce a full-length record holding half
+    /// of each version, which a scan would accept as sound.
+    #[test]
+    fn a_torn_rewrite_keeps_the_sectors_previous_contents() {
+        let path = temp_path("torn-rewrite.chd");
+        write_hard_disk(&path, 9, [7; 20]);
+        {
+            let mut drive = open(&path);
+            drive.write_sector(3, &vec![0xA5; SECTOR_SIZE]).unwrap();
+            drive.write_sector(3, &vec![0x5A; SECTOR_SIZE]).unwrap();
+            drive.flush().unwrap();
+        }
+        // Cut the second record short, as a crash mid-append would.
+        let overlay = overlay_path(&path);
+        let len = std::fs::metadata(&overlay).unwrap().len();
+        let file = OpenOptions::new().write(true).open(&overlay).unwrap();
+        file.set_len(len - 8).unwrap();
+        drop(file);
+
+        let mut drive = open(&path);
+        let mut back = vec![0u8; SECTOR_SIZE];
+        drive.read_sector(3, &mut back).unwrap();
+        assert!(
+            back.iter().all(|&b| b == 0xA5),
+            "the completed write must survive the torn one"
+        );
+        cleanup(&path);
+    }
+
+    /// Superseded records are folded away when reopening the sidecar, so a
+    /// volume that rewrites the same sectors does not grow the file without
+    /// bound.
+    #[test]
+    fn reopening_compacts_superseded_records() {
+        let path = temp_path("compact.chd");
+        write_hard_disk(&path, 9, [7; 20]);
+        {
+            let mut drive = open(&path);
+            for fill in 0..6u8 {
+                drive
+                    .write_sector(3, &vec![0x10 + fill; SECTOR_SIZE])
+                    .unwrap();
+            }
+            drive.flush().unwrap();
+        }
+        let overlay = overlay_path(&path);
+        assert_eq!(
+            std::fs::metadata(&overlay).unwrap().len(),
+            OVERLAY_HEADER_BYTES + 6 * RECORD_BYTES
+        );
+
+        let mut drive = open(&path);
+        assert_eq!(
+            std::fs::metadata(&overlay).unwrap().len(),
+            OVERLAY_HEADER_BYTES + RECORD_BYTES,
+            "one live record should remain"
+        );
+        let mut back = vec![0u8; SECTOR_SIZE];
+        drive.read_sector(3, &mut back).unwrap();
+        assert!(
+            back.iter().all(|&b| b == 0x15),
+            "compaction must keep the newest contents"
+        );
+        // And the compacted file is still a working overlay.
+        drive.write_sector(4, &vec![0x99; SECTOR_SIZE]).unwrap();
+        drive.flush().unwrap();
+        drop(drive);
+        let mut drive = open(&path);
+        drive.read_sector(4, &mut back).unwrap();
+        assert!(back.iter().all(|&b| b == 0x99));
         cleanup(&path);
     }
 

--- a/src/harddrive/chd.rs
+++ b/src/harddrive/chd.rs
@@ -1,0 +1,1370 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! CHD (MAME "Compressed Hunks of Data") hard-disk image backend.
+//!
+//! A hard-disk CHD, as `chdman createhd` writes one from an HDF, stores the
+//! disk as compressed hunks of whole 512-byte sectors and describes it with
+//! one `GDDD` metadata entry (`CYLS:401,HEADS:16,SECS:32,BPS:512.`).
+//! chdman derives the CHS geometry from the file size and pads the last
+//! cylinder with zero sectors, so the disk can come out slightly larger than
+//! the hardfile it was made from; `chdman extracthd` gives the original
+//! bytes back exactly. The container is the same CHD v5 the CD backend in
+//! `cdrom/chd.rs` parses; the sector arithmetic is simpler (LBA to
+//! hunk/offset, no track layout, no audio byte order).
+//!
+//! The `chd` crate is read-only and nothing rewrites compressed hunks in
+//! place, so guest writes go to a copy-on-write overlay sidecar beside the
+//! image (`disk.chd.wov`, see [`Overlay`]): a write lands in the sidecar,
+//! a read checks the sidecar before decompressing, and the CHD itself is
+//! never modified. When the sidecar cannot be created the image attaches
+//! write-protected, and the controllers report that to the guest the way a
+//! write-protected volume is reported.
+//!
+//! [`media_kind`] tells hard-disk CHDs from CD ones by their metadata tags
+//! without decoding a hunk map, which is what the configuration and the
+//! window's drop classification use: a `.chd` on a drive slot is a hard
+//! disk or a CD-ROM depending on what chdman put in it, not on its name.
+
+use anyhow::{anyhow, bail, Context, Result};
+use chd::metadata::{KnownMetadata, Metadata};
+use chd::Chd;
+use std::collections::{BTreeMap, HashMap};
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
+
+use super::SECTOR_SIZE;
+
+/// Every CHD version starts with this.
+const MAGIC: &[u8; 8] = b"MComprHD";
+/// The v5 header, the longest of the versions accepted here.
+const HEADER_BYTES: usize = 124;
+/// The largest hunk MAME's own header validation accepts (`chd.cpp`:
+/// `hunkbytes >= 65536 * 256` is rejected). The `chd` crate applies the
+/// same bound to v1-v4 headers but skips v5 validation entirely.
+const MAX_HUNK_BYTES: u32 = 65536 * 256;
+/// The largest disk a hard-disk CHD may describe: 1 TiB, far past anything
+/// an Amiga filesystem addresses and small enough that the hunk count fits
+/// the `u32` the crate keeps it in at the smallest hunk size.
+const MAX_DISK_BYTES: u64 = 1 << 40;
+/// A metadata chain longer than this is not chdman's (it writes a handful
+/// of entries); the bound keeps a looping chain from spinning the classifier.
+const MAX_METADATA_ENTRIES: usize = 256;
+/// One metadata entry header: tag, flags and length, next-entry offset.
+const METADATA_HEADER_BYTES: usize = 16;
+
+/// What a CHD holds, as its metadata tags say.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChdMedia {
+    /// `GDDD` hard-disk metadata (chdman `createhd`), or a v1/v2 image,
+    /// which the format only ever used for hard disks.
+    HardDisk,
+    /// CD-ROM (or GD-ROM) track metadata (chdman `createcd`).
+    CdRom,
+}
+
+fn be32(raw: &[u8], at: usize) -> u32 {
+    u32::from_be_bytes(raw[at..at + 4].try_into().unwrap())
+}
+
+fn be64(raw: &[u8], at: usize) -> u64 {
+    u64::from_be_bytes(raw[at..at + 8].try_into().unwrap())
+}
+
+/// Whether `head` (the first bytes of a file) opens with the CHD magic.
+pub fn is_chd(head: &[u8]) -> bool {
+    head.starts_with(MAGIC)
+}
+
+/// Read the metadata tags of a CHD and say what kind of media it holds.
+///
+/// Reads the header and walks the metadata chain only: the hunk map, which
+/// the `chd` crate sizes from the header and decodes on open, is never
+/// touched, so this is cheap enough for the launcher to call while a path
+/// field is being edited. A file that is not a CHD, or carries neither kind
+/// of metadata, is an error.
+pub fn media_kind(path: &Path) -> Result<ChdMedia> {
+    let mut file =
+        File::open(path).with_context(|| format!("opening CHD image {}", path.display()))?;
+    let mut raw = [0u8; HEADER_BYTES];
+    file.read_exact(&mut raw).map_err(|_| {
+        anyhow!(
+            "{}: not a readable CHD image: header truncated",
+            path.display()
+        )
+    })?;
+    if !is_chd(&raw) {
+        bail!("{}: not a readable CHD image: bad magic", path.display());
+    }
+    let length = be32(&raw, 8);
+    let version = be32(&raw, 12);
+    let meta_offset = match (version, length) {
+        // v1 and v2 predate metadata and only ever held hard disks.
+        (1 | 2, _) => return Ok(ChdMedia::HardDisk),
+        (3, 120) | (4, 108) => be64(&raw, 36),
+        (5, 124) => be64(&raw, 48),
+        _ => bail!(
+            "{}: not a readable CHD image: unknown version {version} (header {length} bytes)",
+            path.display()
+        ),
+    };
+    let cd_tags = [
+        KnownMetadata::CdRomOld as u32,
+        KnownMetadata::CdRomTrack as u32,
+        KnownMetadata::CdRomTrack2 as u32,
+        KnownMetadata::GdRomOld as u32,
+        KnownMetadata::GdRomTrack as u32,
+    ];
+    let mut offset = meta_offset;
+    let mut entry = [0u8; METADATA_HEADER_BYTES];
+    for _ in 0..MAX_METADATA_ENTRIES {
+        if offset == 0 {
+            break;
+        }
+        file.seek(SeekFrom::Start(offset))
+            .and_then(|_| file.read_exact(&mut entry))
+            .map_err(|_| anyhow!("{}: CHD metadata chain is truncated", path.display()))?;
+        let tag = be32(&entry, 0);
+        if tag == KnownMetadata::HardDisk as u32 {
+            return Ok(ChdMedia::HardDisk);
+        }
+        if cd_tags.contains(&tag) {
+            return Ok(ChdMedia::CdRom);
+        }
+        offset = be64(&entry, 8);
+    }
+    bail!(
+        "{}: CHD carries neither hard-disk (GDDD) nor CD-ROM track metadata",
+        path.display()
+    )
+}
+
+/// Whether `path` is a CHD holding a hard disk. Anything else -- a CD CHD,
+/// a file that cannot be read, a path that does not exist yet -- is `false`,
+/// so a `.chd` a caller cannot classify keeps its traditional reading as a
+/// CD image and the open that follows reports the real problem.
+///
+/// The verdict is cached against the file's size and modification time:
+/// the launcher and the configuration screen ask about the same path on
+/// every redraw, and a stat per call is all that costs.
+pub fn is_hard_disk_chd(path: &Path) -> bool {
+    type Cache = HashMap<PathBuf, (u64, Option<SystemTime>, ChdMedia)>;
+    static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    let stamp = (meta.len(), meta.modified().ok());
+    let cache = CACHE.get_or_init(Mutex::default);
+    let cached = cache.lock().unwrap().get(path).copied();
+    if let Some((len, modified, kind)) = cached {
+        if (len, modified) == stamp {
+            return kind == ChdMedia::HardDisk;
+        }
+    }
+    match media_kind(path) {
+        Ok(kind) => {
+            cache
+                .lock()
+                .unwrap()
+                .insert(path.to_path_buf(), (stamp.0, stamp.1, kind));
+            kind == ChdMedia::HardDisk
+        }
+        Err(_) => false,
+    }
+}
+
+/// Refuse a CHD whose header describes more than the file can hold, before
+/// the `chd` crate acts on it. `Chd::open` sizes the whole hunk map
+/// (`hunk_count * 12` bytes, then walks it) and the codecs' hunk-sized
+/// buffers straight from the header's words, computes the hunk count with
+/// unchecked arithmetic, and performs no bounds checks at all on a v5
+/// header, so a 124-byte file claiming a petabyte disk would otherwise take
+/// the process down in the allocator (or an overflow panic) instead of
+/// being refused. The CD backend guards the same way; the bounds here are a
+/// hard disk's.
+///
+/// Only the fields the bounds need are decoded; everything else is left to
+/// the crate, which re-reads the header from offset 0.
+fn bound_raw_header(reader: &mut BufReader<File>, path: &Path) -> Result<()> {
+    let mut raw = [0u8; HEADER_BYTES];
+    reader.read_exact(&mut raw).map_err(|_| {
+        anyhow!(
+            "{}: not a readable CHD image: header truncated",
+            path.display()
+        )
+    })?;
+    if !is_chd(&raw) {
+        bail!("{}: not a readable CHD image: bad magic", path.display());
+    }
+    let length = be32(&raw, 8);
+    let version = be32(&raw, 12);
+    // (logical bytes, hunk bytes, stated hunk count) as the header has them.
+    let (logical_bytes, hunk_bytes, stated_hunks) = match (version, length) {
+        (3, 120) => (be64(&raw, 28), be32(&raw, 76), Some(be32(&raw, 24))),
+        (4, 108) => (be64(&raw, 28), be32(&raw, 44), Some(be32(&raw, 24))),
+        (5, 124) => (be64(&raw, 32), be32(&raw, 56), None),
+        (1 | 2, _) => bail!(
+            "{}: CHD v{version} images are too old to read; re-create it with a current \
+             chdman (createhd)",
+            path.display()
+        ),
+        _ => bail!(
+            "{}: not a readable CHD image: unknown version {version} (header {length} bytes)",
+            path.display()
+        ),
+    };
+    if hunk_bytes == 0
+        || hunk_bytes >= MAX_HUNK_BYTES
+        || !(hunk_bytes as usize).is_multiple_of(SECTOR_SIZE)
+    {
+        bail!(
+            "{}: not a hard-disk CHD (hunk {hunk_bytes} bytes; expected hunks of whole \
+             {SECTOR_SIZE}-byte sectors)",
+            path.display()
+        );
+    }
+    if version == 5 && be32(&raw, 60) as usize != SECTOR_SIZE {
+        bail!(
+            "{}: not a hard-disk CHD (unit {} bytes; expected {SECTOR_SIZE}-byte sectors)",
+            path.display(),
+            be32(&raw, 60)
+        );
+    }
+    if logical_bytes == 0 || !logical_bytes.is_multiple_of(SECTOR_SIZE as u64) {
+        bail!(
+            "{}: CHD describes {logical_bytes} bytes, not a whole number of {SECTOR_SIZE}-byte \
+             sectors",
+            path.display()
+        );
+    }
+    if logical_bytes > MAX_DISK_BYTES {
+        bail!(
+            "{}: CHD describes {logical_bytes} bytes, more than the {} GiB a hard-disk image \
+             may hold",
+            path.display(),
+            MAX_DISK_BYTES >> 30
+        );
+    }
+    let hunk_count = logical_bytes.div_ceil(u64::from(hunk_bytes));
+    if let Some(stated) = stated_hunks {
+        if u64::from(stated) != hunk_count {
+            bail!(
+                "{}: CHD states {stated} hunks but its size needs {hunk_count}",
+                path.display()
+            );
+        }
+    }
+    // Every hunk has a map entry in the file, and no map encoding spends
+    // less than a bit on one, so a file shorter than an eighth of its hunk
+    // count cannot be real. The crate allocates 12 bytes per hunk before it
+    // reads any of them.
+    let file_len = reader
+        .seek(SeekFrom::End(0))
+        .map_err(|e| anyhow!("{}: reading CHD image: {e}", path.display()))?;
+    if hunk_count > file_len.saturating_mul(8) {
+        bail!(
+            "{}: CHD claims {hunk_count} hunks in a {file_len}-byte file",
+            path.display()
+        );
+    }
+    // A v5 compressed hunk map carries its own byte count as a u32 at the
+    // map offset, and the chd crate allocates that many bytes before
+    // reading them. The map is stored verbatim, so it must fit inside the
+    // file; refuse one that does not before the crate sizes a buffer from it.
+    if version == 5 && be32(&raw, 16) != 0 {
+        let map_offset = be64(&raw, 40);
+        let mut map_head = [0u8; 4];
+        let map_bytes = map_offset
+            .checked_add(16)
+            .filter(|&end| end <= file_len)
+            .and_then(|_| {
+                reader.seek(SeekFrom::Start(map_offset)).ok()?;
+                reader.read_exact(&mut map_head).ok()?;
+                Some(u64::from(u32::from_be_bytes(map_head)))
+            })
+            .ok_or_else(|| {
+                anyhow!(
+                    "{}: CHD map offset {map_offset} lies past the end of the file",
+                    path.display()
+                )
+            })?;
+        if map_offset + 16 + map_bytes > file_len {
+            bail!(
+                "{}: CHD compressed map claims {map_bytes} bytes, past the end of the file",
+                path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+/// The bytes-per-sector a `GDDD` entry states, e.g. from
+/// `CYLS:401,HEADS:16,SECS:32,BPS:512.`.
+fn parse_hard_disk_metadata(text: &str) -> Result<u32> {
+    let mut bps = None;
+    for field in text.trim_end_matches(['\0', '.']).split(',') {
+        if let Some((key, value)) = field.trim().split_once(':') {
+            if key == "BPS" {
+                bps = Some(value.parse::<u32>().context("bad BPS value")?);
+            }
+        }
+    }
+    bps.context("hard-disk metadata without a BPS field")
+}
+
+/// A hard-disk CHD open for reading, with its overlay when writes are
+/// possible.
+pub(super) struct ChdHardDisk {
+    chd: Chd<BufReader<File>>,
+    path: PathBuf,
+    total_sectors: u64,
+    sectors_per_hunk: u64,
+    /// Decompressed contents of hunk `cached_hunk`.
+    hunk_buf: Vec<u8>,
+    /// Scratch buffer for compressed hunk bytes, kept between reads.
+    comp_buf: Vec<u8>,
+    cached_hunk: Option<u32>,
+    /// Where guest writes go. `None` attaches the disk write-protected.
+    overlay: Option<Overlay>,
+}
+
+impl std::fmt::Debug for ChdHardDisk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChdHardDisk")
+            .field("path", &self.path)
+            .field("total_sectors", &self.total_sectors)
+            .field("overlay", &self.overlay.as_ref().map(|o| &o.path))
+            .finish_non_exhaustive()
+    }
+}
+
+impl ChdHardDisk {
+    /// Open a hard-disk CHD. With `writable`, the overlay sidecar beside the
+    /// image is opened (or created) to take guest writes; when that fails
+    /// the disk attaches write-protected with a warning rather than
+    /// refusing to open, since reading it is still worth something. Without
+    /// `writable` no sidecar is touched at all.
+    pub(super) fn open(path: &Path, bus_name: &str, writable: bool) -> Result<Self> {
+        let file = File::open(path)
+            .map_err(|e| anyhow!("opening {bus_name} image {}: {e}", path.display()))?;
+        let mut reader = BufReader::new(file);
+        bound_raw_header(&mut reader, path)?;
+        let mut chd = Chd::open(reader, None)
+            .map_err(|e| anyhow!("{}: not a readable CHD image: {e}", path.display()))?;
+        if chd.header().has_parent() {
+            bail!(
+                "{}: delta CHD with a parent is not supported; flatten it with chdman",
+                path.display()
+            );
+        }
+        let unit_bytes = chd.header().unit_bytes();
+        let hunk_bytes = chd.header().hunk_size();
+        let logical_bytes = chd.header().logical_bytes();
+        // `bound_raw_header` already refused such files, but the values used
+        // from here on are the crate's, so check those.
+        if unit_bytes as usize != SECTOR_SIZE
+            || hunk_bytes == 0
+            || !(hunk_bytes as usize).is_multiple_of(SECTOR_SIZE)
+            || logical_bytes == 0
+            || !logical_bytes.is_multiple_of(SECTOR_SIZE as u64)
+        {
+            bail!(
+                "{}: not a hard-disk CHD (unit {unit_bytes} bytes, hunk {hunk_bytes} bytes, \
+                 {logical_bytes} bytes; expected hunks of whole {SECTOR_SIZE}-byte sectors)",
+                path.display()
+            );
+        }
+
+        let entries: Vec<Metadata> = chd
+            .metadata_refs()
+            .try_into()
+            .map_err(|e| anyhow!("{}: reading CHD metadata: {e}", path.display()))?;
+        let mut geometry = None;
+        for entry in &entries {
+            if entry.metatag == KnownMetadata::HardDisk as u32 {
+                let text = std::str::from_utf8(&entry.value)
+                    .map(|s| s.trim_end_matches('\0'))
+                    .map_err(|_| {
+                        anyhow!("{}: CHD hard-disk metadata is not text", path.display())
+                    })?;
+                let bps = parse_hard_disk_metadata(text)
+                    .with_context(|| format!("{}: {text:?}", path.display()))?;
+                if bps as usize != SECTOR_SIZE {
+                    bail!(
+                        "{}: CHD hard disk has {bps}-byte sectors; only {SECTOR_SIZE}-byte \
+                         sectors are supported",
+                        path.display()
+                    );
+                }
+                geometry = Some(text.to_string());
+            } else if KnownMetadata::is_cdrom(entry.metatag) {
+                bail!(
+                    "{}: this CHD holds a CD-ROM, not a hard disk; attach it as a CD image",
+                    path.display()
+                );
+            }
+        }
+        let Some(geometry) = geometry else {
+            bail!(
+                "{}: CHD carries no hard-disk (GDDD) metadata; re-create it with chdman createhd",
+                path.display()
+            );
+        };
+
+        let total_sectors = logical_bytes / SECTOR_SIZE as u64;
+        let overlay = if writable {
+            let sha1 = chd.header().sha1().unwrap_or([0; 20]);
+            match Overlay::open(path, total_sectors, sha1) {
+                Ok(overlay) => Some(overlay),
+                Err(error) => {
+                    log::warn!(
+                        "{bus_name}: {}: cannot open the write overlay ({error:#}); the \
+                         disk is attached WRITE-PROTECTED",
+                        path.display()
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        log::info!(
+            "{bus_name}: {} is a CHD hard disk ({geometry}; {total_sectors} sectors, {} bytes \
+             on disk){}",
+            path.display(),
+            std::fs::metadata(path).map_or(0, |m| m.len()),
+            match &overlay {
+                Some(o) => format!("; guest writes go to {}", o.path.display()),
+                None => "; write-protected".to_string(),
+            }
+        );
+        let hunk_buf = chd.get_hunksized_buffer();
+        Ok(Self {
+            chd,
+            path: path.to_path_buf(),
+            total_sectors,
+            sectors_per_hunk: u64::from(hunk_bytes) / SECTOR_SIZE as u64,
+            hunk_buf,
+            comp_buf: Vec::new(),
+            cached_hunk: None,
+            overlay,
+        })
+    }
+
+    pub(super) fn total_sectors(&self) -> u64 {
+        self.total_sectors
+    }
+
+    /// Whether guest writes are refused: no overlay could be opened.
+    pub(super) fn write_protected(&self) -> bool {
+        self.overlay.is_none()
+    }
+
+    fn out_of_range(lba: u64) -> std::io::Error {
+        std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            format!("sector {lba} beyond end of CHD image"),
+        )
+    }
+
+    pub(super) fn read_sector(&mut self, lba: u64, buf: &mut [u8]) -> std::io::Result<()> {
+        if lba >= self.total_sectors {
+            return Err(Self::out_of_range(lba));
+        }
+        if let Some(overlay) = &self.overlay {
+            if overlay.read(lba, buf)? {
+                return Ok(());
+            }
+        }
+        // The hunk count fits a u32 by header validation.
+        self.load_hunk((lba / self.sectors_per_hunk) as u32)?;
+        let offset = (lba % self.sectors_per_hunk) as usize * SECTOR_SIZE;
+        buf[..SECTOR_SIZE].copy_from_slice(&self.hunk_buf[offset..offset + SECTOR_SIZE]);
+        Ok(())
+    }
+
+    pub(super) fn write_sector(&mut self, lba: u64, buf: &[u8]) -> std::io::Result<()> {
+        if lba >= self.total_sectors {
+            return Err(Self::out_of_range(lba));
+        }
+        match &mut self.overlay {
+            Some(overlay) => overlay.write(lba, buf),
+            None => Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "CHD image is write-protected (no write overlay)",
+            )),
+        }
+    }
+
+    pub(super) fn flush(&mut self) -> std::io::Result<()> {
+        match &mut self.overlay {
+            Some(overlay) => overlay.file.flush(),
+            None => Ok(()),
+        }
+    }
+
+    /// Every overlaid sector, for a save state. `None` when the disk is
+    /// write-protected.
+    pub(super) fn overlay_contents(&self) -> std::io::Result<Option<BTreeMap<u64, Vec<u8>>>> {
+        self.overlay.as_ref().map(Overlay::contents).transpose()
+    }
+
+    /// Make the overlay hold exactly `sectors` (a save state's contents),
+    /// discarding whatever it held. With no overlay open, a non-empty set
+    /// cannot be honoured and is an error: the restored machine would see
+    /// a disk other than the one it saved.
+    pub(super) fn restore_overlay(
+        &mut self,
+        sectors: &BTreeMap<u64, Vec<u8>>,
+    ) -> std::io::Result<()> {
+        self.cached_hunk = None;
+        match &mut self.overlay {
+            Some(overlay) => overlay.replace(sectors, self.total_sectors),
+            None if sectors.is_empty() => Ok(()),
+            None => Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "the state carries guest writes but the CHD's write overlay cannot be opened",
+            )),
+        }
+    }
+
+    fn load_hunk(&mut self, hunk: u32) -> std::io::Result<()> {
+        if self.cached_hunk == Some(hunk) {
+            return Ok(());
+        }
+        self.cached_hunk = None;
+        self.chd
+            .hunk(hunk)
+            .and_then(|mut h| h.read_hunk_in(&mut self.comp_buf, &mut self.hunk_buf))
+            .map_err(|e| {
+                std::io::Error::other(format!(
+                    "{}: reading CHD hunk {hunk}: {e}",
+                    self.path.display()
+                ))
+            })?;
+        self.cached_hunk = Some(hunk);
+        Ok(())
+    }
+}
+
+/// The overlay's file name: the image's own name with this appended
+/// (`disk.chd` -> `disk.chd.wov`), so the pair sorts together and nothing
+/// has to guess which image an overlay belongs to.
+pub const OVERLAY_SUFFIX: &str = ".wov";
+const OVERLAY_MAGIC: &[u8; 8] = b"CLWOV001";
+/// Magic, sector size (u32 LE), image sectors (u64 LE), the image's SHA-1
+/// from its CHD header, and 8 reserved zero bytes.
+const OVERLAY_HEADER_BYTES: u64 = 48;
+/// One record: the LBA (u64 LE) followed by the sector's bytes.
+const RECORD_BYTES: u64 = 8 + SECTOR_SIZE as u64;
+
+/// The copy-on-write overlay sidecar of a CHD hard disk.
+///
+/// A log of `(lba, sector)` records behind a header naming the image it
+/// belongs to. The first write to a sector appends a record; later writes
+/// to the same sector overwrite that record in place, so the file grows
+/// only with the number of distinct sectors written. The index from LBA to
+/// record is rebuilt by scanning the log at open. A record cut short by a
+/// crash is dropped at open, which is the only recovery the format needs:
+/// every record is complete or absent, and a sector's latest bytes are
+/// either in its record or still in the CHD.
+struct Overlay {
+    file: File,
+    path: PathBuf,
+    /// LBA to the file offset of the record's sector bytes.
+    index: BTreeMap<u64, u64>,
+    /// Length of the file as this handle knows it; the next record goes here.
+    len: u64,
+}
+
+/// The sidecar path for `image`.
+pub fn overlay_path(image: &Path) -> PathBuf {
+    let mut name = image.as_os_str().to_owned();
+    name.push(OVERLAY_SUFFIX);
+    PathBuf::from(name)
+}
+
+impl Overlay {
+    fn open(image: &Path, total_sectors: u64, sha1: [u8; 20]) -> Result<Self> {
+        let path = overlay_path(image);
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .map_err(|e| anyhow!("opening overlay {}: {e}", path.display()))?;
+        let len = file
+            .metadata()
+            .map_err(|e| anyhow!("stat overlay {}: {e}", path.display()))?
+            .len();
+        let mut overlay = Self {
+            file,
+            path,
+            index: BTreeMap::new(),
+            len,
+        };
+        if len == 0 {
+            overlay.write_header(total_sectors, sha1)?;
+            return Ok(overlay);
+        }
+
+        let mut header = [0u8; OVERLAY_HEADER_BYTES as usize];
+        overlay.file.rewind()?;
+        overlay.file.read_exact(&mut header).map_err(|_| {
+            anyhow!(
+                "overlay {} is too short to carry a header; move it aside if it is not one",
+                overlay.path.display()
+            )
+        })?;
+        if &header[..8] != OVERLAY_MAGIC {
+            bail!(
+                "overlay {} is not a Copperline CHD write overlay; move it aside",
+                overlay.path.display()
+            );
+        }
+        let sector_bytes = u32::from_le_bytes(header[8..12].try_into().unwrap());
+        let sectors = u64::from_le_bytes(header[12..20].try_into().unwrap());
+        if sector_bytes as usize != SECTOR_SIZE || sectors != total_sectors {
+            bail!(
+                "overlay {} describes a {sectors}-sector disk of {sector_bytes}-byte sectors, \
+                 not this image ({total_sectors} sectors of {SECTOR_SIZE}); move it aside",
+                overlay.path.display()
+            );
+        }
+        if header[20..40] != sha1 {
+            bail!(
+                "overlay {} belongs to a different CHD image (its SHA-1 differs); move it \
+                 aside or delete it",
+                overlay.path.display()
+            );
+        }
+
+        // Rebuild the index from the log, reading only each record's LBA.
+        let mut reader = BufReader::new(&overlay.file);
+        let mut pos = OVERLAY_HEADER_BYTES;
+        let mut lba_bytes = [0u8; 8];
+        while pos + RECORD_BYTES <= len {
+            reader.seek(SeekFrom::Start(pos))?;
+            reader.read_exact(&mut lba_bytes)?;
+            let lba = u64::from_le_bytes(lba_bytes);
+            if lba >= total_sectors {
+                bail!(
+                    "overlay {} records sector {lba} past the end of the {total_sectors}-sector \
+                     image; it is corrupt",
+                    overlay.path.display()
+                );
+            }
+            overlay.index.insert(lba, pos + 8);
+            pos += RECORD_BYTES;
+        }
+        drop(reader);
+        if pos < len {
+            log::warn!(
+                "overlay {}: dropping {} trailing bytes of an incomplete record",
+                overlay.path.display(),
+                len - pos
+            );
+            overlay.file.set_len(pos)?;
+            overlay.len = pos;
+        }
+        Ok(overlay)
+    }
+
+    fn write_header(&mut self, total_sectors: u64, sha1: [u8; 20]) -> Result<()> {
+        let mut header = [0u8; OVERLAY_HEADER_BYTES as usize];
+        header[..8].copy_from_slice(OVERLAY_MAGIC);
+        header[8..12].copy_from_slice(&(SECTOR_SIZE as u32).to_le_bytes());
+        header[12..20].copy_from_slice(&total_sectors.to_le_bytes());
+        header[20..40].copy_from_slice(&sha1);
+        self.file.rewind()?;
+        self.file
+            .write_all(&header)
+            .map_err(|e| anyhow!("writing overlay {}: {e}", self.path.display()))?;
+        self.len = OVERLAY_HEADER_BYTES;
+        Ok(())
+    }
+
+    /// Copy the overlaid bytes of `lba` into `buf`, if it has any.
+    fn read(&self, lba: u64, buf: &mut [u8]) -> std::io::Result<bool> {
+        let Some(&offset) = self.index.get(&lba) else {
+            return Ok(false);
+        };
+        let mut file = &self.file;
+        file.seek(SeekFrom::Start(offset))?;
+        file.read_exact(&mut buf[..SECTOR_SIZE])?;
+        Ok(true)
+    }
+
+    fn write(&mut self, lba: u64, buf: &[u8]) -> std::io::Result<()> {
+        match self.index.get(&lba) {
+            Some(&offset) => {
+                self.file.seek(SeekFrom::Start(offset))?;
+                self.file.write_all(&buf[..SECTOR_SIZE])
+            }
+            None => {
+                let record = self.len;
+                self.file.seek(SeekFrom::Start(record))?;
+                self.file.write_all(&lba.to_le_bytes())?;
+                self.file.write_all(&buf[..SECTOR_SIZE])?;
+                self.index.insert(lba, record + 8);
+                self.len = record + RECORD_BYTES;
+                Ok(())
+            }
+        }
+    }
+
+    fn contents(&self) -> std::io::Result<BTreeMap<u64, Vec<u8>>> {
+        let mut file = &self.file;
+        let mut out = BTreeMap::new();
+        for (&lba, &offset) in &self.index {
+            let mut sector = vec![0u8; SECTOR_SIZE];
+            file.seek(SeekFrom::Start(offset))?;
+            file.read_exact(&mut sector)?;
+            out.insert(lba, sector);
+        }
+        Ok(out)
+    }
+
+    /// Truncate the log and rewrite it from `sectors`.
+    fn replace(
+        &mut self,
+        sectors: &BTreeMap<u64, Vec<u8>>,
+        total_sectors: u64,
+    ) -> std::io::Result<()> {
+        if let Some((&lba, _)) = sectors
+            .iter()
+            .find(|(&lba, data)| lba >= total_sectors || data.len() != SECTOR_SIZE)
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("state carries an invalid overlay record for sector {lba}"),
+            ));
+        }
+        self.file.set_len(OVERLAY_HEADER_BYTES)?;
+        self.len = OVERLAY_HEADER_BYTES;
+        self.index.clear();
+        for (&lba, data) in sectors {
+            self.write(lba, data)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::harddrive::{HardDriveImage, CYL_BYTES, CYL_SECTORS};
+
+    pub(crate) fn temp_path(name: &str) -> PathBuf {
+        static UNIQUE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let unique = UNIQUE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "copperline-chdhd-{}-{unique}-{name}",
+            std::process::id()
+        ))
+    }
+
+    /// Four sectors per hunk, so a small image spans several hunks.
+    pub(crate) const HUNK_BYTES: u32 = 4 * SECTOR_SIZE as u32;
+
+    /// Write a minimal uncompressed CHD v5: 124-byte header, raw hunk map
+    /// (one big-endian u32 per hunk, the hunk's file offset in hunk-size
+    /// units), a metadata chain, and hunk-aligned data. `sha1` lands where
+    /// the crate reads the image's SHA-1 from.
+    pub(crate) fn write_chd_v5(
+        path: &Path,
+        hunk_bytes: u32,
+        unit_bytes: u32,
+        data: &[u8],
+        metas: &[([u8; 4], Vec<u8>)],
+        sha1: [u8; 20],
+    ) {
+        let hunk_count = match hunk_bytes {
+            0 => 0,
+            _ => data.len().div_ceil(hunk_bytes as usize),
+        };
+        let map_offset = 124u64;
+        let meta_offset = map_offset + 4 * hunk_count as u64;
+        let metas_len: u64 = metas.iter().map(|(_, v)| 16 + v.len() as u64).sum();
+        let data_start = match hunk_bytes {
+            0 => meta_offset + metas_len,
+            _ => (meta_offset + metas_len).div_ceil(u64::from(hunk_bytes)) * u64::from(hunk_bytes),
+        };
+
+        let mut out = Vec::new();
+        out.extend_from_slice(b"MComprHD");
+        out.extend_from_slice(&124u32.to_be_bytes());
+        out.extend_from_slice(&5u32.to_be_bytes());
+        out.extend_from_slice(&[0u8; 16]); // four codecs: none (uncompressed)
+        out.extend_from_slice(&(data.len() as u64).to_be_bytes());
+        out.extend_from_slice(&map_offset.to_be_bytes());
+        out.extend_from_slice(&meta_offset.to_be_bytes());
+        out.extend_from_slice(&hunk_bytes.to_be_bytes());
+        out.extend_from_slice(&unit_bytes.to_be_bytes());
+        out.extend_from_slice(&[0u8; 20]); // raw SHA-1
+        out.extend_from_slice(&sha1); // SHA-1
+        out.extend_from_slice(&[0u8; 20]); // parent SHA-1
+        assert_eq!(out.len(), 124);
+
+        for hunk in 0..hunk_count as u64 {
+            let entry = data_start / u64::from(hunk_bytes) + hunk;
+            out.extend_from_slice(&(entry as u32).to_be_bytes());
+        }
+        let mut next = meta_offset;
+        for (i, (tag, value)) in metas.iter().enumerate() {
+            next += 16 + value.len() as u64;
+            out.extend_from_slice(tag);
+            out.extend_from_slice(&(0x01u32 << 24 | value.len() as u32).to_be_bytes());
+            let next_field = if i + 1 == metas.len() { 0 } else { next };
+            out.extend_from_slice(&next_field.to_be_bytes());
+            out.extend_from_slice(value);
+        }
+        out.resize(data_start as usize, 0);
+        out.extend_from_slice(data);
+        out.resize(data_start as usize + hunk_count * hunk_bytes as usize, 0);
+        std::fs::write(path, out).unwrap();
+    }
+
+    pub(crate) fn gddd(cyls: u32, heads: u32, secs: u32, bps: u32) -> ([u8; 4], Vec<u8>) {
+        let mut value = format!("CYLS:{cyls},HEADS:{heads},SECS:{secs},BPS:{bps}.").into_bytes();
+        value.push(0);
+        (*b"GDDD", value)
+    }
+
+    /// A hard-disk CHD of `sectors` sectors, each filled with its own LBA
+    /// (low byte) so any addressing slip shows.
+    pub(crate) fn write_hard_disk(path: &Path, sectors: usize, sha1: [u8; 20]) -> Vec<u8> {
+        let mut data = vec![0u8; sectors * SECTOR_SIZE];
+        for (lba, sector) in data.chunks_mut(SECTOR_SIZE).enumerate() {
+            sector.fill(lba as u8);
+            sector[..4].copy_from_slice(&(lba as u32).to_be_bytes());
+        }
+        write_chd_v5(
+            path,
+            HUNK_BYTES,
+            SECTOR_SIZE as u32,
+            &data,
+            &[gddd(1, 1, sectors as u32, SECTOR_SIZE as u32)],
+            sha1,
+        );
+        data
+    }
+
+    fn open(path: &Path) -> HardDriveImage {
+        HardDriveImage::open(
+            path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap()
+    }
+
+    fn cleanup(path: &Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(overlay_path(path));
+        let _ = std::fs::remove_dir(overlay_path(path));
+    }
+
+    /// A write-protected drive for the controller tests: a hard-disk CHD
+    /// whose overlay cannot be created because a directory sits where the
+    /// sidecar would go. The image has no `DOS`/`RDSK` signature, so every
+    /// LBA is a direct image sector. Pass the path back to
+    /// [`remove_write_protected_image`] when done.
+    pub(crate) fn write_protected_image(name: &str, sectors: usize) -> (HardDriveImage, PathBuf) {
+        let path = temp_path(&format!("{name}.chd"));
+        let mut sha1 = [0u8; 20];
+        sha1[..name.len().min(20)].copy_from_slice(&name.as_bytes()[..name.len().min(20)]);
+        write_hard_disk(&path, sectors, sha1);
+        std::fs::create_dir(overlay_path(&path)).unwrap();
+        let drive = open(&path);
+        assert!(drive.write_protected());
+        (drive, path)
+    }
+
+    pub(crate) fn remove_write_protected_image(path: &Path) {
+        cleanup(path);
+    }
+
+    #[test]
+    fn media_kind_reads_the_metadata_tags() {
+        let hd = temp_path("kind-hd.chd");
+        write_hard_disk(&hd, 4, [1; 20]);
+        assert_eq!(media_kind(&hd).unwrap(), ChdMedia::HardDisk);
+        assert!(is_hard_disk_chd(&hd));
+
+        let cd = temp_path("kind-cd.chd");
+        write_chd_v5(
+            &cd,
+            2448 * 2,
+            2448,
+            &[0u8; 2448 * 4],
+            &[(
+                *b"CHT2",
+                b"TRACK:1 TYPE:MODE1 SUBTYPE:NONE FRAMES:4 PREGAP:0 PGTYPE:MODE1 PGSUB:NONE \
+                  POSTGAP:0\0"
+                    .to_vec(),
+            )],
+            [2; 20],
+        );
+        assert_eq!(media_kind(&cd).unwrap(), ChdMedia::CdRom);
+        assert!(!is_hard_disk_chd(&cd));
+
+        // Neither kind of metadata, a truncated header, a non-CHD, and a
+        // missing file all classify as "not a hard disk" without an error
+        // escaping to the caller.
+        let bare = temp_path("kind-none.chd");
+        write_chd_v5(
+            &bare,
+            HUNK_BYTES,
+            SECTOR_SIZE as u32,
+            &[0u8; 2048],
+            &[],
+            [3; 20],
+        );
+        assert!(media_kind(&bare).is_err());
+        assert!(!is_hard_disk_chd(&bare));
+        let short = temp_path("kind-short.chd");
+        std::fs::write(&short, b"MComprHD").unwrap();
+        assert!(media_kind(&short).is_err());
+        assert!(!is_hard_disk_chd(&short));
+        let hdf = temp_path("kind-plain.chd");
+        std::fs::write(&hdf, vec![0u8; 1024]).unwrap();
+        assert!(!is_hard_disk_chd(&hdf));
+        assert!(!is_hard_disk_chd(&temp_path("kind-missing.chd")));
+
+        // A rewritten file is re-read, not answered from the cache.
+        std::fs::remove_file(&hd).unwrap();
+        std::fs::copy(&cd, &hd).unwrap();
+        assert!(!is_hard_disk_chd(&hd));
+
+        for path in [&hd, &cd, &bare, &short, &hdf] {
+            cleanup(path);
+        }
+    }
+
+    #[test]
+    fn hard_disk_chd_serves_sectors_across_hunks() {
+        let path = temp_path("read.chd");
+        let data = write_hard_disk(&path, 11, [4; 20]);
+        let mut drive = open(&path);
+        assert_eq!(drive.total_sectors(), 11);
+        assert!(drive.has_own_rdb(), "no DOS boot block, so nothing to wrap");
+        assert!(!drive.write_protected());
+        let mut sector = vec![0u8; SECTOR_SIZE];
+        // Backwards, so the hunk cache is exercised in both directions.
+        for lba in (0..11u64).rev() {
+            drive.read_sector(lba, &mut sector).unwrap();
+            let want = &data[lba as usize * SECTOR_SIZE..(lba as usize + 1) * SECTOR_SIZE];
+            assert_eq!(sector.as_slice(), want, "lba {lba}");
+        }
+        assert!(drive.read_sector(11, &mut sector).is_err());
+        cleanup(&path);
+    }
+
+    #[test]
+    fn bare_partition_chd_gets_a_synthesized_rdb() {
+        let path = temp_path("bare.chd");
+        let mut data = vec![0u8; CYL_BYTES as usize];
+        data[..4].copy_from_slice(b"DOS\x01");
+        data[5 * SECTOR_SIZE..5 * SECTOR_SIZE + 4].copy_from_slice(b"MARK");
+        write_chd_v5(
+            &path,
+            HUNK_BYTES,
+            SECTOR_SIZE as u32,
+            &data,
+            &[gddd(1, 16, 32, 512)],
+            [5; 20],
+        );
+        let mut drive = open(&path);
+        assert!(!drive.has_own_rdb());
+        assert_eq!(drive.total_sectors(), 2 * u64::from(CYL_SECTORS));
+        let mut sector = vec![0u8; SECTOR_SIZE];
+        drive.read_sector(0, &mut sector).unwrap();
+        assert_eq!(&sector[..4], b"RDSK");
+        drive
+            .read_sector(u64::from(CYL_SECTORS) + 5, &mut sector)
+            .unwrap();
+        assert_eq!(&sector[..4], b"MARK");
+        cleanup(&path);
+    }
+
+    #[test]
+    fn rdb_chd_is_left_alone() {
+        let path = temp_path("rdb.chd");
+        let mut data = vec![0u8; 16 * SECTOR_SIZE];
+        data[..4].copy_from_slice(b"RDSK");
+        write_chd_v5(
+            &path,
+            HUNK_BYTES,
+            SECTOR_SIZE as u32,
+            &data,
+            &[gddd(1, 1, 16, 512)],
+            [6; 20],
+        );
+        let mut drive = open(&path);
+        assert!(drive.has_own_rdb());
+        assert_eq!(drive.total_sectors(), 16);
+        let mut sector = vec![0u8; SECTOR_SIZE];
+        drive.read_sector(0, &mut sector).unwrap();
+        assert_eq!(&sector[..4], b"RDSK");
+        cleanup(&path);
+    }
+
+    #[test]
+    fn writes_land_in_the_overlay_and_persist_across_reopen() {
+        let path = temp_path("overlay.chd");
+        let data = write_hard_disk(&path, 9, [7; 20]);
+        let pristine = std::fs::read(&path).unwrap();
+        {
+            let mut drive = open(&path);
+            let sector = vec![0xA5; SECTOR_SIZE];
+            drive.write_sector(3, &sector).unwrap();
+            drive.write_sector(8, &sector).unwrap();
+            // A second write to the same sector overwrites its record.
+            let again = vec![0x5A; SECTOR_SIZE];
+            drive.write_sector(3, &again).unwrap();
+            drive.flush().unwrap();
+            let mut back = vec![0u8; SECTOR_SIZE];
+            drive.read_sector(3, &mut back).unwrap();
+            assert_eq!(back, again);
+            drive.read_sector(4, &mut back).unwrap();
+            assert_eq!(&back[..], &data[4 * SECTOR_SIZE..5 * SECTOR_SIZE]);
+        }
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            pristine,
+            "the CHD is untouched"
+        );
+        let overlay = std::fs::metadata(overlay_path(&path)).unwrap().len();
+        assert_eq!(overlay, OVERLAY_HEADER_BYTES + 2 * RECORD_BYTES);
+
+        let mut drive = open(&path);
+        let mut back = vec![0u8; SECTOR_SIZE];
+        drive.read_sector(3, &mut back).unwrap();
+        assert!(back.iter().all(|&b| b == 0x5A));
+        drive.read_sector(8, &mut back).unwrap();
+        assert!(back.iter().all(|&b| b == 0xA5));
+        drive.read_sector(2, &mut back).unwrap();
+        assert_eq!(&back[..], &data[2 * SECTOR_SIZE..3 * SECTOR_SIZE]);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn overlay_of_another_image_is_refused_and_the_disk_goes_write_protected() {
+        let a = temp_path("mine.chd");
+        let b = temp_path("theirs.chd");
+        write_hard_disk(&a, 8, [8; 20]);
+        write_hard_disk(&b, 8, [9; 20]);
+        {
+            let mut drive = open(&a);
+            drive.write_sector(1, &[1; SECTOR_SIZE]).unwrap();
+        }
+        std::fs::rename(overlay_path(&a), overlay_path(&b)).unwrap();
+        let mut drive = open(&b);
+        assert!(drive.write_protected());
+        let err = drive.write_sector(1, &[2; SECTOR_SIZE]).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        // The foreign overlay is not read from either.
+        let mut sector = vec![0u8; SECTOR_SIZE];
+        drive.read_sector(1, &mut sector).unwrap();
+        assert_eq!(&sector[..4], &1u32.to_be_bytes());
+        // And it was not touched.
+        let foreign = std::fs::read(overlay_path(&b)).unwrap();
+        assert_eq!(foreign.len() as u64, OVERLAY_HEADER_BYTES + RECORD_BYTES);
+        cleanup(&a);
+        cleanup(&b);
+    }
+
+    #[test]
+    fn torn_trailing_record_is_dropped_at_open() {
+        let path = temp_path("torn.chd");
+        write_hard_disk(&path, 8, [10; 20]);
+        {
+            let mut drive = open(&path);
+            drive.write_sector(5, &[0xEE; SECTOR_SIZE]).unwrap();
+            drive.write_sector(6, &[0xDD; SECTOR_SIZE]).unwrap();
+        }
+        let overlay = overlay_path(&path);
+        let full = std::fs::read(&overlay).unwrap();
+        std::fs::write(&overlay, &full[..full.len() - 100]).unwrap();
+        let mut drive = open(&path);
+        assert!(!drive.write_protected());
+        let mut sector = vec![0u8; SECTOR_SIZE];
+        drive.read_sector(5, &mut sector).unwrap();
+        assert!(sector.iter().all(|&b| b == 0xEE));
+        drive.read_sector(6, &mut sector).unwrap();
+        assert_eq!(
+            &sector[..4],
+            &6u32.to_be_bytes(),
+            "torn record reads from the CHD"
+        );
+        assert_eq!(
+            std::fs::metadata(&overlay).unwrap().len(),
+            OVERLAY_HEADER_BYTES + RECORD_BYTES
+        );
+        // A new write appends cleanly after the truncation point.
+        drive.write_sector(6, &[0xCC; SECTOR_SIZE]).unwrap();
+        drop(drive);
+        let mut drive = open(&path);
+        drive.read_sector(6, &mut sector).unwrap();
+        assert!(sector.iter().all(|&b| b == 0xCC));
+        cleanup(&path);
+    }
+
+    #[test]
+    fn unwritable_overlay_location_attaches_the_disk_write_protected() {
+        let path = temp_path("noverlay.chd");
+        write_hard_disk(&path, 4, [11; 20]);
+        // A directory where the sidecar would go cannot be opened as a file.
+        std::fs::create_dir(overlay_path(&path)).unwrap();
+        let mut drive = open(&path);
+        assert!(drive.write_protected());
+        let err = drive.write_sector(0, &[0; SECTOR_SIZE]).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        let mut sector = vec![0u8; SECTOR_SIZE];
+        drive.read_sector(2, &mut sector).unwrap();
+        assert_eq!(&sector[..4], &2u32.to_be_bytes());
+        let _ = std::fs::remove_dir(overlay_path(&path));
+        cleanup(&path);
+    }
+
+    #[test]
+    fn save_state_carries_the_overlay_and_restores_it() {
+        let path = temp_path("state.chd");
+        write_hard_disk(&path, 8, [12; 20]);
+        let mut drive = open(&path);
+        drive.write_sector(2, &[0x11; SECTOR_SIZE]).unwrap();
+        let encoded = bincode::serialize(&drive).unwrap();
+        // Writes after the snapshot...
+        drive.write_sector(2, &[0x22; SECTOR_SIZE]).unwrap();
+        drive.write_sector(7, &[0x33; SECTOR_SIZE]).unwrap();
+        drop(drive);
+
+        // ...are undone by restoring it: the overlay is part of the state.
+        let mut restored: HardDriveImage = bincode::deserialize(&encoded).unwrap();
+        let mut sector = vec![0u8; SECTOR_SIZE];
+        restored.read_sector(2, &mut sector).unwrap();
+        assert!(sector.iter().all(|&b| b == 0x11));
+        restored.read_sector(7, &mut sector).unwrap();
+        assert_eq!(&sector[..4], &7u32.to_be_bytes());
+        drop(restored);
+        assert_eq!(
+            std::fs::metadata(overlay_path(&path)).unwrap().len(),
+            OVERLAY_HEADER_BYTES + RECORD_BYTES
+        );
+
+        // A state saved with no writes leaves an empty overlay behind.
+        let clean = open(&path);
+        let mut fresh = open(&path);
+        fresh.write_sector(0, &[0x44; SECTOR_SIZE]).unwrap();
+        drop(fresh);
+        let encoded = bincode::serialize(&clean).unwrap();
+        drop(clean);
+        let mut restored: HardDriveImage = bincode::deserialize(&encoded).unwrap();
+        restored.read_sector(0, &mut sector).unwrap();
+        assert_eq!(&sector[..4], &0u32.to_be_bytes());
+
+        std::fs::remove_file(&path).unwrap();
+        let Err(err) = bincode::deserialize::<HardDriveImage>(&encoded) else {
+            panic!("deserializing with the CHD gone must fail");
+        };
+        assert!(
+            err.to_string().contains("reopening hard-drive image"),
+            "{err}"
+        );
+        cleanup(&path);
+    }
+
+    #[test]
+    fn session_copy_decompresses_the_whole_image_and_never_writes_a_sidecar() {
+        let path = temp_path("session.chd");
+        let data = write_hard_disk(&path, 6, [13; 20]);
+        let mut drive = HardDriveImage::open_session(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )
+        .unwrap();
+        drive.write_sector(1, &[0x99; SECTOR_SIZE]).unwrap();
+        let mut sector = vec![0u8; SECTOR_SIZE];
+        drive.read_sector(1, &mut sector).unwrap();
+        assert!(sector.iter().all(|&b| b == 0x99));
+        drive.read_sector(5, &mut sector).unwrap();
+        assert_eq!(&sector[..], &data[5 * SECTOR_SIZE..]);
+        assert!(!overlay_path(&path).exists());
+        cleanup(&path);
+    }
+
+    #[test]
+    fn cd_chd_is_refused_by_the_hard_disk_opener() {
+        let path = temp_path("cd.chd");
+        write_chd_v5(
+            &path,
+            2448 * 2,
+            2448,
+            &[0u8; 2448 * 4],
+            &[(
+                *b"CHT2",
+                b"TRACK:1 TYPE:MODE1 SUBTYPE:NONE FRAMES:4\0".to_vec(),
+            )],
+            [14; 20],
+        );
+        let Err(err) = HardDriveImage::open(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        ) else {
+            panic!("a CD CHD is not a hard disk");
+        };
+        assert!(err.to_string().contains("not a hard-disk CHD"), "{err:#}");
+        // A CD-shaped image whose hunks happen to be sector multiples is
+        // told apart by its metadata instead.
+        write_chd_v5(
+            &path,
+            HUNK_BYTES,
+            SECTOR_SIZE as u32,
+            &[0u8; 4096],
+            &[(
+                *b"CHT2",
+                b"TRACK:1 TYPE:MODE1 SUBTYPE:NONE FRAMES:4\0".to_vec(),
+            )],
+            [14; 20],
+        );
+        let Err(err) = HardDriveImage::open(
+            &path,
+            "DH0",
+            "ide",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        ) else {
+            panic!("CD track metadata marks a CD, whatever the hunk size");
+        };
+        assert!(err.to_string().contains("holds a CD-ROM"), "{err:#}");
+        assert!(!overlay_path(&path).exists());
+        cleanup(&path);
+    }
+
+    #[test]
+    fn missing_metadata_and_odd_sector_sizes_are_refused() {
+        let path = temp_path("nometa.chd");
+        write_chd_v5(
+            &path,
+            HUNK_BYTES,
+            SECTOR_SIZE as u32,
+            &[0u8; 4096],
+            &[],
+            [15; 20],
+        );
+        let err = ChdHardDisk::open(&path, "ide", false).unwrap_err();
+        assert!(
+            err.to_string().contains("no hard-disk (GDDD) metadata"),
+            "{err:#}"
+        );
+        write_chd_v5(
+            &path,
+            HUNK_BYTES,
+            SECTOR_SIZE as u32,
+            &[0u8; 4096],
+            &[gddd(1, 1, 2, 2048)],
+            [15; 20],
+        );
+        let err = ChdHardDisk::open(&path, "ide", false).unwrap_err();
+        assert!(err.to_string().contains("2048-byte sectors"), "{err:#}");
+        cleanup(&path);
+    }
+
+    /// Rewrite one big-endian field of an on-disk CHD v5 header in place.
+    fn patch_header(path: &Path, offset: usize, value: &[u8]) {
+        let mut bytes = std::fs::read(path).unwrap();
+        bytes[offset..offset + value.len()].copy_from_slice(value);
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    #[test]
+    fn hostile_headers_are_refused_before_the_map_is_allocated() {
+        let path = temp_path("hostile.chd");
+        write_hard_disk(&path, 4, [16; 20]);
+        let open = |what: &str| {
+            let err = ChdHardDisk::open(&path, "ide", false).unwrap_err();
+            assert!(err.to_string().contains(what), "{err:#}");
+        };
+        // logical_bytes is the u64 at offset 32 of the v5 header: a petabyte
+        // disk, then a size that overflows the crate's own hunk arithmetic.
+        patch_header(&path, 32, &(1u64 << 50).to_be_bytes());
+        open("more than the");
+        patch_header(&path, 32, &u64::MAX.to_be_bytes());
+        open("not a whole number");
+        // Inside the size cap but far more hunks than the file could map.
+        patch_header(&path, 32, &(1u64 << 36).to_be_bytes());
+        open("claims");
+        patch_header(&path, 32, &(4 * SECTOR_SIZE as u64).to_be_bytes());
+
+        // Hunk size (u32 at 56): zero, huge, and not a sector multiple.
+        patch_header(&path, 56, &0u32.to_be_bytes());
+        open("not a hard-disk CHD");
+        patch_header(&path, 56, &MAX_HUNK_BYTES.to_be_bytes());
+        open("not a hard-disk CHD");
+        patch_header(&path, 56, &(SECTOR_SIZE as u32 + 1).to_be_bytes());
+        open("not a hard-disk CHD");
+        patch_header(&path, 56, &HUNK_BYTES.to_be_bytes());
+
+        // Unit size (u32 at 60) other than a sector.
+        patch_header(&path, 60, &2448u32.to_be_bytes());
+        open("not a hard-disk CHD");
+        patch_header(&path, 60, &(SECTOR_SIZE as u32).to_be_bytes());
+
+        // A compressed map claiming 2 GiB in a tiny file: the codec tag at
+        // offset 16 marks the image compressed, the map sits at 124.
+        patch_header(&path, 16, b"lzma");
+        patch_header(&path, 124, &0x8000_0000u32.to_be_bytes());
+        open("past the end of the file");
+        patch_header(&path, 16, &[0u8; 4]);
+
+        // A parent SHA-1 (offset 104) makes it a delta.
+        patch_header(&path, 104, &[1u8; 20]);
+        open("delta CHD");
+        patch_header(&path, 104, &[0u8; 20]);
+
+        // Old container versions.
+        patch_header(&path, 12, &2u32.to_be_bytes());
+        open("too old");
+        patch_header(&path, 12, &9u32.to_be_bytes());
+        open("unknown version");
+        cleanup(&path);
+    }
+
+    #[test]
+    fn overlay_path_appends_the_suffix_to_the_image_name() {
+        assert_eq!(
+            overlay_path(Path::new("/disks/work.chd")),
+            PathBuf::from("/disks/work.chd.wov")
+        );
+    }
+
+    #[test]
+    fn hard_disk_metadata_parser_reads_bps() {
+        assert_eq!(
+            parse_hard_disk_metadata("CYLS:401,HEADS:16,SECS:32,BPS:512.").unwrap(),
+            512
+        );
+        assert_eq!(parse_hard_disk_metadata("BPS:2048\0").unwrap(), 2048);
+        assert!(parse_hard_disk_metadata("CYLS:1,HEADS:1,SECS:1").is_err());
+        assert!(parse_hard_disk_metadata("BPS:lots").is_err());
+    }
+}

--- a/src/inputrec.rs
+++ b/src/inputrec.rs
@@ -82,12 +82,29 @@ fn mouse_port_suffix(port: usize) -> &'static str {
     }
 }
 
-/// Trailing port token for a joystick/pot directive (default port 2).
+/// Trailing port token for a joystick/pot directive (default port 2;
+/// 3 and 4 are the parallel-port adapter's sockets).
 fn joy_port_suffix(port: usize) -> &'static str {
-    if port == 0 {
-        " 1"
-    } else {
-        ""
+    match port {
+        0 => " 1",
+        2 => " 3",
+        3 => " 4",
+        _ => "",
+    }
+}
+
+/// The light pen's tip switch / trigger by `click-after` name: the pen
+/// puts it on POTxX, and `set_mouse_button` index 0 (left) closes it on a
+/// pen port, so the replay directive is the left click.
+const PEN_BUTTONS: [(&str, ControlRead); 1] = [("left", |p| p.button3)];
+
+/// A port's controls as one `ControllerPort` view, whichever connector it
+/// is on: the game ports as they are, the adapter's sockets through
+/// [`ParallelJoystick::as_controller_port`].
+fn port_view(input: &InputState, port: usize) -> ControllerPort {
+    match port {
+        0 | 1 => input.ports[port],
+        _ => input.parallel_joysticks[port - crate::bus::PARALLEL_PORT_FIRST].as_controller_port(),
     }
 }
 
@@ -113,11 +130,12 @@ pub struct InputRecorder {
     lines: Vec<(f64, String)>,
     /// Open key presses: rawkey -> press time.
     open_keys: HashMap<u8, f64>,
-    /// Open mouse-button presses per port, indexed like MOUSE_BUTTONS.
+    /// Open mouse-button presses per game port, indexed like MOUSE_BUTTONS
+    /// (a light pen's switch uses slot 0, like PEN_BUTTONS).
     open_clicks: [[Option<f64>; 3]; 2],
-    /// Open joystick/pad control presses per port, indexed like
-    /// JOY_CONTROLS.
-    open_joys: [[Option<f64>; 11]; 2],
+    /// Open joystick/pad control presses per port (game ports and the
+    /// adapter's sockets), indexed like JOY_CONTROLS.
+    open_joys: [[Option<f64>; 11]; crate::bus::PORT_COUNT],
     /// Input state at the previous `observe`, the diff baseline. Controls
     /// already held when recording starts are not recorded.
     prev: Option<InputState>,
@@ -145,7 +163,7 @@ impl InputRecorder {
             lines: Vec::new(),
             open_keys: HashMap::new(),
             open_clicks: [[None; 3]; 2],
-            open_joys: [[None; 11]; 2],
+            open_joys: [[None; 11]; crate::bus::PORT_COUNT],
             prev: None,
             first_devices: None,
         }
@@ -222,9 +240,11 @@ impl InputRecorder {
 
     /// Close every hold a port's device left open, at `secs`.
     fn close_port_holds(&mut self, port: usize, secs: f64) {
-        for idx in 0..MOUSE_BUTTONS.len() {
-            if let Some(press) = self.open_clicks[port][idx].take() {
-                self.emit_click(port, MOUSE_BUTTONS[idx].0, press, secs);
+        if port < 2 {
+            for idx in 0..MOUSE_BUTTONS.len() {
+                if let Some(press) = self.open_clicks[port][idx].take() {
+                    self.emit_click(port, MOUSE_BUTTONS[idx].0, press, secs);
+                }
             }
         }
         for idx in 0..JOY_CONTROLS.len() {
@@ -243,9 +263,18 @@ impl InputRecorder {
             return;
         };
 
-        for port in 0..2 {
-            let old = &prev.ports[port];
-            let cur = &input.ports[port];
+        if input.light_pen != prev.light_pen {
+            if let Some(port) = input.light_pen_port() {
+                let (x, y) = input.light_pen.position.unwrap_or((-1, -1));
+                self.lines.push((
+                    secs,
+                    format!("pen-after {} {x} {y} {}", fmt_secs(secs), port + 1),
+                ));
+            }
+        }
+        for port in 0..crate::bus::PORT_COUNT {
+            let old = &port_view(&prev, port);
+            let cur = &port_view(input, port);
             if old.device != cur.device {
                 // Hot-plug: close what the old device held; the device
                 // change itself has no script directive.
@@ -304,6 +333,19 @@ impl InputRecorder {
                         }
                     }
                 }
+                PortDevice::LightPen => {
+                    for (idx, (name, read)) in PEN_BUTTONS.iter().enumerate() {
+                        match (read(old), read(cur)) {
+                            (false, true) => self.open_clicks[port][idx] = Some(secs),
+                            (true, false) => {
+                                if let Some(press) = self.open_clicks[port][idx].take() {
+                                    self.emit_click(port, name, press, secs);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
                 PortDevice::None => {}
             }
         }
@@ -324,7 +366,7 @@ impl InputRecorder {
                 ),
             ));
         }
-        for port in 0..2 {
+        for port in 0..crate::bus::PORT_COUNT {
             self.close_port_holds(port, end);
         }
         self.lines
@@ -538,5 +580,26 @@ mod tests {
         let mouse_pos = script.find("mouse-after").unwrap();
         let key_pos = script.find("key-after").unwrap();
         assert!(mouse_pos < key_pos, "{script}");
+    }
+
+    #[test]
+    fn adapter_sockets_and_the_pen_record_with_their_own_directives() {
+        let mut rec = InputRecorder::new(0.0);
+        let mut input = base_input();
+        input.set_parallel_adapter(true, [true, true]);
+        input.set_port_device(0, PortDevice::LightPen);
+        rec.observe(&input, 1.0);
+        input.set_joystick(3, false, false, true, false, true, false);
+        input.set_light_pen_position(Some((300, 120)));
+        input.set_mouse_button(0, 0, true);
+        rec.observe(&input, 1.5);
+        input.set_joystick(3, false, false, false, false, false, false);
+        input.set_mouse_button(0, 0, false);
+        rec.observe(&input, 2.0);
+        let script = rec.finish();
+        assert!(script.contains("joy-after 1.500 left 500 4"), "{script}");
+        assert!(script.contains("joy-after 1.500 red 500 4"), "{script}");
+        assert!(script.contains("pen-after 1.500 300 120 1"), "{script}");
+        assert!(script.contains("click-after 1.500 left 500\n"), "{script}");
     }
 }

--- a/src/inputsched.rs
+++ b/src/inputsched.rs
@@ -50,6 +50,8 @@ pub enum ReplayAction {
     Joy { port: u8, state: JoyState },
     /// Analogue pot positions on a port.
     Pot { port: u8, x: u8, y: u8 },
+    /// The light pen's position on the glass (`None` = lifted off).
+    Pen { position: Option<(i32, i32)> },
     /// A floppy media change occurred. Replaying across a media change cannot
     /// be reconstructed from the log (the inserted image is host-file state),
     /// so the engine warns rather than silently diverging.
@@ -87,6 +89,7 @@ impl ReplayAction {
                     .set_cd32_buttons(port, j.play, j.rwd, j.ffw, j.green, j.yellow);
             }
             ReplayAction::Pot { port, x, y } => bus.input.set_analogue(port as usize, x, y),
+            ReplayAction::Pen { position } => bus.input.set_light_pen_position(position),
             ReplayAction::DiskChange => {
                 log::warn!(
                     "reverse-debug replay crossed a floppy media change; \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub mod gamelib;
 pub mod gamepad;
 pub mod gary;
 pub mod gayle;
+pub mod pcmcia;
 // The remote GDB stub (`--gdb`). Gated so player builds -- shipped games
 // with no debugging surface -- can compile it out; everything else keeps it
 // through the default features.

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,7 @@ fn validate_benchmark_args(cli: &CliArgs) -> Result<()> {
         || !cli.mouse_after.is_empty()
         || !cli.mouse_to_after.is_empty()
         || !cli.pot_after.is_empty()
+        || !cli.pen_after.is_empty()
         || !cli.freeze_after.is_empty()
     {
         return Err(anyhow!(
@@ -217,6 +218,7 @@ fn validate_gdb_args(cli: &CliArgs) -> Result<()> {
         || !cli.mouse_after.is_empty()
         || !cli.mouse_to_after.is_empty()
         || !cli.pot_after.is_empty()
+        || !cli.pen_after.is_empty()
         || !cli.freeze_after.is_empty()
     {
         return Err(anyhow!(
@@ -286,6 +288,7 @@ fn validate_control_args(cli: &CliArgs) -> Result<()> {
         || !cli.mouse_after.is_empty()
         || !cli.mouse_to_after.is_empty()
         || !cli.pot_after.is_empty()
+        || !cli.pen_after.is_empty()
         || !cli.freeze_after.is_empty()
     {
         return Err(anyhow!(
@@ -695,6 +698,26 @@ fn list_midi_endpoints() -> Result<()> {
     Ok(())
 }
 
+/// `--list-serial-ports`: the host serial ports `[serial] device` /
+/// `--serial-device` take, as the paths to spell them by.
+fn list_serial_ports() -> Result<()> {
+    if !cfg!(feature = "host-serial") {
+        println!(
+            "This build has no host serial port support; rebuild with --features host-serial."
+        );
+        return Ok(());
+    }
+    let ports = copperline::serial::device::available_host_ports();
+    println!("Serial ports (for --serial-device):");
+    if ports.is_empty() {
+        println!("  (none)");
+    }
+    for port in &ports {
+        println!("  {port}");
+    }
+    Ok(())
+}
+
 fn main() -> Result<()> {
     let mut log_builder =
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"));
@@ -749,6 +772,9 @@ fn main() -> Result<()> {
     }
     if cli.list_midi {
         return list_midi_endpoints();
+    }
+    if cli.list_serial_ports {
+        return list_serial_ports();
     }
     if cli.list_audio_devices {
         return print_audio_output_devices();
@@ -1286,6 +1312,7 @@ fn main() -> Result<()> {
         cli.mouse_after,
         cli.mouse_to_after,
         cli.pot_after,
+        cli.pen_after,
         disk_insert_after,
         cli.cd_insert_after,
         cli.freeze_after,
@@ -1461,6 +1488,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         Vec::new(),
         Vec::new(),
         Vec::new(),
+        Vec::new(),
         None,
         None,
         None,
@@ -1536,6 +1564,7 @@ fn launcher_requested(cli: &CliArgs) -> bool {
         && cli.mouse_after.is_empty()
         && cli.mouse_to_after.is_empty()
         && cli.pot_after.is_empty()
+        && cli.pen_after.is_empty()
         && cli.freeze_after.is_empty()
         && cli.disk_insert_after.is_empty()
         && cli.record_input.is_none()
@@ -2028,6 +2057,51 @@ mod tests {
         assert_eq!(args.click_after, vec![(5.0, MouseButtonKind::Left, 100, 1)]);
         assert_eq!(args.joy_after, vec![(60.0, JoyButtonKind::Red, 300, 0)]);
         assert_eq!(args.pot_after, vec![(12.0, 50, 200, 0)]);
+        Ok(())
+    }
+
+    #[test]
+    fn joy_after_reaches_the_adapter_sockets_and_pen_after_positions_the_pen() -> Result<()> {
+        let args = parse(&[
+            "--joy-after",
+            "4",
+            "red",
+            "100",
+            "3",
+            "--joy-after",
+            "5",
+            "up",
+            "100",
+            "4",
+            "--pen-after",
+            "3",
+            "320",
+            "128",
+            "--pen-after",
+            "6",
+            "-1",
+            "-1",
+            "2",
+            "--noaudio",
+        ])?;
+        assert_eq!(
+            args.joy_after,
+            vec![
+                (4.0, JoyButtonKind::Red, 100, 2),
+                (5.0, JoyButtonKind::Up, 100, 3)
+            ]
+        );
+        assert_eq!(
+            args.pen_after,
+            vec![(3.0, 320, 128, None), (6.0, -1, -1, Some(1))]
+        );
+        assert!(!args.audio_live);
+        // The same directives inside a script.
+        let path = temp_script("pen", "pen-after 4.5 100 40 1\njoy-after 1 fire 50 4\n");
+        let args = parse(&["--script", &path.display().to_string()])?;
+        assert_eq!(args.pen_after, vec![(4.5, 100, 40, Some(0))]);
+        assert_eq!(args.joy_after, vec![(1.0, JoyButtonKind::Red, 50, 3)]);
+        std::fs::remove_file(&path).ok();
         Ok(())
     }
 

--- a/src/pcmcia.rs
+++ b/src/pcmcia.rs
@@ -1,0 +1,911 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The card in the A600/A1200 PCMCIA (credit-card) slot.
+//!
+//! Gayle decodes the slot into the CPU's address space as the Commodore
+//! schematics, the Linux `amigayle.h` header (derived from card.resource),
+//! and WinUAE's `gayle.cpp` describe it:
+//!
+//! | CPU address           | slot cycle                                    |
+//! |-----------------------|-----------------------------------------------|
+//! | `$600000`-`$9FFFFF`   | common memory, 4 MiB (REG# high)               |
+//! | `$A00000`-`$A1FFFF`   | attribute memory (REG# low, CE1#/CE2# memory)  |
+//! | `$A20000`-`$A2FFFF`   | I/O space, 16-bit and even 8-bit registers     |
+//! | `$A30000`-`$A3FFFF`   | I/O space, odd 8-bit registers (A0 forced high)|
+//! | `$A40000`-`$A7FFFF`   | card RESET: a write asserts it, a read releases |
+//!
+//! Gayle cross-wires the byte lanes so a byte at card address N is the byte
+//! at CPU address N: the CPU's even byte (D15-D8) is the card's D7-D0 byte
+//! and vice versa. A 16-bit register therefore reads on the CPU with its
+//! bytes exchanged, exactly as the Gayle IDE data port does, which is what
+//! [`crate::ata::AtaBus`] already models; sector data passes through in
+//! natural memory order.
+//!
+//! The slot's pins that Gayle folds into its status register are modelled
+//! by [`PcmciaCard::pins`]; the register file, the change latches, and the
+//! INT2/INT6 routing are Gayle's own and live in [`crate::gayle`]. This
+//! module holds the card: a CompactFlash/ATA card driving the shared ATA
+//! command engine through the CF register layout (memory-mapped, contiguous
+//! I/O, or PC-style primary/secondary I/O, selected by the card's
+//! Configuration Option Register), or an SRAM memory card with a CIS that
+//! Kickstart's card.resource accepts as credit-card RAM.
+
+use std::path::{Path, PathBuf};
+
+use crate::ata::{AtaBus, IdeDrive, IdeReg};
+
+/// Common memory window: `$600000`-`$9FFFFF`.
+pub const COMMON_BASE: u32 = 0x0060_0000;
+pub const COMMON_SIZE: u32 = 0x0040_0000;
+/// Attribute memory window: `$A00000`-`$A1FFFF`.
+pub const ATTRIBUTE_BASE: u32 = 0x00A0_0000;
+pub const ATTRIBUTE_SIZE: u32 = 0x0002_0000;
+/// I/O window, 16-bit and even 8-bit registers: `$A20000`-`$A2FFFF`.
+pub const IO_BASE: u32 = 0x00A2_0000;
+pub const IO_SIZE: u32 = 0x0001_0000;
+/// I/O window, odd 8-bit registers: `$A30000`-`$A3FFFF`.
+pub const IO_ODD_BASE: u32 = 0x00A3_0000;
+/// Card reset register: `$A40000`-`$A7FFFF`.
+pub const RESET_BASE: u32 = 0x00A4_0000;
+pub const RESET_SIZE: u32 = 0x0004_0000;
+/// Everything above common memory that Gayle decodes for the slot:
+/// `$A00000`-`$A7FFFF`.
+pub const SLOT_BASE: u32 = ATTRIBUTE_BASE;
+pub const SLOT_SIZE: u32 = 0x0008_0000;
+
+/// The largest SRAM card the 4 MiB common window can hold.
+pub const MAX_SRAM_BYTES: usize = COMMON_SIZE as usize;
+
+/// Zorro II fast RAM configures upward from `$200000`; more than this much
+/// reaches into the common-memory window and Gayle's PCMCIA decode gives
+/// way to it.
+pub const MAX_FAST_RAM_WITH_SLOT: usize = 4 * 1024 * 1024;
+
+// The slot pins as Gayle's status register presents them (bit positions
+// shared with the change and enable registers).
+/// Card detect (CD1#/CD2# grounded by an inserted card).
+pub const PIN_CCDET: u8 = 0x40;
+/// Battery voltage detect 1 (memory cards) / STSCHG# (I/O cards).
+pub const PIN_BVD1: u8 = 0x20;
+/// Battery voltage detect 2 (memory cards) / SPKR (I/O cards).
+pub const PIN_BVD2: u8 = 0x10;
+/// Write enable: 1 when the card's write-protect switch is off.
+pub const PIN_WR: u8 = 0x08;
+/// READY low (memory cards, "busy") / IREQ# low (I/O cards, "interrupt").
+pub const PIN_BSY_IRQ: u8 = 0x04;
+
+/// Whether `addr` falls in one of the slot windows Gayle decodes.
+pub fn decodes(addr: u32) -> bool {
+    addr.wrapping_sub(COMMON_BASE) < COMMON_SIZE || addr.wrapping_sub(SLOT_BASE) < SLOT_SIZE
+}
+
+/// Which slot cycle a CPU address selects, with the offset inside it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotAccess {
+    Common(u32),
+    Attribute(u32),
+    /// I/O cycle; the offset already has A0 forced high for the odd-byte
+    /// window at `$A30000`.
+    Io(u32),
+    Reset,
+}
+
+pub fn classify(addr: u32) -> Option<SlotAccess> {
+    let common = addr.wrapping_sub(COMMON_BASE);
+    if common < COMMON_SIZE {
+        return Some(SlotAccess::Common(common));
+    }
+    let slot = addr.wrapping_sub(SLOT_BASE);
+    if slot >= SLOT_SIZE {
+        return None;
+    }
+    Some(match slot {
+        0x0_0000..=0x1_FFFF => SlotAccess::Attribute(slot),
+        0x2_0000..=0x2_FFFF => SlotAccess::Io(slot - 0x2_0000),
+        // The odd-register window: the same 64 KiB of I/O space with A0
+        // driven high, so a byte at $A30000+2n reaches register 2n+1.
+        0x3_0000..=0x3_FFFF => SlotAccess::Io((slot - 0x3_0000) | 1),
+        _ => SlotAccess::Reset,
+    })
+}
+
+/// What kind of card `[pcmcia] card` asks for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CardKind {
+    Cf,
+    Sram,
+}
+
+impl CardKind {
+    pub fn token(self) -> &'static str {
+        match self {
+            Self::Cf => "cf",
+            Self::Sram => "sram",
+        }
+    }
+}
+
+/// A card in the slot.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum PcmciaCard {
+    /// Boxed: the ATA engine's sector buffer makes it far larger than
+    /// an SRAM card's header.
+    Cf(Box<CfCard>),
+    Sram(SramCard),
+}
+
+impl PcmciaCard {
+    /// A CF card in the slot.
+    pub fn cf(card: CfCard) -> Self {
+        Self::Cf(Box::new(card))
+    }
+
+    pub fn kind(&self) -> CardKind {
+        match self {
+            Self::Cf(_) => CardKind::Cf,
+            Self::Sram(_) => CardKind::Sram,
+        }
+    }
+
+    /// The slot pins this card drives, in Gayle's status-register layout.
+    pub fn pins(&self) -> u8 {
+        match self {
+            Self::Cf(card) => card.pins(),
+            Self::Sram(card) => card.pins(),
+        }
+    }
+
+    /// One line for logs, OSDs, and `pcmcia.query`.
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Cf(card) => card.describe(),
+            Self::Sram(card) => card.describe(),
+        }
+    }
+
+    /// The host path behind the card, if a file backs it.
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            Self::Cf(card) => Some(card.ata_path()),
+            Self::Sram(card) => card.path.as_deref(),
+        }
+    }
+
+    /// The card's RESET pin: asserted by the system reset line and by a
+    /// write to `$A40000`. A CF card drops its configuration registers and
+    /// resets its ATA function; an SRAM card has nothing to reset.
+    pub fn reset(&mut self) {
+        if let Self::Cf(card) = self {
+            card.reset();
+        }
+    }
+
+    pub fn read_attribute(&mut self, off: u32) -> u8 {
+        match self {
+            Self::Cf(card) => card.read_attribute(off),
+            Self::Sram(card) => card.read_attribute(off),
+        }
+    }
+
+    pub fn write_attribute(&mut self, off: u32, value: u8) {
+        if let Self::Cf(card) = self {
+            card.write_attribute(off, value);
+        }
+    }
+
+    /// A byte or word of common memory. `size` is 1 or 2; a word starts at
+    /// an even offset.
+    pub fn read_common(&mut self, off: u32, size: usize) -> u32 {
+        match self {
+            Self::Cf(card) => card.read_common(off, size),
+            Self::Sram(card) => card.read_common(off, size),
+        }
+    }
+
+    pub fn write_common(&mut self, off: u32, size: usize, value: u32) {
+        match self {
+            Self::Cf(card) => card.write_common(off, size, value),
+            Self::Sram(card) => card.write_common(off, size, value),
+        }
+    }
+
+    /// An I/O cycle. A memory card does not answer them: the bus floats.
+    pub fn read_io(&mut self, off: u32, size: usize) -> Option<u32> {
+        match self {
+            Self::Cf(card) => card.read_io(off, size),
+            Self::Sram(_) => None,
+        }
+    }
+
+    pub fn write_io(&mut self, off: u32, size: usize, value: u32) {
+        if let Self::Cf(card) = self {
+            card.write_io(off, size, value);
+        }
+    }
+
+    /// Drain the activity latch (data-port traffic, command issue), for
+    /// the HDD LED.
+    pub fn take_activity(&mut self) -> bool {
+        match self {
+            Self::Cf(card) => card.ata.take_activity(),
+            Self::Sram(card) => std::mem::take(&mut card.activity),
+        }
+    }
+
+    /// Write an SRAM card's contents back to its backing file if they
+    /// changed. A CF card writes through its image as it goes.
+    pub fn flush(&mut self) {
+        if let Self::Sram(card) = self {
+            card.flush();
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn pending_host_disks(&self, out: &mut Vec<(String, String, bool)>) {
+        if let Self::Cf(card) = self {
+            card.ata.pending_host_disks(out);
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn materialize_host_disks(&mut self) -> anyhow::Result<()> {
+        match self {
+            Self::Cf(card) => card.ata.materialize_host_disks(),
+            Self::Sram(_) => Ok(()),
+        }
+    }
+
+    pub fn release_host_disks(&mut self) -> usize {
+        match self {
+            Self::Cf(card) => card.ata.release_host_disks(),
+            Self::Sram(_) => 0,
+        }
+    }
+}
+
+// ----- CompactFlash / PCMCIA ATA card ---------------------------------------
+
+/// Configuration Option Register bits (attribute `$200`).
+const COR_SRESET: u8 = 0x80;
+const COR_INDEX_MASK: u8 = 0x3F;
+/// Attribute-memory offsets of the card configuration registers.
+const COR_OFFSET: u32 = 0x200;
+const CCSR_OFFSET: u32 = 0x202;
+const PRR_OFFSET: u32 = 0x204;
+const SCR_OFFSET: u32 = 0x206;
+
+/// A CompactFlash card (PCMCIA ATA): the ATA engine behind the CF register
+/// layout, plus the CIS and configuration registers in attribute memory.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct CfCard {
+    ata: AtaBus,
+    /// The CIS, one byte per even attribute address.
+    cis: Vec<u8>,
+    /// Configuration Option Register: bit 7 soft reset, bit 6 LevlREQ,
+    /// bits 5-0 the configuration index.
+    cor: u8,
+    /// Card Configuration and Status Register.
+    ccsr: u8,
+    /// Pin Replacement Register.
+    prr: u8,
+    /// Socket and Copy Register.
+    scr: u8,
+}
+
+impl CfCard {
+    /// Wrap an ATA drive (an image opened by [`IdeDrive::open`] or a real
+    /// disk from [`IdeDrive::open_host_disk`]) as a CF card.
+    pub fn new(drive: IdeDrive) -> Self {
+        let mut ata = AtaBus::new();
+        ata.attach_drive(0, drive);
+        Self {
+            ata,
+            cis: cf_cis(),
+            cor: 0,
+            ccsr: 0,
+            prr: 0,
+            scr: 0,
+        }
+    }
+
+    /// Open a hard-disk image (anything the shared drive backend accepts:
+    /// an RDB HDF, a bare partition hardfile, a gzip-compressed image, or
+    /// a host directory) as the card's medium.
+    pub fn open(path: &Path) -> anyhow::Result<Self> {
+        let disk = crate::harddrive::HardDriveImage::open(
+            path,
+            "CF0",
+            "pcmcia",
+            None,
+            0,
+            crate::diskimage::FileSystem::FFS,
+        )?;
+        Ok(Self::new(IdeDrive::from_disk(disk)))
+    }
+
+    fn ata_path(&self) -> &Path {
+        self.ata.drive_path(0).unwrap_or_else(|| Path::new(""))
+    }
+
+    /// The hard disk behind the card, for frontend save persistence.
+    pub fn hard_disk_mut(&mut self) -> Option<&mut crate::harddrive::HardDriveImage> {
+        self.ata.hard_disk_mut(0)
+    }
+
+    fn describe(&self) -> String {
+        let sectors = self.ata.drive_total_sectors(0).unwrap_or(0);
+        format!(
+            "CF card {} ({} MiB)",
+            self.ata_path().display(),
+            sectors * crate::ata::SECTOR_SIZE as u64 / (1024 * 1024)
+        )
+    }
+
+    /// CF cards drive WP low (never protected) and, as memory cards before
+    /// configuration, BVD1/BVD2 high (STSCHG#/SPKR inactive); READY is high
+    /// since the ATA engine completes commands within the access. In an I/O
+    /// configuration the same pin carries IREQ#, asserted by the ATA
+    /// function's INTRQ.
+    fn pins(&self) -> u8 {
+        let mut pins = PIN_CCDET | PIN_BVD1 | PIN_BVD2 | PIN_WR;
+        if self.io_configured() && self.ata.irq_level() {
+            pins |= PIN_BSY_IRQ;
+        }
+        pins
+    }
+
+    fn config_index(&self) -> u8 {
+        self.cor & COR_INDEX_MASK
+    }
+
+    /// Whether the card is in an I/O configuration (index 1-3), as opposed
+    /// to the power-on memory-mapped one (index 0).
+    fn io_configured(&self) -> bool {
+        matches!(self.config_index(), 1..=3)
+    }
+
+    fn reset(&mut self) {
+        self.cor = 0;
+        self.ccsr = 0;
+        self.prr = 0;
+        self.scr = 0;
+        self.ata.reset();
+    }
+
+    fn read_attribute(&mut self, off: u32) -> u8 {
+        // Attribute memory is eight bits wide on the even byte; the odd
+        // byte is not driven and reads as its even neighbour.
+        let even = off & !1;
+        match even {
+            COR_OFFSET => self.cor,
+            CCSR_OFFSET => self.ccsr,
+            PRR_OFFSET => self.prr,
+            SCR_OFFSET => self.scr,
+            _ => self.cis.get((even / 2) as usize).copied().unwrap_or(0xFF),
+        }
+    }
+
+    fn write_attribute(&mut self, off: u32, value: u8) {
+        match off & !1 {
+            COR_OFFSET => {
+                if value & COR_SRESET != 0 {
+                    // Soft reset through the COR: the function resets and
+                    // the register keeps only the reset bit until it is
+                    // written clear.
+                    self.ata.reset();
+                    self.cor = COR_SRESET;
+                } else {
+                    self.cor = value & (COR_INDEX_MASK | 0x40);
+                    if crate::envcfg::flag("COPPERLINE_DIAG_GAYLE") {
+                        log::info!("pcmcia: CF configuration index {}", self.config_index());
+                    }
+                }
+            }
+            CCSR_OFFSET => self.ccsr = value & 0x4E,
+            PRR_OFFSET => self.prr = value,
+            SCR_OFFSET => self.scr = value,
+            _ => {}
+        }
+    }
+
+    /// The CF task-file register at a 16-byte-block offset (memory-mapped
+    /// and contiguous-I/O layouts alike, CF+ spec table "ATA register
+    /// layout"): 0-7 the ATA task file, 8/9 the data register again, `$D`
+    /// error/feature again, `$E` alternate status / device control, `$F`
+    /// the drive address register.
+    fn block_reg(off: u32) -> Option<IdeReg> {
+        Some(match off & 0xF {
+            0x0 | 0x8 | 0x9 => IdeReg::Data,
+            0x1 | 0xD => IdeReg::ErrorFeature,
+            0x2 => IdeReg::SectorCount,
+            0x3 => IdeReg::SectorNumber,
+            0x4 => IdeReg::CylLow,
+            0x5 => IdeReg::CylHigh,
+            0x6 => IdeReg::DriveHead,
+            0x7 => IdeReg::StatusCommand,
+            0xE => IdeReg::AltStatusDevCtl,
+            _ => return None,
+        })
+    }
+
+    /// Memory-mapped layout (configuration 0): the register block at the
+    /// start of each 2 KiB of common memory, with `$400`-`$7FF` a window
+    /// onto the data register for block transfers. Only A10-A0 take part
+    /// in the decode.
+    fn common_reg(off: u32) -> Option<IdeReg> {
+        match off & 0x7FF {
+            0x000..=0x00F => Self::block_reg(off),
+            0x400..=0x7FF => Some(IdeReg::Data),
+            _ => None,
+        }
+    }
+
+    /// I/O layouts: contiguous 16 registers (configuration 1, A3-A0
+    /// decoded), PC primary (2: `$1F0`-`$1F7`, `$3F6`-`$3F7`) or secondary
+    /// (3: `$170`-`$177`, `$376`-`$377`).
+    fn io_reg(&self, off: u32) -> Option<IdeReg> {
+        let off = off & 0xFFFF;
+        match self.config_index() {
+            1 => Self::block_reg(off),
+            2 | 3 => {
+                let (task, control) = if self.config_index() == 2 {
+                    (0x1F0, 0x3F6)
+                } else {
+                    (0x170, 0x376)
+                };
+                if (task..task + 8).contains(&off) {
+                    Self::block_reg(off - task)
+                } else if off == control {
+                    Some(IdeReg::AltStatusDevCtl)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// One byte or word of a register block. A word lands the even
+    /// register on the CPU's high byte (Gayle's lane swap) and, for the
+    /// data register, is the whole 16-bit data word.
+    fn read_regs(
+        &mut self,
+        reg_at: &dyn Fn(&Self, u32) -> Option<IdeReg>,
+        off: u32,
+        size: usize,
+    ) -> u32 {
+        let reg = reg_at(self, off);
+        if size == 2 {
+            if reg == Some(IdeReg::Data) {
+                return self.ata.read_reg(reg, 2);
+            }
+            let hi = self.read_regs(reg_at, off, 1);
+            let lo = self.read_regs(reg_at, off | 1, 1);
+            return (hi << 8) | lo;
+        }
+        match reg {
+            // A byte read of the data port takes the even (first) byte.
+            Some(IdeReg::Data) => self.ata.read_reg(reg, 1) & 0xFF,
+            Some(_) => self.ata.read_reg(reg, 1) & 0xFF,
+            None => 0,
+        }
+    }
+
+    fn write_regs(
+        &mut self,
+        reg_at: &dyn Fn(&Self, u32) -> Option<IdeReg>,
+        off: u32,
+        size: usize,
+        value: u32,
+    ) {
+        let reg = reg_at(self, off);
+        if size == 2 {
+            if reg == Some(IdeReg::Data) {
+                self.ata.write_reg(reg, 2, value & 0xFFFF);
+                return;
+            }
+            self.write_regs(reg_at, off, 1, (value >> 8) & 0xFF);
+            self.write_regs(reg_at, off | 1, 1, value & 0xFF);
+            return;
+        }
+        if reg.is_some() {
+            self.ata.write_reg(reg, 1, value & 0xFF);
+        }
+    }
+
+    fn read_common(&mut self, off: u32, size: usize) -> u32 {
+        if self.io_configured() {
+            // In an I/O configuration the registers leave common memory.
+            return 0;
+        }
+        self.read_regs(&|_, o| Self::common_reg(o), off, size)
+    }
+
+    fn write_common(&mut self, off: u32, size: usize, value: u32) {
+        if self.io_configured() {
+            return;
+        }
+        self.write_regs(&|_, o| Self::common_reg(o), off, size, value);
+    }
+
+    fn read_io(&mut self, off: u32, size: usize) -> Option<u32> {
+        if !self.io_configured() {
+            return None;
+        }
+        Some(self.read_regs(&Self::io_reg, off, size))
+    }
+
+    fn write_io(&mut self, off: u32, size: usize, value: u32) {
+        if !self.io_configured() {
+            return;
+        }
+        self.write_regs(&Self::io_reg, off, size, value);
+    }
+}
+
+/// The CIS a CF card presents, tuple for tuple the layout of the CF+ and
+/// CompactFlash specification's example CIS (as shipped by SanDisk-era
+/// cards and copied by WinUAE): device, JEDEC, version, function
+/// (fixed disk, ATA interface), configuration registers at `$200`, and
+/// one configuration table entry per addressing mode (0 memory-mapped,
+/// 1 contiguous I/O, 2 primary, 3 secondary).
+fn cf_cis() -> Vec<u8> {
+    let mut cis = Vec::with_capacity(256);
+    // CISTPL_DEVICE: 250 ns function-specific device, 2 units.
+    cis.extend_from_slice(&[0x01, 0x04, 0xDF, 0x4A, 0x01, 0xFF]);
+    // CISTPL_DEVICE_OC: same at 3.3 V.
+    cis.extend_from_slice(&[0x1C, 0x04, 0x02, 0xD9, 0x01, 0xFF]);
+    // CISTPL_JEDEC_C.
+    cis.extend_from_slice(&[0x18, 0x02, 0xDF, 0x01]);
+    // CISTPL_VERS_1: PCMCIA 2.1, manufacturer / product / info strings.
+    let strings: &[&[u8]] = &[b"COPPERLINE", b"68000", b"PCMCIA ATA CARD", b"1.0"];
+    let mut vers = vec![0x04, 0x01];
+    for s in strings {
+        vers.extend_from_slice(s);
+        vers.push(0);
+    }
+    vers.push(0xFF);
+    cis.push(0x15);
+    cis.push(vers.len() as u8);
+    cis.extend_from_slice(&vers);
+    // CISTPL_FUNCID: fixed disk, initialise at POST.
+    cis.extend_from_slice(&[0x21, 0x02, 0x04, 0x01]);
+    // CISTPL_FUNCE: disk interface = ATA.
+    cis.extend_from_slice(&[0x22, 0x02, 0x01, 0x01]);
+    // CISTPL_FUNCE: ATA extension, 5 V / 3.3 V, unique 16-bit data.
+    cis.extend_from_slice(&[0x22, 0x03, 0x02, 0x0C, 0x0F]);
+    // CISTPL_CONFIG: last index 3, registers at $200, COR/CCSR/PRR/SCR.
+    cis.extend_from_slice(&[0x1A, 0x05, 0x01, 0x03, 0x00, 0x02, 0x0F]);
+    // CISTPL_CFTABLE_ENTRY 0 (default): memory interface, 2 KiB of common
+    // memory at offset 0 for the register block.
+    cis.extend_from_slice(&[
+        0x1B, 0x0B, 0xC0, 0xC0, 0xA1, 0x27, 0x55, 0x4D, 0x5D, 0x75, 0x08, 0x00, 0x21,
+    ]);
+    // CISTPL_CFTABLE_ENTRY 1: contiguous I/O, 16 registers, 8/16-bit.
+    cis.extend_from_slice(&[
+        0x1B, 0x0D, 0xC1, 0x41, 0x99, 0x27, 0x55, 0x4D, 0x5D, 0x75, 0x64, 0xF0, 0xFF, 0xFF, 0x20,
+    ]);
+    // CISTPL_CFTABLE_ENTRY 2: primary I/O ($1F0-$1F7, $3F6-$3F7).
+    cis.extend_from_slice(&[
+        0x1B, 0x12, 0xC2, 0x41, 0x99, 0x27, 0x55, 0x4D, 0x5D, 0x75, 0xEA, 0x61, 0xF0, 0x01, 0x07,
+        0xF6, 0x03, 0x01, 0xEE, 0x20,
+    ]);
+    // CISTPL_CFTABLE_ENTRY 3: secondary I/O ($170-$177, $376-$377).
+    cis.extend_from_slice(&[
+        0x1B, 0x12, 0xC3, 0x41, 0x99, 0x27, 0x55, 0x4D, 0x5D, 0x75, 0xEA, 0x61, 0x70, 0x01, 0x07,
+        0x76, 0x03, 0x01, 0xEE, 0x20,
+    ]);
+    // CISTPL_NO_LINK, CISTPL_END.
+    cis.extend_from_slice(&[0x14, 0x00, 0xFF]);
+    cis
+}
+
+// ----- SRAM memory card -----------------------------------------------------
+
+/// An SRAM memory card: up to 4 MiB of battery-backed static RAM in the
+/// common window, optionally mirrored to a host file, with the CIS that
+/// Kickstart's card.resource reads to size and add it as credit-card RAM.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct SramCard {
+    data: Vec<u8>,
+    cis: Vec<u8>,
+    /// Backing file: read at insert, written back on flush and eject.
+    path: Option<PathBuf>,
+    /// The write-protect switch.
+    read_only: bool,
+    #[serde(skip)]
+    dirty: bool,
+    #[serde(skip)]
+    activity: bool,
+}
+
+impl SramCard {
+    /// Build a card of `size` bytes. With a `path`, the file's contents
+    /// (up to `size`) seed the RAM and a missing file is created at the
+    /// first flush; without one the RAM starts zeroed and lives only for
+    /// the session (and inside save states).
+    pub fn new(size: usize, path: Option<&Path>, read_only: bool) -> anyhow::Result<Self> {
+        let encoded = sram_device_size_byte(size).ok_or_else(|| {
+            anyhow::anyhow!(
+                "PCMCIA SRAM size {} bytes cannot be described by a CISTPL_DEVICE tuple: \
+                 use a multiple of 64 KiB up to 1 MiB, or of 128 KiB up to 4 MiB",
+                size
+            )
+        })?;
+        let mut data = vec![0u8; size];
+        if let Some(path) = path {
+            match std::fs::read(path) {
+                Ok(bytes) => {
+                    let n = bytes.len().min(size);
+                    data[..n].copy_from_slice(&bytes[..n]);
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    return Err(anyhow::Error::new(e)
+                        .context(format!("PCMCIA SRAM backing file {}", path.display())))
+                }
+            }
+        }
+        Ok(Self {
+            data,
+            cis: sram_cis(size, encoded, read_only),
+            path: path.map(Path::to_path_buf),
+            read_only,
+            dirty: false,
+            activity: false,
+        })
+    }
+
+    pub fn size(&self) -> usize {
+        self.data.len()
+    }
+
+    /// The card's RAM, for tests and the debugger.
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    fn describe(&self) -> String {
+        let backing = match &self.path {
+            Some(p) => format!(" ({})", p.display()),
+            None => String::new(),
+        };
+        format!(
+            "SRAM card {} KiB{}{}",
+            self.data.len() / 1024,
+            backing,
+            if self.read_only {
+                ", write-protected"
+            } else {
+                ""
+            }
+        )
+    }
+
+    /// Battery good (BVD1/BVD2 high), READY high, WP from the switch.
+    fn pins(&self) -> u8 {
+        let mut pins = PIN_CCDET | PIN_BVD1 | PIN_BVD2;
+        if !self.read_only {
+            pins |= PIN_WR;
+        }
+        pins
+    }
+
+    fn read_attribute(&self, off: u32) -> u8 {
+        self.cis
+            .get(((off & !1) / 2) as usize)
+            .copied()
+            .unwrap_or(0xFF)
+    }
+
+    fn read_common(&mut self, off: u32, size: usize) -> u32 {
+        let off = off as usize;
+        // Beyond the card's own size the common window is undecoded.
+        if off + size > self.data.len() {
+            return 0;
+        }
+        self.activity = true;
+        if size == 2 {
+            (u32::from(self.data[off]) << 8) | u32::from(self.data[off + 1])
+        } else {
+            u32::from(self.data[off])
+        }
+    }
+
+    fn write_common(&mut self, off: u32, size: usize, value: u32) {
+        let off = off as usize;
+        if self.read_only || off + size > self.data.len() {
+            return;
+        }
+        self.activity = true;
+        self.dirty = true;
+        if size == 2 {
+            self.data[off] = (value >> 8) as u8;
+            self.data[off + 1] = value as u8;
+        } else {
+            self.data[off] = value as u8;
+        }
+    }
+
+    /// Whether unsaved writes are waiting for a flush.
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Write the RAM back to the backing file.
+    pub fn flush(&mut self) {
+        if !self.dirty {
+            return;
+        }
+        let Some(path) = &self.path else {
+            return;
+        };
+        match std::fs::write(path, &self.data) {
+            Ok(()) => self.dirty = false,
+            Err(e) => log::warn!(
+                "pcmcia: SRAM card write-back to {} failed: {e}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl Drop for SramCard {
+    fn drop(&mut self) {
+        self.flush();
+    }
+}
+
+/// The CISTPL_DEVICE size byte for an SRAM card: bits 2-0 a unit size
+/// (512 B, 2 K, 8 K, 32 K, 128 K, 512 K, 2 M), bits 7-3 the unit count
+/// minus one. Picks the largest unit that divides the size into at most
+/// 32 units; `None` when no unit does.
+pub fn sram_device_size_byte(size: usize) -> Option<u8> {
+    if size == 0 {
+        return None;
+    }
+    const UNITS: [usize; 7] = [512, 2048, 8192, 32768, 131_072, 524_288, 2_097_152];
+    UNITS
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, &unit)| size.is_multiple_of(unit) && size / unit <= 32)
+        .map(|(code, &unit)| (((size / unit - 1) as u8) << 3) | code as u8)
+}
+
+/// The CIS card.resource reads off an SRAM card (the tuple set WinUAE
+/// established as sufficient for Kickstart 2.05-3.x to add the card as
+/// credit-card RAM): device (SRAM, 100 ns, size), geometry, version,
+/// function (memory card), manufacturer, end.
+fn sram_cis(size: usize, size_byte: u8, read_only: bool) -> Vec<u8> {
+    let mut cis = Vec::with_capacity(96);
+    // CISTPL_DEVICE: DTYPE_SRAM, WPS from the switch, DSPEED 100 ns.
+    let device_id = (6 << 4) | if read_only { 8 } else { 0 } | 4;
+    cis.extend_from_slice(&[0x01, 0x03, device_id, size_byte, 0xFF]);
+    // CISTPL_DEVICEGEO: 16-bit bus, erase/read/write geometry of 1.
+    cis.extend_from_slice(&[0x1E, 0x07, 0x02, 0x00, 0x01, 0x01, 0x01, 0x01, 0xFF]);
+    // CISTPL_VERS_1.
+    let info = format!("{}KB SRAM CARD", size / 1024);
+    let strings: [&[u8]; 3] = [b"COPPERLINE", b"68000", info.as_bytes()];
+    let mut vers = vec![0x04, 0x01];
+    for s in strings {
+        vers.extend_from_slice(s);
+        vers.push(0);
+    }
+    vers.push(0xFF);
+    cis.push(0x15);
+    cis.push(vers.len() as u8);
+    cis.extend_from_slice(&vers);
+    // CISTPL_FUNCID: memory card.
+    cis.extend_from_slice(&[0x21, 0x02, 0x01, 0x00]);
+    // CISTPL_MANFID.
+    cis.extend_from_slice(&[0x20, 0x04, 0xFF, 0xFF, 0x01, 0x01]);
+    // CISTPL_END.
+    cis.push(0xFF);
+    cis
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slot_windows_decode_as_gayle_wires_them() {
+        assert_eq!(classify(0x0060_0000), Some(SlotAccess::Common(0)));
+        assert_eq!(classify(0x009F_FFFF), Some(SlotAccess::Common(0x3F_FFFF)));
+        assert_eq!(classify(0x00A0_0000), Some(SlotAccess::Attribute(0)));
+        assert_eq!(classify(0x00A1_FFFE), Some(SlotAccess::Attribute(0x1_FFFE)));
+        assert_eq!(classify(0x00A2_01F0), Some(SlotAccess::Io(0x1F0)));
+        // The odd-byte window forces A0 high: $A30000 + 2n is register 2n+1.
+        assert_eq!(classify(0x00A3_0000), Some(SlotAccess::Io(1)));
+        assert_eq!(classify(0x00A3_03F6), Some(SlotAccess::Io(0x3F7)));
+        assert_eq!(classify(0x00A4_0000), Some(SlotAccess::Reset));
+        assert_eq!(classify(0x00A7_FFFF), Some(SlotAccess::Reset));
+        assert_eq!(classify(0x00A8_0000), None);
+        assert_eq!(classify(0x005F_FFFF), None);
+        assert!(decodes(0x0070_0000));
+        assert!(!decodes(0x00DA_8000));
+    }
+
+    #[test]
+    fn sram_size_byte_follows_the_cistpl_device_encoding() {
+        // 4 MiB = 2 units of 2 MiB: count-1 = 1, code 6.
+        assert_eq!(sram_device_size_byte(4 * 1024 * 1024), Some((1 << 3) | 6));
+        // 512 KiB = 1 unit of 512 KiB.
+        assert_eq!(sram_device_size_byte(512 * 1024), Some(5));
+        // 64 KiB = 2 units of 32 KiB.
+        assert_eq!(sram_device_size_byte(64 * 1024), Some((1 << 3) | 3));
+        // 1088 KiB (17 x 64K) has no unit that fits 32 units.
+        assert_eq!(sram_device_size_byte(17 * 64 * 1024), None);
+        assert_eq!(sram_device_size_byte(0), None);
+    }
+
+    #[test]
+    fn sram_card_cis_names_an_sram_device_and_the_ram_reads_back() {
+        let mut card = SramCard::new(512 * 1024, None, false).unwrap();
+        // CISTPL_DEVICE at attribute 0: tuple code, link, device id
+        // (SRAM type 6, 100 ns), size byte, end-of-devices.
+        assert_eq!(card.read_attribute(0), 0x01);
+        assert_eq!(card.read_attribute(2), 0x03);
+        assert_eq!(card.read_attribute(4), 0x64);
+        assert_eq!(card.read_attribute(6), 5);
+        assert_eq!(card.read_attribute(8), 0xFF);
+        // Odd attribute bytes mirror their even neighbour.
+        assert_eq!(card.read_attribute(1), 0x01);
+        assert_eq!(card.pins(), PIN_CCDET | PIN_BVD1 | PIN_BVD2 | PIN_WR);
+
+        card.write_common(0x1000, 2, 0xBEEF);
+        card.write_common(0x1002, 1, 0x42);
+        assert_eq!(card.read_common(0x1000, 2), 0xBEEF);
+        assert_eq!(card.read_common(0x1000, 1), 0xBE);
+        assert_eq!(card.read_common(0x1002, 1), 0x42);
+        assert!(card.is_dirty());
+        // Past the card's own size the window is undecoded.
+        assert_eq!(card.read_common(512 * 1024, 2), 0);
+
+        let protected = SramCard::new(64 * 1024, None, true).unwrap();
+        assert_eq!(protected.pins() & PIN_WR, 0);
+        assert_eq!(protected.read_attribute(4) & 0x08, 0x08, "WPS bit");
+    }
+
+    #[test]
+    fn sram_card_backing_file_round_trips() {
+        let path = std::env::temp_dir().join(format!(
+            "copperline-pcmcia-sram-{}-{:?}.bin",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::remove_file(&path).ok();
+        {
+            let mut card = SramCard::new(64 * 1024, Some(&path), false).unwrap();
+            card.write_common(0x10, 2, 0x1234);
+            card.flush();
+        }
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(bytes.len(), 64 * 1024);
+        assert_eq!(&bytes[0x10..0x12], &[0x12, 0x34]);
+        let mut again = SramCard::new(64 * 1024, Some(&path), false).unwrap();
+        assert_eq!(again.read_common(0x10, 2), 0x1234);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn cf_cis_declares_an_ata_fixed_disk_with_config_registers_at_200() {
+        let cis = cf_cis();
+        assert_eq!(&cis[..2], &[0x01, 0x04], "CISTPL_DEVICE first");
+        let funcid = cis.windows(4).position(|w| w == [0x21, 0x02, 0x04, 0x01]);
+        assert!(funcid.is_some(), "CISTPL_FUNCID fixed disk");
+        let config = cis
+            .windows(7)
+            .position(|w| w == [0x1A, 0x05, 0x01, 0x03, 0x00, 0x02, 0x0F]);
+        assert!(config.is_some(), "CISTPL_CONFIG: last index 3, base $200");
+        assert_eq!(*cis.last().unwrap(), 0xFF);
+        // Four configuration table entries, indices 0-3.
+        let indices: Vec<u8> = cis
+            .windows(3)
+            .filter(|w| w[0] == 0x1B)
+            .map(|w| w[2] & 0x3F)
+            .collect();
+        assert_eq!(indices, [0, 1, 2, 3]);
+    }
+}

--- a/src/savestate/chunk.rs
+++ b/src/savestate/chunk.rs
@@ -79,6 +79,8 @@ pub(crate) struct ChunkSpec {
 // none is possible.
 //
 //   all chunks v1: the chunked format (container version 81).
+//   PCMC v1: the PCMCIA card chunk, added beside GAYL (additive: a state
+//     without it loads with an empty socket).
 
 const fn value(tag: &[u8; 4], version: u32, name: &'static str) -> ChunkSpec {
     ChunkSpec {
@@ -123,6 +125,9 @@ pub(crate) const BLIT: ChunkSpec = bus(b"BLIT", 1, "blitter", &["blitter"], true
 pub(crate) const FLOP: ChunkSpec = bus(b"FLOP", 1, "floppy controller", &["floppy"], true);
 pub(crate) const RTC: ChunkSpec = bus(b"RTC ", 1, "real-time clock", &["rtc", "rtc_present"], true);
 pub(crate) const GAYL: ChunkSpec = bus(b"GAYL", 1, "Gayle", &["gayle"], false);
+/// The card in Gayle's PCMCIA slot. Absent from states written before the
+/// slot existed, which load with an empty socket.
+pub(crate) const PCMC: ChunkSpec = bus(b"PCMC", 1, "PCMCIA card", &["pcmcia"], false);
 pub(crate) const MOBO: ChunkSpec = bus(
     b"MOBO",
     1,
@@ -152,7 +157,7 @@ pub(crate) const BUS: ChunkSpec = ChunkSpec {
 /// the order of their fields in `Bus`, which is what lets them stream.
 pub(crate) const CHUNKS: &[ChunkSpec] = &[
     DESC, CPU, MACH, ICAC, DCAC, MEM, CIAA, CIAB, PAUL, AGNS, COPR, DENI, BLIT, FLOP, RTC, GAYL,
-    MOBO, UAEL, CART, AKIK, CDTV, ZORR, KEYB, INPT, BUS,
+    PCMC, MOBO, UAEL, CART, AKIK, CDTV, ZORR, KEYB, INPT, BUS,
 ];
 
 pub(crate) fn spec_for(tag: Tag) -> Option<&'static ChunkSpec> {

--- a/src/scsi.rs
+++ b/src/scsi.rs
@@ -111,7 +111,9 @@ pub(crate) const SK_NOT_READY: u8 = 0x02;
 pub(crate) const SK_HARDWARE_ERROR: u8 = 0x04;
 pub(crate) const SK_ILLEGAL_REQUEST: u8 = 0x05;
 pub(crate) const SK_UNIT_ATTENTION: u8 = 0x06;
+pub(crate) const SK_DATA_PROTECT: u8 = 0x07;
 pub(crate) const ASC_INVALID_OPCODE: u8 = 0x20;
+pub(crate) const ASC_WRITE_PROTECTED: u8 = 0x27;
 pub(crate) const ASC_LBA_OUT_OF_RANGE: u8 = 0x21;
 pub(crate) const ASC_INVALID_FIELD_IN_CDB: u8 = 0x24;
 pub(crate) const ASC_LUN_NOT_SUPPORTED: u8 = 0x25;
@@ -426,7 +428,11 @@ impl ScsiDisk {
                     return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
                 };
                 let mut data = Vec::new();
-                data.extend_from_slice(&[0, 0, 0, if dbd { 0 } else { 8 }]);
+                // Device-specific parameter: WP (bit 7) on a medium the
+                // guest cannot write, exactly what a drive with its
+                // write-protect jumper set reports.
+                let wp = if self.disk.write_protected() { 0x80 } else { 0 };
+                data.extend_from_slice(&[0, 0, wp, if dbd { 0 } else { 8 }]);
                 if !dbd {
                     // Block descriptor: density 0, all blocks, 512-byte blocks.
                     let blocks = total.min(0x00FF_FFFF) as u32;
@@ -451,6 +457,9 @@ impl ScsiDisk {
                     return self.check(SK_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
                 };
                 let mut data = vec![0u8; 8];
+                if self.disk.write_protected() {
+                    data[3] = 0x80; // device-specific parameter: WP
+                }
                 if !dbd {
                     data[7] = 8; // block descriptor length
                     let blocks = total.min(u64::from(u32::MAX)) as u32;
@@ -626,7 +635,15 @@ impl ScsiDisk {
                             self.disk.path().display(),
                             lba + i as u64
                         );
-                        self.set_sense(SK_HARDWARE_ERROR, 0x00);
+                        // A refused write on a write-protected medium is
+                        // DATA PROTECT / WRITE PROTECTED, which the guest's
+                        // filesystem turns into its own write-protect
+                        // error rather than a disk fault.
+                        if e.kind() == std::io::ErrorKind::PermissionDenied {
+                            self.set_sense(SK_DATA_PROTECT, ASC_WRITE_PROTECTED);
+                        } else {
+                            self.set_sense(SK_HARDWARE_ERROR, 0x00);
+                        }
                         return CHECK_CONDITION;
                     }
                 }
@@ -1809,6 +1826,63 @@ mod tests {
         assert_eq!(status, GOOD);
 
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn write_protected_disk_reports_wp_and_refuses_writes_as_data_protect() {
+        let (image, path) = crate::harddrive::chd::tests::write_protected_image("scsi-wp", 64);
+        let mut disk = ScsiDisk::from_disk(image);
+
+        // MODE SENSE(6) and (10): the WP bit of the device-specific
+        // parameter is what a drive with its write-protect jumper set shows.
+        let (exec, status) = disk.execute(&[0x1A, 0, 0x03, 0, 254, 0], 0);
+        assert_eq!(status, GOOD);
+        let ScsiExec::DataIn(data) = exec else {
+            panic!("MODE SENSE(6) returns data");
+        };
+        assert_eq!(data[2] & 0x80, 0x80, "WP in the mode parameter header");
+        let (exec, status) = disk.execute(&[0x5A, 0, 0x03, 0, 0, 0, 0, 0, 254, 0], 0);
+        assert_eq!(status, GOOD);
+        let ScsiExec::DataIn(data) = exec else {
+            panic!("MODE SENSE(10) returns data");
+        };
+        assert_eq!(data[3] & 0x80, 0x80, "WP in the 10-byte header");
+
+        // WRITE(10) is accepted as a command, then refused once the data is
+        // in: DATA PROTECT / WRITE PROTECTED, not a hardware error.
+        let cdb = [0x2A, 0, 0, 0, 0, 5, 0, 0, 1, 0];
+        let (exec, status) = disk.execute(&cdb, 0);
+        assert!(matches!(exec, ScsiExec::DataOut(n) if n == SECTOR_SIZE));
+        assert_eq!(status, GOOD);
+        assert_eq!(
+            disk.complete_out(&cdb, &[0xAAu8; SECTOR_SIZE]),
+            CHECK_CONDITION
+        );
+        let sense = disk.sense_bytes();
+        assert_eq!(sense[2] & 0x0F, SK_DATA_PROTECT);
+        assert_eq!(sense[12], ASC_WRITE_PROTECTED);
+
+        // Reads still work, and the refused write left nothing behind.
+        let (exec, status) = disk.execute(&[0x28, 0, 0, 0, 0, 5, 0, 0, 1, 0], 0);
+        assert_eq!(status, GOOD);
+        let ScsiExec::DataIn(data) = exec else {
+            panic!("READ(10) returns data");
+        };
+        assert_eq!(&data[..4], &5u32.to_be_bytes());
+
+        // A writable image reports neither.
+        let path_rw = temp_image(64);
+        let mut rw =
+            ScsiDisk::open(&path_rw, 0, None, 0, crate::diskimage::FileSystem::FFS).unwrap();
+        let (exec, _) = rw.execute(&[0x1A, 0, 0x03, 0, 254, 0], 0);
+        let ScsiExec::DataIn(data) = exec else {
+            panic!("MODE SENSE(6) returns data");
+        };
+        assert_eq!(data[2] & 0x80, 0);
+        assert_eq!(rw.complete_out(&cdb, &[0xAAu8; SECTOR_SIZE]), GOOD);
+
+        crate::harddrive::chd::tests::remove_write_protected_image(&path);
+        std::fs::remove_file(&path_rw).ok();
     }
 
     #[test]

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -6,6 +6,11 @@ use crate::timebase::Instant;
 use std::collections::VecDeque;
 use std::io::{self, Write};
 
+/// A real host serial port (`mode = "device"`). Threads and tty ioctls,
+/// so not for the browser build.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod device;
+
 /// Maximum number of completed Paula transmissions retained for a host-side
 /// observer. The tap evicts the oldest word once full; it must never let a
 /// debugger client apply unbounded back-pressure to the emulated UART.

--- a/src/serial/device.rs
+++ b/src/serial/device.rs
@@ -45,7 +45,7 @@
 
 use super::{SerialControlLines, SerialSink};
 use std::io;
-use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicU64, AtomicU8, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -187,6 +187,11 @@ struct Shared {
     attached: AtomicBool,
     /// Set when the sink is dropped, so the reader stops reopening.
     shutdown: AtomicBool,
+    /// Bumped when the emulated timeline jumps (a state load, a rewind).
+    /// Bytes are stamped with the generation they were read or queued in,
+    /// so the ones belonging to the abandoned timeline are dropped instead
+    /// of reaching either endpoint late.
+    generation: AtomicU64,
     /// Host bytes staged for the guest, mirrored for the idle fast path.
     buffered: AtomicIsize,
     opener: HostPortOpener,
@@ -274,10 +279,11 @@ fn apply_settings(port: &mut dyn HostSerialPort, settings: &HostLineSettings, na
 /// docs for the model.
 pub struct DeviceSerialSink {
     shared: Arc<Shared>,
-    /// Host -> guest bytes from the reader thread.
-    rx: mpsc::Receiver<u8>,
-    /// Guest -> host bytes for the writer thread.
-    tx: mpsc::SyncSender<u8>,
+    /// Host -> guest bytes from the reader thread, with the generation
+    /// they were read in.
+    rx: mpsc::Receiver<(u64, u8)>,
+    /// Guest -> host bytes for the writer thread, likewise stamped.
+    tx: mpsc::SyncSender<(u64, u8)>,
     /// Whether the 9-bit word warning has been given.
     warned_nine_bit: bool,
     /// The guest rate SERPER last set, so a repeat write is not re-applied.
@@ -319,6 +325,7 @@ impl DeviceSerialSink {
             ring: AtomicBool::new(false),
             attached: AtomicBool::new(false),
             shutdown: AtomicBool::new(false),
+            generation: AtomicU64::new(0),
             buffered: AtomicIsize::new(0),
             opener,
             name: name.to_string(),
@@ -401,13 +408,18 @@ impl Drop for DeviceSerialSink {
     }
 }
 
-fn reader_loop(shared: Arc<Shared>, mut port: Box<dyn HostSerialPort>, tx: mpsc::Sender<u8>) {
+fn reader_loop(
+    shared: Arc<Shared>,
+    mut port: Box<dyn HostSerialPort>,
+    tx: mpsc::Sender<(u64, u8)>,
+) {
     let mut buf = [0u8; 512];
     while !shared.shutdown.load(Ordering::Acquire) {
         match port.read(&mut buf) {
             Ok(n) => {
+                let generation = shared.generation.load(Ordering::Acquire);
                 for &b in &buf[..n] {
-                    if tx.send(b).is_err() {
+                    if tx.send((generation, b)).is_err() {
                         return;
                     }
                     shared.buffered.fetch_add(1, Ordering::Release);
@@ -439,16 +451,26 @@ fn reader_loop(shared: Arc<Shared>, mut port: Box<dyn HostSerialPort>, tx: mpsc:
     }
 }
 
-fn writer_loop(shared: Arc<Shared>, rx: mpsc::Receiver<u8>) {
+fn writer_loop(shared: Arc<Shared>, rx: mpsc::Receiver<(u64, u8)>) {
     let mut batch = Vec::with_capacity(OUTPUT_QUEUE_CAPACITY);
-    while let Ok(first) = rx.recv() {
+    while let Ok((generation, first)) = rx.recv() {
         batch.clear();
-        batch.push(first);
-        while let Ok(b) = rx.try_recv() {
+        // A byte the guest queued before the timeline jumped belongs to a
+        // run that no longer happened; it must not reach the wire.
+        if generation == shared.generation.load(Ordering::Acquire) {
+            batch.push(first);
+        }
+        while let Ok((generation, b)) = rx.try_recv() {
+            if generation != shared.generation.load(Ordering::Acquire) {
+                continue;
+            }
             batch.push(b);
             if batch.len() == OUTPUT_QUEUE_CAPACITY {
                 break;
             }
+        }
+        if batch.is_empty() {
+            continue;
         }
         // Retry a full kernel buffer (the far end is slow, or has dropped
         // CTS and the driver honours it); anything else is the port gone.
@@ -457,6 +479,13 @@ fn writer_loop(shared: Arc<Shared>, rx: mpsc::Receiver<u8>) {
                 return;
             }
             let mut guard = shared.port.lock().unwrap();
+            // Under the port lock, so a jump cannot land between the test
+            // and the write: the timeline moving on while this batch waited
+            // for a slow far end makes it a batch from a run that no longer
+            // happened.
+            if generation != shared.generation.load(Ordering::Acquire) {
+                break;
+            }
             let Some(port) = guard.as_mut() else {
                 // Detached: an unplugged cable drops what is sent down it.
                 break;
@@ -487,7 +516,8 @@ impl SerialSink for DeviceSerialSink {
         // wire (an unthrottled run): the wire paces the machine, as it
         // would a real one. A closed queue means the writer thread is
         // gone, which only happens at teardown.
-        let _ = self.tx.send(b);
+        let generation = self.shared.generation.load(Ordering::Acquire);
+        let _ = self.tx.send((generation, b));
     }
 
     fn write_word(&mut self, word: u16, long: bool, at_cck: u64) {
@@ -513,11 +543,16 @@ impl SerialSink for DeviceSerialSink {
     }
 
     fn read_byte(&mut self) -> Option<u8> {
-        let b = self.rx.try_recv().ok();
-        if b.is_some() {
+        // Bytes the reader had already taken off the wire when the
+        // timeline jumped carry the old generation and are dropped here,
+        // which closes the window between the drain and the reader thread.
+        loop {
+            let (generation, b) = self.rx.try_recv().ok()?;
             self.shared.buffered.fetch_sub(1, Ordering::Release);
+            if generation == self.shared.generation.load(Ordering::Acquire) {
+                return Some(b);
+            }
         }
-        b
     }
 
     fn has_pending_input(&self) -> bool {
@@ -584,10 +619,18 @@ impl SerialSink for DeviceSerialSink {
     /// and whatever the OS holds, and stay attached. The bus republishes
     /// the restored machine's DTR/RTS and SERPER rate right after this.
     fn reset_after_timeline_jump(&mut self) {
-        while self.read_byte().is_some() {}
-        if let Some(port) = self.shared.port.lock().unwrap().as_mut() {
-            let _ = port.discard_buffers();
+        {
+            // Hold the port while the generation moves, so the writer
+            // cannot be between its check and its write: everything queued
+            // in either direction, and anything the reader thread is
+            // mid-read on, is stamped with the generation left behind.
+            let mut port = self.shared.port.lock().unwrap();
+            self.shared.generation.fetch_add(1, Ordering::AcqRel);
+            if let Some(port) = port.as_mut() {
+                let _ = port.discard_buffers();
+            }
         }
+        while self.read_byte().is_some() {}
     }
 
     fn flush(&mut self) {}
@@ -755,6 +798,11 @@ struct FakePortState {
     dead: bool,
     /// Baud rates the fake refuses, to model a driver that cannot do them.
     refused_bauds: Vec<u32>,
+    /// While set, writes report a full kernel buffer, so the writer thread
+    /// holds what it has instead of putting it on the wire.
+    blocked: bool,
+    /// Write attempts, blocked or not: proof the writer has a batch.
+    write_attempts: u32,
 }
 
 #[cfg(test)]
@@ -783,6 +831,12 @@ impl FakeHostPort {
         let mut s = self.inner.0.lock().unwrap();
         s.to_guest.extend(bytes.iter().copied());
         self.inner.1.notify_all();
+    }
+
+    /// Hold (or release) the far end, so a test can leave bytes in the
+    /// writer's hands across a timeline jump.
+    fn block_writes(&self, blocked: bool) {
+        self.inner.0.lock().unwrap().blocked = blocked;
     }
 
     fn take_from_guest(&self) -> Vec<u8> {
@@ -850,6 +904,10 @@ impl HostSerialPort for FakeHostPort {
         let mut s = self.inner.0.lock().unwrap();
         if s.dead {
             return Err(gone());
+        }
+        s.write_attempts += 1;
+        if s.blocked {
+            return Err(io::Error::from(io::ErrorKind::TimedOut));
         }
         s.from_guest.extend_from_slice(bytes);
         Ok(())
@@ -1148,6 +1206,37 @@ mod tests {
         fake.push_to_guest(b"z");
         wait_until("fresh input", || sink.has_pending_input());
         assert_eq!(sink.read_byte(), Some(b'z'));
+    }
+
+    /// The other direction: bytes the guest wrote before the jump belong
+    /// to a run that no longer happened, so the wire must never see them,
+    /// even when the writer is already holding them against a far end that
+    /// has not taken them yet.
+    #[test]
+    fn timeline_jump_drops_guest_bytes_still_queued_for_the_wire() {
+        let (mut sink, fake) = open_fake();
+        // A far end that will not take anything: the writer keeps the
+        // bytes rather than putting them on the wire.
+        fake.block_writes(true);
+        sink.write_byte(b'a', 0);
+        sink.write_byte(b'b', 0);
+        wait_until("the writer holds the batch", || {
+            fake.state(|s| s.write_attempts > 0)
+        });
+
+        sink.reset_after_timeline_jump();
+        fake.block_writes(false);
+        // Whatever the writer does from here, those two bytes are gone: a
+        // fresh byte written after the jump is the only thing that lands.
+        sink.write_byte(b'c', 0);
+        wait_until("the fresh byte reaches the wire", || {
+            fake.state(|s| s.from_guest.contains(&b'c'))
+        });
+        assert_eq!(
+            fake.state(|s| s.from_guest.clone()),
+            vec![b'c'],
+            "bytes from the abandoned timeline reached the wire"
+        );
     }
 
     #[test]

--- a/src/serial/device.rs
+++ b/src/serial/device.rs
@@ -1,0 +1,1167 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! A real host serial port on Paula's UART (`[serial] mode = "device"`).
+//!
+//! The sink stands in for the cable: guest bytes leaving SERDAT go out of
+//! the host port, host bytes come back in as received serial data (Paula
+//! still clocks them in at the emulated SERPER rate, so the guest sees the
+//! same timing it would on a real machine), the guest's `/DTR` and `/RTS`
+//! outputs on CIA-B port A drive the host port's DTR and RTS pins, and the
+//! host port's CTS, DSR and DCD inputs come back on CIA-B PA3-5 through
+//! [`SerialSink::control_lines`]. That is the whole 7-wire null-modem
+//! picture, which is what a terminal program or a file-transfer tool (Amiga
+//! Explorer, a term program's ZMODEM) needs when the far end is a real
+//! Amiga or a PC. The Amiga has no CIA input for RI, so ring indicator is
+//! read but only reported on the host side ([`DeviceSerialSink::ring`]).
+//!
+//! The host port follows the guest's line settings: SERPER's bit period is
+//! mapped to the nearest standard rate ([`host_baud_for`]) and the stop-bit
+//! count is inferred from the SERDAT word the guest writes (Paula has no
+//! stop-bit register: the guest supplies the stop bits as high bits above
+//! the data, so `0x1xx` is one stop bit and `0x3xx` two). Host UARTs carry
+//! at most eight data bits, so a 9-bit (`SERPER` long) word goes out with
+//! its ninth bit dropped, and a received byte comes back with bit 8 clear.
+//! OS-level flow control stays off: the guest owns the handshake, the same
+//! as on a real machine, and the lines are mirrored rather than managed.
+//!
+//! Host I/O lives on two background threads so Paula's idle fast path
+//! never touches a syscall: a reader that blocks on the port (sampling the
+//! handshake inputs after every read, so line changes are seen within one
+//! read timeout) and a writer draining a bounded queue. A port that
+//! disappears mid-run -- a USB adapter pulled -- detaches rather than
+//! panics: every handshake input floats high (an unplugged cable, so a
+//! guest sees carrier loss), output is dropped, and the reader keeps
+//! trying to reopen the same path, restoring the line settings and the
+//! guest's DTR/RTS when it comes back.
+//!
+//! The port is a live host boundary like a network socket: nothing about
+//! it is in a save state. On a state load or rewind the sink stays
+//! attached, discards what was queued on the abandoned timeline, and the
+//! bus republishes the restored machine's DTR/RTS and SERPER rate onto it.
+//!
+//! The sink is written against [`HostSerialPort`], a small trait the real
+//! backend (the `serialport` crate, behind the `host-serial` feature)
+//! implements, so the whole thing runs against an in-memory fake in tests.
+
+use super::{SerialControlLines, SerialSink};
+use std::io;
+use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicU8, Ordering};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// How long the reader blocks in one read before sampling the handshake
+/// inputs again: the latency a CTS/DSR/DCD change is seen with.
+pub const READ_TIMEOUT: Duration = Duration::from_millis(20);
+/// How often a detached sink retries opening its port.
+pub const RECONNECT_INTERVAL: Duration = Duration::from_secs(1);
+/// Guest -> host bytes queued ahead of the wire. Small on purpose: in
+/// real time the guest transmits at the wire's own rate and the queue
+/// never fills, and an unthrottled run (warp, headless) that outruns it
+/// waits on the wire rather than sending bytes the far end's CTS has
+/// already refused.
+pub const OUTPUT_QUEUE_CAPACITY: usize = 256;
+
+/// The handshake inputs a host port reports, as RS-232 assertions
+/// (`true` = the line is ON).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct HostLineInputs {
+    pub cts: bool,
+    pub dsr: bool,
+    pub cd: bool,
+    pub ri: bool,
+}
+
+/// The line settings the sink keeps the host port at.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HostLineSettings {
+    /// Host line rate in bits per second.
+    pub baud: u32,
+    /// Two stop bits rather than one.
+    pub two_stop_bits: bool,
+    /// DTR asserted.
+    pub dtr: bool,
+    /// RTS asserted.
+    pub rts: bool,
+}
+
+impl HostLineSettings {
+    /// What the port is opened at before the guest programs SERPER: the
+    /// Kickstart default, 8N1, both outputs deasserted (a machine that has
+    /// not opened its port yet).
+    pub const INITIAL: Self = Self {
+        baud: 9600,
+        two_stop_bits: false,
+        dtr: false,
+        rts: false,
+    };
+}
+
+/// What the sink needs from a host serial port. Every method may block
+/// only for the port's own bounded timeout; all of them run on the sink's
+/// background threads or under a short lock from the emulation thread.
+pub trait HostSerialPort: Send {
+    /// Wait up to the port's read timeout for input. `Ok(0)` means nothing
+    /// arrived within the timeout (not end of stream); `Err` means the
+    /// port is gone.
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize>;
+    /// Write everything, waiting on the wire as needed. An error means the
+    /// port is gone; a timeout is reported as `io::ErrorKind::TimedOut`
+    /// and may be retried.
+    fn write_all(&mut self, bytes: &[u8]) -> io::Result<()>;
+    fn set_baud_rate(&mut self, bps: u32) -> io::Result<()>;
+    fn set_two_stop_bits(&mut self, two: bool) -> io::Result<()>;
+    fn set_dtr(&mut self, asserted: bool) -> io::Result<()>;
+    fn set_rts(&mut self, asserted: bool) -> io::Result<()>;
+    fn read_inputs(&mut self) -> io::Result<HostLineInputs>;
+    /// Drop whatever the OS has buffered in either direction.
+    fn discard_buffers(&mut self) -> io::Result<()>;
+    /// A second handle on the same port, so the reader can block in
+    /// `read` while the writer writes.
+    fn try_clone(&self) -> io::Result<Box<dyn HostSerialPort>>;
+}
+
+/// Opens the port -- at startup, and again after an unplug.
+pub type HostPortOpener = Box<dyn Fn() -> io::Result<Box<dyn HostSerialPort>> + Send + Sync>;
+
+/// Line rates a host UART is expected to support, ascending. A guest rate
+/// within [`BAUD_MATCH_TOLERANCE`] of one of these is mapped onto it; the
+/// odd ones (14400, 28800, 31250 for MIDI, 76800) are here because Amiga
+/// software asks for them and a USB adapter usually obliges.
+pub const STANDARD_BAUD_RATES: [u32; 18] = [
+    110, 300, 600, 1200, 2400, 4800, 9600, 14400, 19200, 28800, 31250, 38400, 57600, 76800, 115200,
+    230400, 460800, 921600,
+];
+/// How far (as a fraction) a SERPER-derived rate may sit from a standard
+/// rate and still be taken for it. Paula's divisor lands every standard
+/// rate within 1% (19200 is really 19172, 115200 is 114416), while the
+/// nearest neighbours are 33% apart, so 3% separates the two cases with
+/// room to spare.
+pub const BAUD_MATCH_TOLERANCE: f64 = 0.03;
+/// Rates outside this range are not a line rate a guest means to use --
+/// Paula's SERPER reset value of 0 works out to 3.5 Mbit/s -- and are
+/// left off the host port.
+pub const BAUD_RANGE: std::ops::RangeInclusive<u32> = 50..=1_000_000;
+
+/// The host rate to program for a SERPER-derived guest rate: the standard
+/// rate within [`BAUD_MATCH_TOLERANCE`], the exact rate when none is that
+/// close (a driver that cannot do it says so at apply time), or `None`
+/// for a rate outside [`BAUD_RANGE`].
+pub fn host_baud_for(guest_bps: u32) -> Option<u32> {
+    if !BAUD_RANGE.contains(&guest_bps) {
+        return None;
+    }
+    let nearest = STANDARD_BAUD_RATES
+        .iter()
+        .copied()
+        .min_by_key(|&rate| rate.abs_diff(guest_bps))?;
+    let error = f64::from(nearest.abs_diff(guest_bps)) / f64::from(nearest);
+    Some(if error <= BAUD_MATCH_TOLERANCE {
+        nearest
+    } else {
+        guest_bps
+    })
+}
+
+/// Whether a SERDAT word carries two stop bits. Paula shifts the word out
+/// LSB first up to its highest set bit; the guest puts the stop bits above
+/// the data (bit 8 up in 8-bit mode, bit 9 up in 9-bit mode), so two
+/// consecutive set bits there are two stop bits. A word with no stop bit
+/// at all is a framing error on the wire; the host port keeps one.
+pub fn two_stop_bits_in(word: u16, long: bool) -> bool {
+    let stop = word >> if long { 9 } else { 8 };
+    stop & 0b11 == 0b11
+}
+
+/// State shared between the sink and its threads.
+struct Shared {
+    /// The port the writer writes and the control lines are set on;
+    /// `None` while detached.
+    port: Mutex<Option<Box<dyn HostSerialPort>>>,
+    /// The settings the port is kept at, re-applied after a reopen.
+    settings: Mutex<HostLineSettings>,
+    /// `SerialControlLines` bits the guest sees; unplugged while detached.
+    lines: AtomicU8,
+    /// Ring indicator, host-side only.
+    ring: AtomicBool,
+    attached: AtomicBool,
+    /// Set when the sink is dropped, so the reader stops reopening.
+    shutdown: AtomicBool,
+    /// Host bytes staged for the guest, mirrored for the idle fast path.
+    buffered: AtomicIsize,
+    opener: HostPortOpener,
+    name: String,
+}
+
+impl Shared {
+    /// Mark the port gone: lines float high, output is dropped, and the
+    /// reader starts trying to reopen. Idempotent, so whichever thread
+    /// notices first says so once.
+    fn detach(&self, why: &io::Error) {
+        if !self.attached.swap(false, Ordering::AcqRel) {
+            return;
+        }
+        *self.port.lock().unwrap() = None;
+        self.lines
+            .store(SerialControlLines::UNPLUGGED.to_bits(), Ordering::Release);
+        self.ring.store(false, Ordering::Release);
+        log::warn!(
+            "serial: host port {} lost ({why}); the guest sees an unplugged cable until it \
+             comes back",
+            self.name
+        );
+    }
+
+    /// Bring a freshly opened port up to the guest's settings and install
+    /// it as the writer/control handle, returning the reader's clone.
+    fn attach(&self, mut port: Box<dyn HostSerialPort>) -> io::Result<Box<dyn HostSerialPort>> {
+        let settings = *self.settings.lock().unwrap();
+        apply_settings(port.as_mut(), &settings, &self.name);
+        let _ = port.discard_buffers();
+        let reader = port.try_clone()?;
+        self.publish_inputs(&mut *port);
+        *self.port.lock().unwrap() = Some(port);
+        self.attached.store(true, Ordering::Release);
+        Ok(reader)
+    }
+
+    /// Sample the handshake inputs and publish them for the guest.
+    fn publish_inputs(&self, port: &mut dyn HostSerialPort) {
+        if let Ok(inputs) = port.read_inputs() {
+            let lines = SerialControlLines {
+                dsr: inputs.dsr,
+                cts: inputs.cts,
+                cd: inputs.cd,
+            };
+            self.lines.store(lines.to_bits(), Ordering::Release);
+            if inputs.ri != self.ring.swap(inputs.ri, Ordering::AcqRel) {
+                log::info!(
+                    "serial: host port {} ring indicator {}",
+                    self.name,
+                    if inputs.ri { "asserted" } else { "dropped" }
+                );
+            }
+        }
+    }
+}
+
+/// Program every line setting onto a port, one at a time so a driver that
+/// refuses one (an odd rate, two stop bits) still gets the others. A
+/// refusal is logged, not fatal: the bytes still flow at whatever the
+/// port stayed at, which is better than no port.
+fn apply_settings(port: &mut dyn HostSerialPort, settings: &HostLineSettings, name: &str) {
+    if let Err(e) = port.set_baud_rate(settings.baud) {
+        log::warn!(
+            "serial: host port {name} refused {} baud ({e}); keeping its current rate",
+            settings.baud
+        );
+    }
+    if let Err(e) = port.set_two_stop_bits(settings.two_stop_bits) {
+        log::warn!(
+            "serial: host port {name} refused {} stop bits ({e})",
+            if settings.two_stop_bits { 2 } else { 1 }
+        );
+    }
+    if let Err(e) = port.set_dtr(settings.dtr) {
+        log::warn!("serial: host port {name}: setting DTR: {e}");
+    }
+    if let Err(e) = port.set_rts(settings.rts) {
+        log::warn!("serial: host port {name}: setting RTS: {e}");
+    }
+}
+
+/// Paula's serial port wired to a real host serial port. See the module
+/// docs for the model.
+pub struct DeviceSerialSink {
+    shared: Arc<Shared>,
+    /// Host -> guest bytes from the reader thread.
+    rx: mpsc::Receiver<u8>,
+    /// Guest -> host bytes for the writer thread.
+    tx: mpsc::SyncSender<u8>,
+    /// Whether the 9-bit word warning has been given.
+    warned_nine_bit: bool,
+    /// The guest rate SERPER last set, so a repeat write is not re-applied.
+    last_guest_bps: Option<u32>,
+}
+
+impl DeviceSerialSink {
+    /// Open the host port at `path` (`/dev/tty.usbserial-XXXX`,
+    /// `/dev/ttyUSB0`, `COM3`). Failure is a startup error that names the
+    /// path, the reason, and the ports the host does have.
+    #[cfg(feature = "host-serial")]
+    pub fn open(path: &str) -> anyhow::Result<Self> {
+        let path = path.to_string();
+        let opener: HostPortOpener = {
+            let path = path.clone();
+            Box::new(move || native::open(&path, HostLineSettings::INITIAL.baud))
+        };
+        let port = opener().map_err(|e| anyhow::anyhow!("{}", describe_open_error(&path, &e)))?;
+        let sink = Self::attach(&path, port, opener)?;
+        log::info!(
+            "serial: host port {path} open (8N1 at {} baud until the guest programs SERPER; \
+             DTR/RTS follow CIA-B, CTS/DSR/DCD feed it)",
+            HostLineSettings::INITIAL.baud
+        );
+        Ok(sink)
+    }
+
+    /// Wire an already-open port, keeping `opener` for reopening it after
+    /// an unplug. The port is brought to [`HostLineSettings::INITIAL`].
+    pub fn attach(
+        name: &str,
+        port: Box<dyn HostSerialPort>,
+        opener: HostPortOpener,
+    ) -> anyhow::Result<Self> {
+        let shared = Arc::new(Shared {
+            port: Mutex::new(None),
+            settings: Mutex::new(HostLineSettings::INITIAL),
+            lines: AtomicU8::new(SerialControlLines::UNPLUGGED.to_bits()),
+            ring: AtomicBool::new(false),
+            attached: AtomicBool::new(false),
+            shutdown: AtomicBool::new(false),
+            buffered: AtomicIsize::new(0),
+            opener,
+            name: name.to_string(),
+        });
+        let reader_port = shared
+            .attach(port)
+            .map_err(|e| anyhow::anyhow!("[serial] device: {name}: {e}"))?;
+
+        let (in_tx, rx) = mpsc::channel();
+        let (tx, out_rx) = mpsc::sync_channel(OUTPUT_QUEUE_CAPACITY);
+        let reader_shared = Arc::clone(&shared);
+        std::thread::Builder::new()
+            .name("serial-device-rx".into())
+            .spawn(move || reader_loop(reader_shared, reader_port, in_tx))?;
+        let writer_shared = Arc::clone(&shared);
+        std::thread::Builder::new()
+            .name("serial-device-tx".into())
+            .spawn(move || writer_loop(writer_shared, out_rx))?;
+        Ok(Self {
+            shared,
+            rx,
+            tx,
+            warned_nine_bit: false,
+            last_guest_bps: None,
+        })
+    }
+
+    /// The path the port was opened by.
+    pub fn name(&self) -> &str {
+        &self.shared.name
+    }
+
+    /// Whether the port is open right now (false after an unplug, until
+    /// the reopen succeeds).
+    pub fn attached(&self) -> bool {
+        self.shared.attached.load(Ordering::Acquire)
+    }
+
+    /// The host port's ring indicator. The Amiga has no CIA pin for it, so
+    /// it never reaches the guest; a host-side status only.
+    pub fn ring(&self) -> bool {
+        self.shared.ring.load(Ordering::Acquire)
+    }
+
+    /// The settings the host port is being kept at.
+    pub fn settings(&self) -> HostLineSettings {
+        *self.shared.settings.lock().unwrap()
+    }
+
+    /// Change one line setting and push it to the port if it is open.
+    fn update_settings(
+        &self,
+        change: impl FnOnce(&mut HostLineSettings) -> bool,
+        apply: impl FnOnce(&mut dyn HostSerialPort, &HostLineSettings) -> io::Result<()>,
+        what: &str,
+    ) {
+        let settings = {
+            let mut settings = self.shared.settings.lock().unwrap();
+            if !change(&mut settings) {
+                return;
+            }
+            *settings
+        };
+        let mut guard = self.shared.port.lock().unwrap();
+        if let Some(port) = guard.as_mut() {
+            if let Err(e) = apply(port.as_mut(), &settings) {
+                log::warn!("serial: host port {}: {what}: {e}", self.shared.name);
+            }
+        }
+    }
+}
+
+impl Drop for DeviceSerialSink {
+    fn drop(&mut self) {
+        self.shared.shutdown.store(true, Ordering::Release);
+        // The writer exits when its queue's sender (ours) goes; the reader
+        // sees the flag within one read timeout. Closing the control
+        // handle here means the OS gets the port back promptly.
+        *self.shared.port.lock().unwrap() = None;
+    }
+}
+
+fn reader_loop(shared: Arc<Shared>, mut port: Box<dyn HostSerialPort>, tx: mpsc::Sender<u8>) {
+    let mut buf = [0u8; 512];
+    while !shared.shutdown.load(Ordering::Acquire) {
+        match port.read(&mut buf) {
+            Ok(n) => {
+                for &b in &buf[..n] {
+                    if tx.send(b).is_err() {
+                        return;
+                    }
+                    shared.buffered.fetch_add(1, Ordering::Release);
+                }
+                shared.publish_inputs(&mut *port);
+            }
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => {
+                shared.detach(&e);
+                drop(port);
+                // Keep trying the same path until it is back or we are
+                // done. The reopen sleeps first: the device node of a
+                // pulled adapter lingers for a moment after the error.
+                port = loop {
+                    if shared.shutdown.load(Ordering::Acquire) {
+                        return;
+                    }
+                    std::thread::sleep(RECONNECT_INTERVAL);
+                    match (shared.opener)().and_then(|p| shared.attach(p)) {
+                        Ok(reader) => {
+                            log::info!("serial: host port {} is back", shared.name);
+                            break reader;
+                        }
+                        Err(_) => continue,
+                    }
+                };
+            }
+        }
+    }
+}
+
+fn writer_loop(shared: Arc<Shared>, rx: mpsc::Receiver<u8>) {
+    let mut batch = Vec::with_capacity(OUTPUT_QUEUE_CAPACITY);
+    while let Ok(first) = rx.recv() {
+        batch.clear();
+        batch.push(first);
+        while let Ok(b) = rx.try_recv() {
+            batch.push(b);
+            if batch.len() == OUTPUT_QUEUE_CAPACITY {
+                break;
+            }
+        }
+        // Retry a full kernel buffer (the far end is slow, or has dropped
+        // CTS and the driver honours it); anything else is the port gone.
+        loop {
+            if shared.shutdown.load(Ordering::Acquire) {
+                return;
+            }
+            let mut guard = shared.port.lock().unwrap();
+            let Some(port) = guard.as_mut() else {
+                // Detached: an unplugged cable drops what is sent down it.
+                break;
+            };
+            match port.write_all(&batch) {
+                Ok(()) => break,
+                Err(e) if e.kind() == io::ErrorKind::TimedOut => {
+                    drop(guard);
+                    std::thread::yield_now();
+                }
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => {
+                    drop(guard);
+                    shared.detach(&e);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+impl SerialSink for DeviceSerialSink {
+    fn write_byte(&mut self, b: u8, _at_cck: u64) {
+        if !self.attached() {
+            return;
+        }
+        // Blocks only when the guest is more than a queue ahead of the
+        // wire (an unthrottled run): the wire paces the machine, as it
+        // would a real one. A closed queue means the writer thread is
+        // gone, which only happens at teardown.
+        let _ = self.tx.send(b);
+    }
+
+    fn write_word(&mut self, word: u16, long: bool, at_cck: u64) {
+        let two = two_stop_bits_in(word, long);
+        self.update_settings(
+            |s| {
+                let changed = s.two_stop_bits != two;
+                s.two_stop_bits = two;
+                changed
+            },
+            |port, s| port.set_two_stop_bits(s.two_stop_bits),
+            "setting stop bits",
+        );
+        if long && word & 0x100 != 0 && !self.warned_nine_bit {
+            self.warned_nine_bit = true;
+            log::warn!(
+                "serial: the guest is sending 9-bit words; host port {} carries 8, so the \
+                 ninth bit is dropped",
+                self.shared.name
+            );
+        }
+        self.write_byte((word & 0x00FF) as u8, at_cck);
+    }
+
+    fn read_byte(&mut self) -> Option<u8> {
+        let b = self.rx.try_recv().ok();
+        if b.is_some() {
+            self.shared.buffered.fetch_sub(1, Ordering::Release);
+        }
+        b
+    }
+
+    fn has_pending_input(&self) -> bool {
+        self.shared.buffered.load(Ordering::Acquire) > 0
+    }
+
+    fn can_produce_input(&self) -> bool {
+        true
+    }
+
+    /// What the far end is driving on the real wire, sampled by the reader
+    /// thread; every line high (unplugged) while the port is detached.
+    fn control_lines(&self) -> SerialControlLines {
+        SerialControlLines::from_bits(self.shared.lines.load(Ordering::Acquire))
+    }
+
+    fn set_control_outputs(&mut self, dtr: bool, rts: bool) {
+        self.update_settings(
+            |s| {
+                let changed = s.dtr != dtr || s.rts != rts;
+                s.dtr = dtr;
+                s.rts = rts;
+                changed
+            },
+            |port, s| {
+                port.set_dtr(s.dtr)?;
+                port.set_rts(s.rts)
+            },
+            "setting DTR/RTS",
+        );
+    }
+
+    fn baud_changed(&mut self, bps: u32) {
+        if self.last_guest_bps == Some(bps) {
+            return;
+        }
+        self.last_guest_bps = Some(bps);
+        let Some(host) = host_baud_for(bps) else {
+            log::debug!(
+                "serial: ignoring SERPER rate {bps} bps for host port {} (outside {:?})",
+                self.shared.name,
+                BAUD_RANGE
+            );
+            return;
+        };
+        if host != bps {
+            log::debug!(
+                "serial: SERPER rate {bps} bps -> host port {} at {host} baud",
+                self.shared.name
+            );
+        }
+        self.update_settings(
+            |s| {
+                let changed = s.baud != host;
+                s.baud = host;
+                changed
+            },
+            |port, s| port.set_baud_rate(s.baud),
+            "setting baud rate",
+        );
+    }
+
+    /// The timeline the queued host bytes belonged to is gone: drop them
+    /// and whatever the OS holds, and stay attached. The bus republishes
+    /// the restored machine's DTR/RTS and SERPER rate right after this.
+    fn reset_after_timeline_jump(&mut self) {
+        while self.read_byte().is_some() {}
+        if let Some(port) = self.shared.port.lock().unwrap().as_mut() {
+            let _ = port.discard_buffers();
+        }
+    }
+
+    fn flush(&mut self) {}
+}
+
+/// A startup failure to open `path`, spelled for the person reading the
+/// log: what went wrong, the usual fix, and the ports that were found.
+pub fn describe_open_error(path: &str, e: &io::Error) -> String {
+    let reason = match e.kind() {
+        io::ErrorKind::NotFound => "no such device".to_string(),
+        io::ErrorKind::PermissionDenied => {
+            "permission denied (another program may have the port open; on Linux, add your \
+             user to the group that owns the device, usually dialout or uucp, and log in \
+             again)"
+                .to_string()
+        }
+        _ if e.raw_os_error() == Some(libc::EBUSY) => {
+            "the port is in use by another program".to_string()
+        }
+        _ => e.to_string(),
+    };
+    let found = available_host_ports();
+    let listing = if found.is_empty() {
+        "no serial ports were found on this host".to_string()
+    } else {
+        format!("serial ports found: {}", found.join(", "))
+    };
+    format!("[serial] device: opening {path:?}: {reason}; {listing}")
+}
+
+/// The serial ports the host has, by the path `[serial] device` takes,
+/// sorted. Empty when the build has no host-serial backend or the host
+/// cannot enumerate them.
+pub fn available_host_ports() -> Vec<String> {
+    #[cfg(feature = "host-serial")]
+    {
+        native::available_ports()
+    }
+    #[cfg(not(feature = "host-serial"))]
+    {
+        Vec::new()
+    }
+}
+
+/// The `serialport` backend.
+#[cfg(feature = "host-serial")]
+mod native {
+    use super::{HostLineInputs, HostSerialPort, READ_TIMEOUT};
+    use std::io;
+
+    pub struct NativePort(Box<dyn serialport::SerialPort>);
+
+    pub fn open(path: &str, baud: u32) -> io::Result<Box<dyn HostSerialPort>> {
+        let port = serialport::new(path, baud)
+            .data_bits(serialport::DataBits::Eight)
+            .parity(serialport::Parity::None)
+            .stop_bits(serialport::StopBits::One)
+            // The guest owns the handshake (see the module docs); the OS
+            // only mirrors the lines.
+            .flow_control(serialport::FlowControl::None)
+            .timeout(READ_TIMEOUT)
+            .open()
+            .map_err(io::Error::from)?;
+        Ok(Box::new(NativePort(port)))
+    }
+
+    pub fn available_ports() -> Vec<String> {
+        let mut names: Vec<String> = serialport::available_ports()
+            .map(|ports| ports.into_iter().map(|p| p.port_name).collect())
+            .unwrap_or_default();
+        names.sort();
+        names.dedup();
+        names
+    }
+
+    impl HostSerialPort for NativePort {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            match io::Read::read(&mut self.0, buf) {
+                // A tty that reads zero bytes without a timeout has
+                // hung up (the adapter is gone); serialport reports a
+                // quiet line as TimedOut instead.
+                Ok(0) => Err(io::Error::new(io::ErrorKind::BrokenPipe, "port closed")),
+                Ok(n) => Ok(n),
+                Err(e) if e.kind() == io::ErrorKind::TimedOut => Ok(0),
+                Err(e) => Err(e),
+            }
+        }
+
+        fn write_all(&mut self, bytes: &[u8]) -> io::Result<()> {
+            io::Write::write_all(&mut self.0, bytes)
+        }
+
+        fn set_baud_rate(&mut self, bps: u32) -> io::Result<()> {
+            self.0.set_baud_rate(bps).map_err(io::Error::from)
+        }
+
+        fn set_two_stop_bits(&mut self, two: bool) -> io::Result<()> {
+            let bits = if two {
+                serialport::StopBits::Two
+            } else {
+                serialport::StopBits::One
+            };
+            self.0.set_stop_bits(bits).map_err(io::Error::from)
+        }
+
+        fn set_dtr(&mut self, asserted: bool) -> io::Result<()> {
+            self.0
+                .write_data_terminal_ready(asserted)
+                .map_err(io::Error::from)
+        }
+
+        fn set_rts(&mut self, asserted: bool) -> io::Result<()> {
+            self.0
+                .write_request_to_send(asserted)
+                .map_err(io::Error::from)
+        }
+
+        fn read_inputs(&mut self) -> io::Result<HostLineInputs> {
+            Ok(HostLineInputs {
+                cts: self.0.read_clear_to_send()?,
+                dsr: self.0.read_data_set_ready()?,
+                cd: self.0.read_carrier_detect()?,
+                // Not every driver reports RI; a refusal is not a lost
+                // port, just no ring indicator.
+                ri: self.0.read_ring_indicator().unwrap_or(false),
+            })
+        }
+
+        fn discard_buffers(&mut self) -> io::Result<()> {
+            self.0
+                .clear(serialport::ClearBuffer::All)
+                .map_err(io::Error::from)
+        }
+
+        fn try_clone(&self) -> io::Result<Box<dyn HostSerialPort>> {
+            let clone = self.0.try_clone().map_err(io::Error::from)?;
+            Ok(Box::new(NativePort(clone)))
+        }
+    }
+}
+
+/// An in-memory port for tests: what the sink writes lands in
+/// `from_guest`, what the test pushes to `to_guest` the sink reads, and
+/// the settings the sink programs are recorded. [`FakeHostPort::unplug`]
+/// makes every call fail the way a pulled adapter does, and the opener
+/// [`FakeHostPort::opener`] hands out only refuses until
+/// [`FakeHostPort::replug`].
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct FakeHostPort {
+    inner: Arc<(Mutex<FakePortState>, std::sync::Condvar)>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct FakePortState {
+    to_guest: std::collections::VecDeque<u8>,
+    from_guest: Vec<u8>,
+    inputs: HostLineInputs,
+    baud: Option<u32>,
+    two_stop_bits: Option<bool>,
+    dtr: Option<bool>,
+    rts: Option<bool>,
+    discards: u32,
+    dead: bool,
+    /// Baud rates the fake refuses, to model a driver that cannot do them.
+    refused_bauds: Vec<u32>,
+}
+
+#[cfg(test)]
+impl FakeHostPort {
+    fn handle(&self) -> Box<dyn HostSerialPort> {
+        Box::new(FakeHostPort {
+            inner: Arc::clone(&self.inner),
+        })
+    }
+
+    /// An opener that reopens this same fake (after `replug`).
+    fn opener(&self) -> HostPortOpener {
+        let inner = Arc::clone(&self.inner);
+        Box::new(move || {
+            if inner.0.lock().unwrap().dead {
+                Err(io::Error::new(io::ErrorKind::NotFound, "no such device"))
+            } else {
+                Ok(Box::new(FakeHostPort {
+                    inner: Arc::clone(&inner),
+                }))
+            }
+        })
+    }
+
+    fn push_to_guest(&self, bytes: &[u8]) {
+        let mut s = self.inner.0.lock().unwrap();
+        s.to_guest.extend(bytes.iter().copied());
+        self.inner.1.notify_all();
+    }
+
+    fn take_from_guest(&self) -> Vec<u8> {
+        std::mem::take(&mut self.inner.0.lock().unwrap().from_guest)
+    }
+
+    fn set_inputs(&self, inputs: HostLineInputs) {
+        let mut s = self.inner.0.lock().unwrap();
+        s.inputs = inputs;
+        self.inner.1.notify_all();
+    }
+
+    fn unplug(&self) {
+        let mut s = self.inner.0.lock().unwrap();
+        s.dead = true;
+        self.inner.1.notify_all();
+    }
+
+    fn replug(&self) {
+        let mut s = self.inner.0.lock().unwrap();
+        s.dead = false;
+        s.baud = None;
+        s.two_stop_bits = None;
+        s.dtr = None;
+        s.rts = None;
+    }
+
+    fn refuse_baud(&self, bps: u32) {
+        self.inner.0.lock().unwrap().refused_bauds.push(bps);
+    }
+
+    fn state<R>(&self, f: impl FnOnce(&FakePortState) -> R) -> R {
+        f(&self.inner.0.lock().unwrap())
+    }
+}
+
+#[cfg(test)]
+fn gone() -> io::Error {
+    io::Error::new(io::ErrorKind::BrokenPipe, "device unplugged")
+}
+
+#[cfg(test)]
+impl HostSerialPort for FakeHostPort {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let (lock, cvar) = &*self.inner;
+        let mut s = lock.lock().unwrap();
+        if s.to_guest.is_empty() && !s.dead {
+            s = cvar.wait_timeout(s, READ_TIMEOUT).unwrap().0;
+        }
+        if s.dead {
+            return Err(gone());
+        }
+        let mut n = 0;
+        while n < buf.len() {
+            let Some(b) = s.to_guest.pop_front() else {
+                break;
+            };
+            buf[n] = b;
+            n += 1;
+        }
+        Ok(n)
+    }
+
+    fn write_all(&mut self, bytes: &[u8]) -> io::Result<()> {
+        let mut s = self.inner.0.lock().unwrap();
+        if s.dead {
+            return Err(gone());
+        }
+        s.from_guest.extend_from_slice(bytes);
+        Ok(())
+    }
+
+    fn set_baud_rate(&mut self, bps: u32) -> io::Result<()> {
+        let mut s = self.inner.0.lock().unwrap();
+        if s.dead {
+            return Err(gone());
+        }
+        if s.refused_bauds.contains(&bps) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "unsupported baud",
+            ));
+        }
+        s.baud = Some(bps);
+        Ok(())
+    }
+
+    fn set_two_stop_bits(&mut self, two: bool) -> io::Result<()> {
+        let mut s = self.inner.0.lock().unwrap();
+        if s.dead {
+            return Err(gone());
+        }
+        s.two_stop_bits = Some(two);
+        Ok(())
+    }
+
+    fn set_dtr(&mut self, asserted: bool) -> io::Result<()> {
+        let mut s = self.inner.0.lock().unwrap();
+        if s.dead {
+            return Err(gone());
+        }
+        s.dtr = Some(asserted);
+        Ok(())
+    }
+
+    fn set_rts(&mut self, asserted: bool) -> io::Result<()> {
+        let mut s = self.inner.0.lock().unwrap();
+        if s.dead {
+            return Err(gone());
+        }
+        s.rts = Some(asserted);
+        Ok(())
+    }
+
+    fn read_inputs(&mut self) -> io::Result<HostLineInputs> {
+        let s = self.inner.0.lock().unwrap();
+        if s.dead {
+            return Err(gone());
+        }
+        Ok(s.inputs)
+    }
+
+    fn discard_buffers(&mut self) -> io::Result<()> {
+        let mut s = self.inner.0.lock().unwrap();
+        if s.dead {
+            return Err(gone());
+        }
+        s.to_guest.clear();
+        s.discards += 1;
+        Ok(())
+    }
+
+    fn try_clone(&self) -> io::Result<Box<dyn HostSerialPort>> {
+        if self.inner.0.lock().unwrap().dead {
+            return Err(gone());
+        }
+        Ok(self.handle())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wait_until(what: &str, mut ok: impl FnMut() -> bool) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !ok() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "{what}: never happened"
+            );
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    fn open_fake() -> (DeviceSerialSink, FakeHostPort) {
+        let fake = FakeHostPort::default();
+        let sink = DeviceSerialSink::attach("fake0", fake.handle(), fake.opener()).unwrap();
+        (sink, fake)
+    }
+
+    #[test]
+    fn serper_rates_map_to_the_nearest_standard_host_rate() {
+        // Paula's divisor never lands exactly on a standard rate; each of
+        // these is what PAULA_CLOCK_HZ / (n + 1) gives for the usual n.
+        for (guest, host) in [
+            (9586, 9600),
+            (19172, 19200),
+            (38139, 38400),
+            (57208, 57600),
+            (114416, 115200),
+            (2400, 2400),
+            (31388, 31250),
+            (1200, 1200),
+        ] {
+            assert_eq!(host_baud_for(guest), Some(host), "{guest} bps");
+        }
+        // A rate nowhere near a standard one passes through as-is, for
+        // the driver to accept or refuse.
+        assert_eq!(host_baud_for(250_000), Some(250_000));
+        assert_eq!(host_baud_for(45_000), Some(45_000));
+        // SERPER's reset value works out to 3.5 Mbit/s: not a line rate.
+        assert_eq!(host_baud_for(3_546_895), None);
+        assert_eq!(host_baud_for(10), None);
+    }
+
+    #[test]
+    fn stop_bits_are_read_off_the_serdat_word() {
+        // 8-bit words: the guest sets bit 8 for one stop bit, 8-9 for two.
+        assert!(!two_stop_bits_in(0x141, false));
+        assert!(two_stop_bits_in(0x341, false));
+        // No stop bit at all is a framing error; the host keeps one.
+        assert!(!two_stop_bits_in(0x041, false));
+        // 9-bit words: the stop bits start at bit 9.
+        assert!(!two_stop_bits_in(0x341, true));
+        assert!(two_stop_bits_in(0x741, true));
+    }
+
+    #[test]
+    fn bytes_round_trip_through_the_host_port() {
+        let (mut sink, fake) = open_fake();
+        assert!(sink.attached());
+        assert!(sink.can_produce_input());
+
+        // Host -> guest: staged by the reader thread, one byte per read.
+        fake.push_to_guest(b"ab");
+        wait_until("input staged", || sink.has_pending_input());
+        assert_eq!(sink.read_byte(), Some(b'a'));
+        wait_until("second byte staged", || sink.has_pending_input());
+        assert_eq!(sink.read_byte(), Some(b'b'));
+        assert!(!sink.has_pending_input());
+        assert_eq!(sink.read_byte(), None);
+
+        // Guest -> host: SERDAT words land as their data byte.
+        sink.write_word(0x141, false, 0);
+        sink.write_word(0x142, false, 1);
+        wait_until("output written", || fake.state(|s| s.from_guest.len() == 2));
+        assert_eq!(fake.take_from_guest(), b"AB");
+    }
+
+    #[test]
+    fn handshake_inputs_reach_the_guest_and_ring_stays_host_side() {
+        let (sink, fake) = open_fake();
+        // A port with nothing driving its inputs: the lines float high.
+        assert_eq!(sink.control_lines(), SerialControlLines::UNPLUGGED);
+        fake.set_inputs(HostLineInputs {
+            cts: true,
+            dsr: true,
+            cd: false,
+            ri: false,
+        });
+        wait_until("DSR/CTS seen", || {
+            sink.control_lines() == SerialControlLines::READY
+        });
+        fake.set_inputs(HostLineInputs {
+            cts: true,
+            dsr: true,
+            cd: true,
+            ri: true,
+        });
+        wait_until("carrier seen", || {
+            sink.control_lines() == SerialControlLines::CONNECTED
+        });
+        wait_until("ring seen", || sink.ring());
+        // CTS alone maps to its own line.
+        fake.set_inputs(HostLineInputs {
+            cts: true,
+            dsr: false,
+            cd: false,
+            ri: false,
+        });
+        wait_until("CTS alone", || {
+            sink.control_lines()
+                == SerialControlLines {
+                    dsr: false,
+                    cts: true,
+                    cd: false,
+                }
+        });
+        assert!(!sink.ring());
+    }
+
+    #[test]
+    fn guest_dtr_and_rts_drive_the_host_port() {
+        let (mut sink, fake) = open_fake();
+        // Attaching brings the port to the initial settings: both down.
+        assert_eq!(fake.state(|s| (s.dtr, s.rts)), (Some(false), Some(false)));
+        sink.set_control_outputs(true, false);
+        assert_eq!(fake.state(|s| (s.dtr, s.rts)), (Some(true), Some(false)));
+        sink.set_control_outputs(true, true);
+        assert_eq!(fake.state(|s| (s.dtr, s.rts)), (Some(true), Some(true)));
+        assert_eq!(
+            sink.settings(),
+            HostLineSettings {
+                dtr: true,
+                rts: true,
+                ..HostLineSettings::INITIAL
+            }
+        );
+    }
+
+    #[test]
+    fn serper_and_serdat_program_the_host_line_settings() {
+        let (mut sink, fake) = open_fake();
+        assert_eq!(fake.state(|s| s.baud), Some(9600));
+        sink.baud_changed(19172);
+        assert_eq!(fake.state(|s| s.baud), Some(19200));
+        assert_eq!(sink.settings().baud, 19200);
+        // A rate the driver refuses is logged and the port keeps its rate;
+        // the sink still remembers what the guest asked for.
+        fake.refuse_baud(250_000);
+        sink.baud_changed(250_000);
+        assert_eq!(fake.state(|s| s.baud), Some(19200));
+        assert_eq!(sink.settings().baud, 250_000);
+        // Not a line rate: left alone entirely.
+        sink.baud_changed(3_546_895);
+        assert_eq!(sink.settings().baud, 250_000);
+
+        // Stop bits follow the SERDAT word.
+        assert_eq!(fake.state(|s| s.two_stop_bits), Some(false));
+        sink.write_word(0x341, false, 0);
+        assert_eq!(fake.state(|s| s.two_stop_bits), Some(true));
+        sink.write_word(0x141, false, 1);
+        assert_eq!(fake.state(|s| s.two_stop_bits), Some(false));
+        // A 9-bit word goes out as its low byte.
+        sink.write_word(0x2FF, true, 2);
+        wait_until("output written", || fake.state(|s| s.from_guest.len() == 3));
+        assert_eq!(fake.take_from_guest(), [0x41, 0x41, 0xFF]);
+    }
+
+    #[test]
+    fn unplug_degrades_to_an_unplugged_cable_and_replug_restores_the_settings() {
+        let (mut sink, fake) = open_fake();
+        fake.set_inputs(HostLineInputs {
+            cts: true,
+            dsr: true,
+            cd: true,
+            ri: false,
+        });
+        wait_until("carrier seen", || {
+            sink.control_lines() == SerialControlLines::CONNECTED
+        });
+        sink.set_control_outputs(true, true);
+        sink.baud_changed(57208);
+
+        fake.unplug();
+        wait_until("detach noticed", || !sink.attached());
+        // No carrier, no panic: writes are dropped, reads yield nothing,
+        // outputs are remembered for the reopen.
+        assert_eq!(sink.control_lines(), SerialControlLines::UNPLUGGED);
+        sink.write_word(0x141, false, 0);
+        sink.set_control_outputs(false, true);
+        assert_eq!(sink.read_byte(), None);
+
+        // Back again: the reader reopens it and programs the settings the
+        // guest had reached in the meantime.
+        fake.replug();
+        wait_until("reattached", || sink.attached());
+        assert_eq!(fake.state(|s| s.baud), Some(57600));
+        assert_eq!(fake.state(|s| (s.dtr, s.rts)), (Some(false), Some(true)));
+        wait_until("carrier seen again", || {
+            sink.control_lines() == SerialControlLines::CONNECTED
+        });
+        sink.write_word(0x142, false, 1);
+        wait_until("output flows again", || {
+            fake.state(|s| !s.from_guest.is_empty())
+        });
+        assert_eq!(fake.take_from_guest(), b"B");
+    }
+
+    #[test]
+    fn timeline_jump_drops_queued_host_bytes_but_keeps_the_port() {
+        let (mut sink, fake) = open_fake();
+        fake.push_to_guest(b"stale");
+        wait_until("input staged", || sink.has_pending_input());
+        sink.reset_after_timeline_jump();
+        assert!(!sink.has_pending_input());
+        assert_eq!(sink.read_byte(), None);
+        assert!(sink.attached());
+        // The attach discards once, the jump a second time.
+        assert_eq!(fake.state(|s| s.discards), 2);
+        // And the port still works afterwards.
+        fake.push_to_guest(b"z");
+        wait_until("fresh input", || sink.has_pending_input());
+        assert_eq!(sink.read_byte(), Some(b'z'));
+    }
+
+    #[test]
+    fn open_errors_say_what_went_wrong() {
+        let denied = io::Error::from(io::ErrorKind::PermissionDenied);
+        let text = describe_open_error("/dev/ttyUSB0", &denied);
+        assert!(text.contains("/dev/ttyUSB0"), "{text}");
+        assert!(text.contains("dialout"), "{text}");
+        let missing = io::Error::from(io::ErrorKind::NotFound);
+        let text = describe_open_error("COM7", &missing);
+        assert!(text.contains("no such device"), "{text}");
+        assert!(text.contains("serial ports"), "{text}");
+        let busy = io::Error::from_raw_os_error(libc::EBUSY);
+        let text = describe_open_error("/dev/cu.usbserial-1", &busy);
+        assert!(text.contains("in use by another program"), "{text}");
+    }
+}

--- a/src/video/bitplane.rs
+++ b/src/video/bitplane.rs
@@ -4699,6 +4699,39 @@ pub fn sprite_framebuffer_origin(bus: &Bus, sprite: usize) -> Option<(i32, i32)>
     Some((x * scale, top.beam_y - geometry.visible_start_vpos as i32))
 }
 
+/// The beam position (`vpos`, `hpos` in colour clocks) at which the
+/// display paints presented pixel (`x`, `y`) -- the inverse of the
+/// column map [`sprite_framebuffer_origin`] reports the pointer through,
+/// in the same coordinates. This is what a light pen held over that
+/// pixel sees: the row is the beam line, and the column maps back
+/// through the comparator origin to Denise's lo-res pixel counter, two
+/// of which make one Agnus colour clock. `None` when the pixel is off
+/// the scan (a pen aimed at the bezel sees no beam).
+///
+/// The pipeline delay between a fetch position and the pixel leaving
+/// Denise is not subtracted: real pens read a few clocks late for the
+/// same reason, and light-pen software calibrates the offset away.
+pub fn framebuffer_beam_position(bus: &Bus, x: i32, y: i32) -> Option<(u32, u32)> {
+    let geometry = bus.frame_geometry();
+    let scale = bus.frame_canvas_scale() as i32;
+    let shift = if geometry.programmable {
+        H_COUNTER_LINE_ORIGIN
+    } else {
+        0
+    };
+    if x < 0 || y < 0 {
+        return None;
+    }
+    let lores = x / (2 * scale.max(1)) + DIW_HSTART_FB0 - shift;
+    let hpos = lores / 2;
+    let vpos = geometry.visible_start_vpos as i32 + y;
+    let frame_lines = bus.frame_lines() as i32;
+    if hpos < 0 || hpos >= geometry.line_cck as i32 || vpos < 0 || vpos >= frame_lines {
+        return None;
+    }
+    Some((vpos as u32, hpos as u32))
+}
+
 pub fn render_from_input(input: &RenderInput, fb: &mut [u32]) -> RenderResult {
     render_from_input_impl(input, fb, false)
 }

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -479,22 +479,24 @@ const MOUSE_CAPTURES: [MouseCapture; 3] = [
     MouseCapture::Manual,
 ];
 // Controller devices a game port accepts, in stepper order.
-const PORT_DEVICES: [PortDevice; 5] = [
+const PORT_DEVICES: [PortDevice; 6] = [
     PortDevice::Mouse,
     PortDevice::Joystick,
     PortDevice::Cd32Pad,
     PortDevice::Analogue,
+    PortDevice::LightPen,
     PortDevice::None,
 ];
 // Port 1 offers one more: a mouse a gamepad can move as well as the
 // hand on the desk. Only port 1, because only port 1 is where a mouse
 // belongs -- Workbench and nearly every game read it there.
-const PORT1_DEVICES: [PortDevice; 6] = [
+const PORT1_DEVICES: [PortDevice; 7] = [
     PortDevice::Mouse,
     PortDevice::GamepadMouse,
     PortDevice::Joystick,
     PortDevice::Cd32Pad,
     PortDevice::Analogue,
+    PortDevice::LightPen,
     PortDevice::None,
 ];
 // `None` = no SCSI board fitted; the two boards are mutually exclusive here even
@@ -514,7 +516,7 @@ const LIDE_BOARDS: [Option<LidePersonality>; 4] = [
     Some(LidePersonality::AtBus2008),
 ];
 #[cfg(feature = "midi")]
-const SERIAL_MODES: [SerialMode; 7] = [
+const SERIAL_MODES: [SerialMode; 8] = [
     SerialMode::Off,
     SerialMode::Stdout,
     SerialMode::Midi,
@@ -522,6 +524,7 @@ const SERIAL_MODES: [SerialMode; 7] = [
     SerialMode::TcpConnect,
     SerialMode::Pty,
     SerialMode::Modem,
+    SerialMode::Device,
 ];
 /// Stereo-separation presets the picker steps through (percent), ascending so
 /// the right arrow steps up (wrapping 100 -> 0) and the left arrow steps down.
@@ -781,6 +784,14 @@ pub struct MachineSetup {
     /// `AT*T1`/`AT*T0` default at power-on for `mode = "modem"`, toggled by
     /// the Telnet row that mode shows.
     serial_telnet: bool,
+    /// The host serial port for `mode = "device"`, picked in the Port row
+    /// that mode shows. `None` has nothing to open, and the run says so
+    /// rather than the launcher refusing the mode.
+    serial_device: Option<String>,
+    /// The host's serial ports for that picker: filled when the screen
+    /// opens and re-read each time the row is cycled, so a just-plugged
+    /// adapter appears.
+    serial_devices: Vec<String>,
     /// The Centronics parallel-port device (None/Printer/Sampler), edited in the
     /// I/O Ports tab's Parallel section.
     parallel_device: crate::config::ParallelDevice,
@@ -952,6 +963,15 @@ impl MachineSetup {
         self.midi_endpoints = crate::midi::enumerate();
     }
 
+    /// Re-read the host serial ports for the Serial section's Port picker.
+    #[cfg(feature = "midi")]
+    pub fn refresh_serial_devices(&mut self) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.serial_devices = crate::serial::device::available_host_ports();
+        }
+    }
+
     /// Re-read the host audio output devices for the "Audio output" picker.
     pub fn refresh_audio_devices(&mut self) {
         self.audio_devices = crate::audio::picker_output_devices();
@@ -1064,6 +1084,8 @@ impl MachineSetup {
     pub fn refresh_host_devices(&mut self) {
         #[cfg(feature = "midi")]
         self.refresh_midi_endpoints();
+        #[cfg(feature = "midi")]
+        self.refresh_serial_devices();
         self.refresh_audio_devices();
         self.refresh_sampler_inputs();
         self.refresh_bridge_interfaces();
@@ -1995,6 +2017,9 @@ impl MachineSetup {
                     PortDevice::Analogue => {
                         "--pot-after scripting or the control protocol".to_string()
                     }
+                    PortDevice::LightPen => {
+                        "the host pointer over the display (click = pen switch)".to_string()
+                    }
                     PortDevice::None => "nothing (empty port)".to_string(),
                 }
             };
@@ -2741,6 +2766,7 @@ impl MachineSetup {
             A::LideMaster(ch) | A::LideSlave(ch) => self
                 .lide_board
                 .is_some_and(|b| usize::from(ch) < b.channels()),
+            A::Pcmcia => self.has_gayle(),
         }
     }
 
@@ -2962,6 +2988,9 @@ impl MachineSetup {
                     *name = None;
                 }
             }
+            // The launcher has no image row for the slot; `[pcmcia]` is
+            // written by hand, and validation refuses both at once.
+            crate::config::HostDiskAttach::Pcmcia => {}
         }
     }
 
@@ -5735,6 +5764,7 @@ fn rows_contains_kind(field: LauncherField, kind: RowKind) -> bool {
         &SERIAL_ROWS_TCP_CONNECT,
         &SERIAL_ROWS_TCP_LISTEN,
         &SERIAL_ROWS_MODEM,
+        &SERIAL_ROWS_DEVICE,
     ];
     #[cfg(all(feature = "midi", feature = "mt32", not(feature = "coppersynth")))]
     let serial: &[&[Row]] = &[
@@ -5743,6 +5773,7 @@ fn rows_contains_kind(field: LauncherField, kind: RowKind) -> bool {
         &SERIAL_ROWS_TCP_CONNECT,
         &SERIAL_ROWS_TCP_LISTEN,
         &SERIAL_ROWS_MODEM,
+        &SERIAL_ROWS_DEVICE,
     ];
     #[cfg(all(feature = "midi", not(feature = "mt32"), feature = "coppersynth"))]
     let serial: &[&[Row]] = &[
@@ -5751,6 +5782,7 @@ fn rows_contains_kind(field: LauncherField, kind: RowKind) -> bool {
         &SERIAL_ROWS_TCP_CONNECT,
         &SERIAL_ROWS_TCP_LISTEN,
         &SERIAL_ROWS_MODEM,
+        &SERIAL_ROWS_DEVICE,
     ];
     #[cfg(all(feature = "midi", not(feature = "mt32"), not(feature = "coppersynth")))]
     let serial: &[&[Row]] = &[
@@ -5758,6 +5790,7 @@ fn rows_contains_kind(field: LauncherField, kind: RowKind) -> bool {
         &SERIAL_ROWS_TCP_CONNECT,
         &SERIAL_ROWS_TCP_LISTEN,
         &SERIAL_ROWS_MODEM,
+        &SERIAL_ROWS_DEVICE,
     ];
     #[cfg(not(feature = "midi"))]
     let serial: &[&[Row]] = &[];

--- a/src/video/launcher/fields.rs
+++ b/src/video/launcher/fields.rs
@@ -532,6 +532,10 @@ pub enum LauncherField {
     /// Serial section's Listen box.
     #[cfg(feature = "midi")]
     SerialListen,
+    /// The host serial port `device` mode wires to, picked from the ports
+    /// the host has in the Serial section's Device row.
+    #[cfg(feature = "midi")]
+    SerialDevice,
     /// `AT*T1`/`AT*T0`'s default at power-on, edited in the Serial
     /// section's Telnet row (modem mode only).
     #[cfg(feature = "midi")]
@@ -1105,6 +1109,13 @@ pub(super) const SERIAL_ROWS_MODEM: [Row; 3] = [
     row(F::SerialListen, "  Listen", RowKind::Text),
     row(F::SerialTelnet, "  Telnet", Cycle),
 ];
+// A real host port: the path is picked from what the host enumerates,
+// the way the MIDI and audio pickers work, rather than typed.
+#[cfg(feature = "midi")]
+pub(super) const SERIAL_ROWS_DEVICE: [Row; 2] = [
+    row(F::SerialMode, "  Device / Mode", Cycle),
+    row(F::SerialDevice, "  Port", Cycle),
+];
 #[cfg(feature = "midi")]
 pub(super) const SERIAL_ROWS_MIDI: [Row; 3] = [
     row(F::SerialMode, "  Device / Mode", Cycle),
@@ -1445,6 +1456,7 @@ pub(super) fn serial_rows(
                 SerialMode::TcpConnect => &SERIAL_ROWS_TCP_CONNECT,
                 SerialMode::Tcp => &SERIAL_ROWS_TCP_LISTEN,
                 SerialMode::Modem => &SERIAL_ROWS_MODEM,
+                SerialMode::Device => &SERIAL_ROWS_DEVICE,
                 _ => &SERIAL_ROWS_BASE,
             };
         }
@@ -1472,7 +1484,9 @@ pub(super) fn parallel_rows(parallel_device: ParallelDevice) -> &'static [Row] {
     match parallel_device {
         ParallelDevice::Sampler => &PARALLEL_ROWS_SAMPLER,
         ParallelDevice::Printer => &PARALLEL_ROWS_PRINTER,
-        ParallelDevice::None => &PARALLEL_ROWS_BASE,
+        // The adapter's sockets are [input] port3/port4 in the config; the
+        // launcher offers the adapter itself, with both sockets filled.
+        ParallelDevice::None | ParallelDevice::JoystickAdapter => &PARALLEL_ROWS_BASE,
     }
 }
 

--- a/src/video/launcher/setup_config.rs
+++ b/src/video/launcher/setup_config.rs
@@ -241,6 +241,8 @@ impl MachineSetup {
             serial_listen: cfg.serial.listen.clone(),
             serial_connect: cfg.serial.connect.clone(),
             serial_telnet: cfg.serial.telnet.unwrap_or(false),
+            serial_device: cfg.serial.device.clone(),
+            serial_devices: Vec::new(),
             parallel_device: cfg.parallel.device,
             parallel_output: cfg.parallel.printer_output.clone(),
             sampler_input: cfg.parallel.sampler_input.clone(),
@@ -878,6 +880,7 @@ impl MachineSetup {
         // was typed so emptying a box reverts it.
         raw.serial.listen = self.serial_listen.as_deref().map(complete_listen);
         raw.serial.connect = self.serial_connect.as_deref().map(complete_connect);
+        raw.serial.device = self.serial_device.clone();
         // Compared against the resolved value, not the raw tri-state: the
         // toggle is a plain on/off, so "unset" and "explicitly off" look
         // the same to it and must not produce a spurious `telnet = false`
@@ -911,6 +914,9 @@ impl MachineSetup {
                 .is_some()
                 .then(|| ParallelDevice::Printer.label().to_string()),
             ParallelDevice::Sampler => Some(ParallelDevice::Sampler.label().to_string()),
+            ParallelDevice::JoystickAdapter => {
+                Some(ParallelDevice::JoystickAdapter.label().to_string())
+            }
         };
         // Ethernet: no profile fits an A2065 by default, so the board is
         // emitted whenever it is on (absent key = not fitted).

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -394,7 +394,7 @@ fn a_place_exists_only_while_the_disk_is_ticked() {
 
     let mut setup = MachineSetup::default();
     setup.select_model(Some(MachineModel::A1200));
-    setup.set_host_disks_for_test(disks(3));
+    setup.set_host_disks_for_test(disks(4));
 
     // Blank until ticked, and stepping a blank cell is not a request.
     assert_eq!(setup.host_disks()[0].attach, None);
@@ -420,11 +420,16 @@ fn a_place_exists_only_while_the_disk_is_ticked() {
         "the freed place is picked up by the next tick"
     );
 
-    // Nothing left on a machine with no SCSI: the third tick is refused,
-    // stays unticked, and the next tick clears the warning.
+    // An A1200 has one more place after the IDE cable: its PCMCIA slot,
+    // where the third disk goes in as a CF card.
     setup.select_host_disk(2);
-    assert!(!setup.host_disk_is_selected("disk2"));
-    assert_eq!(setup.host_disks()[2].attach, None);
+    assert_eq!(setup.host_disks()[2].attach, Some(A::Pcmcia));
+
+    // Nothing left on a machine with no SCSI: the fourth tick is refused,
+    // stays unticked, and the next tick clears the warning.
+    setup.select_host_disk(3);
+    assert!(!setup.host_disk_is_selected("disk3"));
+    assert_eq!(setup.host_disks()[3].attach, None);
     assert_eq!(
         setup.host_disk_warning(),
         Some("Every attachment point is already in use")
@@ -4754,13 +4759,15 @@ fn midi_rows_appear_only_in_midi_mode() {
 }
 
 #[test]
-fn parallel_device_cycles_none_printer_sampler() {
+fn parallel_device_cycles_none_printer_sampler_adapter() {
     let mut s = MachineSetup::default();
     assert_eq!(s.parallel_device, ParallelDevice::None);
     s.cycle(LauncherField::ParallelDevice, true);
     assert_eq!(s.parallel_device, ParallelDevice::Printer);
     s.cycle(LauncherField::ParallelDevice, true);
     assert_eq!(s.parallel_device, ParallelDevice::Sampler);
+    s.cycle(LauncherField::ParallelDevice, true);
+    assert_eq!(s.parallel_device, ParallelDevice::JoystickAdapter);
     s.cycle(LauncherField::ParallelDevice, true);
     assert_eq!(s.parallel_device, ParallelDevice::None);
 }
@@ -5810,4 +5817,96 @@ fn internet_netplay_launcher_shares_invitation_and_adopts_host_timing() -> Resul
     host.netplay.generate_code()?;
     assert!(host.netplay.connection_options().is_ok());
     Ok(())
+}
+
+#[cfg(feature = "midi")]
+#[test]
+fn device_mode_rows_are_the_port_picker_only() {
+    let has = |mode, field| {
+        rows(
+            LauncherTab::IoPorts,
+            ParallelDevice::None,
+            mode,
+            false,
+            false,
+        )
+        .iter()
+        .any(|r| r.field == field)
+    };
+    // A real port has a path to pick and nothing to dial or bind.
+    assert!(has(SerialMode::Device, LauncherField::SerialDevice));
+    assert!(!has(SerialMode::Device, LauncherField::SerialConnect));
+    assert!(!has(SerialMode::Device, LauncherField::SerialListen));
+    assert!(!has(SerialMode::Device, LauncherField::SerialTelnet));
+    // And the picker shows for no other mode.
+    for mode in SERIAL_MODES {
+        if mode != SerialMode::Device {
+            assert!(!has(mode, LauncherField::SerialDevice), "{mode:?}");
+        }
+    }
+    // It is a picker, not a typed box, so the address widget stays out.
+    let r = rows(
+        LauncherTab::IoPorts,
+        ParallelDevice::None,
+        SerialMode::Device,
+        false,
+        false,
+    );
+    let found = r
+        .iter()
+        .find(|r| r.field == LauncherField::SerialDevice)
+        .unwrap();
+    assert_eq!(found.kind, RowKind::Cycle);
+    assert!(!LauncherState::is_serial_addr(LauncherField::SerialDevice));
+}
+
+#[cfg(feature = "midi")]
+#[test]
+fn serial_device_round_trips_through_raw() {
+    // The port path is carried whole, whether or not the host lists it.
+    let mut raw = RawConfig::default();
+    raw.serial.mode = Some("device".into());
+    raw.serial.device = Some("/dev/tty.usbserial-1420".into());
+    let setup = MachineSetup::from_raw(&raw).unwrap();
+    assert_eq!(setup.serial_mode, SerialMode::Device);
+    assert_eq!(
+        setup.serial_device.as_deref(),
+        Some("/dev/tty.usbserial-1420")
+    );
+    let back = setup.to_raw();
+    assert_eq!(back.serial.mode.as_deref(), Some("device"));
+    assert_eq!(
+        back.serial.device.as_deref(),
+        Some("/dev/tty.usbserial-1420")
+    );
+}
+
+#[cfg(feature = "midi")]
+#[test]
+fn serial_device_picker_walks_the_host_ports_and_keeps_an_unlisted_path() {
+    let mut setup = MachineSetup {
+        serial_mode: SerialMode::Device,
+        serial_device: Some("/dev/ttyUSB9".into()),
+        ..Default::default()
+    };
+    // A path the host does not list is shown as such, not dropped.
+    assert_eq!(
+        setup.value_label(LauncherField::SerialDevice),
+        "/dev/ttyUSB9 (not found)"
+    );
+    setup.serial_device = None;
+    setup.serial_devices = vec!["/dev/ttyUSB0".into(), "/dev/ttyUSB1".into()];
+    assert_eq!(
+        setup.value_label(LauncherField::SerialDevice),
+        "(pick a port)"
+    );
+    // Cycling walks the listed ports (re-read from the host on each step,
+    // which on a test host may find none: then the step lands back on
+    // unset and the label says so).
+    setup.cycle(LauncherField::SerialDevice, true);
+    let label = setup.value_label(LauncherField::SerialDevice);
+    match setup.serial_device.as_deref() {
+        Some(path) => assert!(setup.serial_devices.iter().any(|p| p == path), "{label}"),
+        None => assert!(label.starts_with("(no serial ports found)") || label == "(pick a port)"),
+    }
 }

--- a/src/video/launcher/values.rs
+++ b/src/video/launcher/values.rs
@@ -216,6 +216,17 @@ impl MachineSetup {
                 SerialMode::TcpConnect => "TCP connect".to_string(),
                 SerialMode::Pty => "PTY".to_string(),
                 SerialMode::Modem => "Modem".to_string(),
+                SerialMode::Device => "Host port".to_string(),
+            },
+            // The port is shown by the path the config spells it with; a
+            // path the host does not list right now (an adapter not
+            // plugged in yet) is kept, and marked.
+            #[cfg(feature = "midi")]
+            F::SerialDevice => match self.serial_device.as_deref() {
+                Some(path) if self.serial_devices.iter().any(|p| p == path) => path.to_string(),
+                Some(path) => format!("{path} (not found)"),
+                None if self.serial_devices.is_empty() => "(no serial ports found)".to_string(),
+                None => "(pick a port)".to_string(),
             },
             // The dial-out address has no default -- there is no host to
             // guess -- so an empty box says what it wants instead.
@@ -268,6 +279,7 @@ impl MachineSetup {
                 ParallelDevice::None => "None".to_string(),
                 ParallelDevice::Printer => "Printer".to_string(),
                 ParallelDevice::Sampler => "Sampler".to_string(),
+                ParallelDevice::JoystickAdapter => "Joystick Adapter".to_string(),
             },
             F::SamplerInput => self
                 .sampler_input
@@ -685,6 +697,17 @@ impl MachineSetup {
                 self.serial_mode = cycle_slice(&SERIAL_MODES, self.serial_mode, forward)
             }
             #[cfg(feature = "midi")]
+            F::SerialDevice => {
+                // Re-read on each step so an adapter plugged in since the
+                // screen opened appears; on-demand only, no polling.
+                self.refresh_serial_devices();
+                self.serial_device = crate::midi::next_endpoint(
+                    self.serial_device.as_deref(),
+                    &self.serial_devices,
+                    forward,
+                );
+            }
+            #[cfg(feature = "midi")]
             F::MidiOut => {
                 // The built-in synths ride at the end of the output
                 // list: always there to be chosen, whatever the host
@@ -747,13 +770,15 @@ impl MachineSetup {
                 self.csynth_mt32_mode = next.map(str::to_string);
             }
             F::ParallelDevice => {
-                // None -> Printer -> Sampler. Selecting Printer reveals its
-                // Output file row (with a Browse button); until a file is set
-                // the printer is not persisted or attached (see to_raw).
-                const DEVICES: [ParallelDevice; 3] = [
+                // None -> Printer -> Sampler -> Joystick Adapter. Selecting
+                // Printer reveals its Output file row (with a Browse button);
+                // until a file is set the printer is not persisted or
+                // attached (see to_raw).
+                const DEVICES: [ParallelDevice; 4] = [
                     ParallelDevice::None,
                     ParallelDevice::Printer,
                     ParallelDevice::Sampler,
+                    ParallelDevice::JoystickAdapter,
                 ];
                 self.parallel_device = cycle_slice(&DEVICES, self.parallel_device, forward);
             }

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -57,6 +57,13 @@ pub enum MenuAction {
     ToggleStatusBar,
     TogglePerfOverlay,
 
+    // Media.
+    /// Pick a hard-disk image and push it into the PCMCIA slot as a CF
+    /// card (ejecting whatever is there).
+    InsertPcmciaCard,
+    /// Pull the card out of the PCMCIA slot.
+    EjectPcmciaCard,
+
     // Input.
     SetPortDevice(usize, PortDevice),
     SetJoystickInput(JoystickInputMode),
@@ -129,6 +136,8 @@ impl MenuAction {
                 | MenuAction::OpenShortcuts
                 | MenuAction::OpenAbout
                 | MenuAction::LoadRom
+                | MenuAction::InsertPcmciaCard
+                | MenuAction::EjectPcmciaCard
                 | MenuAction::SaveState
                 | MenuAction::LoadState
                 | MenuAction::ResetMachine
@@ -470,6 +479,10 @@ pub struct MenuState<'a> {
     /// Whether the on-screen Amiga keyboard is up.
     pub keyboard_panel: bool,
     pub port_devices: [PortDevice; 2],
+    /// Whether the machine has a PCMCIA slot (A600/A1200), and what is
+    /// in it: the category is only offered on a machine with the slot.
+    pub pcmcia_slot: bool,
+    pub pcmcia_card: Option<String>,
     pub pixel_aspect: PixelAspect,
     pub scaling: DisplayScaling,
     /// Whether the window presentation crops to the programmed display
@@ -602,6 +615,16 @@ pub fn build(s: &MenuState) -> Vec<MenuRow> {
     }
     if !s.sampler_inputs.is_empty() {
         rows.push(MenuRow::submenu("Parallel Port", parallel_rows(s)));
+    }
+
+    // Only a machine with the slot has anything to put in it. The floppy
+    // and CD controls live on the status bar; the slot has no bar icon,
+    // so its insert/eject sit here.
+    if s.pcmcia_slot {
+        rows.push(
+            MenuRow::submenu("PCMCIA Card", pcmcia_rows(s))
+                .with_value(s.pcmcia_card.clone().unwrap_or_else(|| "Empty".to_string())),
+        );
     }
 
     rows.extend([
@@ -830,7 +853,7 @@ fn player_video_rows(s: &MenuState) -> Vec<MenuRow> {
 }
 
 fn input_rows(s: &MenuState) -> Vec<MenuRow> {
-    const DEVICES: [PortDevice; 6] = [
+    const DEVICES: [PortDevice; 7] = [
         PortDevice::Mouse,
         // A mouse a gamepad can move as well as the hand on the desk,
         // offered on port 1 alone: that is where a mouse belongs.
@@ -838,6 +861,7 @@ fn input_rows(s: &MenuState) -> Vec<MenuRow> {
         PortDevice::Joystick,
         PortDevice::Cd32Pad,
         PortDevice::Analogue,
+        PortDevice::LightPen,
         PortDevice::None,
     ];
     let port = |n: usize| -> Vec<MenuRow> {
@@ -1063,6 +1087,14 @@ fn parallel_rows(s: &MenuState) -> Vec<MenuRow> {
             ],
         )
         .with_value(gain_label(s.sampler_gain)),
+    ]
+}
+
+fn pcmcia_rows(s: &MenuState) -> Vec<MenuRow> {
+    vec![
+        MenuRow::action("Insert CF Card Image...", MenuAction::InsertPcmciaCard),
+        MenuRow::action("Eject Card", MenuAction::EjectPcmciaCard)
+            .available(s.pcmcia_card.is_some()),
     ]
 }
 
@@ -1345,6 +1377,8 @@ mod tests {
             joystick_input_mode: JoystickInputMode::Gamepad,
             keyboard_panel: false,
             port_devices: [PortDevice::Mouse, PortDevice::Joystick],
+            pcmcia_slot: false,
+            pcmcia_card: None,
             pixel_aspect: PixelAspect::Tv,
             scaling: DisplayScaling::Smooth,
             autocrop: false,

--- a/src/video/present_common.rs
+++ b/src/video/present_common.rs
@@ -374,6 +374,40 @@ impl FieldPlacement {
         let y1 = (row_scale * y1).clamp(y0, present_rows);
         (x1 > x0 && y1 > y0).then_some(bitplane::ContentRect { x0, x1, y0, y1 })
     }
+
+    /// The field-space pixel (`x` in the field's canvas pitch, `y` in
+    /// rendered field rows) that placed buffer pixel (`x`, `y`) shows --
+    /// [`Self::content_rect`] run backwards for one point, so a host
+    /// pointer over the presented picture can be turned back into the
+    /// rendered pixel under it (what a light pen sees). `None` for a
+    /// buffer pixel that shows no field pixel: the centring bands, a
+    /// programmable scan's blanked porches, or off the buffer.
+    pub fn field_point(&self, x: usize, y: usize, present_rows: usize) -> Option<(i32, i32)> {
+        let width = FB_WIDTH * self.canvas_scale;
+        if x >= width || y >= present_rows {
+            return None;
+        }
+        let row_scale = if present_rows >= 2 * self.rows { 2 } else { 1 };
+        let placed_y = y / row_scale;
+        if placed_y >= self.rows {
+            return None;
+        }
+        match self.map {
+            PlacementMap::Standard { y_offset, h_shift } => {
+                let fx = x + h_shift;
+                let fy = placed_y.checked_sub(y_offset)?;
+                (fx < width).then_some((fx as i32, fy as i32))
+            }
+            PlacementMap::Programmable { columns, rows } => {
+                let (src_x, _) = columns.source(x, width);
+                let fy = placed_y.checked_sub(rows.pad_top)?;
+                if fy >= rows.content_rows {
+                    return None;
+                }
+                Some((src_x.min(width - 1) as i32, (fy + rows.skip_top) as i32))
+            }
+        }
+    }
 }
 
 /// Where [`apply_presentation_v_window`] puts the captured rows of a

--- a/src/video/ui/tests.rs
+++ b/src/video/ui/tests.rs
@@ -339,6 +339,8 @@ fn every_launcher_tab_row_fits_inside_the_panel() {
         SerialMode::Tcp,
         SerialMode::TcpConnect,
         SerialMode::Pty,
+        SerialMode::Modem,
+        SerialMode::Device,
     ];
     // The strip tabs, plus the sub-pages and A/V categories reached from a
     // nav row rather than the strip.
@@ -3482,6 +3484,8 @@ fn panels_render_into_their_rects() {
             crate::bus::PortDevice::Mouse,
             crate::bus::PortDevice::Joystick,
         ],
+        pcmcia_slot: false,
+        pcmcia_card: None,
         pixel_aspect: PixelAspect::Tv,
         scaling: crate::config::DisplayScaling::Smooth,
         autocrop: false,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -99,23 +99,46 @@ pub(crate) struct HostRouting {
 /// launcher's Input-tab summary, so what the GUI promises is exactly what
 /// the pump does. The rules are documented on [`App::host_routing`].
 pub(crate) fn host_routing_for(devices: [PortDevice; 2], mode: JoystickInputMode) -> HostRouting {
+    host_routing_for_ports(devices, [PortDevice::None; 2], mode)
+}
+
+/// [`host_routing_for`] with the parallel-port adapter's sockets (ports 3
+/// and 4) in the picture. They are plain joystick ports that come after
+/// the game ports in the queue for the host sources: the pad and the
+/// keyboard mappings take the game ports first, and a socket gets a
+/// source only when the game ports have none left for it -- so a
+/// four-joystick wiring drives ports 1 and 2 from the pad and the
+/// cursor-key mapping, with the numpad mapping standing in where no pad
+/// is present, exactly as a two-joystick wiring does.
+pub(crate) fn host_routing_for_ports(
+    devices: [PortDevice; 2],
+    parallel: [PortDevice; 2],
+    mode: JoystickInputMode,
+) -> HostRouting {
     let mouse = devices.iter().position(|&d| d.is_mouse());
-    let mut remaining = (0..2).filter(|&p| {
-        Some(p) != mouse
-            && matches!(
-                devices[p],
-                PortDevice::Mouse
-                    | PortDevice::GamepadMouse
-                    | PortDevice::Joystick
-                    | PortDevice::Cd32Pad
-            )
-    });
+    let mut remaining = (0..2)
+        .filter(|&p| {
+            Some(p) != mouse
+                && matches!(
+                    devices[p],
+                    PortDevice::Mouse
+                        | PortDevice::GamepadMouse
+                        | PortDevice::Joystick
+                        | PortDevice::Cd32Pad
+                )
+        })
+        .chain(
+            (0..2)
+                .filter(|&s| parallel[s] == PortDevice::Joystick)
+                .map(|s| s + crate::bus::PARALLEL_PORT_FIRST),
+        );
     let first = remaining.next();
     let second = remaining.next();
+    let is_mouse = |p: usize| p < 2 && devices[p].is_mouse();
     let (gamepad, keyboard, keyboard2) = match (first, second, mode) {
         (None, _, _) => (None, None, None),
         (Some(p), None, JoystickInputMode::Gamepad) => {
-            if devices[p].is_mouse() {
+            if is_mouse(p) {
                 (None, None, None)
             } else {
                 (Some(p), None, None)
@@ -975,6 +998,10 @@ pub struct App {
     /// shows, in woven presentation-buffer space (see [`AutocropLatch`]);
     /// `None` until a standard frame has painted playfield.
     present_content_rect: Option<bitplane::ContentRect>,
+    /// How the last rendered field was placed on the presentation
+    /// buffer, so a canvas pixel can be traced back to the rendered pixel
+    /// it shows (see `canvas_to_field_pixel`).
+    present_placement: Option<crate::video::present_common::FieldPlacement>,
     /// The last layout the COPPERLINE_DIAG_AUTOCROP trace logged, so the
     /// trace reports changes rather than every redraw. Unused while the
     /// flag is off.
@@ -1083,8 +1110,12 @@ pub struct App {
     /// release.
     auto_joys: Vec<ScheduledJoy>,
     pending_auto_joys: Vec<(f32, JoyButtonKind, u32, u8)>,
-    auto_joy_held: [AutoJoyHeld; 2],
-    auto_joy_engaged: [bool; 2],
+    auto_joy_held: [AutoJoyHeld; crate::bus::PORT_COUNT],
+    auto_joy_engaged: [bool; crate::bus::PORT_COUNT],
+    /// Scheduled light-pen positions from --pen-after (one-shot each):
+    /// (at_emulated_secs, x, y, port or None for the pen's port).
+    auto_pens: Vec<(f64, i32, i32, Option<u8>)>,
+    pending_auto_pens: Vec<(f32, i32, i32, Option<u8>)>,
     /// The windowed control-protocol server (`--control-gui`), attached
     /// after construction via [`App::attach_control`]; its commands are
     /// drained at the top of `about_to_wait` (see window/control.rs).
@@ -1938,6 +1969,7 @@ impl App {
         mouse_after: Vec<(f32, i32, i32, u8)>,
         mouse_to_after: Vec<(f32, i32, i32, u8)>,
         pot_after: Vec<(f32, u8, u8, u8)>,
+        pen_after: Vec<(f32, i32, i32, Option<u8>)>,
         disk_insert_after: Vec<DiskInsertSpec>,
         cd_insert_after: Vec<(f32, PathBuf)>,
         freeze_after: Vec<f32>,
@@ -2054,6 +2086,7 @@ impl App {
             present_tv_aperture_rows: Some(TV_PAL_PRESENT_HEIGHT),
             presentation_latch: PresentationLatch::default(),
             present_content_rect: None,
+            present_placement: None,
             last_diag_layout: None,
             autocrop_latch: AutocropLatch::default(),
             present_programmable: false,
@@ -2099,8 +2132,10 @@ impl App {
             pending_auto_clicks: click_after,
             auto_joys: Vec::new(),
             pending_auto_joys: joy_after,
-            auto_joy_held: [AutoJoyHeld::default(); 2],
-            auto_joy_engaged: [false; 2],
+            auto_joy_held: [AutoJoyHeld::default(); crate::bus::PORT_COUNT],
+            auto_joy_engaged: [false; crate::bus::PORT_COUNT],
+            auto_pens: Vec::new(),
+            pending_auto_pens: pen_after,
             #[cfg(feature = "control")]
             control: None,
             #[cfg(feature = "gdb")]
@@ -2400,8 +2435,9 @@ impl App {
     /// mouse.
     fn host_routing(&self) -> HostRouting {
         let input = &self.emu.bus().input;
-        host_routing_for(
+        host_routing_for_ports(
             [input.ports[0].device, input.ports[1].device],
+            [input.device(2), input.device(3)],
             self.joystick_input_mode,
         )
     }
@@ -2468,11 +2504,51 @@ impl App {
         }
         // Scripted joy state on ports no host source drives asserts
         // independently.
-        for port in 0..2 {
+        for port in 0..crate::bus::PORT_COUNT {
             if Some(port) != r.gamepad && Some(port) != r.keyboard && self.auto_joy_engaged[port] {
                 self.apply_auto_joy_state(port);
             }
         }
+    }
+
+    /// The rendered-field pixel (the `--mouse-to-after` coordinates) that
+    /// logical canvas pixel (`x`, `y`) shows: back through the display
+    /// copy to the presentation buffer, then back through the field
+    /// placement. `None` over chrome, pads, or before a frame has been
+    /// presented.
+    fn canvas_to_field_pixel(&self, x: usize, y: usize) -> Option<(i32, i32)> {
+        let placement = self.present_placement?;
+        let (sx, sy) = canvas_source_point(
+            x,
+            y,
+            self.present_rows,
+            self.present_width,
+            self.overscan,
+            self.tv_centre,
+            self.present_tv_aperture_rows,
+            present_height(),
+        )?;
+        placement.field_point(sx, sy, self.present_rows)
+    }
+
+    /// Hold the light pen where the host pointer is over the display, or
+    /// lift it off when the pointer leaves. `pos` is a logical canvas
+    /// pixel; the pen wants the rendered field's coordinates, so it goes
+    /// back through the presentation the way the pixels came.
+    fn track_light_pen_pointer(&mut self, pos: Option<(i32, i32)>) {
+        if self.emu.bus().input.light_pen_port().is_none() {
+            return;
+        }
+        let field = pos
+            .filter(|p| cursor_in_display(*p))
+            .and_then(|(x, y)| self.canvas_to_field_pixel(x as usize, y as usize));
+        if self.emu.bus().input.light_pen.position == field {
+            return;
+        }
+        self.emu.bus_mut().input.set_light_pen_position(field);
+        // Reverse-debug: note the move so replay can reproduce it.
+        self.emu
+            .tt_note_input(crate::inputsched::ReplayAction::Pen { position: field });
     }
 
     /// Whether the pad has been handed the calibration panel's buttons,
@@ -2924,6 +3000,38 @@ impl App {
         true
     }
 
+    /// Hold the light pen over presented pixel (`x`, `y`) -- or lift it
+    /// off the glass with a negative coordinate -- from `--pen-after` or
+    /// the control protocol. `port` names the port the pen must be in;
+    /// `None` takes whichever port has one.
+    fn apply_scripted_pen_position(&mut self, x: i32, y: i32, port: Option<u8>) {
+        let input = &mut self.emu.bus_mut().input;
+        let pen_port = input.light_pen_port();
+        match (port, pen_port) {
+            (Some(p), Some(pen)) if p as usize != pen => {
+                warn!(
+                    "pen: port {} named but the light pen is in port {}; ignored",
+                    p + 1,
+                    pen + 1
+                );
+                return;
+            }
+            (_, None) => {
+                warn!("pen: no light pen fitted ([input] port1/port2 = \"lightpen\"); ignored");
+                return;
+            }
+            _ => {}
+        }
+        let position = (x >= 0 && y >= 0).then_some((x, y));
+        info!(
+            "auto-pen: {position:?} on port {}",
+            pen_port.unwrap_or(0) + 1
+        );
+        input.set_light_pen_position(position);
+        self.emu
+            .tt_note_input(crate::inputsched::ReplayAction::Pen { position });
+    }
+
     /// Drive a port's emulated joystick/CD32 pad from the --joy-after
     /// held-control set.
     fn apply_auto_joy_state(&mut self, port: usize) {
@@ -3248,6 +3356,15 @@ impl App {
         for (secs, x, y, port) in self.pending_auto_pots.drain(..) {
             self.auto_pots.push((secs.max(0.0) as f64, x, y, port));
         }
+        for (secs, x, y, port) in self.pending_auto_pens.drain(..) {
+            self.auto_pens.push((secs.max(0.0) as f64, x, y, port));
+        }
+        if !self.auto_pens.is_empty() {
+            info!(
+                "auto-pen armed: {} scheduled positions",
+                self.auto_pens.len()
+            );
+        }
         if !self.auto_pots.is_empty() {
             info!(
                 "auto-pot armed: {} scheduled positions",
@@ -3347,10 +3464,10 @@ impl App {
         // Fire any scheduled --joy-after events into the named port's
         // joystick/CD32-pad state, then assert the held sets (input polling
         // re-applies them every quantum while scripting is engaged).
-        let mut joy_changed = [false; 2];
+        let mut joy_changed = [false; crate::bus::PORT_COUNT];
         let held = &mut self.auto_joy_held;
         self.auto_joys.retain_mut(|j| {
-            let port = usize::from(j.port != 0);
+            let port = (j.port as usize).min(crate::bus::PORT_COUNT - 1);
             if !j.pressed && emu_secs >= j.press_at_emulated_secs {
                 info!("auto-joy pressing: {:?} (port {})", j.button, port + 1);
                 held[port].set(j.button, true);
@@ -3365,7 +3482,7 @@ impl App {
             }
             true
         });
-        for port in 0..2 {
+        for port in 0..crate::bus::PORT_COUNT {
             if joy_changed[port] {
                 self.auto_joy_engaged[port] = true;
                 self.apply_auto_joy_state(port);
@@ -3422,6 +3539,20 @@ impl App {
             self.emu.bus_mut().input.set_analogue(port as usize, x, y);
             self.emu
                 .tt_note_input(crate::inputsched::ReplayAction::Pot { port, x, y });
+        }
+        // Fire any scheduled --pen-after light-pen positions (one-shot
+        // each).
+        let mut pen_sets = Vec::new();
+        self.auto_pens.retain(|&(at, x, y, port)| {
+            if emu_secs >= at {
+                pen_sets.push((x, y, port));
+                false
+            } else {
+                true
+            }
+        });
+        for (x, y, port) in pen_sets {
+            self.apply_scripted_pen_position(x, y, port);
         }
         let mut disk_inserts = Vec::new();
         let mut disk_change_available = self.netplay.as_ref().is_none_or(|s| s.can_change_disk());
@@ -4077,6 +4208,7 @@ impl ApplicationHandler for App {
                         self.last_display_cursor_pos = None;
                     } else {
                         self.track_uncaptured_cursor_motion(pos);
+                        self.track_light_pen_pointer(pos);
                     }
                     // A hand actually moving the mouse takes over from
                     // the keyboard: the marker goes away, though where it
@@ -4135,6 +4267,8 @@ impl ApplicationHandler for App {
                 self.cursor_pos = None;
                 self.last_cursor_phys = None;
                 self.last_display_cursor_pos = None;
+                // The hand holding the pen has left the glass with it.
+                self.track_light_pen_pointer(None);
                 self.volume_dragging = false;
                 self.analyzer_dragging = false;
                 self.menu_hover_arm = None;
@@ -4389,6 +4523,15 @@ impl ApplicationHandler for App {
                         MouseButton::Right => input.set_mouse_button(port, 1, pressed),
                         MouseButton::Middle => input.set_mouse_button(port, 2, pressed),
                         _ => {}
+                    }
+                }
+                // The host pointer is the light pen as well as the mouse:
+                // a left click over the display presses the pen's tip
+                // switch / pulls the gun's trigger.
+                if button == MouseButton::Left && self.netplay.is_none() {
+                    let input = &mut self.emu.bus_mut().input;
+                    if let Some(port) = input.light_pen_port() {
+                        input.set_mouse_button(port, 0, pressed);
                     }
                 }
             }
@@ -5439,14 +5582,17 @@ fn display_file_name(path: &std::path::Path) -> String {
 
 /// What a file dropped on the window should be treated as. Extension-based:
 /// only floppies get content-sniffed (by the insert path itself), and cue
-/// sheets/hard disks/ROMs have no shared magic worth probing here.
+/// sheets/hard disks/ROMs have no shared magic worth probing here. The one
+/// exception is `.chd`, which holds either a CD or a hard disk and says
+/// which in its metadata.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DroppedMediaKind {
     /// Anything the floppy loader may accept (floppy::IMAGE_EXTENSIONS and
     /// unknown extensions): FloppyImage::from_bytes sniffs the content and
     /// rejects what it cannot read, surfacing a clean OSD failure.
     Floppy,
-    /// A CD image (cue sheet, bare ISO, Nero NRG, or CHD) for the CD drive.
+    /// A CD image (cue sheet, bare ISO, Nero NRG, or CD-ROM CHD) for the
+    /// CD drive.
     Cd,
     /// Hard disk images cannot be hot-attached; point at the config screen.
     HardDisk,
@@ -5462,6 +5608,7 @@ fn classify_dropped_media(path: &std::path::Path) -> DroppedMediaKind {
         .extension()
         .map(|e| e.to_string_lossy().to_ascii_lowercase());
     match ext.as_deref() {
+        Some("chd") if crate::harddrive::chd::is_hard_disk_chd(path) => DroppedMediaKind::HardDisk,
         Some("cue") | Some("iso") | Some("nrg") | Some("chd") => DroppedMediaKind::Cd,
         Some("hdf") | Some("hdz") | Some("img") => DroppedMediaKind::HardDisk,
         Some("rom") => DroppedMediaKind::Rom,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -4327,6 +4327,21 @@ impl ApplicationHandler for App {
                 if pressed {
                     self.log_cursor_diag(button);
                 }
+                // The host pointer is the light pen as well as the mouse.
+                // This runs before the UI's early returns below: a press
+                // over the display that ends over the status bar or a
+                // panel must still release the pen's tip switch, or the
+                // guest sees it held for good. A press only counts where
+                // the pen is actually pointing, over the display.
+                if button == MouseButton::Left && self.netplay.is_none() {
+                    let over_display = self.cursor_pos.is_some_and(cursor_in_display);
+                    if !pressed || over_display {
+                        let input = &mut self.emu.bus_mut().input;
+                        if let Some(port) = input.light_pen_port() {
+                            input.set_mouse_button(port, 0, pressed);
+                        }
+                    }
+                }
                 if button == MouseButton::Left {
                     if pressed {
                         self.analyzer_dragging = false;
@@ -4523,15 +4538,6 @@ impl ApplicationHandler for App {
                         MouseButton::Right => input.set_mouse_button(port, 1, pressed),
                         MouseButton::Middle => input.set_mouse_button(port, 2, pressed),
                         _ => {}
-                    }
-                }
-                // The host pointer is the light pen as well as the mouse:
-                // a left click over the display presses the pen's tip
-                // switch / pulls the gun's trigger.
-                if button == MouseButton::Left && self.netplay.is_none() {
-                    let input = &mut self.emu.bus_mut().input;
-                    if let Some(port) = input.light_pen_port() {
-                        input.set_mouse_button(port, 0, pressed);
                     }
                 }
             }

--- a/src/video/window/app_display.rs
+++ b/src/video/window/app_display.rs
@@ -1032,6 +1032,9 @@ impl App {
             h_shift,
             self.overscan,
         );
+        // Kept so a host pointer over the picture can be traced back to
+        // the rendered pixel under it (the light pen's position).
+        self.present_placement = Some(placement);
         let base = self.emu.bus().frame_render_base();
         // Standard 15 kHz fields line-double / weave to 2x rows; a
         // programmable progressive scan already carries every line.

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -172,7 +172,7 @@ impl App {
             | LauncherField::LideDrive1
             | LauncherField::LideDrive2
             | LauncherField::LideDrive3 => dialog
-                .add_filter("Hard disk images", &["hdf", "hdz", "img", "bin"])
+                .add_filter("Hard disk images", &["hdf", "hdz", "img", "bin", "chd"])
                 .add_filter("CD images", &["cue", "iso", "nrg", "chd"]),
             // copperhf.device serves hard disks only -- no ATAPI/SCSI-CDROM
             // emulation behind it (`copperhf_drive_image` rejects a CD
@@ -185,9 +185,9 @@ impl App {
             | LauncherField::CopperhfUnit4
             | LauncherField::CopperhfUnit5
             | LauncherField::CopperhfUnit6 => {
-                dialog.add_filter("Hard disk images", &["hdf", "hdz", "img", "bin"])
+                dialog.add_filter("Hard disk images", &["hdf", "hdz", "img", "bin", "chd"])
             }
-            _ => dialog.add_filter("Hard disk images", &["hdf", "hdz", "img", "bin"]),
+            _ => dialog.add_filter("Hard disk images", &["hdf", "hdz", "img", "bin", "chd"]),
         };
         if let Some(dir) = start_dir {
             dialog = dialog.set_directory(dir);
@@ -919,7 +919,7 @@ impl App {
         } else {
             // The same bytes either way: .hdf is what emulators look for,
             // .img what a card writer expects, so both are offered.
-            ("Amiga hard disk image", vec!["hdf", "img"])
+            ("Amiga hard disk image", vec!["hdf", "img", "chd"])
         };
         let picked = rfd::FileDialog::new()
             .set_title("Create disk image")

--- a/src/video/window/app_media.rs
+++ b/src/video/window/app_media.rs
@@ -161,6 +161,48 @@ impl App {
         }
     }
 
+    /// Pick a hard-disk image and push it into the PCMCIA slot as a CF
+    /// card, ejecting whatever was there. The menu offers this only on a
+    /// machine with the slot.
+    pub(super) fn insert_pcmcia_card_from_dialog(&mut self) {
+        if !self.emu.bus().pcmcia_slot_present() {
+            self.show_osd("PCMCIA: no slot on this machine");
+            return;
+        }
+        self.suspend_live_audio_for_host_io();
+        let picked = rfd::FileDialog::new()
+            .set_title("Insert PCMCIA CF card image")
+            .add_filter("Hard-disk images", &["hdf", "hdz", "img"])
+            .pick_file();
+        if let Some(path) = picked {
+            match crate::pcmcia::CfCard::open(&path) {
+                Ok(card) => {
+                    let card = crate::pcmcia::PcmciaCard::cf(card);
+                    info!("pcmcia: {}", card.describe());
+                    self.emu.bus_mut().pcmcia_insert(card);
+                    self.show_osd(format!("PCMCIA: {}", display_file_name(&path)));
+                    self.request_redraw();
+                }
+                Err(e) => {
+                    warn!("pcmcia: card image open failed ({}): {e:#}", path.display());
+                    self.show_osd("PCMCIA: card image open failed (see log)");
+                }
+            }
+        }
+        self.finish_host_io_pause();
+    }
+
+    /// Pull the card out of the PCMCIA slot; says whether there was one.
+    pub(super) fn eject_pcmcia_card(&mut self) -> bool {
+        if self.emu.bus_mut().pcmcia_eject().is_none() {
+            self.show_osd("PCMCIA: no card");
+            return false;
+        }
+        self.show_osd("PCMCIA: card ejected");
+        self.request_redraw();
+        true
+    }
+
     pub(super) fn eject_cd(&mut self) {
         if !self.emu.bus().cd_disc_inserted() {
             self.show_osd("CD: no disc");

--- a/src/video/window/app_media.rs
+++ b/src/video/window/app_media.rs
@@ -172,7 +172,7 @@ impl App {
         self.suspend_live_audio_for_host_io();
         let picked = rfd::FileDialog::new()
             .set_title("Insert PCMCIA CF card image")
-            .add_filter("Hard-disk images", &["hdf", "hdz", "img"])
+            .add_filter("Hard-disk images", &["hdf", "hdz", "img", "chd"])
             .pick_file();
         if let Some(path) = picked {
             match crate::pcmcia::CfCard::open(&path) {

--- a/src/video/window/app_menus.rs
+++ b/src/video/window/app_menus.rs
@@ -122,6 +122,12 @@ impl App {
                 self.emu.bus().input.device(0),
                 self.emu.bus().input.device(1),
             ],
+            pcmcia_slot: self.emu.bus().pcmcia_slot_present(),
+            pcmcia_card: self
+                .emu
+                .bus()
+                .pcmcia_card()
+                .map(crate::pcmcia::PcmciaCard::describe),
             pixel_aspect: crate::video::pixel_aspect(),
             scaling: crate::video::display_scaling(),
             autocrop: crate::video::autocrop(),
@@ -254,6 +260,10 @@ impl App {
                 self.ui.panel = Some(Panel::About);
             }
             A::LoadRom => self.load_rom_from_dialog(),
+            A::InsertPcmciaCard => self.insert_pcmcia_card_from_dialog(),
+            A::EjectPcmciaCard => {
+                self.eject_pcmcia_card();
+            }
 
             A::SetAudioOutput(choice) => {
                 let want = match choice {

--- a/src/video/window/control.rs
+++ b/src/video/window/control.rs
@@ -473,6 +473,40 @@ impl App {
                 };
                 self.control_send(line);
             }
+            HostOp::PcmciaInsert {
+                kind,
+                path,
+                size,
+                read_only,
+            } => {
+                let line = match crate::control::exec::pcmcia_insert(
+                    &mut self.emu,
+                    kind,
+                    path.as_deref(),
+                    size,
+                    read_only,
+                ) {
+                    Ok(description) => {
+                        self.show_osd(format!("PCMCIA: {description}"));
+                        self.request_redraw();
+                        proto::ok_line(&id, json!({"card": description}))
+                    }
+                    Err(e) => proto::err_line(&id, &e),
+                };
+                self.control_send(line);
+            }
+            HostOp::PcmciaEject => {
+                let line = if !self.emu.bus().pcmcia_slot_present() {
+                    proto::err_line(
+                        &id,
+                        &CtlError::unsupported("no PCMCIA slot on this machine"),
+                    )
+                } else {
+                    let ejected = self.eject_pcmcia_card();
+                    proto::ok_line(&id, json!({"ejected": ejected}))
+                };
+                self.control_send(line);
+            }
             HostOp::CopperhfAttach {
                 unit,
                 path,
@@ -1037,6 +1071,10 @@ impl App {
                 self.emu.bus_mut().input.set_analogue(port as usize, x, y);
                 self.emu
                     .tt_note_input(crate::inputsched::ReplayAction::Pot { port, x, y });
+            }
+            InputAction::Pen { position } => {
+                let (x, y) = position.unwrap_or((-1, -1));
+                self.apply_scripted_pen_position(x, y, None);
             }
         }
     }

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -197,6 +197,52 @@ pub(super) fn render_job_to_presentation(
 /// rather than deriving closed forms: a few hundred iterations, run only
 /// when autocrop is presenting, and immune to drifting out of agreement
 /// with the copy it mirrors.
+/// The presentation-buffer pixel logical canvas pixel (`x`, `y`) shows:
+/// the display copy's forward maps ([`canvas_content_rect`] scans the
+/// same ones) evaluated for one point. `None` for a canvas pixel that
+/// shows no buffer pixel -- the tv canvas's side pads and bezel bands, or
+/// a source row the centre nudge pushes off the buffer.
+pub(super) fn canvas_source_point(
+    x: usize,
+    y: usize,
+    src_rows: usize,
+    src_width: usize,
+    overscan: Overscan,
+    tv_centre: TvCentre,
+    tv_aperture_rows: Option<usize>,
+    canvas_rows: usize,
+) -> Option<(usize, usize)> {
+    if x >= FB_WIDTH || y >= canvas_rows || src_rows == 0 || src_width == 0 {
+        return None;
+    }
+    match tv_aperture_rows {
+        Some(aperture_rows) if overscan == Overscan::Tv => {
+            let (x_off, y_off) = tv_centre_source_offset(tv_centre);
+            let src_y = tv_aperture_source_row(y, canvas_rows, 1, aperture_rows)
+                .map(|crop_y| (TV_PRESENT_SOURCE_Y + crop_y) as i32 + y_off)?;
+            let square = canvas_rows == crate::video::PRESENT_HEIGHT_SQUARE;
+            let src_x = if square {
+                (TV_LIVE_PAD_X..TV_LIVE_PAD_X + TV_CAPTURED_WIDTH)
+                    .contains(&x)
+                    .then(|| TV_CAPTURED_SOURCE_X as i32 + x_off + (x - TV_LIVE_PAD_X) as i32)?
+            } else {
+                let s = (TV_CAPTURED_SOURCE_X as i64 + x_off as i64) * 256
+                    + ((2 * x as i64 + 1) * (TV_CAPTURED_WIDTH as i64) * 256)
+                        / (2 * FB_WIDTH as i64)
+                    - 128;
+                (s >> 8) as i32
+            };
+            ((0..src_width as i32).contains(&src_x) && (0..src_rows as i32).contains(&src_y))
+                .then_some((src_x as usize, src_y as usize))
+        }
+        _ => {
+            let src_y = screenshot::scaled_source_row(y, src_rows, canvas_rows);
+            let src_x = (x * src_width / FB_WIDTH).min(src_width - 1);
+            Some((src_x, src_y))
+        }
+    }
+}
+
 pub(super) fn canvas_content_rect(
     content: bitplane::ContentRect,
     src_rows: usize,

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4175,6 +4175,7 @@ fn test_app_with_audio_cpu_and_program(
         Vec::new(),
         Vec::new(),
         Vec::new(),
+        Vec::new(),
         None,
         None,
         None,
@@ -4243,6 +4244,7 @@ fn test_app_with_copperhf_units(units: &[(usize, PathBuf)]) -> super::App {
         Vec::new(),
         Vec::new(),
         None,
+        Vec::new(),
         Vec::new(),
         Vec::new(),
         Vec::new(),
@@ -7472,6 +7474,13 @@ fn dropped_media_classifies_by_extension() {
     assert_eq!(kind("game.CUE"), DroppedMediaKind::Cd);
     assert_eq!(kind("game.iso"), DroppedMediaKind::Cd);
     assert_eq!(kind("game.NRG"), DroppedMediaKind::Cd);
+    // A .chd that cannot be read is a CD, as it always was; one whose
+    // metadata says hard disk goes where hard disks go.
+    assert_eq!(kind("game.chd"), DroppedMediaKind::Cd);
+    let chd = crate::harddrive::chd::tests::temp_path("drop.chd");
+    crate::harddrive::chd::tests::write_hard_disk(&chd, 4, [3; 20]);
+    assert_eq!(classify_dropped_media(&chd), DroppedMediaKind::HardDisk);
+    let _ = std::fs::remove_file(&chd);
     assert_eq!(kind("disk.hdf"), DroppedMediaKind::HardDisk);
     assert_eq!(kind("disk.HDZ"), DroppedMediaKind::HardDisk);
     assert_eq!(kind("disk.img"), DroppedMediaKind::HardDisk);
@@ -12176,4 +12185,64 @@ fn netplay_host_mouse_owns_only_the_local_mouse_port() -> anyhow::Result<()> {
         })?
         .join()
         .unwrap()
+}
+
+#[test]
+fn adapter_sockets_queue_behind_the_game_ports_for_host_sources() {
+    use super::{host_routing_for_ports, JoystickInputMode as M};
+    use crate::bus::PortDevice as D;
+    // Stock wiring plus two socket joysticks: the pad keeps port 2, the
+    // cursor-key mapping takes port 3, the numpad stands in on port 2.
+    let r = host_routing_for_ports(
+        [D::Mouse, D::Joystick],
+        [D::Joystick, D::Joystick],
+        M::Gamepad,
+    );
+    assert_eq!(
+        (r.mouse, r.gamepad, r.keyboard, r.keyboard2),
+        (Some(0), Some(1), Some(2), Some(1))
+    );
+    // Four joysticks in keyboard mode: the game ports still come first.
+    let r = host_routing_for_ports(
+        [D::Joystick, D::Joystick],
+        [D::Joystick, D::None],
+        M::Keyboard,
+    );
+    assert_eq!(
+        (r.gamepad, r.keyboard, r.keyboard2),
+        (Some(1), Some(0), Some(1))
+    );
+    // A lone socket joystick gets the pad.
+    let r = host_routing_for_ports([D::Mouse, D::None], [D::None, D::Joystick], M::Gamepad);
+    assert_eq!((r.gamepad, r.keyboard), (Some(3), None));
+    // Empty sockets are not in the queue at all.
+    let r = host_routing_for_ports([D::Mouse, D::Joystick], [D::None, D::None], M::Gamepad);
+    assert_eq!(
+        r,
+        super::host_routing_for([D::Mouse, D::Joystick], M::Gamepad)
+    );
+}
+
+#[test]
+fn field_point_inverts_the_field_placement() {
+    use crate::video::bitplane::ContentRect;
+    use crate::video::present_common::FieldPlacement;
+    let rect = ContentRect {
+        x0: 100,
+        x1: 200,
+        y0: 20,
+        y1: 40,
+    };
+    let placement = FieldPlacement::standard(crate::video::FB_HEIGHT, 0x2C, 10);
+    let placed = placement.content_rect(rect, 570).unwrap();
+    assert_eq!(
+        placement.field_point(placed.x0, placed.y0, 570),
+        Some((100, 20))
+    );
+    assert_eq!(
+        placement.field_point(placed.x1 - 1, placed.y1 - 1, 570),
+        Some((199, 39))
+    );
+    // The centring band above the field shows no field pixel.
+    assert_eq!(placement.field_point(0, 0, 570), None);
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -390,6 +390,8 @@ baselines to maintain.
 | `picasso2_p96cts_reports_all_modes_clean` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-picasso2-cts.hdf` (startup runs p96cts at 8/16/24 bpp and writes `P96OUT:p96cts.result`) |
 | `graffity_z2_workbench_opens_640x480x8` / `graffity_z3_workbench_opens_640x480x8` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `p96-graffity.hdf` (WB + Picasso96 with `Graffity.card`, default 640x480x8 screen) |
 | `chd_cd32_disc_serves_iso9660_data_and_smooth_audio` | `Pinball Fantasies (EU).chd` (a chdman v5 CD32 disc with a MODE1_RAW data track and CD audio tracks) |
+| `chd_hard_disk_matches_its_source_hdf_and_takes_writes_in_the_overlay` | `AmigaSYS3PlusAGA-rdb.hdf` and `AmigaSYS3PlusAGA-rdb.chd`, its conversion (`chdman createhd -i AmigaSYS3PlusAGA-rdb.hdf -o AmigaSYS3PlusAGA-rdb.chd`; `brew install rom-tools`) |
+| `chd_hard_disk_boots_amigasys_under_kick31` | `KICK31.ROM`, `AmigaSYS3PlusAGA-rdb.chd` (as above) |
 | `nrg_cd32_disc_serves_iso9660_data_and_smooth_audio` | `30 Games Compilation CD (2005)(Stuermer, A.).nrg` (a Nero 5 DAO CD32 disc with one MODE1/2048 data track and nine CD audio tracks) |
 | `toccata_ahi_driver_recognizes_the_board` | `Kickstart v3.1 r40.68 (1993)(Commodore)(A4000).rom`, `toccata-ahi.hdf` (WB3.1 + AHI 4.18 with `toccata.audio` staged into `Devs/AHI` and Unit 0 set to Toccata) |
 | `zz9k_sdk_tools_pass_on_zorro_ii` / `zz9k_sdk_tools_pass_on_zorro_iii` | `zz9k/C/zz9k-{info,hash,chacha,aead,irqtest}` -- the unmodified ZZ9000 SDK m68k tools, built from the zz9000-sdk revision pinned in `docs/internals/zz9k.md` (build recipe in `tests/zz9k_sdk_tools.rs`'s module comment) |

--- a/tests/chd_hdd.rs
+++ b/tests/chd_hdd.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Asset-gated checks of the CHD hard-disk backend against a real chdman
+//! image: `AmigaSYS3PlusAGA-rdb.chd`, made from the AmigaSYS RDB hardfile
+//! with `chdman createhd -i AmigaSYS3PlusAGA-rdb.hdf -o
+//! AmigaSYS3PlusAGA-rdb.chd`. The unit tests in `src/harddrive/chd.rs`
+//! cover addressing, the overlay, and header validation with synthesized
+//! uncompressed CHDs; these prove the compressed-codec path (LZMA/Deflate
+//! hunks, a real 25,000-hunk map) against the hardfile it came from, and
+//! boot AmigaOS from it.
+
+use copperline::diskimage::FileSystem;
+use copperline::harddrive::{chd::overlay_path, HardDriveImage, SECTOR_SIZE};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The integration-test asset directory (see `tests/README.md`):
+/// `COPPERLINE_TEST_ASSETS`, else `test-assets/` under the repo root,
+/// else the repo root itself.
+fn asset_dir() -> PathBuf {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    match std::env::var_os("COPPERLINE_TEST_ASSETS") {
+        Some(d) => PathBuf::from(d),
+        None => {
+            let d = root.join("test-assets");
+            if d.is_dir() {
+                d
+            } else {
+                root
+            }
+        }
+    }
+}
+
+fn asset(name: &str) -> Option<PathBuf> {
+    let path = asset_dir().join(name);
+    path.is_file().then_some(path)
+}
+
+/// A scratch directory holding a private copy of the CHD, so the overlay
+/// sidecar the drive creates lands beside the copy and never in the asset
+/// directory.
+fn scratch_copy(source: &Path) -> (PathBuf, PathBuf) {
+    let dir = std::env::temp_dir().join(format!(
+        "copperline-chd-hdd-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let copy = dir.join("work.chd");
+    std::fs::copy(source, &copy).unwrap();
+    (dir, copy)
+}
+
+fn open(path: &Path) -> HardDriveImage {
+    HardDriveImage::open(path, "DH0", "ide", None, 0, FileSystem::FFS).expect("image opens")
+}
+
+fn toml_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+fn distinct_colors(path: &Path) -> usize {
+    let decoder = png::Decoder::new(std::io::BufReader::new(std::fs::File::open(path).unwrap()));
+    let mut reader = decoder.read_info().unwrap();
+    let mut data = vec![0; reader.output_buffer_size().unwrap()];
+    let info = reader.next_frame(&mut data).unwrap();
+    let stride = match info.color_type {
+        png::ColorType::Rgb => 3,
+        png::ColorType::Rgba => 4,
+        other => panic!("unexpected screenshot pixel format {other:?}"),
+    };
+    data[..info.buffer_size()]
+        .chunks_exact(stride)
+        .map(|pixel| pixel[..3].to_vec())
+        .collect::<HashSet<_>>()
+        .len()
+}
+
+#[test]
+#[ignore = "needs the AmigaSYS RDB hardfile and its chdman conversion (see tests/README.md)"]
+fn chd_hard_disk_matches_its_source_hdf_and_takes_writes_in_the_overlay() {
+    let (Some(chd), Some(hdf)) = (
+        asset("AmigaSYS3PlusAGA-rdb.chd"),
+        asset("AmigaSYS3PlusAGA-rdb.hdf"),
+    ) else {
+        eprintln!("skipping: AmigaSYS CHD/HDF pair not in the asset directory");
+        return;
+    };
+    let (dir, copy) = scratch_copy(&chd);
+    let pristine = std::fs::read(&copy).unwrap();
+
+    let mut source = open(&hdf);
+    let mut disk = open(&copy);
+    assert!(disk.has_own_rdb(), "the RDB image is served as-is");
+    assert!(!disk.write_protected(), "the overlay opened");
+    // chdman pads the last cylinder; the disk is never smaller than its source.
+    assert!(disk.total_sectors() >= source.total_sectors());
+
+    // Every sector of the RDB and the start of the first partition, a
+    // stride across the whole disk, and the tail, against the hardfile.
+    let last = source.total_sectors() - 1;
+    let mut lbas: Vec<u64> = (0..8192).collect();
+    lbas.extend((0..last).step_by(4099));
+    lbas.extend(last.saturating_sub(64)..=last);
+    let mut a = vec![0u8; SECTOR_SIZE];
+    let mut b = vec![0u8; SECTOR_SIZE];
+    for &lba in &lbas {
+        source.read_sector(lba, &mut a).unwrap();
+        disk.read_sector(lba, &mut b).unwrap();
+        assert_eq!(a, b, "lba {lba}");
+    }
+    // Padding, if any, reads as zero.
+    for lba in source.total_sectors()..disk.total_sectors() {
+        disk.read_sector(lba, &mut b).unwrap();
+        assert!(b.iter().all(|&x| x == 0), "padding sector {lba}");
+    }
+
+    // A write goes to the sidecar, persists across a reopen, and leaves the
+    // CHD byte-identical.
+    let written = vec![0x5A; SECTOR_SIZE];
+    disk.write_sector(1234, &written).unwrap();
+    disk.flush().unwrap();
+    drop(disk);
+    assert_eq!(std::fs::read(&copy).unwrap(), pristine, "CHD untouched");
+    assert!(
+        overlay_path(&copy).is_file(),
+        "sidecar created beside the copy"
+    );
+    let mut disk = open(&copy);
+    disk.read_sector(1234, &mut b).unwrap();
+    assert_eq!(b, written);
+    disk.read_sector(1235, &mut b).unwrap();
+    source.read_sector(1235, &mut a).unwrap();
+    assert_eq!(a, b, "the neighbouring sector still comes from the CHD");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+#[ignore = "runs the emulator and needs KICK31.ROM plus the AmigaSYS CHD (see tests/README.md)"]
+fn chd_hard_disk_boots_amigasys_under_kick31() {
+    let (Some(chd), Some(kick)) = (asset("AmigaSYS3PlusAGA-rdb.chd"), asset("KICK31.ROM")) else {
+        eprintln!("skipping: AmigaSYS CHD or KICK31.ROM not in the asset directory");
+        return;
+    };
+    let (dir, copy) = scratch_copy(&chd);
+    let pristine_len = std::fs::metadata(&copy).unwrap().len();
+    let cfg = dir.join("config.toml");
+    std::fs::write(
+        &cfg,
+        format!(
+            r#"[machine]
+profile = "A1200"
+
+[memory]
+fast = "8M"
+
+[ide]
+master = "{}"
+"#,
+            toml_path(&copy)
+        ),
+    )
+    .unwrap();
+
+    let png = dir.join("boot.png");
+    let output = Command::new(env!("CARGO_BIN_EXE_copperline"))
+        .env("RUST_LOG", "copperline=info")
+        .arg("--factory")
+        .arg("--config")
+        .arg(&cfg)
+        .arg("--noaudio")
+        .arg("--screenshot-after")
+        .arg("90")
+        .arg(&png)
+        .arg(&kick)
+        .output()
+        .unwrap();
+    let log = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "copperline failed: {}\n{log}",
+        output.status
+    );
+    assert!(
+        log.contains("is a CHD hard disk"),
+        "the drive was not attached from the CHD:\n{log}"
+    );
+    // AmigaSYS's Workbench is a full-colour AGA desktop: far more than the
+    // handful of colours a boot failure (insert-disk screen, guru) shows.
+    let colors = distinct_colors(&png);
+    assert!(
+        colors > 64,
+        "only {colors} distinct colours after boot; see {log}"
+    );
+    // The boot wrote to the disk (Workbench updates its volume state), all of
+    // it in the sidecar.
+    assert_eq!(std::fs::metadata(&copy).unwrap().len(), pristine_len);
+    assert!(overlay_path(&copy).is_file());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Four peripherals the emulator had no model for. Each is derived from the hardware, not from the software that uses it; the titles named below are regression examples only.

## Parallel-port four-player adapter

The passive adapter puts joystick 3's directions on CIA-A PRB bits 0-3 and joystick 4's on bits 4-7, with fire on CIA-B PRA (SEL for port 3, BUSY for port 4, POUT shared by the second buttons), all active low and respecting the data-direction registers, so a port the guest drives as output reads the CIA's own pins. The fire-line assignment was checked against WinUAE's `handle_parport_joystick` rather than guessed.

Fitted with `[parallel] device = "joystick-adapter"` and `[input] port3`/`port4`. `--joy-after`'s trailing port token accepts 3 and 4, the control protocol's `input.joy`, `input.set_port` and `input.get_ports` reach them, and `copperline-import-uae` maps WinUAE's third and fourth port bindings. Exercises the four-player modes of Kick Off 2, Sensible Soccer, Dyna Blaster and Super Skidmarks. Netplay and the libretro core stay two-player.

## Light pen and light gun

A pen device on the port the board wires to Agnus LP (port 2 on every machine after the A1000, whose WCS identifies it) latches the beam position as the raster sweeps past the pen, readable through VPOSR and VHPOSR while BPLCON0 LPEN is set. The tip switch reads on the port's third-button line (POTxX), not the fire pin, which is the pulse line. `--pen-after SECS X Y [PORT]` positions it headlessly and the window follows the host pointer through the same presentation geometry the sprite servo uses. `copperline-import-uae` no longer reports WinUAE's lightpen port as unsupported.

## PCMCIA slot (A600/A1200)

Gayle's status, change, config and reset registers with their card-detect and status-change interrupts routed to INT2 and INT6 per the config bits, the common, attribute and I/O windows, and the rule that more than 4 MB of Zorro II fast RAM shadows the slot (with a startup warning). Register behaviour follows Linux's `amigayle.h` and WinUAE's gayle.cpp; an empty socket now reads its pin bits clear, which those two agree on and the previous pulled-up value contradicted.

A CompactFlash card presents an ATA device through the CF register layout the Aminet drivers use; an SRAM card presents a CIS that card.resource accepts as credit-card RAM. Cards can be inserted and ejected at runtime from the menu or through `pcmcia.insert` / `pcmcia.eject`.

## CHD hard disks

Compressed CHD images attach on every controller through the shared drive backend, so Gayle IDE, A4000 IDE, lide, the SCSI controllers and copperhf all accept them. Raw-header validation runs before the decoder sees the file, bounding the allocations that the CD path already had to guard. Guest writes land in a copy-on-write `.wov` sidecar, so the image itself stays byte-identical and an unwritable sidecar degrades to a write-protected volume rather than losing writes. Write protection now surfaces properly: DATA PROTECT with ASC 0x27 over SCSI, `TDERR_WriteProt` over copperhf, and the mode-sense WP bit.

`.chd` files are classified by their metadata rather than their extension, which is what previously caused a hard-disk CHD to be attached as a CD-ROM.

## Host serial port

`[serial] mode = "device"` bridges Paula's UART to a real host port. The guest's SERPER rate is mapped onto the line, DTR and RTS follow CIA-B, and CTS, DSR and DCD feed back through the existing control-line model, so a null-modem session against real hardware behaves. Hot-unplug reads as an unplugged cable and reconnects rather than panicking.

## Testing

- `cargo test`: 3851 pass, 0 fail. New hardware tests cover the adapter's pin grounding per socket and under DDR, the light-pen latch read back through VPOSR/VHPOSR on both A500 and A1000 wiring, the pen switch on the third-button line, Gayle's pins and change latches, the CF task-file mapping per configuration, CHD addressing across hunks, and the overlay's persistence, foreign-image refusal and torn-record recovery.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- Golden render probes unchanged (45 pass): the new input devices do not perturb the emulated timeline.
- Booted Kickstart 3.1 on an A1200 with an empty slot, with a CF card, with 8 MB of fast RAM shadowing the slot, and with a 2 MB SRAM card, where card.resource adds the card as credit-card RAM. Booted AmigaSYS Workbench from a converted CHD and confirmed the image checksum is unchanged with the writes in the sidecar.
- Not covered: a real serial adapter (none available; a pty cannot stand in on macOS because the line-rate ioctl rejects it), and SRAM `CC0:` carddisk use.

## Note for whoever merges

One of three PRs from the same batch. The others touch `docs/guide/configuration.md` and `src/config/tests.rs` nearby, so the later ones will need a small rebase.