### PR TITLE
Band-limit Paula's output onto the host mixer grid

### DIFF
--- a/docs/internals/audio.md
+++ b/docs/internals/audio.md
@@ -6,6 +6,82 @@ routes the master mix and individual sources to playback or WAV capture.
 Mixing, LED filtering, volume, and stereo width are applied in
 `Paula::push_mixed_frame` (`src/chipset/paula.rs`).
 
+## Getting Paula onto the host grid
+
+Paula's four channels are a staircase: each holds its 8-bit sample for
+`AUDxPER` colour clocks, so a channel steps at up to ~28.6 kHz and the
+summed output only ever changes on the 3.546895 MHz colour-clock grid.
+Landing that on the mixer's 44.1 kHz grid is a decimation by ~80.4, and
+doing it by reading the staircase at each output instant would fold
+everything above the mixer's Nyquist straight back into the audible band.
+The staircase is rich up there: a full-scale 10 kHz square (two samples at
+`AUDxPER` 177, what Amiga Test Kit's audio page plays) carries harmonics at
+30, 50 and 70 kHz, which point sampling turns into tones at 14.0, 6.0 and
+18.1 kHz -- inharmonic, so heard as ringing rather than brightness, and
+loud, the worst of them only 10 dB under the tone itself.
+
+So the mix runs in two stages, both in `Paula::advance_audio`:
+
+1. **Exact integration to an oversample grid.** `PAULA_OVERSAMPLE` (4) times
+   the mixer rate, so 176.4 kHz. `advance_audio` splits its span so that no
+   oversample instant and no channel period expiry falls strictly inside a
+   step (`cck_until_mix_input_changes`), which means each channel's
+   contribution is constant across the step and `channel_area` can
+   accumulate `sample * volume * clocks` exactly. Dividing by the interval
+   width at each oversample instant is then a true box average of the
+   staircase, not a sample of whichever step the instant landed on.
+2. **Windowed-sinc decimation to the mixer grid.** One
+   `audio::resample::Decimator` per channel, 4:1, sharing the 64-tap
+   Blackman-windowed kernel `Resampler` uses. Per channel rather than per
+   side because decimation is linear -- filtering each channel and summing
+   is the same signal as filtering the sum -- which keeps the per-channel
+   stem taps exactly consistent with the mix they add up to.
+
+Neither stage touches the emulated timeline: `advance_audio` runs the same
+channel state machine over the same colour clocks either way, and the extra
+splitting only changes how often it is re-entered. The box stage needs the
+oversample rate well above Paula's own; the sinc stage needs it low enough
+that the kernel's transition band stays clear of the top of the audio band.
+Four satisfies both, and puts the worst surviving image about 47 dB under
+the tone. Raising the oversample rate or lengthening the kernel does not
+measurably improve on it.
+
+The genuine zero-order-hold images of Paula's own sample rate are *not*
+filtered out, because they are real output: the 500 Hz sine test at
+`AUDxPER` 177 keeps its images at 19.5 and 20.5 kHz, exactly as the
+hardware produces them ahead of its analogue filter.
+
+### Level
+
+One channel's DAC level is `sample * volume`, -8192..8128. Two channels
+reach each side, so full scale is both of them saturated at full volume --
+and then the band-limited waveform overshoots the steps it came from, since
+taking the harmonics away leaves something taller than the square that
+carried them. The most any Paula channel can overshoot is set by its
+shortest legal period: `AUDxPER` 124 holds a sample for a little over six
+oversample intervals, and the most a run that long can draw out of the
+kernel is 1.3241x the staircase. `PAULA_RECONSTRUCTION_HEADROOM` rounds
+that to 1.33, and `PAULA_MIX_SCALE` divides it out, so nothing Paula can
+play leaves [-1.0, 1.0] and nothing downstream has to clip it. A real
+Amiga's analogue reconstruction filter overshoots its own DAC the same way;
+this is just where a line input would have to be set.
+
+Everything line-mixed alongside Paula (drive sounds, CD-DA, an in-process
+synth, Toccata, MHI) is added after this scaling and keeps its level
+relative to a Paula channel. Their sum with Paula is not separately limited,
+so a CD32 playing a full-scale CD track under a full-scale module can still
+ask for more than full scale.
+
+### The LED filter sits after all of this
+
+`StereoLedFilter` runs at the mixer rate, on the decimated sum, which is
+where hardware puts it -- after the channel mixer's summation. That only
+works because the decimation above is band-limited. Filtering a
+point-sampled mix instead would attenuate the real tone while leaving
+untouched the aliases that had already folded below the cutoff: with the
+filter engaged, the 10 kHz test used to come out as a 2 kHz buzz nearly 6 dB
+*louder* than the tone it was supposed to be attenuating.
+
 (why-a-mux-exists)=
 ## Mixing and capture
 
@@ -81,6 +157,17 @@ runs. Reproducibility still depends on repeatable source input; see the
 `Bus::adopt_host_resources` moves the live mux, including open stem writers,
 onto the restored Bus. A capture therefore continues in the same files
 across a save-state load.
+
+The decimation state does ride the state: `channel_area`/`area_cck` carry
+the partly integrated oversample interval, and each `Decimator` carries its
+tap history (but not its kernel, which `Deserialize` rebuilds from the
+factor, as `Resampler` does). `host_sample_acc` keeps the meaning and range
+it always had -- colour clocks times the mixer rate, rolling at
+`PAULA_CLOCK_HZ` -- with the oversample grid read off it as a finer
+threshold, so the `PAUL` chunk needed no version bump. All three fields are
+`#[serde(default)]`: a state written before the decimation existed resumes
+with silent tap histories, which is a millisecond of filter warm-up and no
+click.
 
 ## Web build
 

--- a/docs/internals/audio.md
+++ b/docs/internals/audio.md
@@ -57,14 +57,23 @@ One channel's DAC level is `sample * volume`, -8192..8128. Two channels
 reach each side, so full scale is both of them saturated at full volume --
 and then the band-limited waveform overshoots the steps it came from, since
 taking the harmonics away leaves something taller than the square that
-carried them. The most any Paula channel can overshoot is set by its
-shortest legal period: `AUDxPER` 124 holds a sample for a little over six
-oversample intervals, and the most a run that long can draw out of the
-kernel is 1.3241x the staircase. `PAULA_RECONSTRUCTION_HEADROOM` rounds
-that to 1.33, and `PAULA_MIX_SCALE` divides it out, so nothing Paula can
-play leaves [-1.0, 1.0] and nothing downstream has to clip it. A real
-Amiga's analogue reconstruction filter overshoots its own DAC the same way;
-this is just where a line input would have to be set.
+carried them. A full-scale 10 kHz square keeps only its fundamental, at
+4/PI of the square's peak; a 25% pulse train does better still.
+
+How much better depends on how fast the staircase is allowed to move, and
+nothing bounds that. `AUDxPER` has no floor in the hardware or in
+`aud_percntrld`, `PAL_AUDIO_MIN_PERIOD_CCK` and `NTSC_AUDIO_MIN_PERIOD_CCK`
+describe what audio DMA can sustain rather than what a channel will accept,
+and a CPU feeding `AUDxDAT` in IRQ mode is not held to either. So the
+headroom comes from the decimation kernel instead: the sum of its absolute
+taps, 1.5792, is the most it can make of input bounded by full scale,
+whatever that input is. `PAULA_RECONSTRUCTION_HEADROOM` rounds that up to
+1.58 and `PAULA_MIX_SCALE` divides it out, so nothing Paula can play leaves
+[-1.0, 1.0] and nothing downstream has to clip it. The bound is held to the
+kernel it is claimed for by
+`the_mix_headroom_covers_the_decimation_kernel`. A real Amiga's analogue
+reconstruction filter overshoots its own DAC the same way; this is just
+where a line input would have to be set.
 
 Everything line-mixed alongside Paula (drive sounds, CD-DA, an in-process
 synth, Toccata, MHI) is added after this scaling and keeps its level
@@ -163,11 +172,18 @@ the partly integrated oversample interval, and each `Decimator` carries its
 tap history (but not its kernel, which `Deserialize` rebuilds from the
 factor, as `Resampler` does). `host_sample_acc` keeps the meaning and range
 it always had -- colour clocks times the mixer rate, rolling at
-`PAULA_CLOCK_HZ` -- with the oversample grid read off it as a finer
-threshold, so the `PAUL` chunk needed no version bump. All three fields are
-`#[serde(default)]`: a state written before the decimation existed resumes
-with silent tap histories, which is a millisecond of filter warm-up and no
-click.
+`PAULA_CLOCK_HZ` -- with both the oversample grid and the mixer frame read
+off it as thresholds, so the `PAUL` chunk needed no version bump. All three
+fields are `#[serde(default)]`: a state written before the decimation
+existed resumes with silent tap histories, which is a millisecond of filter
+warm-up and no click.
+
+Nothing else tracks where in a mixer frame the machine is. A `Decimator`
+holds tap history and nothing more -- it is `advance_audio` that says when
+an output is due, from the accumulator. Had the decimators counted their
+own way to each frame, a state restored with the accumulator part way
+through one would have set them counting from zero, and the mix would have
+come out a slice or three late from then on, permanently.
 
 ## Web build
 

--- a/src/audio/resample.rs
+++ b/src/audio/resample.rs
@@ -170,7 +170,9 @@ impl<'de> serde::Deserialize<'de> for Resampler {
 /// filtering the sum, and it keeps the per-channel stem taps exactly
 /// consistent with the mix.
 pub struct Decimator {
-    /// Input samples per output sample.
+    /// Input samples per output sample. Kept only to rebuild `taps` on
+    /// deserialization; the caller owns the grid and says when it wants an
+    /// output, so this type does no counting of its own.
     factor: u32,
     /// The single windowed-sinc kernel, cutting just inside the output's
     /// Nyquist. A pure function of `factor`, so `Deserialize` rebuilds it
@@ -180,8 +182,6 @@ pub struct Decimator {
     /// window starting at `head` is always one contiguous slice.
     history: Vec<f32>,
     head: usize,
-    /// Input samples taken since the last output sample.
-    count: u32,
 }
 
 impl Decimator {
@@ -192,49 +192,58 @@ impl Decimator {
             taps: build_kernels(1, factor),
             history: vec![0.0; 2 * TAPS],
             head: 0,
-            count: 0,
         }
     }
 
-    /// One input sample in; the band-limited output sample once `factor` of
-    /// them have arrived. Starting from a zeroed history means a fresh
-    /// decimator (or one restored from a state written before Paula had
-    /// one) opens on silence rather than a click.
-    pub fn push(&mut self, sample: f32) -> Option<f32> {
+    /// One input sample into the history. Starting from a zeroed history
+    /// means a fresh decimator (or one restored from a state written before
+    /// Paula had one) opens on silence rather than a click.
+    pub fn push(&mut self, sample: f32) {
         self.history[self.head] = sample;
         self.history[self.head + TAPS] = sample;
         self.head += 1;
         if self.head == TAPS {
             self.head = 0;
         }
-        self.count += 1;
-        if self.count < self.factor {
-            return None;
-        }
-        self.count = 0;
+    }
+
+    /// The band-limited value at the current instant. Meaningful once
+    /// `factor` samples have been pushed since the last one was taken --
+    /// which is the caller's business, not this type's, so that the phase
+    /// of the output grid lives in exactly one place instead of being
+    /// mirrored in a counter here that a restored state could contradict.
+    pub fn output(&self) -> f32 {
         let window = &self.history[self.head..self.head + TAPS];
-        Some(window.iter().zip(&self.taps).map(|(&s, &t)| s * t).sum())
+        window.iter().zip(&self.taps).map(|(&s, &t)| s * t).sum()
+    }
+
+    /// The largest output magnitude the kernel can produce from input
+    /// bounded by 1.0, the sum of the absolute taps. Unlike any bound
+    /// argued from how fast the source can change, this holds for every
+    /// input, so it is what a caller sizes its headroom against.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn peak_gain(&self) -> f32 {
+        self.taps.iter().map(|tap| tap.abs()).sum()
     }
 }
 
-/// `factor`/`history`/`head`/`count` -- everything except the derived
-/// `taps`, rebuilt from `factor` by [`build_kernels`], exactly as
-/// [`Resampler`] treats its kernel bank.
+/// `factor`/`history`/`head` -- everything except the derived `taps`,
+/// rebuilt from `factor` by [`build_kernels`], exactly as [`Resampler`]
+/// treats its kernel bank.
 impl serde::Serialize for Decimator {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        (self.factor, &self.history, self.head, self.count).serialize(serializer)
+        (self.factor, &self.history, self.head).serialize(serializer)
     }
 }
 
 impl<'de> serde::Deserialize<'de> for Decimator {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let (factor, history, head, count) = serde::Deserialize::deserialize(deserializer)?;
+        let (factor, history, head) = serde::Deserialize::deserialize(deserializer)?;
         Ok(Decimator {
             factor,
             taps: build_kernels(1, factor),
             history,
             head,
-            count,
         })
     }
 }
