### PR TITLE
Fit the clipboard services board only where it was asked for

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -669,12 +669,14 @@ video = "PAL"
 # in clipboard.device unit 0) lands on the host clipboard, and host text is
 # available to paste in the guest, with Latin-1 and line-end conversion.
 # The guest side rides the services board's ROM (Kickstart 1.3 and later,
-# no guest configuration). Unset, the session decides: on in a windowed
-# session, off headless -- the host clipboard is live host state a replay
-# cannot reproduce. share = true fits the bridge even headless (reachable
-# through the control protocol's clipboard.get/set); share = false leaves
-# it out. Also --clipboard / --no-clipboard, and Input Settings > Share
-# Clipboard at runtime.
+# no guest configuration). Off by default in every session, because fitting
+# the bridge puts an autoconfig board on the Zorro chain that the machine
+# you configured does not have, and every Exec allocation behind it moves;
+# software that reads memory it has not written yet can tell. share = true
+# fits it, windowed or headless (headless it is reachable through the
+# control protocol's clipboard.get/set, not the host clipboard, so the run
+# stays deterministic). Also --clipboard / --no-clipboard, and Input
+# Settings > Share Clipboard at runtime.
 # [clipboard]
 # share = true
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -2216,7 +2216,7 @@ hook entirely and never see the mounts.
 
 ```toml
 [clipboard]
-share = true    # default: on in a windowed session, off headless
+share = true    # default: false -- sharing is opt-in
 ```
 
 Text copied in the guest -- anything an application posts to

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -50,7 +50,7 @@ range checks as the equivalent TOML fields:
 | `--cpu-clock MHZ` | `[cpu] clock_mhz` | a number of MHz |
 | `--fpu` / `--no-fpu` | `[cpu] fpu` | fit / omit a 68881/68882 |
 | `--jit` / `--no-jit` | `[cpu] jit` | experimental fast batch/trace-JIT CPU execution (68020+; not cycle-exact) |
-| `--clipboard` / `--no-clipboard` | `[clipboard] share` | share the host clipboard with the guest's `clipboard.device` (default: on windowed, off headless) |
+| `--clipboard` / `--no-clipboard` | `[clipboard] share` | share the host clipboard with the guest's `clipboard.device`; fits an extra autoconfig board, so it is opt-in (default: off) |
 | `--cartridge MODEL` | `[cartridge] model` | `none` (default) or `hrtmon`, the bundled HRTMon freezer cartridge |
 | `--chip SIZE` | `[memory] chip` | `512K`, `1M`, `2M`, ... |
 | `--fast SIZE` | `[memory] fast` | `0`, `1M`, `4M`, `8M`, ... |
@@ -2247,18 +2247,33 @@ in the log and then left alone rather than reopened on every poll; the
 guest side of the bridge still runs, so `clipboard.get`/`clipboard.set`
 over the control protocol keep working.
 
