### PR TITLE
deps: bump m68k to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,9 +3495,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e596886511cf8e15e844b7a2448874f91d288eb22370c5f200b8f5e9bdfa3c"
+checksum = "b7e614e34e0fe46c6b8d6e9e8b778eb6bc6ff1e0ffafabcb8243f2bd2c9f5b29"
 dependencies = [
  "cranelift-codegen 0.132.3",
  "cranelift-frontend 0.132.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ fluxbridge = ["dep:fluxbridge"]
 host-serial = ["dep:serialport"]
 
 [dependencies]
-m68k = { version = "0.12", features = ["serde"] }
+m68k = { version = "0.13", features = ["serde"] }
 # The MT-32 synthesiser engine: our own port of Munt, pinned by revision.
 mt32-rs = { git = "https://github.com/CopperlineHQ/mt32-rs", rev = "ac00f818629a549a2712747660091e4f84d55599", optional = true }
 # The General MIDI synthesiser (Coppersynth), pinned by revision.

--- a/crates/copperline-libretro/Cargo.lock
+++ b/crates/copperline-libretro/Cargo.lock
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e596886511cf8e15e844b7a2448874f91d288eb22370c5f200b8f5e9bdfa3c"
+checksum = "b7e614e34e0fe46c6b8d6e9e8b778eb6bc6ff1e0ffafabcb8243f2bd2c9f5b29"
 dependencies = [
  "serde",
 ]

--- a/crates/copperline-player/Cargo.lock
+++ b/crates/copperline-player/Cargo.lock
@@ -1980,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e596886511cf8e15e844b7a2448874f91d288eb22370c5f200b8f5e9bdfa3c"
+checksum = "b7e614e34e0fe46c6b8d6e9e8b778eb6bc6ff1e0ffafabcb8243f2bd2c9f5b29"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/crates/copperline-web/Cargo.lock
+++ b/crates/copperline-web/Cargo.lock
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "m68k"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e596886511cf8e15e844b7a2448874f91d288eb22370c5f200b8f5e9bdfa3c"
+checksum = "b7e614e34e0fe46c6b8d6e9e8b778eb6bc6ff1e0ffafabcb8243f2bd2c9f5b29"
 dependencies = [
  "serde",
 ]

--- a/crates/cputest-runner/Cargo.lock
+++ b/crates/cputest-runner/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "m68k"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e596886511cf8e15e844b7a2448874f91d288eb22370c5f200b8f5e9bdfa3c"
+checksum = "b7e614e34e0fe46c6b8d6e9e8b778eb6bc6ff1e0ffafabcb8243f2bd2c9f5b29"
 
 [[package]]
 name = "shlex"

--- a/crates/cputest-runner/Cargo.toml
+++ b/crates/cputest-runner/Cargo.toml
@@ -15,7 +15,7 @@ name = "cputest-runner"
 path = "src/main.rs"
 
 [dependencies]
-m68k = "0.12"
+m68k = "0.13"
 
 [build-dependencies]
 cc = "1"

--- a/docs/internals/cpu.md
+++ b/docs/internals/cpu.md
@@ -3,7 +3,7 @@
 ## The wrapper and the bus adapter
 
 `M68kMachine` (`src/cpu.rs`) wraps the published pure-Rust
-[`m68k` 0.12 core](https://docs.rs/crate/m68k/0.12.1). The core sees
+[`m68k` 0.13 core](https://docs.rs/crate/m68k/0.13.0). The core sees
 the machine through an adapter implementing its `AddressBus` trait, so
 every CPU-visible access -- RAM, ROM, custom registers, CIA, RTC,
 autoconfig, Gayle, Akiko -- routes into the shared `Bus` and is billed in
@@ -35,7 +35,7 @@ fits a 68881/68882 to any 020/030 (and is on by default for the 68040,
 whose FPU is on-die): the `m68k` core executes the 6888x instruction
 set in true 80-bit extended precision via a pure-Rust software floating-
 point engine
-([`softfloat.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/fpu/softfloat.rs)).
+([`softfloat.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.13.0/src/fpu/softfloat.rs)).
 Arithmetic (add, sub,
 mul, div, sqrt, and the single-accuracy FSGLMUL/FSGLDIV, which round the
 mantissa to 24 bits but keep the extended exponent range -- gcc -m68040
@@ -53,13 +53,13 @@ whose saved FPU frame carries a foreign size) are all modelled. The transcendent
 FASIN/FACOS/FATAN, the hyperbolics, FETOX/FETOXM1/FTWOTOX/FTENTOX,
 FLOGN/FLOGNP1/FLOG2/FLOG10) and FSINCOS run in extended precision too: a
 double-`FloatX80` ("double-double", ~128-bit) layer
-([`dd.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/fpu/dd.rs))
+([`dd.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.13.0/src/fpu/dd.rs))
 evaluates Taylor/atanh series over reduced
 ranges and rounds the result to extended under the FPCR mode, setting INEX
 and the domain flags (OPERR/DZ). Accuracy is validated against an
 arbitrary-precision oracle (the pure-Rust `astro-float`, a dev-only
 dependency;
-[`fpu_accuracy.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/tests/fpu_accuracy.rs)):
+[`fpu_accuracy.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.13.0/tests/fpu_accuracy.rs)):
 every function is within
 1 ULP across a wide sweep and all four rounding modes, and round-to-nearest
 is correctly rounded in practice. They are not chip-bit-exact -- the real
@@ -69,7 +69,7 @@ quotient byte. This covers Kickstart's
 detection and per-task FPU context switching. The
 68000's per-instruction cycle counts in the `m68k` core have been
 corrected to exact totals across the SingleStepTests 68000 cycle corpus
-([validation details](https://github.com/benletchford/m68k-rs/tree/m68k-v0.12.1#validation--testing)),
+([validation details](https://github.com/benletchford/m68k-rs/tree/m68k-v0.13.0#validation--testing)),
 which is what makes
 cycle-budgeted pacing trustworthy.
 
@@ -139,7 +139,7 @@ precise.
 
 The 68000's two-word instruction prefetch queue (IRD/IRC) is modelled in
 the `m68k` core
-([`prefetch_queue`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/core/cpu.rs)):
+([`prefetch_queue`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.13.0/src/core/cpu.rs)):
 the
 next opcode is fetched before the current instruction finishes, so
 self-modifying code that overwrites the *next* instruction executes the
@@ -201,13 +201,13 @@ DBcc loop mode: a DBcc that branches -4 back to a loopable one-word
 instruction holds the body/DBcc pair in the prefetch queue and re-executes
 it with no instruction fetches until the condition turns true, the counter
 expires, or an exception intervenes (`loop_mode` in
-[`core/cpu.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/core/cpu.rs);
+[`core/cpu.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.13.0/src/core/cpu.rs);
 the loopable set and the DBcc entry/exit arms live in
-[`core/decode.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/core/decode.rs)).
+[`core/decode.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.13.0/src/core/decode.rs)).
 A looping DBcc iteration costs 6 internal
 clocks and touches the bus only for the body's operands, which is what
 makes tight copy/clear loops measurably faster on a real 68010.
-[`loop_mode_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/tests/loop_mode_timing_tests.rs)
+[`loop_mode_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.13.0/tests/loop_mode_timing_tests.rs)
 pins engagement, the
 68000's non-engagement, and the no-fetch iteration cost.
 
@@ -231,7 +231,7 @@ the STOP itself, so the handler's RTE re-executes it; a pending trace
 (T set in the SR the instruction started with) has priority and recovers
 from the stop, while a T bit loaded *by* STOP does not fire while
 stopped.
-[`stop_and_68010_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/tests/stop_and_68010_timing_tests.rs)
+[`stop_and_68010_timing_tests.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.13.0/tests/stop_and_68010_timing_tests.rs)
 pins all of these.
 
 ## Caches
@@ -327,7 +327,7 @@ shares the 040's three-level walker and TC[15] enable; PTEST is gone
 faulting with the format $4 frame.
 
 **Timing.**
-[`timing_060.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/core/timing_060.rs)
+[`timing_060.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.13.0/src/core/timing_060.rs)
 replaces the 020+
 scaling formula for the 060: every opcode word classifies (a build-once
 64K table over a pure function) into the MC68060UM Chapter 10 dispatch
@@ -369,7 +369,7 @@ instruction cache, a three-stage pipeline, execution overlap, dynamic bus
 sizing, and alignment-dependent transfers, so an opcode does not have one
 context-free cycle count.
 
-[`timing_020.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/core/timing_020.rs)
+[`timing_020.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.13.0/src/core/timing_020.rs)
 transcribes the integer timing tables
 from section 8.2 of the
 [MC68020 User's Manual](https://www.nxp.com/docs/en/data-sheet/MC68020UM.pdf).
@@ -396,7 +396,7 @@ bare taken `dbra` from 1.35x to 1.18x over. The call, `movem`, and chip-stack
 
 ## 68040 timing
 
-[`timing_040.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.12.1/src/core/timing_040.rs)
+[`timing_040.rs`](https://github.com/benletchford/m68k-rs/blob/m68k-v0.13.0/src/core/timing_040.rs)
 (m68k 0.12) gives the 68040 a single-issue pipeline model in place of the
 scaled approximation, which the same accelprobe columns (a 25 MHz A3640,
 two byte-identical serial captures) measured as ~2-2.5x pessimistic on

--- a/docs/internals/timing.md
+++ b/docs/internals/timing.md
@@ -720,7 +720,7 @@ debits a per-frame instruction budget one of two ways, selected by
   tails, chip-bus grants and contention waits -- so the slice's elapsed bus
   CCK is the true hardware cost (`real_slice_accounting` in
   `src/emulator.rs`). Because the m68k core's 68000 cycle totals are exact
-  across its [SingleStepTests validation corpus](https://github.com/benletchford/m68k-rs/tree/m68k-v0.12.1#validation--testing),
+  across its [SingleStepTests validation corpus](https://github.com/benletchford/m68k-rs/tree/m68k-v0.13.0#validation--testing),
   this matches a stock PAL 68000.
 - `instructions`: a flat cycles-per-instruction quota
   (`COPPERLINE_REAL_CPU_CPI`, default 4.0), debited by retired


### PR DESCRIPTION
## What is in 0.13.0

Twenty commits upstream, four source files, no bug fixes and no timing-model
change:

| File | Change | Reach |
|---|---|---|
| `src/core/trace_jit.rs` | +2717 / -335 | The Cranelift trace compiler, entered only with `[cpu] jit` |
| `src/core/instructions/data_movement.rs` | +49 / -9 | MOVE provenance plumbing |
| `src/core/memory.rs` | +23 | Two new `AddressBus` methods, both defaulted |
| `src/core/op_cache.rs` | +4 / -1 | One `#[inline]` promoted to `#[inline(always)]` |

The sole feature is `begin_memory_copy` / `end_memory_copy`, observational
metadata around memory-to-memory MOVE. Both are defaulted, so `impl
AddressBus for CpuBus` compiles untouched and they stay inert. Upstream
suppresses them whenever the bus exposes a `fast_mem` window; `jit_fast_mem()`
only offers one under `[cpu] jit`, so they remain available to the precise
core if a data-flow or provenance view ever wants them.

The MOVE rewrite only splits `read_ea` into `resolve_ea` + `read_resolved_ea`
-- the same bus accesses in the same order -- so the interpreter timeline
cannot move.

## Verification

- All 45 `probe_golden` renders unchanged, `golden_timing_test` included.
  That is why the m68k 0.12 accelprobe columns in `timing-test/` still stand
  and were not re-run.
- `--dump-frames` output byte-identical to 0.12.1 for State of the Art
  (A500 OCS 68000, 30s) and Roots 2 (A1200 020 AGA, 45s), in **both**
  precise and jit modes.
- `cargo test --release` passes, clippy and fmt clean, and every committed
  lockfile resolves with `--locked` (the same six checks `locks.yml` runs).

## Performance

A wash. Alternating A/B, three reps, wall seconds, 0.12.1 vs 0.13.0:

| Workload | 0.12.1 | 0.13.0 |
|---|---|---|
| State of the Art, A500 OCS 68000 | 5.10 | 5.09 |
| Roots 2 AGA, precise | 8.49 | 8.52 |
| Roots 2 AGA, jit | 6.04 | 6.02 |
| OS 3.9 68030 boot, jit | 5.20 | 5.28 |
| CPU-bound 68030 guest loop, jit (47 MIPS) | 8.23 | 8.05 |
| CPU-bound 68030 guest loop, precise | 9.90 | 9.87 |

Everything sits inside run-to-run noise. The upstream traces target indexed
dispatch, guarded indirect jumps and PC-relative LEA; our jit runs are
chip-bus and IO bound rather than trace-limited, and jit is off by default.
So this is a stay-current bump, not one that buys us anything measurable
today.

## Pins

`crates/copperline-libretro/Cargo.lock` carries m68k as well -- the 0.12.1
bump missed it -- so the dependency now moves in six lockfiles. The
documentation links pinned to the `m68k-v0.12.1` tag move to `m68k-v0.13.0`;
the two "(m68k 0.12)" mentions in `docs/internals/cpu.md` date when the 030
and 040 timing models landed and stay as they are, as do the m68k 0.12
column labels in `timing-test/`.

## Not verified locally

`cargo check --target wasm32-unknown-unknown` could not run in the
development sandbox ("can't find crate for `core`" despite the target being
installed). CI covers `crates/copperline-web`; the risk is low, since
`trace_jit.rs` is behind the `jit` feature that browser builds leave off and
the remaining changes are target-independent.
