### PR TITLE
Step a stopped CPU to its wake-up, and stop reopening an absent clipboard

### DIFF
--- a/docs/debugger/console.md
+++ b/docs/debugger/console.md
@@ -58,6 +58,12 @@ Commands are case-insensitive. Addresses and data values use hexadecimal notatio
 | `RFRAME` | Step one video frame backward |
 | `RRUN` (or `RC`) | Run backward to previous breakpoint or watchpoint |
 
+`STEP`, `OVER`, `OUT` and `RUNTO` carry a CPU parked in `STOP` to the
+interrupt that wakes it -- a stopped 68000 retires nothing until one
+arrives -- so a single `STEP` there retires the handler's first
+instruction. A CPU no interrupt can reach (SR mask 7, or nothing enabled
+in `INTENA`) stays stopped after two video frames of waiting.
+
 ### Breakpoints and watchpoints
 
 | Command | Description |

--- a/docs/debugger/control.md
+++ b/docs/debugger/control.md
@@ -255,7 +255,12 @@ events.unsubscribe {"events":["serial"]}
 
 ### Execution control
 - `continue`: Resume execution.
-- `step {"n": 1}`: Single-step CPU instructions.
+- `step {"n": 1}`: Single-step CPU instructions. A CPU parked in `STOP` retires
+  nothing until an interrupt arrives, so a step there carries it to the one that
+  wakes it and retires the handler's first instruction; when no interrupt can
+  reach it (SR mask 7, or nothing enabled in `INTENA`) the step gives up after
+  two video frames and the stop event reports the unchanged
+  `retired_instructions`.
 - `step_over`: Step over subroutine call.
 - `step_out`: Step out of current subroutine.
 - `step_copper`: Step single Copper instruction.

--- a/docs/debugger/gdb.md
+++ b/docs/debugger/gdb.md
@@ -79,6 +79,10 @@ The target starts halted at reset. The stub supports:
 - Memory read and write operations
 - Breakpoints plus write (`Z2`), read (`Z3`), and access (`Z4`) watchpoints
 - Single-stepping and continuation; forced PC writes discard stale instruction prefetch
+- `stepi` on a CPU parked in `STOP` carries it to the interrupt that wakes it
+  and retires the handler's first instruction, rather than reporting a stop at
+  the PC it was asked to step from; a CPU no interrupt can reach (SR mask 7, or
+  nothing enabled in `INTENA`) stays stopped after two video frames of waiting
 - Ctrl-C interrupt handling
 - Reverse execution (`reverse-step`, `reverse-continue`)
 - Program relocation querying (`qOffsets`) and dynamic library tracking (`qXfer:libraries:read`)

--- a/docs/debugger/window.md
+++ b/docs/debugger/window.md
@@ -282,6 +282,18 @@ Examples:
 | **`< Step`** | -- | Step backward one instruction (see [](reverse.md)) |
 | **`< Run`** | -- | Run backward to preceding breakpoint |
 
+A CPU parked in `STOP` (an idle Workbench waiting for a disk, a program
+waiting for its interrupt) executes nothing until an interrupt arrives, so
+**Step**, **Step Over**, **Step Out** and **Run to** carry it to the
+interrupt that wakes it. A single **Step** there runs the machine on to
+that interrupt and retires one instruction -- the first of its handler,
+where control actually goes -- so the PC lands inside the handler instead
+of standing still. The CPU tab shows *CPU stopped* while it is parked.
+When no interrupt can reach the CPU -- the SR mask is 7, or nothing is
+enabled in `INTENA` -- a step gives up after two video frames and leaves
+the machine stopped where the hardware itself is stuck, and says so on the
+display.
+
 (frame-analyzer-pane)=
 ## Frame Analyzer
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -2241,6 +2241,11 @@ host as UTF-8 with the platform's line ends. Only text is shared; a
 picture on either clipboard is left alone. The host clipboard is read a
 few times a second while the emulator window has the focus, and only
 when its text changed. Up to 1 MiB of text crosses in either direction.