@@ -305,22 +314,30 @@ mod tests {
         let mut decimator = Decimator::new(4);
         let mut worst = 0.0f32;
         for i in 0..4_000 {
-            if let Some(out) = decimator.push(0.25) {
-                // Skip the tap history filling with the opening zeros.
-                if i > TAPS {
-                    worst = worst.max((out - 0.25).abs());
-                }
+            decimator.push(0.25);
+            // Skip the tap history filling with the opening zeros.
+            if i > TAPS && i % 4 == 0 {
+                worst = worst.max((decimator.output() - 0.25).abs());
             }
         }
         assert!(worst < 1e-6, "DC shifted by {worst}");
     }
 
-    /// One output sample per `factor` inputs, exactly, from the first one on.
+    /// The peak gain bound is the sum of the absolute taps, and it really
+    /// does bound the output: the worst input is one that matches the sign
+    /// of every tap.
     #[test]
-    fn decimation_yields_one_sample_per_factor_inputs() {
-        let mut decimator = Decimator::new(4);
-        let yielded = (0..400).filter(|_| decimator.push(0.0).is_some()).count();
-        assert_eq!(yielded, 100);
+    fn peak_gain_bounds_the_worst_case_input() {
+        let decimator = Decimator::new(4);
+        let bound = decimator.peak_gain();
+        assert!(bound > 1.0, "a band-limiting kernel overshoots: {bound}");
+
+        let mut worst = Decimator::new(4);
+        let signs: Vec<f32> = worst.taps.iter().map(|&t| t.signum()).collect();
+        for sign in &signs {
+            worst.push(*sign);
+        }
+        assert!((worst.output() - bound).abs() < 1e-5);
     }
 
     /// Content above the output's Nyquist is suppressed, not folded back
@@ -333,10 +350,9 @@ mod tests {
         let mut peak = 0.0f32;
         for i in 0..8_192 {
             let input = (std::f64::consts::TAU * 30_000.0 * f64::from(i) / rate).sin() as f32;
-            if let Some(out) = decimator.push(input) {
-                if i > TAPS as i32 {
-                    peak = peak.max(out.abs());
-                }
+            decimator.push(input);
+            if i > TAPS as i32 && i % 4 == 0 {
+                peak = peak.max(decimator.output().abs());
             }
         }
         assert!(peak < 0.001, "30 kHz survived decimation at {peak}");

--- a/src/audio/resample.rs
+++ b/src/audio/resample.rs
@@ -156,6 +156,89 @@ impl<'de> serde::Deserialize<'de> for Resampler {
     }
 }
 
+/// Fixed integer-ratio decimation of a source already produced on a whole
+/// multiple of the mixer's grid -- Paula's oversampled channel stream.
+///
+/// [`Resampler`] pulls from a source running on its own clock at an
+/// arbitrary rational ratio; this is the other shape. The emulated chipset
+/// pushes samples as colour clocks go by and already knows when each
+/// output frame is due, so the conversion is one fixed windowed-sinc
+/// kernel (the `l == 1` case of [`build_kernels`]) and a counter: push
+/// `factor` input samples, get one band-limited output sample back.
+/// Mono, because the caller band-limits each Paula channel separately and
+/// sums the results -- decimation is linear, so that is the same signal as
+/// filtering the sum, and it keeps the per-channel stem taps exactly
+/// consistent with the mix.
+pub struct Decimator {
+    /// Input samples per output sample.
+    factor: u32,
+    /// The single windowed-sinc kernel, cutting just inside the output's
+    /// Nyquist. A pure function of `factor`, so `Deserialize` rebuilds it
+    /// rather than carrying it in the savestate, as [`Resampler`] does.
+    taps: Vec<f32>,
+    /// The last [`TAPS`] input samples, written twice [`TAPS`] apart so the
+    /// window starting at `head` is always one contiguous slice.
+    history: Vec<f32>,
+    head: usize,
+    /// Input samples taken since the last output sample.
+    count: u32,
+}
+
+impl Decimator {
+    pub fn new(factor: u32) -> Decimator {
+        let factor = factor.max(1);
+        Decimator {
+            factor,
+            taps: build_kernels(1, factor),
+            history: vec![0.0; 2 * TAPS],
+            head: 0,
+            count: 0,
+        }
+    }
+
+    /// One input sample in; the band-limited output sample once `factor` of
+    /// them have arrived. Starting from a zeroed history means a fresh
+    /// decimator (or one restored from a state written before Paula had
+    /// one) opens on silence rather than a click.
+    pub fn push(&mut self, sample: f32) -> Option<f32> {
+        self.history[self.head] = sample;
+        self.history[self.head + TAPS] = sample;
+        self.head += 1;
+        if self.head == TAPS {
+            self.head = 0;
+        }
+        self.count += 1;
+        if self.count < self.factor {
+            return None;
+        }
+        self.count = 0;
+        let window = &self.history[self.head..self.head + TAPS];
+        Some(window.iter().zip(&self.taps).map(|(&s, &t)| s * t).sum())
+    }
+}
+
+/// `factor`/`history`/`head`/`count` -- everything except the derived
+/// `taps`, rebuilt from `factor` by [`build_kernels`], exactly as
+/// [`Resampler`] treats its kernel bank.
+impl serde::Serialize for Decimator {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        (self.factor, &self.history, self.head, self.count).serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Decimator {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let (factor, history, head, count) = serde::Deserialize::deserialize(deserializer)?;
+        Ok(Decimator {
+            factor,
+            taps: build_kernels(1, factor),
+            history,
+            head,
+            count,
+        })
+    }
+}
+
 fn gcd(a: u32, b: u32) -> u32 {
     if b == 0 {
         a
@@ -213,6 +296,50 @@ mod tests {
         // The first TAPS frames prime the history; every 441 outputs
         // after that pull exactly 320 more.
         assert_eq!(pulled, TAPS as u64 + 320 * 100);
+    }
+
+    /// A constant comes out the same constant: the decimation kernel is
+    /// unity at DC, like the resampler's.
+    #[test]
+    fn decimation_preserves_dc() {
+        let mut decimator = Decimator::new(4);
+        let mut worst = 0.0f32;
+        for i in 0..4_000 {
+            if let Some(out) = decimator.push(0.25) {
+                // Skip the tap history filling with the opening zeros.
+                if i > TAPS {
+                    worst = worst.max((out - 0.25).abs());
+                }
+            }
+        }
+        assert!(worst < 1e-6, "DC shifted by {worst}");
+    }
+
+    /// One output sample per `factor` inputs, exactly, from the first one on.
+    #[test]
+    fn decimation_yields_one_sample_per_factor_inputs() {
+        let mut decimator = Decimator::new(4);
+        let yielded = (0..400).filter(|_| decimator.push(0.0).is_some()).count();
+        assert_eq!(yielded, 100);
+    }
+
+    /// Content above the output's Nyquist is suppressed, not folded back
+    /// down the band: 30 kHz decimated to 44.1 kHz would otherwise arrive as
+    /// a 14.1 kHz tone at full level.
+    #[test]
+    fn decimation_suppresses_content_above_the_output_nyquist() {
+        let mut decimator = Decimator::new(4);
+        let rate = 44_100.0 * 4.0;
+        let mut peak = 0.0f32;
+        for i in 0..8_192 {
+            let input = (std::f64::consts::TAU * 30_000.0 * f64::from(i) / rate).sin() as f32;
+            if let Some(out) = decimator.push(input) {
+                if i > TAPS as i32 {
+                    peak = peak.max(out.abs());
+                }
+            }
+        }
+        assert!(peak < 0.001, "30 kHz survived decimation at {peak}");
     }
 
     /// A tone under the source's Nyquist keeps its level; imaging above

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -2321,14 +2321,17 @@ fn audio_time_flushes_before_audio_register_write() {
     bus.paula.write_audio_reg(0x08, 64, 0);
     assert!(!bus.custom_write(0xDFF096, 2, (0x8000 | DMACON_DMAEN | 0x0001) as u64));
 
-    // Two scanlines for the two start-up fetches, then some output time.
-    bus.advance_chipset(800);
+    // Two scanlines for the two start-up fetches, then enough output time
+    // for the band-limiting decimators to settle on the held sample -- the
+    // mix reaches its DC level only once their tap histories have filled.
+    bus.advance_chipset(6000);
     frames.borrow_mut().clear();
 
     let _ = bus.custom_write(0xDFF0A8, 2, 0);
     let frames = frames.borrow();
+    let audible = 0.5 * 127.0 * 64.0 * crate::chipset::paula::PAULA_MIX_SCALE;
     assert!(
-        frames.iter().any(|(left, _)| left.abs() > 0.5),
+        frames.iter().any(|(left, _)| left.abs() > audible),
         "pending audio should be mixed with the old volume before AUD0VOL is changed: {frames:?}"
     );
 }

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -77,16 +77,20 @@ const PAULA_OVERSAMPLE: u32 = 4;
 /// Band-limiting takes the staircase's harmonics away, and what is left
 /// overshoots the steps it came from: a full-scale square at 10 kHz keeps
 /// only its fundamental, whose peak is 4/PI of the square's, and a
-/// full-scale 25% pulse train does slightly better still. The worst any
-/// Paula channel can reach is set by its shortest legal period: AUDxPER
-/// 124 holds each sample for a little over six oversample intervals, and
-/// the most a run that long can pull out of the decimation kernel is
-/// 1.3241 times the staircase it came from. A real Amiga's analogue
-/// reconstruction filter overshoots its own DAC the same way, so this is
-/// simply where a line input would have to be set; folding it in here is
-/// what keeps the loudest thing Paula can play inside the host's range
-/// instead of clipping on the way out.
-const PAULA_RECONSTRUCTION_HEADROOM: f32 = 1.33;
+/// full-scale 25% pulse train does slightly better still. How much better
+/// depends on how fast the staircase is allowed to move, and nothing here
+/// bounds that -- AUDxPER has no floor in the hardware or in
+/// `aud_percntrld`, and a CPU feeding AUDxDAT in IRQ mode is not held to
+/// the period audio DMA can sustain -- so the headroom is taken from the
+/// decimation kernel instead: the sum of its absolute taps is the most it
+/// can produce from input bounded by full scale, whatever the input is.
+/// `the_mix_headroom_covers_the_decimation_kernel` holds this to the
+/// kernel it is claimed for. A real Amiga's analogue reconstruction filter
+/// overshoots its own DAC the same way, so this is simply where a line
+/// input would have to be set; folding it in here is what keeps everything
+/// Paula can play inside the host's range instead of clipping on the way
+/// out.
+const PAULA_RECONSTRUCTION_HEADROOM: f32 = 1.58;
 
 /// What one channel's DAC level (sample * volume, -8192..8128) is worth in
 /// the host mix. Two channels reach each side, and the band-limited
@@ -532,7 +536,9 @@ pub struct Paula {
     #[serde(default)]
     area_cck: u32,
     /// Band-limits each channel's oversampled staircase onto the mixer
-    /// grid. Per channel rather than per side because decimation is linear:
+    /// grid. Holds tap history only: the phase of the mixer grid lives in
+    /// `host_sample_acc` alone, so nothing here can contradict it.
+    /// Per channel rather than per side because decimation is linear:
     /// filtering each channel and summing is the same signal as filtering
     /// the sum, and it leaves the per-channel stem taps exactly consistent
     /// with the mix they add up to.
@@ -1714,8 +1720,14 @@ impl Paula {
             for _ in before..self.oversample_index() {
                 self.push_oversample_frame();
             }
+            // The last slice of the frame is the frame: the accumulator is
+            // the only thing that says when a mixer frame is due, so a
+            // state restored mid-frame stays in phase without the
+            // decimators having to agree about where they were.
             if self.host_sample_acc >= PAULA_CLOCK_HZ as u64 {
                 self.host_sample_acc -= PAULA_CLOCK_HZ as u64;
+                let mixed = std::array::from_fn(|i| self.channel_decimator[i].output());
+                self.push_mixed_frame(mixed);
             }
         }
 
@@ -1730,27 +1742,17 @@ impl Paula {
         self.host_sample_acc * u64::from(PAULA_OVERSAMPLE) / PAULA_CLOCK_HZ as u64
     }
 
-    /// Close one oversample interval: the exact box average of each
-    /// channel over it, band-limited towards the mixer grid, and a mixer
-    /// frame whenever the decimators yield one.
+    /// Close one oversample interval: each channel's exact box average over
+    /// it, into the band-limiting decimators. Whether this interval was
+    /// also a mixer frame is `advance_audio`'s business.
     fn push_oversample_frame(&mut self) {
         let width = self.area_cck.max(1) as f32;
-        // The four decimators run in lockstep -- same factor, pushed
-        // together -- so either all of them yield on this sample or none do.
-        let mut mixed = [0.0f32; 4];
-        let mut due = false;
         for ch_idx in 0..4 {
             let average = self.channel_area[ch_idx] as f32 / width;
-            if let Some(out) = self.channel_decimator[ch_idx].push(average) {
-                mixed[ch_idx] = out;
-                due = true;
-            }
+            self.channel_decimator[ch_idx].push(average);
         }
         self.channel_area = [0; 4];
         self.area_cck = 0;
-        if due {
-            self.push_mixed_frame(mixed);
-        }
     }
 
     // ---- HRM state-machine terms (the appendix's signal names) ----
@@ -4104,14 +4106,59 @@ mod tests {
         }
     }
 
+    /// The headroom the mix leaves has to cover the kernel it is claimed
+    /// for: the sum of the absolute taps is the most that kernel can make
+    /// of input bounded by full scale, so a mix scaled by it cannot leave
+    /// the host's range whatever the guest plays. Bounding this by how fast
+    /// AUDxPER lets the staircase move would not do -- nothing enforces a
+    /// minimum period, and a CPU feeding AUDxDAT in IRQ mode is not held to
+    /// the one audio DMA can sustain.
+    #[test]
+    fn the_mix_headroom_covers_the_decimation_kernel() {
+        let peak = Decimator::new(PAULA_OVERSAMPLE).peak_gain();
+        assert!(
+            peak <= PAULA_RECONSTRUCTION_HEADROOM,
+            "kernel can reach {peak} but the mix only leaves              {PAULA_RECONSTRUCTION_HEADROOM}"
+        );
+    }
+
+    /// A state written before the decimators existed restores them empty,
+    /// but carries `host_sample_acc` meaning exactly what it always meant.
+    /// The mixer cadence is read off that accumulator alone, so such a
+    /// resume is in phase from its first frame instead of being left
+    /// however far into a mixer frame it was saved, forever.
+    #[test]
+    fn the_mixer_cadence_follows_the_accumulator_not_the_decimators() {
+        for slice in 0..u64::from(PAULA_OVERSAMPLE) {
+            let (mut paula, frames) = paula_with_collect_sink();
+            // What an older state restores: an accumulator already part way
+            // into a mixer frame, and decimators that have never seen a
+            // sample.
+            paula.host_sample_acc = slice * PAULA_CLOCK_HZ as u64 / u64::from(PAULA_OVERSAMPLE) + 1;
+
+            // Exactly the colour clocks left in the frame it was saved in.
+            let left_in_frame = (PAULA_CLOCK_HZ as u64 - paula.host_sample_acc)
+                .div_ceil(MIX_SAMPLE_RATE as u64) as u32;
+            paula.advance_audio(left_in_frame, 0);
+
+            // That frame, and no more: a decimator counting its own way to
+            // four would still be waiting on the slices already behind it.
+            assert_eq!(
+                frames.borrow().len(),
+                1,
+                "resuming at oversample slice {slice} did not finish its mixer frame"
+            );
+        }
+    }
+
     /// Full scale is two channels saturated at full volume, plus the
     /// headroom the band-limited waveform needs to overshoot the steps it
     /// came from. Amiga Test Kit plays exactly that -- one sample on all
     /// four channels at volume 64 -- and nothing downstream of the mix
     /// clips, so the mix itself has to stay inside the host's range. Swept
-    /// over periods and duty cycles because the worst overshoot is not the
-    /// square: a 25% pulse train near 4.9 kHz asks for the most, and the
-    /// shortest legal period is what bounds it.
+    /// over duty cycles because the worst overshoot is not the square (a
+    /// 25% pulse train asks for more), and down past the period audio DMA
+    /// can sustain, since nothing stops a guest asking for one.
     #[test]
     fn nothing_paula_can_play_leaves_the_host_range() {
         for pattern in [
@@ -4120,7 +4167,9 @@ mod tests {
             [0x7F, 0x7F, 0x7F, 0x80],
             [0x7F, 0x80, 0x80, 0x80],
         ] {
-            for per in [124u16, 143, 161, 177, 181, 203, 254, 320, 404] {
+            for per in [
+                8u16, 20, 41, 80, 113, 123, 124, 143, 161, 177, 181, 203, 254, 320, 404,
+            ] {
                 let (mut paula, frames) = paula_with_collect_sink();
                 paula.set_led_filter_guest(false);
                 play_all_channels(&mut paula, &pattern, per, 0.05);

--- a/src/chipset/paula.rs
+++ b/src/chipset/paula.rs
@@ -4,6 +4,7 @@
 //! and four-channel audio DMA + mixer.
 
 use crate::audio::mux::AudioMux;
+use crate::audio::resample::Decimator;
 use crate::audio::{AudioRuntimeStatus, AudioSink, MIX_SAMPLE_RATE};
 use crate::drive_sounds::DriveSounds;
 use crate::serial::SerialSink;
@@ -54,6 +55,46 @@ const ADKCON_UARTBRK: u16 = 1 << 11;
 /// DMACON.DMAEN master enable. Stored on agnus.dmacon; Paula audio
 /// gating ANDs this with the per-channel AUDxEN bits 0..3.
 pub const DMACON_DMAEN: u16 = 1 << 9;
+/// How many times the mixer's rate Paula's own channels are summed at
+/// before being filtered down onto it.
+///
+/// Paula's DAC output is a staircase that steps on the colour-clock grid,
+/// at up to ~28.6 kHz per channel. Landing that directly on a 44.1 kHz
+/// grid folds everything above the mixer's Nyquist back into the audible
+/// band: a 10 kHz square's third harmonic at 30 kHz arrives as a 14 kHz
+/// whistle, its fifth as 6 kHz, and so on -- inharmonic, so it is heard as
+/// ringing rather than brightness. Integrating the staircase exactly over
+/// each oversample interval and then filtering 4:1 with a windowed sinc
+/// puts the worst surviving image about 47 dB under the tone. Four is
+/// where the two stages balance: the box average needs the oversample rate
+/// well above Paula's own, and the sinc's transition band needs it low
+/// enough to stay clear of the top of the audio band. See
+/// `docs/internals/audio.md`.
+const PAULA_OVERSAMPLE: u32 = 4;
+
+/// Peak headroom the mix leaves for reconstruction overshoot.
+///
+/// Band-limiting takes the staircase's harmonics away, and what is left
+/// overshoots the steps it came from: a full-scale square at 10 kHz keeps
+/// only its fundamental, whose peak is 4/PI of the square's, and a
+/// full-scale 25% pulse train does slightly better still. The worst any
+/// Paula channel can reach is set by its shortest legal period: AUDxPER
+/// 124 holds each sample for a little over six oversample intervals, and
+/// the most a run that long can pull out of the decimation kernel is
+/// 1.3241 times the staircase it came from. A real Amiga's analogue
+/// reconstruction filter overshoots its own DAC the same way, so this is
+/// simply where a line input would have to be set; folding it in here is
+/// what keeps the loudest thing Paula can play inside the host's range
+/// instead of clipping on the way out.
+const PAULA_RECONSTRUCTION_HEADROOM: f32 = 1.33;
+
+/// What one channel's DAC level (sample * volume, -8192..8128) is worth in
+/// the host mix. Two channels reach each side, and the band-limited
+/// waveform overshoots them by up to
+/// [`PAULA_RECONSTRUCTION_HEADROOM`], so this is the divisor that puts the
+/// loudest thing Paula can play at exactly full scale.
+pub(crate) const PAULA_MIX_SCALE: f32 = 1.0 / (128.0 * 64.0 * 2.0 * PAULA_RECONSTRUCTION_HEADROOM);
+
 const LED_FILTER_CUTOFF_HZ: f32 = 4_000.0;
 
 /// HRM audio state-machine states (Paula's three per-channel state bits).
@@ -427,6 +468,12 @@ fn default_true() -> bool {
     true
 }
 
+/// One band-limiting decimator per Paula channel. Also the `serde` default,
+/// so a state written before Paula had them resumes with silent histories.
+fn channel_decimators() -> [Decimator; 4] {
+    std::array::from_fn(|_| Decimator::new(PAULA_OVERSAMPLE))
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Paula {
     pub serper: u16,
@@ -471,8 +518,26 @@ pub struct Paula {
 
     // Mixer host-sample accumulator in units of
     // color-clocks * MIX_SAMPLE_RATE. One output frame is due each
-    // time this reaches PAULA_CLOCK_HZ.
+    // time this reaches PAULA_CLOCK_HZ, and one oversample frame each
+    // time it crosses a PAULA_OVERSAMPLE'th of the way there.
     host_sample_acc: u64,
+    /// Exact integral of each channel's mixed output (DAC sample * volume)
+    /// over the colour clocks since the last oversample instant, and the
+    /// width of that box. Paula's output only steps at period expiries, so
+    /// accumulating `sample * clocks` as the counters run integrates the
+    /// staircase exactly -- the oversample frame is a true average over its
+    /// interval, not whichever step the instant landed on.
+    #[serde(default)]
+    channel_area: [i64; 4],
+    #[serde(default)]
+    area_cck: u32,
+    /// Band-limits each channel's oversampled staircase onto the mixer
+    /// grid. Per channel rather than per side because decimation is linear:
+    /// filtering each channel and summing is the same signal as filtering
+    /// the sum, and it leaves the per-channel stem taps exactly consistent
+    /// with the mix they add up to.
+    #[serde(default = "channel_decimators")]
+    channel_decimator: [Decimator; 4],
 
     /// Effective filter state (what the mix actually applies), resolved from
     /// the mode and the guest's /LED line.
@@ -625,6 +690,9 @@ impl Paula {
             #[cfg(test)]
             test_line_cck: 0,
             host_sample_acc: 0,
+            channel_area: [0; 4],
+            area_cck: 0,
+            channel_decimator: channel_decimators(),
             led_filter_enabled: true,
             led_filter_mode: crate::config::AudioFilterMode::Auto,
             led_filter_guest_on: true,
@@ -860,6 +928,9 @@ impl Paula {
         self.pot_active = [false; 4];
         self.pot_discharge_lines = 0;
         self.host_sample_acc = 0;
+        self.channel_area = [0; 4];
+        self.area_cck = 0;
+        self.channel_decimator = channel_decimators();
         // A reset releases the guest's /LED line; the filter override is a host
         // preference and stays put.
         self.led_filter_guest_on = true;
@@ -1623,18 +1694,63 @@ impl Paula {
         let mut irq_bits = 0;
         let mut remaining = cck;
         while remaining > 0 {
-            let step = remaining.min(self.cck_until_next_output_frame());
+            // Bounded so the mixed output cannot change inside the step:
+            // no oversample instant and no channel period expiry falls
+            // strictly within it, which is what makes the integration
+            // below exact rather than a sample of one step of the
+            // staircase.
+            let step = remaining.min(self.cck_until_mix_input_changes());
+            for ch_idx in 0..4 {
+                self.channel_area[ch_idx] +=
+                    i64::from(self.channel_mixed_sample(ch_idx)) * i64::from(step);
+            }
+            self.area_cck += step;
+
             irq_bits |= self.advance_audio_channels(step, dmacon);
+
+            let before = self.oversample_index();
             self.host_sample_acc += step as u64 * MIX_SAMPLE_RATE as u64;
             remaining -= step;
-
-            while self.host_sample_acc >= PAULA_CLOCK_HZ as u64 {
+            for _ in before..self.oversample_index() {
+                self.push_oversample_frame();
+            }
+            if self.host_sample_acc >= PAULA_CLOCK_HZ as u64 {
                 self.host_sample_acc -= PAULA_CLOCK_HZ as u64;
-                self.push_mixed_frame();
             }
         }
 
         irq_bits
+    }
+
+    /// Which of the [`PAULA_OVERSAMPLE`] slices of the current mixer frame
+    /// the accumulator sits in, 0..=PAULA_OVERSAMPLE. Reaching the last one
+    /// is the mixer frame itself, so the same counter drives both grids and
+    /// keeps its meaning (and its range) across a save state.
+    fn oversample_index(&self) -> u64 {
+        self.host_sample_acc * u64::from(PAULA_OVERSAMPLE) / PAULA_CLOCK_HZ as u64
+    }
+
+    /// Close one oversample interval: the exact box average of each
+    /// channel over it, band-limited towards the mixer grid, and a mixer
+    /// frame whenever the decimators yield one.
+    fn push_oversample_frame(&mut self) {
+        let width = self.area_cck.max(1) as f32;
+        // The four decimators run in lockstep -- same factor, pushed
+        // together -- so either all of them yield on this sample or none do.
+        let mut mixed = [0.0f32; 4];
+        let mut due = false;
+        for ch_idx in 0..4 {
+            let average = self.channel_area[ch_idx] as f32 / width;
+            if let Some(out) = self.channel_decimator[ch_idx].push(average) {
+                mixed[ch_idx] = out;
+                due = true;
+            }
+        }
+        self.channel_area = [0; 4];
+        self.area_cck = 0;
+        if due {
+            self.push_mixed_frame(mixed);
+        }
     }
 
     // ---- HRM state-machine terms (the appendix's signal names) ----
@@ -1946,9 +2062,28 @@ impl Paula {
         irq_bits
     }
 
-    fn cck_until_next_output_frame(&self) -> u32 {
-        let needed = (PAULA_CLOCK_HZ as u64).saturating_sub(self.host_sample_acc);
-        needed.div_ceil(MIX_SAMPLE_RATE as u64).max(1) as u32
+    /// Colour clocks until the mixed output can next change: the next
+    /// oversample instant, or the next channel period expiry, whichever
+    /// comes first. `advance_audio` integrates across exactly this span, so
+    /// the sample must hold constant for all of it. An outputting channel's
+    /// `percnt` is always at least 1 (`aud_percntrld` reloads a zero
+    /// AUDxPER as 65536), so this never returns zero and never stalls.
+    fn cck_until_mix_input_changes(&self) -> u32 {
+        let mut cck = self.cck_until_next_oversample_frame();
+        for ch in &self.chans {
+            if ch.outputting() {
+                cck = cck.min(ch.percnt);
+            }
+        }
+        cck.max(1)
+    }
+
+    fn cck_until_next_oversample_frame(&self) -> u32 {
+        let edge = (self.oversample_index() + 1) * PAULA_CLOCK_HZ as u64;
+        let needed = edge.saturating_sub(self.host_sample_acc * u64::from(PAULA_OVERSAMPLE));
+        needed
+            .div_ceil(MIX_SAMPLE_RATE as u64 * u64::from(PAULA_OVERSAMPLE))
+            .max(1) as u32
     }
 
     /// The chip-RAM address the channel's next DMA slot will fetch, when a
@@ -2021,7 +2156,22 @@ impl Paula {
         irq_bits
     }
 
-    fn push_mixed_frame(&mut self) {
+    /// Mix one frame straight from the channels' present levels, for tests
+    /// that exercise the stages after the decimation (routing, LED filter,
+    /// volume, stereo width) rather than the decimation itself. The
+    /// decimators are unity at DC, so a held sample reaches the mixer
+    /// unchanged: this is the settled value of driving `advance_audio` with
+    /// the same state.
+    #[cfg(test)]
+    fn push_mixed_frame_from_channels(&mut self) {
+        let mixed = std::array::from_fn(|i| self.channel_mixed_sample(i) as f32);
+        self.push_mixed_frame(mixed);
+    }
+
+    /// Mix one frame onto the host grid from the four band-limited channel
+    /// levels `push_oversample_frame` produced, in DAC units (sample *
+    /// volume).
+    fn push_mixed_frame(&mut self, mixed: [f32; 4]) {
         let observe_host = !self.speculative_host_quiet;
         // Mix and push host-rate stereo frames into the sink. Paula
         // stereo routing follows the common A500/A600/A1200 and
@@ -2033,11 +2183,14 @@ impl Paula {
         // host PCM path linear until modelling the alternate PWM/filter
         // path as an explicit analog output mode.
         // Volume range is 0..64; each channel sample is signed 8-bit
-        // (-128..127). Scale into [-1.0, 1.0] approximately by
-        // dividing by (128.0 * 64.0). We sum two channels per side
-        // unclipped: worst case is +/-2.0 if both channels saturate
-        // with full volume in opposite phase, which is essentially
-        // never the case for real music.
+        // (-128..127). Two channels reach each side, so full scale is what
+        // both of them saturated at full volume produce, plus the headroom
+        // the band-limited waveform needs to overshoot them: dividing by
+        // (128 * 64 * 2 * PAULA_RECONSTRUCTION_HEADROOM) leaves nothing
+        // Paula can play able to run off the end of the host's range.
+        // Paula is the loudest thing in the mix, so everything line-mixed
+        // alongside it below keeps its level relative to a Paula channel
+        // unchanged.
         // Tap each channel's output level (DAC sample * volume, -128..127)
         // for the debugger oscilloscopes. This is pre-mute so a muted
         // channel's trace still shows its activity (drawn greyed).
@@ -2048,11 +2201,10 @@ impl Paula {
                 scope_push(&mut self.channel_scope[i], level as i8);
             }
         }
-        let l_raw = self.channel_mixed_sample(0) + self.channel_mixed_sample(3);
-        let r_raw = self.channel_mixed_sample(1) + self.channel_mixed_sample(2);
-        let scale = 1.0 / (128.0 * 64.0);
-        let mut left = l_raw as f32 * scale;
-        let mut right = r_raw as f32 * scale;
+        let scale = PAULA_MIX_SCALE;
+        let ch_scaled: [f32; 4] = std::array::from_fn(|i| mixed[i] * scale);
+        let mut left = ch_scaled[0] + ch_scaled[3];
+        let mut right = ch_scaled[1] + ch_scaled[2];
         let filtered = self.led_filter.process(left, right);
         if self.led_filter_enabled {
             (left, right) = filtered;
@@ -2061,8 +2213,6 @@ impl Paula {
         // hardware's LED filter sits after the channel mixer's summation, so
         // the per-channel taps below are deliberately *not* filtered.
         self.audio.push_source("paula", left, right);
-        let ch_scaled: [f32; 4] =
-            std::array::from_fn(|i| self.channel_mixed_sample(i) as f32 * scale);
         self.audio.push_source_channel("paula", "0", ch_scaled[0]);
         self.audio.push_source_channel("paula", "1", ch_scaled[1]);
         self.audio.push_source_channel("paula", "2", ch_scaled[2]);
@@ -2429,6 +2579,44 @@ mod tests {
     }
 
     type SharedFrames = Rc<RefCell<Vec<(f32, f32)>>>;
+
+    /// One channel holding DAC sample 64 at full volume, as it lands on its
+    /// side of the mix. The routing, volume and stereo-width tests below are
+    /// about what happens to a level, not what the level is, so they state
+    /// theirs relative to this instead of repeating the mix scale.
+    const CHANNEL_64_LEVEL: f32 = 64.0 * 64.0 * PAULA_MIX_SCALE;
+
+    /// Correlate a run of mixed frames against one frequency, giving that
+    /// tone's amplitude. A plain rectangular-window DFT bin: the tones these
+    /// tests separate sit thousands of bins apart, so the window's leakage
+    /// lands far below anything they assert on.
+    fn tone_amplitude(samples: &[f32], freq_hz: f64) -> f64 {
+        let (mut re, mut im) = (0.0f64, 0.0f64);
+        for (i, &sample) in samples.iter().enumerate() {
+            let phase = std::f64::consts::TAU * freq_hz * i as f64 / f64::from(MIX_SAMPLE_RATE);
+            re += f64::from(sample) * phase.cos();
+            im += f64::from(sample) * phase.sin();
+        }
+        2.0 * re.hypot(im) / samples.len() as f64
+    }
+
+    /// Loop `pattern` (a chip-RAM image, one sample per byte) on all four
+    /// channels at `per` and full volume, and run `seconds` of emulated
+    /// time through the test DMA pump.
+    fn play_all_channels(paula: &mut Paula, pattern: &[u8], per: u16, seconds: f64) {
+        let mut dmacon = DMACON_DMAEN;
+        for ch in 0..4u16 {
+            let base = ch * 0x10;
+            paula.write_audio_reg(base, 0, 0);
+            paula.write_audio_reg(base + 0x02, 0, 0);
+            paula.write_audio_reg(base + 0x04, (pattern.len() / 2) as u16, 0);
+            paula.write_audio_reg(base + 0x06, per, 0);
+            paula.write_audio_reg(base + 0x08, 64, 0);
+            dmacon |= 1 << ch;
+        }
+        let cck = (f64::from(PAULA_CLOCK_HZ) * seconds) as u32;
+        paula.tick_audio(cck, dmacon, pattern);
+    }
 
     fn paula_with_collect_sink() -> (Paula, SharedFrames) {
         let frames = Rc::new(RefCell::new(Vec::new()));
@@ -3418,10 +3606,14 @@ mod tests {
         let lefts: Vec<f32> = samples.chunks_exact(2).map(|frame| frame[0]).collect();
         let rights: Vec<f32> = samples.chunks_exact(2).map(|frame| frame[1]).collect();
         // Silent lead-in while the start-up fetches run, then the sample
-        // alternates +-0.5 at the period cadence. Left channel only.
+        // alternates at the period cadence, left channel only. The mix is
+        // band-limited on its way to the host grid, so the recorded swing
+        // is the reconstructed waveform rather than the raw step: it
+        // reaches the step's level but is not pinned to it.
+        let level = 64.0 * 64.0 * PAULA_MIX_SCALE;
         assert_eq!(lefts[0], 0.0);
-        assert!(lefts.iter().any(|&l| (l - 0.5).abs() < f32::EPSILON));
-        assert!(lefts.iter().any(|&l| (l + 0.5).abs() < f32::EPSILON));
+        assert!(lefts.iter().any(|&l| l > level * 0.9));
+        assert!(lefts.iter().any(|&l| l < -level * 0.9));
         assert!(rights.iter().all(|&r| r == 0.0));
 
         let _ = std::fs::remove_file(&path);
@@ -3443,7 +3635,7 @@ mod tests {
             for ch_idx in 0..4 {
                 paula.chans[ch_idx].current = 64;
                 paula.chans[ch_idx].audvol = 64;
-                paula.push_mixed_frame();
+                paula.push_mixed_frame_from_channels();
                 paula.chans[ch_idx].current = 0;
             }
         }
@@ -3464,7 +3656,15 @@ mod tests {
             .map(|frame| (frame[0], frame[1]))
             .collect::<Vec<_>>();
 
-        assert_eq!(frames, &[(0.5, 0.0), (0.0, 0.5), (0.0, 0.5), (0.5, 0.0)]);
+        assert_eq!(
+            frames,
+            &[
+                (CHANNEL_64_LEVEL, 0.0),
+                (0.0, CHANNEL_64_LEVEL),
+                (0.0, CHANNEL_64_LEVEL),
+                (CHANNEL_64_LEVEL, 0.0),
+            ]
+        );
 
         let _ = std::fs::remove_file(&path);
     }
@@ -3854,12 +4054,110 @@ mod tests {
         paula.chans[1].audvol = 64;
 
         paula.write_adkcon(0x8000 | 0x0001);
-        paula.advance_audio(PAULA_CLOCK_HZ.div_ceil(MIX_SAMPLE_RATE), 0);
+        // Long enough for the band-limiting decimators to fill their tap
+        // histories: the mix only reaches a held sample's DC level once
+        // they have, so the first frame out is not the settled one.
+        paula.advance_audio(PAULA_CLOCK_HZ / 100, 0);
 
         let frames = frames.borrow();
-        let (left, right) = frames[0];
+        let (left, right) = *frames.last().expect("mixed frames");
         assert_eq!(left, 0.0);
-        assert!(right > 0.9, "target channel should remain audible: {right}");
+        let audible = 127.0 * 64.0 * PAULA_MIX_SCALE;
+        assert!(
+            (right - audible).abs() < 1e-4,
+            "target channel should remain audible at its DC level: {right}"
+        );
+    }
+
+    /// Paula's output is a staircase that steps on the colour-clock grid,
+    /// so the 10 kHz square Amiga Test Kit's audio page plays -- two samples
+    /// at AUDxPER 177, full volume on all four channels -- carries harmonics
+    /// at 30, 50 and 70 kHz. Reading that staircase once per host frame
+    /// folds them back into the audible band at 14.0, 6.0 and 18.1 kHz,
+    /// where they were only 10 dB under the tone and, being inharmonic, were
+    /// heard as ringing. The band-limited decimation has to leave the tone
+    /// itself untouched and put those nowhere near it.
+    #[test]
+    fn a_full_scale_square_arrives_without_its_harmonics_folded_back() {
+        let (mut paula, frames) = paula_with_collect_sink();
+        paula.set_led_filter_guest(false);
+        // One word looping, +127 then -128: a full-scale square at
+        // PAULA_CLOCK_HZ / (2 * 177).
+        play_all_channels(&mut paula, &[0x7F, 0x80], 177, 0.5);
+
+        let frames = frames.borrow();
+        // Past the decimators' tap histories, so only settled output is read.
+        let settled: Vec<f32> = frames[512..].iter().map(|(left, _)| *left).collect();
+        let tone = f64::from(PAULA_CLOCK_HZ) / (2.0 * 177.0);
+        let level = tone_amplitude(&settled, tone);
+        assert!(level > 0.5, "the tone itself should survive: {level}");
+
+        let rate = f64::from(MIX_SAMPLE_RATE);
+        for harmonic in [3.0, 5.0, 7.0, 9.0] {
+            let image = harmonic * tone;
+            let folded = (image - (image / rate).round() * rate).abs();
+            let dbc = 20.0 * (tone_amplitude(&settled, folded) / level).log10();
+            assert!(
+                dbc < -40.0,
+                "harmonic {harmonic} folds to {folded:.0} Hz at {dbc:.1} dBc"
+            );
+        }
+    }
+
+    /// Full scale is two channels saturated at full volume, plus the
+    /// headroom the band-limited waveform needs to overshoot the steps it
+    /// came from. Amiga Test Kit plays exactly that -- one sample on all
+    /// four channels at volume 64 -- and nothing downstream of the mix
+    /// clips, so the mix itself has to stay inside the host's range. Swept
+    /// over periods and duty cycles because the worst overshoot is not the
+    /// square: a 25% pulse train near 4.9 kHz asks for the most, and the
+    /// shortest legal period is what bounds it.
+    #[test]
+    fn nothing_paula_can_play_leaves_the_host_range() {
+        for pattern in [
+            [0x7Fu8, 0x80, 0x7F, 0x80],
+            [0x7F, 0x7F, 0x80, 0x80],
+            [0x7F, 0x7F, 0x7F, 0x80],
+            [0x7F, 0x80, 0x80, 0x80],
+        ] {
+            for per in [124u16, 143, 161, 177, 181, 203, 254, 320, 404] {
+                let (mut paula, frames) = paula_with_collect_sink();
+                paula.set_led_filter_guest(false);
+                play_all_channels(&mut paula, &pattern, per, 0.05);
+
+                let peak = frames
+                    .borrow()
+                    .iter()
+                    .flat_map(|&(left, right)| [left.abs(), right.abs()])
+                    .fold(0.0f32, f32::max);
+                assert!(
+                    peak <= 1.0,
+                    "pattern {pattern:?} at AUDxPER {per} peaks at {peak}"
+                );
+            }
+        }
+    }
+
+    /// The decimation kernels are unity at DC, so a channel holding a sample
+    /// reaches the mixer at exactly the share of full scale the mix scale
+    /// gives it -- band-limiting changes what a staircase sounds like, not
+    /// what a held level is worth.
+    #[test]
+    fn a_held_sample_reaches_the_mixer_at_its_dc_level() {
+        let (mut paula, frames) = paula_with_collect_sink();
+        paula.set_led_filter_guest(false);
+        // Both bytes the same, so the channels hold +127 instead of
+        // stepping.
+        play_all_channels(&mut paula, &[0x7F, 0x7F], 177, 0.05);
+
+        let frames = frames.borrow();
+        let settled = frames.last().expect("mixed frames").0;
+        // Channels 0 and 3 both reach the left side.
+        let expected = 2.0 * 127.0 * 64.0 * PAULA_MIX_SCALE;
+        assert!(
+            (settled - expected).abs() < 1e-4,
+            "held sample settled at {settled}, expected {expected}"
+        );
     }
 
     #[test]
@@ -3870,7 +4168,7 @@ mod tests {
             paula.chans[0].audvol = 64;
             for i in 0..256 {
                 paula.chans[0].current = if i & 1 == 0 { 127 } else { -127 };
-                paula.push_mixed_frame();
+                paula.push_mixed_frame_from_channels();
             }
             let frames = frames.borrow();
             let settled = &frames[64..];
@@ -3938,7 +4236,7 @@ mod tests {
                 paula.chans[0].audvol = 64;
                 for i in 0..256 {
                     paula.chans[0].current = if i & 1 == 0 { 127 } else { -127 };
-                    paula.push_mixed_frame();
+                    paula.push_mixed_frame_from_channels();
                 }
             }
 
@@ -3974,12 +4272,12 @@ mod tests {
         paula.chans[0].current = 64;
         paula.chans[0].audvol = 64;
 
-        paula.push_mixed_frame();
+        paula.push_mixed_frame_from_channels();
 
         let frames = frames.borrow();
         assert_eq!(paula.output_volume_percent(), 50);
         assert_eq!(paula.chans[0].audvol, 64);
-        assert!((frames[0].0 - 0.25).abs() < f32::EPSILON);
+        assert!((frames[0].0 - CHANNEL_64_LEVEL * 0.5).abs() < 1e-6);
         assert_eq!(frames[0].1, 0.0);
     }
 
@@ -3993,37 +4291,37 @@ mod tests {
         paula.chans[0].current = 64;
         paula.chans[0].audvol = 64;
 
-        paula.push_mixed_frame();
+        paula.push_mixed_frame_from_channels();
 
         let frames = frames.borrow();
         assert_eq!(frames[0].0, frames[0].1, "mono means identical channels");
-        assert!((frames[0].0 - 0.25).abs() < f32::EPSILON);
+        assert!((frames[0].0 - CHANNEL_64_LEVEL * 0.5).abs() < 1e-6);
     }
 
     #[test]
     fn stereo_separation_narrows_from_hardware_panning_toward_mono() {
-        // Drive left channel only: hardware panning gives (0.5, 0.0).
+        // Drive left channel only: hardware panning puts the whole level left.
         let out = |sep: f32| {
             let (mut paula, frames) = paula_with_collect_sink();
             paula.set_led_filter_guest(false);
             paula.set_stereo_separation(sep);
             paula.chans[0].current = 64;
             paula.chans[0].audvol = 64;
-            paula.push_mixed_frame();
+            paula.push_mixed_frame_from_channels();
             let frame = frames.borrow()[0];
             frame
         };
         // 100%: untouched.
         let full = out(1.0);
-        assert!((full.0 - 0.5).abs() < f32::EPSILON && full.1 == 0.0);
-        // 0%: mono (both = the 0.25 average).
+        assert!((full.0 - CHANNEL_64_LEVEL).abs() < 1e-6 && full.1 == 0.0);
+        // 0%: mono, both sides the average of the two.
         let mono = out(0.0);
         assert_eq!(mono.0, mono.1);
-        assert!((mono.0 - 0.25).abs() < f32::EPSILON);
-        // 50%: mid 0.25 +/- side (0.25 * 0.5) -> (0.375, 0.125).
+        assert!((mono.0 - CHANNEL_64_LEVEL * 0.5).abs() < 1e-6);
+        // 50%: mid +/- half the side, so three quarters left, one quarter right.
         let half = out(0.5);
-        assert!((half.0 - 0.375).abs() < f32::EPSILON);
-        assert!((half.1 - 0.125).abs() < f32::EPSILON);
+        assert!((half.0 - CHANNEL_64_LEVEL * 0.75).abs() < 1e-6);
+        assert!((half.1 - CHANNEL_64_LEVEL * 0.25).abs() < 1e-6);
     }
 
     #[test]


### PR DESCRIPTION
Reported as a ringing, clipping 10 kHz tone in Amiga Test Kit's audio page,
where FS-UAE sounds like real hardware. Two independent faults in the path
from Paula to the host mixer.

## No anti-aliasing on the decimation

Paula's output is a staircase stepping on the 3.546895 MHz colour-clock grid,
and `advance_audio` read it once per 44.1 kHz frame, so everything above the
mixer's Nyquist folded back into the audible band. Test Kit's 10 kHz square
(two samples at AUDxPER 177, full volume on all four channels) has harmonics
at 30, 50 and 70 kHz; measured on A500/KS1.3 with the filter off:

| freq | level | what it is |
|---|---|---|
| 10019.5 | 0 dBc | the tone |
| 14041.5 | **-10.0 dBc** | 3rd harmonic folded at 44100-30058 |
| 5997.5 | **-15.3 dBc** | 5th folded |
| 18063.8 | -17.9 dBc | 7th folded |
| 1975.2 | -19.8 dBc | 9th folded |

plus +/-71.5 Hz sideband pairs from the beat between Paula's 20038.95 Hz
sample rate and 44.1 kHz. An independent model of the exact signal confirmed
point sampling reproduces that spectrum line for line, that integrating over
the output interval (what UAE calls "anti") accounts for the FS-UAE
comparison, and that band-limited decimation leaves a single clean line.

The mix now runs at 4x the mixer rate with exact-area integration, then a 4:1
windowed-sinc decimation per channel. Worst in-band image goes from **-10 dBc
to -51 dBc**. Four was chosen by measurement: 2x leaves a -28 dBc spur, and
neither 8x nor a longer kernel improves on 4x.

**The LED filter made it worse, not better.** Real hardware filters before the
sampling; we filtered after, so the 4 kHz filter attenuated the genuine tone
and left the aliases that had already folded below its cutoff. The 1975 Hz
alias ended up 5.8 dB *above* the tone -- a real A500 goes nearly silent on
this test, we produced a 2 kHz buzz. The tone is now the loudest thing in the
output with everything else at least 43 dB down.

Paula's own zero-order-hold images are deliberately kept: they are real output
ahead of the hardware's analogue filter, so the 500 Hz test still carries its
images at 19.5 and 20.5 kHz.

## No headroom

Two channels reach each side and each was scaled by `1/(128*64)`, so full
scale on all four gave +/-1.98 with nothing clamping between there and the
host device. **97.7% of the 10 kHz capture sat outside +/-1.0.** Full scale is
now both channels saturated plus the overshoot a band-limited waveform needs,
taken from the decimation kernel: the sum of its absolute taps, 1.5792, is the
most it can make of input bounded by full scale, whatever that input is.

Deriving it instead from the shortest period a channel can be given would not
hold. `PAL_AUDIO_MIN_PERIOD_CCK` / `NTSC_AUDIO_MIN_PERIOD_CCK` describe what
audio DMA can sustain, are defined but never referenced, `aud_percntrld` takes
`AUDxPER` as given, and a CPU feeding `AUDxDAT` in IRQ mode is held to
neither. Output is 10.0 dB quieter than the old scaling.

## Results

| | before | after |
|---|---|---|
| worst in-band spur | -10.0 dBc | **-51.3 dBc** |
| 10 kHz test peak | 1.98 (97.7% of samples clipped) | 0.80 |
| LED filter on | alias 5.8 dB **above** the tone | tone loudest, rest >=43 dB down |
| Test Kit module peak | 2.13 (clipping) | 0.67 |
| 500 Hz test peak | 1.98 (65% clipped) | 0.63 |

("before" peaks above are the measured after-values scaled by the exact ratio
of the old and new divisors, 3.16; the mix is linear in it.)

## Verification

- 3834 unit tests pass; `clippy` and `fmt --check` clean.
- Five new Paula regression tests (folded-harmonic levels via DFT; a sweep
  over duty cycles and periods -- down past what DMA can sustain -- asserting
  nothing Paula can play leaves +/-1.0; DC unity through the chain; the
  headroom constant against the kernel's actual peak gain; and the mixer
  cadence surviving a resume at each oversample slice) and three `Decimator`
  tests.
- Six existing tests updated: four for the new scale, two because the
  decimator's ~0.2 ms group delay means the first frame is no longer the
  settled value.
- **Emulated timeline untouched.** Slice counts are byte-identical before and
  after (6305778 on boot, 21777906 on a 45 s four-channel run) and the golden
  probe renders are unchanged. No `PAUL` chunk version bump is needed:
  `host_sample_acc` keeps its meaning, and the new fields are
  `serde(default)`.
- Cost: ~2% slower with all four channels at AUDxPER 177, ~2% on boot.
- `docs/internals/audio.md` documents the decimation, the level reference and
  why the LED filter can only sit where it does once decimation is
  band-limited.

## Known gaps, deliberately not addressed here

- The mix bus still has no headroom for CD-DA plus Paula. CD-DA arrives at
  +/-1.0 and is line-mixed after Paula's scaling, so a CD32 playing a
  full-scale track under a full-scale module can reach ~1.7 (it was ~3.1).
  Fixing that means deciding the hardware line-level balance between
  Akiko/CDTV CD audio and Paula, which wants a measurement first. Same for
  MT-32, Toccata and MHI.
- No always-on output RC network is modelled for any machine, only the
  switchable LED filter, so A500 and A1200 still measure identically. Real
  machines differ.
- Output volume caps at 100% and everything is now 10 dB quieter, so the
  status-bar slider can only attenuate.