-`share` is unset by default, which means the session decides: a windowed
-session shares (the launcher's machines too), a headless run does not,
-since the host clipboard is live host state a replay cannot reproduce
-(see [Determinism and the host boundary](../internals/architecture.md#determinism-and-the-host-boundary)).
-Setting `share = true` (or `--clipboard`) fits the bridge regardless: in a
-headless run it is then reachable through the control protocol's
-`clipboard.get`/`clipboard.set` (see [Control](../debugger/control.md)),
-never through the host clipboard itself, and the run stays
-deterministic. That is also how a recording made in a windowed session
-replays headless with the same machine: pass `--clipboard`. `share =
-false` (or `--no-clipboard`) leaves the bridge out entirely. Netplay
-peers never share, on either side of the session and even with an explicit
+`share` is **off by default**, windowed and headless alike, and the bridge
+is fitted only where it is asked for: `share = true` or `--clipboard`.
+That is because the bridge is a unit of the Copperline services board, so
+sharing puts an autoconfig board on the Zorro chain that the machine you
+configured does not otherwise have. Kickstart binds the board at boot and
+every Exec allocation after it lands somewhere else. That is a different
+machine, and some software can tell: a program that points `COP1LC` at a
+buffer before it has written the list there has the Copper read whatever
+the buffer holds, and where the buffer sits decides what that is. Lotus
+Esprit Turbo Challenge hangs on one layout where the data decodes as a
+`MOVE` to `INTENA` that clears the master interrupt enable. A host
+convenience must not cost the guest its memory map without being asked,
+so it does not.
+
+Up to and including 0.20.0 `share` defaulted on for windowed sessions
+(the launcher's machines too), which is what made that Lotus hang look
+like an emulation bug. It is off everywhere now; turn it back on with
+`share = true` or `--clipboard`.
+
+Headless, `share = true` is still safe for determinism: the bridge is then
+reachable only through the control protocol's `clipboard.get`/`clipboard.set`
+(see [Control](../debugger/control.md)), never through the host clipboard
+itself, since the host clipboard is live host state a replay cannot
+reproduce (see [Determinism and the host boundary](../internals/architecture.md#determinism-and-the-host-boundary)).
+That is also how a recording made in a windowed session with sharing on
+replays headless on the same machine: pass `--clipboard`. Netplay peers
+never share, on either side of the session and even with an explicit
 `--clipboard`: every peer must build the same machine, and the bridge is
 part of the services board's layout, so a session where one side fitted it
 could not agree on a machine at all. *Input

--- a/docs/guide/headless.md
+++ b/docs/guide/headless.md
@@ -274,10 +274,10 @@ Run with `--script`:
   --script test.clscript --screenshot-after 125 /tmp/out.png
 ```
 
-A windowed session shares the host clipboard by default and a headless
-one does not (see `[clipboard]` in [Configuration](configuration.md#clipboard)),
-which puts a different services board in the machine: replay a recording
-made in the window with `--clipboard` so the headless machine matches
+Host clipboard sharing is off unless asked for, windowed or headless (see
+`[clipboard]` in [Configuration](configuration.md#clipboard)). It fits a
+services board, so it is part of the machine: replay a recording made in a
+window that had it on with `--clipboard` so the headless machine matches
 (headless, the bridge never reads the host clipboard, so the replay stays
 deterministic).
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -473,10 +473,11 @@ the guest. Overlay panels remain modal: their keys and clicks stay in the UI.
   recording captures them as individual key events.
 - **Share Clipboard**: host <-> guest clipboard text, both ways (text the
   guest copies lands on the host clipboard; host text is available to paste
-  in the guest). On by default in a windowed session; greyed out when the
-  machine was started with `[clipboard] share = false` / `--no-clipboard`,
-  since the guest side is part of the services board's boot. See the
-  `[clipboard]` section of [Configuration](configuration.md#clipboard).
+  in the guest). Off unless the machine was started with `[clipboard] share
+  = true` / `--clipboard`, and greyed out otherwise: the guest side is part
+  of the services board's boot, and that board is not fitted unless it was
+  asked for, because it moves the guest's memory map. See the `[clipboard]`
+  section of [Configuration](configuration.md#clipboard).
 - **Calibrate Gamepad...**: the guided calibration flow, described below.
 - **Input Mapping...**: edits which host keys drive the controller controls,
   for both keyboard mappings; see [](#input-mapping).

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -316,10 +316,13 @@ snapshot:
 - The host clipboard (`[clipboard] share`, `clipboard.rs`) is live host
   state. It reaches the guest only through the windowed session's poll or
   a control-protocol `clipboard.set`, never from the board itself, so a
-  headless run never depends on it: the bridge is fitted only when
-  configured (off by default headless, on windowed), and a headless run
-  with it fitted (`--clipboard`, so a windowed recording replays on the
-  same machine) executes the same timeline as one with no host traffic.
+  headless run never depends on it: a headless run with the bridge fitted
+  (`--clipboard`, so a windowed recording replays on the same machine)
+  executes the same timeline as one with no host traffic. The bridge is
+  fitted only where it was configured, off by default in every session,
+  because it is a unit of the services board and an autoconfig board the
+  guest did not ask for moves every Exec allocation behind it -- a machine
+  the configuration does not describe (`Config::resolve_clipboard_share`).
 
 Use fixed image files and scripted inputs for deterministic regression
 tests. See [save-state boundaries](savestate.md#determinism-boundaries) for

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1824,7 +1824,8 @@ fn print_help() {
          --jit / --no-jit               fast batch/trace-JIT CPU execution (not cycle-exact,\n  \
          \x20                            like an accelerator card; default: off)\n  \
          --clipboard / --no-clipboard   share the host clipboard with the guest's\n  \
-         \x20                            clipboard.device (default: on windowed, off headless)\n  \
+         \x20                            clipboard.device; fits an extra autoconfig board,\n  \
+         \x20                            so it is off unless asked for (default: off)\n  \
          --cartridge MODEL              freezer cartridge: none (default) or hrtmon (the\n  \
          \x20                            bundled HRTMon monitor, entered with --freeze-after,\n  \
          \x20                            the Freeze menu item, or cartridge.freeze)\n  \

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -289,12 +289,14 @@ pub struct Config {
     /// exist yet (see docs/internals/toccata.md).
     pub toccata: bool,
     /// Host <-> guest clipboard sharing (`[clipboard] share`,
-    /// `--clipboard`/`--no-clipboard`; `crate::clipboard`). `None` leaves
-    /// the choice to the session: a windowed session shares, a headless one
-    /// does not (the host clipboard is live host state a replay cannot
-    /// reproduce). `Some(true)` fits the clipboard unit of the services
-    /// board; headless it is then reachable only through the control
-    /// protocol.
+    /// `--clipboard`/`--no-clipboard`; `crate::clipboard`). `Some(true)`
+    /// fits the clipboard unit of the services board, windowed or headless
+    /// (headless it is reachable only through the control protocol, so the
+    /// run stays deterministic). Unset means off: the unit is an
+    /// autoconfig board the emulated Amiga does not have, and fitting it
+    /// moves the guest's memory map -- see
+    /// [`Config::resolve_clipboard_share`], which every session calls
+    /// before building a machine.
     pub clipboard_share: Option<bool>,
     /// Freezer cartridge (`[cartridge]`, `crate::cartridge`): a system
     /// monitor in its own bank at $A10000, entered by a level-7 interrupt
@@ -2696,6 +2698,27 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Settle host clipboard sharing for a session about to build a
+    /// machine: on only where the configuration asked for it, off
+    /// everywhere else, and off under netplay even when asked.
+    ///
+    /// The bridge is a unit of the Copperline services board, so fitting it
+    /// puts an autoconfig board on the chain that the emulated Amiga does
+    /// not have. Kickstart binds the board at boot and every Exec
+    /// allocation after that lands somewhere else, which is a different
+    /// machine from the one the configuration describes -- enough to move
+    /// where a program's buffers sit, and so what the Copper reads from a
+    /// list the program has pointed at but not yet written. A host
+    /// convenience cannot cost the guest its memory map by default, so it
+    /// is opt-in: `[clipboard] share = true` or `--clipboard`.
+    ///
+    /// Netplay refuses it on either side of the session, and even on an
+    /// explicit request: peers must build the same machine, and a session
+    /// where one side fitted the unit could not agree on one at all.
+    pub fn resolve_clipboard_share(&mut self, netplay: bool) {
+        self.clipboard_share = Some(!netplay && self.clipboard_share == Some(true));
+    }
+
     /// Why this resolved machine shape cannot use per-refresh run-ahead
     /// snapshots. These devices retain or mutate host state outside the
     /// serialized core. Dynamic media and observers are checked on the live

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -986,8 +986,11 @@ pub(crate) struct RawToccata {
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawClipboard {
-    /// Share the host clipboard with the guest's clipboard.device. Absent
-    /// means the session decides: on windowed, off headless.
+    /// Share the host clipboard with the guest's clipboard.device.
+    /// Absent means off, in every session: sharing fits a unit of the
+    /// services board, and an autoconfig board the configuration did not
+    /// ask for moves the guest's memory map (see
+    /// `Config::resolve_clipboard_share`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) share: Option<bool>,
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3784,6 +3784,38 @@ fn clipboard_share_is_unset_by_default_and_follows_the_key_or_flag() -> Result<(
 }
 
 #[test]
+fn resolve_clipboard_share_needs_an_explicit_request() -> Result<()> {
+    // Unset settles off, windowed or headless: the clipboard unit is part
+    // of a services board a real Amiga does not have, and binding it at
+    // boot moves every Exec allocation behind it.
+    let mut cfg = parse_config("")?;
+    cfg.resolve_clipboard_share(false);
+    assert_eq!(cfg.clipboard_share, Some(false));
+
+    let mut cfg = parse_config("[clipboard]\nshare = false\n")?;
+    cfg.resolve_clipboard_share(false);
+    assert_eq!(cfg.clipboard_share, Some(false));
+
+    let mut cfg = parse_config("[clipboard]\nshare = true\n")?;
+    cfg.resolve_clipboard_share(false);
+    assert_eq!(cfg.clipboard_share, Some(true));
+    Ok(())
+}
+
+#[test]
+fn resolve_clipboard_share_refuses_netplay_even_when_asked() -> Result<()> {
+    // Peers must build the same machine, and the unit is part of the
+    // board's layout: a session where one side fitted it could not agree
+    // on a machine at all.
+    for toml in ["", "[clipboard]\nshare = true\n"] {
+        let mut cfg = parse_config(toml)?;
+        cfg.resolve_clipboard_share(true);
+        assert_eq!(cfg.clipboard_share, Some(false), "config: {toml:?}");
+    }
+    Ok(())
+}
+
+#[test]
 fn toccata_is_absent_by_default_and_fits_when_enabled() -> Result<()> {
     assert!(!parse_config("")?.toccata);
     let cfg = parse_config("[toccata]\nenabled = true\n")?;

--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -4010,6 +4010,10 @@ fn build_machine_inner(
     // host clipboard only ever reaches the guest through a windowed
     // session's poll or a control-protocol client, so a headless run with
     // the unit fitted stays deterministic (see docs/internals/architecture.md).
+    // Every one of these is an explicit request: the board is an autoconfig
+    // board a real Amiga does not have, and binding it at boot moves every
+    // Exec allocation behind it, so nothing fits it on the guest's behalf
+    // (`Config::resolve_clipboard_share`).
     let clipboard = cfg.clipboard_share == Some(true);
     if !cfg.filesys.is_empty() || cfg.rom_scsi_device_disable || clipboard {
         let slot = devices.len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1132,18 +1132,9 @@ fn main() -> Result<()> {
         info!("emulation timing: paced to wall-clock because a physical floppy drive is attached");
     }
     info!("emulation timing: deterministic core, paced={paced}");
-    // Host clipboard sharing defaults on for a windowed session and off
-    // headless: the host clipboard is live host state a replay cannot
-    // reproduce (see docs/internals/architecture.md). Netplay peers must
-    // build identical machines, and the unit is part of the services
-    // board's layout, so a session never shares on either side -- not the
-    // guest, not the host, and not on an explicit --clipboard, which would
-    // otherwise leave a host-coupled input live across rollbacks.
-    if cli.netplay.is_some() || netplay_guest {
-        cfg.clipboard_share = Some(false);
-    } else if cfg.clipboard_share.is_none() {
-        cfg.clipboard_share = Some(!headless_capture);
-    }
+    // Host clipboard sharing is off unless the configuration asked for it,
+    // windowed or headless, and off under netplay either way.
+    cfg.resolve_clipboard_share(cli.netplay.is_some() || netplay_guest);
     let mut emu = emulator::build_machine(
         &cfg,
         audio,

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -1404,12 +1404,10 @@ impl App {
         if options.is_some() {
             crate::netplay::prepare_config(&mut cfg)?;
         }
-        // A launcher-started machine is a windowed session: share the host
-        // clipboard unless the config says otherwise -- except under
-        // netplay, where every peer must run the same machine.
-        if cfg.clipboard_share.is_none() {
-            cfg.clipboard_share = Some(options.is_none() && !guest);
-        }
+        // A launcher-started machine settles the host clipboard the same
+        // way a command line does: only where the configuration asked for
+        // it, and never under netplay.
+        cfg.resolve_clipboard_share(options.is_some() || guest);
         if guest {
             let _ = crate::config::resolve_bundled_rom(&mut cfg);
         } else {

--- a/src/video/window/app_session.rs
+++ b/src/video/window/app_session.rs
@@ -635,7 +635,10 @@ impl App {
             .filesys_board_mut()
             .filter(|b| b.clipboard_fitted())
         else {
-            self.show_osd("Clipboard sharing is not fitted ([clipboard] share)");
+            // Off unless asked for: the bridge is part of the services
+            // board's boot, and that board changes the guest's memory map,
+            // so it is a start-time choice and not one to add mid-session.
+            self.show_osd("Clipboard sharing not fitted: start with --clipboard");
             return;
         };
         let on = !board.clipboard_sharing();

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4396,6 +4396,42 @@ fn copperhf_test_fixture_builds_a_machine_with_the_configured_unit() {
     let _ = std::fs::remove_file(&image);
 }
 
+/// A windowed session builds the machine its configuration describes: the
+/// services board carrying the clipboard unit goes on the Zorro chain only
+/// where it was asked for. Binding a board a real Amiga does not have moves
+/// every Exec allocation behind it, which moves a program's buffers, and a
+/// program that lets the Copper run over a list it has not written yet
+/// reads a different word (Lotus Esprit Turbo Challenge hangs on one that
+/// decodes as a MOVE to INTENA).
+#[test]
+fn clipboard_unit_is_fitted_only_where_the_configuration_asked_for_it() {
+    fn board_fitted(toml: &str) -> bool {
+        std::env::set_var(
+            "COPPERLINE_AROS_DIR",
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets/aros"),
+        );
+        let raw: crate::config::RawConfig = toml::from_str(toml).expect("test config");
+        let mut cfg = crate::config::Config::try_from(raw).expect("config validates");
+        cfg.resolve_clipboard_share(false);
+        crate::config::resolve_bundled_rom(&mut cfg).expect("bundled AROS ROM resolves");
+        crate::emulator::build_machine(&cfg, Box::new(NullSink), false, false)
+            .expect("machine builds")
+            .bus()
+            .filesys_board()
+            .is_some()
+    }
+
+    assert!(!board_fitted(""), "an unset config fits no services board");
+    assert!(
+        !board_fitted("[clipboard]\nshare = false\n"),
+        "share = false fits no services board"
+    );
+    assert!(
+        board_fitted("[clipboard]\nshare = true\n"),
+        "share = true fits the board carrying the clipboard unit"
+    );
+}
+
 // ---------------------------------------------------------------------
 // A test machine that draws a hardware pointer.
 //


### PR DESCRIPTION
Host clipboard sharing defaulted on for every windowed session, including
every machine the launcher started. Sharing is a unit of the Copperline
services board, so that default put an autoconfig board on the Zorro chain
of a machine whose configuration never asked for one. Kickstart binds the
board at boot and every Exec allocation behind it moves, which is a
different Amiga from the one the user configured.

Some software can tell. Lotus Esprit Turbo Challenge (Europe) (Promo)
points `COP1LC` at a buffer during loading before it has written the list
there, so for about two seconds the Copper executes whatever that buffer
holds. Where the buffer sits decides what that is. On a stock A500 layout
the data is harmless; with the clipboard unit fitted the buffer lands
where the data decodes as `MOVE $09A, $5632` -- a write to INTENA with
bit 15 clear, which clears the master interrupt enable and VERTB, once
per frame. It lands 0.17 ms after the game's own `MOVE.W ($7D33C).L,($9A,A6)`
writes `$C020`, so INTENA settles at `$0000`. The game then installs its
title-sequence VERTB handler at `$789A6` and spins at `$785E0` waiting for
the handler to count 750 frames. The handler never runs: black screen, no
music, forever.

Fitting the board is now an explicit request in every session --
`[clipboard] share = true` or `--clipboard` -- and the two places that
settled the choice (the command line and the launcher) share one
`Config::resolve_clipboard_share`, which also closes a gap where a
launcher-started netplay session with `share = true` in its config kept
the unit that netplay refuses everywhere else.

Headless behaviour is unchanged: the bridge was already off unless asked
for, and `--clipboard` still fits it for replaying a windowed recording on
the same machine, reachable only through the control protocol.

## Verification

Headless, matched to the reported machine (KS1.3, ECS Agnus 8372 rev 4 +
OCS Denise, 512K chip + 512K slow, the promo IPF in DF0):

| run | INTENA at 47.1 s | result |
|---|---|---|
| before, `--clipboard` | `$0000` | hangs, black screen |
| before, default headless | `$4020` | plays |
| after, default (windowed or headless) | `$4020` | plays |
| after, `--clipboard` | `$0000` | hangs, as asked for |

Patching only `intena` to `$4020` in the reporter's save state and
resuming makes the title fade in and the game continue, which isolates
INTENA as the whole cause.

New tests: `resolve_clipboard_share_needs_an_explicit_request` and
`resolve_clipboard_share_refuses_netplay_even_when_asked` pin the
resolution, and `clipboard_unit_is_fitted_only_where_the_configuration_asked_for_it`
pins the machine -- the services board is on the Zorro chain only where the
configuration asked for it.

Docs updated: `[clipboard]` in the configuration guide (including what
changed since 0.20.0), the CLI table and `--help`, the headless and UI
guides, `copperline.example.toml`, and the host-boundary section of
`docs/internals/architecture.md`.

The 0.20.0 release notes have been amended to flag the default and the
workaround for anyone on that build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MXA2dJLTM2w9q7vNd2H37