+A host with no clipboard to read -- a Wayland compositor that offers no
+data-control protocol, with no X11 display behind it -- is reported once
+in the log and then left alone rather than reopened on every poll; the
+guest side of the bridge still runs, so `clipboard.get`/`clipboard.set`
+over the control protocol keep working.
 
 `share` is unset by default, which means the session decides: a windowed
 session shares (the launcher's machines too), a headless run does not,

--- a/src/control/headless.rs
+++ b/src/control/headless.rs
@@ -706,11 +706,39 @@ impl Session {
         match kind {
             ResumeKind::Step { n } => {
                 for _ in 0..*n {
-                    self.emu.debug_step_realtime_past_stop()?;
-                    self.input.apply_due_scheduled(&mut self.emu);
-                    self.emit_events()?;
-                    if let Some((reason, detail)) = self.take_stop() {
-                        return stop(reason, detail);
+                    // A CPU parked in STOP retires nothing until an
+                    // interrupt reaches it, so the hunt for its wake-up
+                    // runs here rather than inside the emulator: this
+                    // loop owns the scheduled input, and a key or pad
+                    // press due during those frames is what wakes some
+                    // guests. Applied slice by slice, it still lands at
+                    // the emulated time it was scheduled for.
+                    let retired = self.emu.retired_instructions();
+                    let deadline = self
+                        .emu
+                        .bus()
+                        .emulated_frames()
+                        .saturating_add(crate::emulator::DEBUG_STOP_WAKEUP_FRAMES);
+                    loop {
+                        self.emu.debug_step_realtime()?;
+                        self.input.apply_due_scheduled(&mut self.emu);
+                        self.emit_events()?;
+                        if let Some((reason, detail)) = self.take_stop() {
+                            return stop(reason, detail);
+                        }
+                        if self.emu.retired_instructions() != retired {
+                            // The step's instruction ran.
+                            break;
+                        }
+                        if !self.emu.machine.stopped() {
+                            // Retired nothing and is not parked either:
+                            // a halted CPU has nothing to hunt for.
+                            break;
+                        }
+                        if self.emu.bus().emulated_frames() >= deadline {
+                            // Bounded: no interrupt can reach this CPU.
+                            break;
+                        }
                     }
                 }
                 return stop("step", format!("{n} instruction(s)"));

--- a/src/control/headless.rs
+++ b/src/control/headless.rs
@@ -706,7 +706,7 @@ impl Session {
         match kind {
             ResumeKind::Step { n } => {
                 for _ in 0..*n {
-                    self.emu.debug_step_realtime()?;
+                    self.emu.debug_step_realtime_past_stop()?;
                     self.input.apply_due_scheduled(&mut self.emu);
                     self.emit_events()?;
                     if let Some((reason, detail)) = self.take_stop() {

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -2303,10 +2303,88 @@ impl Emulator {
     /// Execute exactly `count` CPU instructions (interactive debugger
     /// single-step). The cycle-exact core advances the chipset in lockstep,
     /// so device state stays consistent; no wall-clock pacing is applied.
+    ///
+    /// A CPU halted in STOP retires nothing under a single-instruction
+    /// slice: the 68000 is waiting for an interrupt, and only device time
+    /// can bring one. Such a step falls back to the real-time loop's idle
+    /// fast-forward, exactly as the run-to / step-over / step-out helpers
+    /// do, until one instruction has run -- the first of the interrupt
+    /// handler, which is where control actually goes next.
     pub fn debug_step_instructions(&mut self, count: usize) -> Result<()> {
         for _ in 0..count {
+            let retired = self.retired_instructions();
             self.execute_cpu_slice(1)?;
             self.machine.refresh_irq_line();
+            if self.retired_instructions() == retired && self.machine.stopped() {
+                self.debug_step_stopped_to_wakeup(retired)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Advance a CPU sitting in STOP until one instruction retires: the
+    /// interrupt arrives, the exception is taken, and the step ends on the
+    /// handler's first instruction having run.
+    ///
+    /// The retired instruction, not the exit from STOP, is what ends this:
+    /// an idle fast-forward slice can carry the wake-up and the first
+    /// handler instruction together, while a single-instruction slice
+    /// takes the exception on its own, and a step means the same thing
+    /// either way.
+    ///
+    /// Bounded in emulated time: a CPU stopped with its interrupts masked
+    /// (or with nothing enabled in INTENA) never wakes, and a step must
+    /// still return. The bound is two video frames -- a VBlank, the wake-up
+    /// nearly every STOP waits for, comes once a frame -- after which the
+    /// machine is left stopped where it is, which is what the hardware is
+    /// doing.
+    fn debug_step_stopped_to_wakeup(&mut self, retired_before: u64) -> Result<()> {
+        const STOP_WAKEUP_FRAMES: u64 = 2;
+        let deadline = self
+            .bus()
+            .emulated_frames()
+            .saturating_add(STOP_WAKEUP_FRAMES);
+        while self.retired_instructions() == retired_before {
+            if self.bus().emulated_frames() >= deadline {
+                break;
+            }
+            self.debug_step_one_with_idle()?;
+            // A breakpoint or watchpoint that the wake-up handler trips
+            // ends the step where it hit, as it does on any other run.
+            if self.machine.ui_debug_stop_pending() {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// A debugger's "step one instruction" over the control protocol:
+    /// [`Self::debug_step_realtime`], and, when the CPU is parked in STOP
+    /// and the slice therefore retired nothing, the bounded run on to the
+    /// interrupt that wakes it that [`Self::debug_step_instructions`]
+    /// makes. The window's Step and this one then land in the same place.
+    pub fn debug_step_realtime_past_stop(&mut self) -> Result<()> {
+        let retired = self.retired_instructions();
+        self.debug_step_realtime()?;
+        if self.retired_instructions() == retired && self.machine.stopped() {
+            self.debug_step_stopped_to_wakeup(retired)?;
+        }
+        Ok(())
+    }
+
+    /// The same for GDB's `stepi`. Only a step asks for this: `continue`
+    /// runs the machine through STOP by itself, and a caller advancing a
+    /// whole frame one slice at a time (the profiler, a state warm-up)
+    /// would overshoot it, so both keep [`Self::debug_step_for_gdb`].
+    pub fn debug_step_for_gdb_past_stop(&mut self, cpu_idle: &mut bool) -> Result<()> {
+        let retired = self.retired_instructions();
+        self.debug_step_for_gdb(cpu_idle)?;
+        if self.retired_instructions() == retired && self.machine.stopped() {
+            self.debug_step_stopped_to_wakeup(retired)?;
+            // The hunt ran slices of its own, so the caller's idle flag
+            // now describes the CPU it is handed back: idle only if it is
+            // still stopped.
+            *cpu_idle = self.machine.stopped();
         }
         Ok(())
     }
@@ -5177,6 +5255,145 @@ mod tests {
             false,
         )
         .unwrap()
+    }
+
+    /// A program that enables the vertical-blank interrupt and then parks
+    /// the CPU in STOP, the way an idle Amiga waits for work:
+    ///
+    /// ```text
+    /// F80010  MOVE.W #$C020,($DFF09A).L  ; INTENA: master + VERTB
+    /// F80018  STOP   #imm                ; wait for an interrupt
+    /// F8001C  MOVEQ  #1,D0
+    /// F8001E  BRA.S  *
+    /// F80040  MOVE.W #$0020,($DFF09C).L  ; handler: clear INTREQ VERTB
+    /// F80048  RTE
+    /// ```
+    ///
+    /// `stop_sr` is the word STOP loads into SR: `$2000` leaves the
+    /// interrupt mask at 0 so VERTB (level 3) wakes the CPU, `$2700`
+    /// masks every interrupt so nothing ever does.
+    fn emulator_stopped_waiting_for_vblank(stop_sr: u16) -> super::Emulator {
+        let mut rom = vec![0u8; crate::memory::ROM_SIZE];
+        let put = |mem: &mut [u8], off: usize, word: u16| {
+            mem[off..off + 2].copy_from_slice(&word.to_be_bytes());
+        };
+        put(&mut rom, 0x10, 0x33FC); // MOVE.W #imm,(abs).L
+        put(&mut rom, 0x12, 0xC020); // SET | INTEN | VERTB
+        put(&mut rom, 0x14, 0x00DF);
+        put(&mut rom, 0x16, 0xF09A); // INTENA
+        put(&mut rom, 0x18, 0x4E72); // STOP #imm
+        put(&mut rom, 0x1A, stop_sr);
+        put(&mut rom, 0x1C, 0x7001); // MOVEQ #1,D0
+        put(&mut rom, 0x1E, 0x60FE); // BRA.S *
+        put(&mut rom, 0x40, 0x33FC); // handler: MOVE.W #imm,(abs).L
+        put(&mut rom, 0x42, 0x0020); // VERTB
+        put(&mut rom, 0x44, 0x00DF);
+        put(&mut rom, 0x46, 0xF09C); // INTREQ
+        put(&mut rom, 0x48, 0x4E73); // RTE
+
+        let mut chip_ram = vec![0u8; 512 * 1024];
+        chip_ram[0..4].copy_from_slice(&0x0000_4000u32.to_be_bytes()); // reset SSP
+        chip_ram[4..8].copy_from_slice(&0x00F8_0010u32.to_be_bytes()); // reset PC
+        let vertb_vector = 27 * 4; // autovector 27: level 3, where VERTB arrives
+        chip_ram[vertb_vector..vertb_vector + 4].copy_from_slice(&0x00F8_0040u32.to_be_bytes());
+
+        let bus = crate::bus::Bus::new(
+            crate::memory::Memory {
+                chip_ram,
+                slow_ram: Vec::new(),
+                mb_ram: Vec::new(),
+                accel_ram: Vec::new(),
+                rom,
+                overlay: false,
+                zorro: crate::zorro::ZorroChain::default(),
+                extended_rom: Vec::new(),
+                extended_rom_base: 0,
+                wcs: Vec::new(),
+                wcs_write_protected: false,
+            },
+            crate::chipset::paula::Paula::new(
+                Box::new(crate::serial::NullSerialSink),
+                Box::new(crate::audio::NullSink),
+            ),
+            crate::floppy::FloppyController::default(),
+        );
+        let mut emu = super::Emulator::new(
+            bus,
+            crate::config::CpuModel::M68000,
+            false,
+            Default::default(),
+            crate::config::PacingBudget::Cycles,
+            2,
+            false,
+        )
+        .unwrap();
+        // Run the INTENA write and the STOP, leaving the CPU parked.
+        emu.debug_step_instructions(2).unwrap();
+        assert!(emu.machine.stopped(), "the program should be in STOP");
+        emu
+    }
+
+    #[test]
+    fn a_single_step_carries_a_stopped_cpu_to_its_wake_up_interrupt() {
+        let mut emu = emulator_stopped_waiting_for_vblank(0x2000);
+        let retired = emu.retired_instructions();
+
+        emu.debug_step_instructions(1).unwrap();
+
+        // The step ran the VERTB interrupt's arrival, its exception, and
+        // the handler's first instruction -- exactly one instruction, in
+        // the place control went -- rather than standing still on a CPU
+        // that executes nothing.
+        assert!(!emu.machine.stopped(), "the interrupt should have woken it");
+        assert_eq!(emu.retired_instructions(), retired + 1);
+        assert_eq!(emu.machine.pc(), 0x00F8_0048); // the handler's RTE
+    }
+
+    #[test]
+    fn the_control_and_gdb_steps_carry_a_stopped_cpu_the_same_way() {
+        // Every debugger surface agrees on where a step from STOP lands,
+        // so a session driven over the control protocol or by GDB reads
+        // the same as the window's Step button.
+        let mut emu = emulator_stopped_waiting_for_vblank(0x2000);
+        let retired = emu.retired_instructions();
+        emu.debug_step_realtime_past_stop().unwrap();
+        assert!(!emu.machine.stopped());
+        assert_eq!(emu.retired_instructions(), retired + 1);
+        assert_eq!(emu.machine.pc(), 0x00F8_0048);
+
+        let mut emu = emulator_stopped_waiting_for_vblank(0x2000);
+        let retired = emu.retired_instructions();
+        let mut cpu_idle = false;
+        emu.debug_step_for_gdb_past_stop(&mut cpu_idle).unwrap();
+        assert!(!emu.machine.stopped());
+        assert_eq!(emu.retired_instructions(), retired + 1);
+        assert_eq!(emu.machine.pc(), 0x00F8_0048);
+        // The caller's idle flag describes the running CPU it got back,
+        // so its next step does not fast-forward as if still parked.
+        assert!(!cpu_idle);
+    }
+
+    #[test]
+    fn stepping_a_stopped_cpu_that_never_wakes_still_returns() {
+        // Interrupts masked in SR: no interrupt can reach the CPU, so the
+        // step gives up at its bound and leaves the machine stopped where
+        // the hardware itself is stuck.
+        let mut emu = emulator_stopped_waiting_for_vblank(0x2700);
+        let retired = emu.retired_instructions();
+        let frames = emu.bus().emulated_frames();
+
+        emu.debug_step_instructions(1).unwrap();
+
+        assert!(emu.machine.stopped(), "nothing can wake a masked CPU");
+        assert_eq!(emu.retired_instructions(), retired);
+        // Bounded: the step advanced device time looking for a wake-up,
+        // but only as far as the two-frame budget allows.
+        assert!(
+            emu.bus().emulated_frames() <= frames + 2,
+            "step ran past its bound: {} -> {}",
+            frames,
+            emu.bus().emulated_frames()
+        );
     }
 
     #[test]

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -29,6 +29,12 @@ const SERIAL_LIVE_IDLE_CAP_CCK: u32 = 256;
 /// (e.g. a permanently halted CPU) cannot spin forever. Far larger than the
 /// instruction distance between two snapshots at any sane capture interval.
 const TT_REPLAY_STEP_CAP: u64 = 100_000_000;
+/// How far a debugger step hunts for the interrupt that wakes a CPU parked
+/// in STOP. A VBlank -- what nearly every STOP waits for -- comes once a
+/// frame, and a CPU whose interrupts are masked never wakes at all, so the
+/// step gives up here and leaves the machine stopped. Shared with the
+/// control session, which runs the same hunt around its scheduled input.
+pub const DEBUG_STOP_WAKEUP_FRAMES: u64 = 2;
 /// Approximate CPU cycles per emulated M68000 instruction for converting
 /// frame-sized instruction budgets and real-mode device cadence. The
 /// instruction-paced backend is not cycle-exact, so use the 68000's
@@ -2332,18 +2338,15 @@ impl Emulator {
     /// takes the exception on its own, and a step means the same thing
     /// either way.
     ///
-    /// Bounded in emulated time: a CPU stopped with its interrupts masked
-    /// (or with nothing enabled in INTENA) never wakes, and a step must
-    /// still return. The bound is two video frames -- a VBlank, the wake-up
-    /// nearly every STOP waits for, comes once a frame -- after which the
-    /// machine is left stopped where it is, which is what the hardware is
-    /// doing.
+    /// Bounded in emulated time by [`DEBUG_STOP_WAKEUP_FRAMES`]: a CPU
+    /// stopped with its interrupts masked (or with nothing enabled in
+    /// INTENA) never wakes, and a step must still return, so the machine
+    /// is left stopped where it is -- which is what the hardware is doing.
     fn debug_step_stopped_to_wakeup(&mut self, retired_before: u64) -> Result<()> {
-        const STOP_WAKEUP_FRAMES: u64 = 2;
         let deadline = self
             .bus()
             .emulated_frames()
-            .saturating_add(STOP_WAKEUP_FRAMES);
+            .saturating_add(DEBUG_STOP_WAKEUP_FRAMES);
         while self.retired_instructions() == retired_before {
             if self.bus().emulated_frames() >= deadline {
                 break;

--- a/src/gdbstub/core.rs
+++ b/src/gdbstub/core.rs
@@ -468,7 +468,10 @@ impl GdbCore {
 
     pub(crate) fn step_forward(&mut self, emu: &mut Emulator) -> Result<String> {
         self.stop = StopReason::Step;
-        emu.debug_step_for_gdb(&mut self.cpu_idle)?;
+        // `stepi` on a CPU parked in STOP carries it to the interrupt that
+        // wakes it, rather than reporting a stop at the same PC the user
+        // stepped from.
+        emu.debug_step_for_gdb_past_stop(&mut self.cpu_idle)?;
         if let Some(stop) = self.check_stop(emu)? {
             self.stop = stop;
         }

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -989,6 +989,12 @@ pub struct App {
     netplay_disk_picker: Option<(usize, app_netplay::DiskPicker)>,
     // Linux serves clipboard selections from the owning instance.
     host_clipboard: Option<arboard::Clipboard>,
+    /// Set once opening the host clipboard has failed. Whether a session
+    /// has one at all is fixed when it starts -- a Wayland compositor
+    /// without a data-control protocol and no X11 display to fall back on
+    /// has none -- so the 300 ms poll must not keep reopening it: every
+    /// attempt walks the protocols again and logs from inside `arboard`.
+    host_clipboard_unavailable: bool,
     /// When the host clipboard is next polled for the guest
     /// (`service_clipboard`).
     clipboard_next_poll: Option<Instant>,
@@ -2371,6 +2377,7 @@ impl App {
             netplay_setup: None,
             netplay_disk_picker: None,
             host_clipboard: None,
+            host_clipboard_unavailable: false,
             run_ahead_frames,
             runahead_machine_block,
             ui: UiState::default(),

--- a/src/video/window/app_debugger.rs
+++ b/src/video/window/app_debugger.rs
@@ -992,7 +992,10 @@ impl App {
         self.sync_live_audio_suspension();
     }
 
-    /// Execute a single instruction while paused in the debugger.
+    /// Execute a single instruction while paused in the debugger. A CPU in
+    /// STOP runs on to the interrupt that wakes it; one that no interrupt
+    /// can reach stays where it is, and says so rather than looking like a
+    /// step that did nothing.
     pub(super) fn debugger_step(&mut self) {
         self.paused = true;
         self.sync_live_audio_suspension();
@@ -1001,6 +1004,9 @@ impl App {
             error!("debugger step halted: {e:?}");
             self.cpu_halted = true;
             self.sync_live_audio_suspension();
+        }
+        if self.emu.machine.stopped() {
+            self.show_osd("CPU is stopped: no interrupt is enabled to wake it");
         }
         self.surface_debug_stop();
     }

--- a/src/video/window/app_netplay.rs
+++ b/src/video/window/app_netplay.rs
@@ -63,7 +63,19 @@ impl App {
     fn copy_netplay_code(&mut self, code: String) -> std::result::Result<(), arboard::Error> {
         // Keep the selection owner alive after this click on X11/Wayland.
         if self.host_clipboard.is_none() {
-            self.host_clipboard = Some(arboard::Clipboard::new()?);
+            match arboard::Clipboard::new() {
+                Ok(clip) => self.host_clipboard = Some(clip),
+                Err(error) => {
+                    // A host with no clipboard has none for the guest
+                    // poll either: latch it here too, or the poll would
+                    // start reopening (and re-logging) what this click
+                    // has just found missing. The click still reports the
+                    // error it got, and a later click may try again --
+                    // it is a deliberate action, not a 300 ms timer.
+                    self.host_clipboard_unavailable = true;
+                    return Err(error);
+                }
+            }
         }
         self.host_clipboard.as_mut().unwrap().set_text(code)
     }

--- a/src/video/window/app_session.rs
+++ b/src/video/window/app_session.rs
@@ -608,11 +608,20 @@ impl App {
     /// The host clipboard, opened on first use and kept open: on X11 and
     /// Wayland the owning instance serves the selection, so the handle
     /// must outlive the copy.
+    ///
+    /// A failure is remembered rather than retried. Nothing about the
+    /// session changes to make a second attempt succeed, and the poll runs
+    /// three times a second: retrying would walk the clipboard protocols
+    /// (and log a warning from inside `arboard`) that often, for the whole
+    /// run. Said once, it tells the user why sharing is doing nothing.
     fn host_clipboard(&mut self) -> Option<&mut arboard::Clipboard> {
-        if self.host_clipboard.is_none() {
+        if self.host_clipboard.is_none() && !self.host_clipboard_unavailable {
             match arboard::Clipboard::new() {
                 Ok(clip) => self.host_clipboard = Some(clip),
-                Err(e) => log::debug!("clipboard: host clipboard unavailable: {e}"),
+                Err(e) => {
+                    self.host_clipboard_unavailable = true;
+                    warn!("clipboard: no host clipboard ({e}); sharing is off this session");
+                }
             }
         }
         self.host_clipboard.as_mut()

--- a/src/video/window/control.rs
+++ b/src/video/window/control.rs
@@ -716,7 +716,10 @@ impl App {
                 ResumeKind::Step { n } => {
                     label = "instruction step";
                     for _ in 0..n {
-                        self.emu.debug_step_realtime()?;
+                        // Past a STOP, like the headless server and the
+                        // workspace's own Step: a parked CPU retires
+                        // nothing until an interrupt reaches it.
+                        self.emu.debug_step_realtime_past_stop()?;
                         if self.emu.machine.ui_debug_stop_pending() {
                             break;
                         }

--- a/src/video/window/gdb.rs
+++ b/src/video/window/gdb.rs
@@ -611,7 +611,9 @@ impl App {
             self.sync_live_audio_suspension();
             self.complete_remote_resumes("pause", "paused for a gdb step");
         }
-        let reply = match self.emu.debug_step_realtime() {
+        // `stepi` carries a CPU parked in STOP to the interrupt that wakes
+        // it, as it does on the headless stub and in the workspace.
+        let reply = match self.emu.debug_step_realtime_past_stop() {
             Err(e) => {
                 error!("gdb: step halted the machine: {e:?}");
                 self.cpu_halted = true;

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -10611,7 +10611,9 @@ fn power_off_releases_a_programmatic_hold() {
 #[cfg(feature = "control")]
 mod warp_control {
     use super::super::app_session::WarpSource;
-    use super::{test_app, test_app_with_audio, SuspensionSink};
+    use super::{
+        test_app, test_app_with_audio, test_app_with_audio_cpu_and_program, SuspensionSink,
+    };
     use crate::control::exec::parse_method;
     use crate::control::windowed::{ControlHandle, CtlMsg};
     use serde_json::{json, Value};
@@ -10823,6 +10825,40 @@ mod warp_control {
         assert!(app.emu.paced());
     }
 
+    /// A machine parked in STOP with every interrupt masked in SR: no
+    /// interrupt can reach the CPU, so a step that hunts for its wake-up
+    /// shows up as the emulated frames it gives the machine, where the
+    /// single slice this used to take stood still. Paused, because the
+    /// control protocol's bounded step verbs refuse a running machine.
+    fn stopped_app() -> App {
+        let mut app = test_app_with_audio_cpu_and_program(
+            Box::new(crate::audio::NullSink),
+            crate::config::CpuModel::M68000,
+            &[0x4E72, 0x2700], // STOP #$2700
+        );
+        app.powered_on = true;
+        app.paused = true;
+        app
+    }
+
+    #[test]
+    fn a_windowed_control_step_carries_a_cpu_parked_in_stop() {
+        let mut app = stopped_app();
+        let (tx, rx) = attach(&mut app);
+        call(&mut app, &tx, &rx, 1, "step", json!({"n": 1}));
+        assert!(app.emu.machine.stopped(), "the program parks the CPU");
+
+        let before = app.emu.bus().emulated_frames();
+        call(&mut app, &tx, &rx, 2, "step", json!({"n": 1}));
+        let advanced = app.emu.bus().emulated_frames() - before;
+        assert!(
+            (1..=crate::emulator::DEBUG_STOP_WAKEUP_FRAMES).contains(&advanced),
+            "a windowed control step should hunt for the wake-up, bounded: \
+             advanced {advanced} frame(s)"
+        );
+        assert!(app.emu.machine.stopped(), "nothing can wake a masked CPU");
+    }
+
     #[test]
     fn control_warp_hold_outlives_a_finishing_boot_gate() {
         let (mut app, states) = audio_app();
@@ -10976,7 +11012,7 @@ mod warp_control {
 
 #[cfg(feature = "gdb")]
 mod gdb_drain {
-    use super::test_app;
+    use super::{test_app, test_app_with_audio_cpu_and_program};
     use crate::gdbstub::core::{checksum, hex_encode};
     use crate::gdbstub::windowed::{GdbHandle, GdbMsg};
     use std::sync::mpsc::{Receiver, Sender};
@@ -11008,6 +11044,39 @@ mod gdb_drain {
             out.push(f);
         }
         out
+    }
+
+    #[test]
+    fn a_windowed_stepi_carries_a_cpu_parked_in_stop() {
+        // STOP #$2700 masks every interrupt, so nothing wakes this CPU:
+        // the hunt for its wake-up is visible as the emulated frames the
+        // `s` packet gives the machine, where a single slice stood still.
+        let mut app = test_app_with_audio_cpu_and_program(
+            Box::new(crate::audio::NullSink),
+            crate::config::CpuModel::M68000,
+            &[0x4E72, 0x2700],
+        );
+        app.powered_on = true;
+        let (handle, cmd_tx, frame_rx) = GdbHandle::test_pair();
+        app.attach_gdb(handle, &crate::gdbstub::Config::new(":0".into()));
+        cmd_tx.send(GdbMsg::Connected).unwrap();
+
+        packet(&cmd_tx, "s");
+        app.drain_gdb();
+        assert!(app.emu.machine.stopped(), "the program parks the CPU");
+        let before = app.emu.bus().emulated_frames();
+
+        packet(&cmd_tx, "s");
+        app.drain_gdb();
+        let advanced = app.emu.bus().emulated_frames() - before;
+        assert!(
+            (1..=crate::emulator::DEBUG_STOP_WAKEUP_FRAMES).contains(&advanced),
+            "stepi should hunt for the wake-up, bounded: advanced {advanced} frame(s)"
+        );
+        assert!(
+            !frames(&frame_rx).is_empty(),
+            "each step replies with a stop"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two things found while testing the Debug workspace on Linux (X11 and Wayland, 1x/1.5x/1.75x/2x).

## Stepping a CPU parked in `STOP`

A stopped 68000 executes nothing -- it waits for an interrupt, and only device time can bring one -- so a single-instruction slice retired nothing and advanced no chipset time. On the AROS "waiting for bootable media" screen, five clicks of **Step** changed the machine not at all: same PC, same frame, zero pixels different. The pane says *CPU stopped*, but the button looks broken.

A step now falls back to the real-time loop's idle fast-forward -- the handling run-to, step-over and step-out have always had -- until one instruction retires: the first of the interrupt's handler, where control actually goes.

The retired instruction, not the exit from `STOP`, ends the hunt: an idle fast-forward slice can carry the wake-up and that first instruction together, while a single-instruction slice takes the exception on its own, and a step should mean the same thing either way.

It is bounded at two video frames (a VBlank comes once a frame, and it is what nearly every `STOP` waits for), so a CPU no interrupt can reach -- SR mask 7, or nothing enabled in `INTENA` -- leaves the machine stopped where the hardware itself is stuck, and the window says so instead of leaving a dead-looking button.

The control protocol's `step` and GDB's `stepi` take the same path, so every debugger surface lands in the same place. `continue`, and the callers that advance a whole frame one slice at a time (the profiler, a `.uss` warm-up), keep the plain slice: only a step asks for this.

Before and after, one **Step** on the idle AROS screen:

| | PC | SR | A7 |
|---|---|---|---|
| before | `00FE9194` (unchanged) | `2000` IPL0 | `00C7FFE0` |
| after | `00FE88B0` | `2200` IPL2 | `00C7FFC2` (exception frame) |

## Reopening a host clipboard that is not there

The clipboard poll runs three times a second and reopened the host clipboard on every one of them once opening had failed. Each attempt walks the clipboard protocols again and logs a warning from inside `arboard`, so a session whose host has no clipboard -- a Wayland compositor with no data-control protocol and no X11 display behind it -- filled the log at that rate for the whole run: **96 warnings in 30 seconds** under Weston.

Whether a session has a host clipboard at all is fixed when it starts, so no retry could succeed. The failure is remembered instead, and said once at a level the user sees:

```
WARN clipboard: no host clipboard (X11 server connection timed out because it
was unreachable); sharing is off this session
```

Same 30-second sample after the change: **1 warning**. The guest side of the bridge is untouched, so `clipboard.get`/`clipboard.set` over the control protocol keep working.

## Testing

- `cargo test --release --lib`: 3842 passed, 2 failed -- `crt_shader::presets_render_the_display_region_only` and `crt_shader::a_magnified_display_never_blends_in_the_status_bar`, both GPU/driver-dependent and failing on a clean tree on this machine; nothing here touches the shader.
- Three new tests cover a `STOP` waiting on VERTB: one step lands in the handler, the control-protocol and GDB entry points land in the same place, and a CPU with interrupts masked still returns inside its bound.
- `cargo fmt --check` clean. `cargo clippy --release --all-targets` reports one pre-existing `nonminimal_bool` in `src/video/nav.rs:627` and an unknown-lint warning in the build script; neither is from this change.
- Both fixes verified live in a headless X11/Wayland harness (Xvfb + Weston, scale 1 and 2).
- The docs build was not run locally (`myst` is not installed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETsT2bovGLiiNVTuh8voQE
