### PR TITLE
Add a live VSync toggle and use strict FIFO by default

### DIFF
--- a/copperline.example.toml
+++ b/copperline.example.toml
@@ -74,13 +74,14 @@ pacing_budget = "cycles"
 # one run (set it to 0/false/off to force it off).
 # realtime_priority = false
 
-# Default speed of Warp Speed (turbo) mode. The window presents with vsync,
-# so emulating one frame per presented frame would pin warp to the host
+# Default speed of Warp Speed (turbo) mode. With VSync enabled,
+# emulating one frame per presented frame would pin warp to the host
 # monitor's refresh rate. This is an output frame skip: warp retires this
 # many emulated frames per presented frame, making warp roughly the limit
 # times the refresh rate (host CPU permitting). One of "2x", "4x", "8x",
-# "16x", or "max" (default; run flat out, still presenting at vsync). Adjust
-# it live from Warp Settings > Warp Limit or Cmd+Shift+W / Alt+Shift+W.
+# "16x", or "max" (default; run flat out). With VSync off, presentation
+# frequency depends on host throughput. Adjust it live from Warp Settings >
+# Warp Limit or Cmd+Shift+W / Alt+Shift+W.
 # warp_speed = "max"
 
 # Warp boot: runs in unthrottled warp mode (audio muted) from power-on until
@@ -748,6 +749,10 @@ video = "PAL"
 # --show-status-bar / --hide-status-bar, and Cmd/Alt+Shift+F toggles it live).
 # menu_scale: how large the pop-up menu is drawn. "1x" (default) or "2x";
 # also --menu-scale, and Video Settings > Menu Size changes it live.
+# vsync: synchronise desktop presentation to vblank (default true).
+# Video Settings > VSync changes it live. Off may reduce latency but can
+# tear; normal emulation speed is unchanged. PAL on a fixed 60/120 Hz screen
+# can still have an uneven cadence with vsync on.
 # [display]
 # overscan = "tv"
 # tv_h_centre = 0
@@ -766,6 +771,7 @@ video = "PAL"
 # menu_scale = "1x"
 # full_screen = false
 # status_bar = true
+# vsync = true
 
 # [recording] -- the GIF clip ring behind Save Clip as GIF (Cmd/Alt+Shift+G)
 # and the rate of every GIF clip, including headless --gif-after captures.

--- a/crates/copperline-player/src/main.rs
+++ b/crates/copperline-player/src/main.rs
@@ -157,6 +157,7 @@ fn main() -> Result<()> {
         config::resolve_bezel(cfg.bezel),
         None,
         false,
+        cfg.vsync,
         config::resolve_tint(cfg.tint),
         cfg.full_screen,
         true,

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -438,13 +438,14 @@ carried no information.)
   `COPPERLINE_REALTIME_PRIORITY` overrides this for one run; set it to
   `0`/`false`/`off` to force it off, or to any other value (or leave it empty)
   to force it on.
-- `warp_speed` sets the default speed of Warp Speed (turbo) mode. The window
-  presents with vsync, so emulating one frame per presented frame would pin
+- `warp_speed` sets the default speed of Warp Speed (turbo) mode. With VSync
+  enabled (the default), emulating one frame per presented frame would pin
   warp to the host monitor's refresh rate. This option is an output frame
   skip -- `"2x"`, `"4x"`, `"8x"`, `"16x"`, or `"max"` (default) -- so warp
   retires that many emulated frames per presented frame, making warp roughly
   the limit times the refresh rate (host CPU permitting). `"max"` runs flat
-  out and still presents at vsync. Adjust it live from the **Warp Limit**
+  out and still presents at vsync when enabled. With VSync off, presentation
+  frequency depends on host throughput. Adjust it live from the **Warp Limit**
   menu item or `Cmd+Shift+W` / `Alt+Shift+W` (see [The window and its
   controls](ui.md)).
 - `warp_boot = true` accelerates boot sequences: from power-on, the machine
@@ -692,7 +693,17 @@ tint = "none"         # "none" (default), "bw", "green", "amber", or "sepia"
 menu_scale = "1x"     # size of the pop-up menu: "1x" (default) or "2x"
 full_screen = false   # open fullscreen at start (default false)
 status_bar = true     # show the status bar at start (default true)
+vsync = true          # synchronise desktop presentation to vblank (default true)
 ```
+
+`vsync` controls desktop presentation. On uses strict FIFO vsync to prevent
+tearing. Off requests unsynchronised presentation where the graphics backend
+supports it; it may reduce latency but can tear. **Video Settings > VSync**
+changes it live without restarting or changing normal emulation speed. The
+choice carries into the configuration screen when saving a config. Headless
+captures and the browser frontend are unaffected. Roughly 50 Hz PAL output
+can still show an uneven cadence on fixed 60 Hz or 120 Hz displays: VSync
+does not make those refresh rates match.
 
 The emulated framebuffer always carries the full overscan field Denise
 produces. `"tv"` presents what the monitor's glass shows: the captured

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -4,6 +4,15 @@ Copperline opens a single window: the emulated display presented at a
 TV-like 4:3 aspect ratio, above a status bar with the machine's controls.
 The window scales continuously when resized.
 
+The display defaults to buffered, synchronised presentation (strict FIFO
+vsync) on all desktop platforms. **Video Settings > VSync** changes this
+immediately; it is also in the configuration screen's A/V & Emu > Display
+category and saved as `[display] vsync`. PAL output is roughly 50 Hz, so
+motion can still have an uneven cadence on a fixed 60 Hz
+or 120 Hz display as some Amiga frames stay on screen for an extra refresh.
+Vsync prevents tearing but does not make those refresh rates match or change
+the emulated machine's speed.
+
 ## Keyboard shortcuts
 
 The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
@@ -427,6 +436,14 @@ the guest. Overlay panels remain modal: their keys and clicks stay in the UI.
   bars as needed, exactly as when resizing the window.
 - **Status Bar** (also `Cmd+Shift+F` / `Alt+Shift+F`): show or hide the
   status bar. Handy alongside fullscreen for a clean, chrome-free picture.
+- **VSync**: synchronise presentation to the monitor's vertical blank
+  (on by default). Turning it off requests presentation without waiting for
+  vblank where the graphics backend supports it; this may reduce latency
+  but can tear. It takes effect immediately and keeps normal emulation
+  speed unchanged. The choice carries into **Machine Configuration...**
+  when saving a config, as `[display] vsync`. VSync prevents tearing but
+  cannot remove the uneven cadence of PAL output on a mismatched monitor
+  refresh rate.
 - **Monitor Bezel**: which monitor front the picture sits inside instead
   of filling the window -- **Disabled**, **1084** (a two-tone cabinet with
   the tube sunk into its moulding, and the model badge, the Copperline name
@@ -549,13 +566,14 @@ boot-time cards, SRAM cards, real card readers, and the fast-RAM rule.
   independently and releases only its own, such a warp mutes live audio, the
   OSD names who asked, and one press of the shortcut ends them all.
 - **Warp Limit** (also `Cmd+Shift+W` / `Alt+Shift+W`): how fast warp runs.
-  Because the window presents with vsync, emulating one frame per presented
+  With VSync enabled, emulating one frame per presented
   frame would cap warp at the host monitor's refresh rate (about 1.2x for
   50 Hz PAL on a 60 Hz display). The limit sets an output frame skip -- 2x,
   4x, 8x, 16x, or **Max** -- so warp retires that many emulated frames per
   presented frame, making the effective speed roughly the limit times the
   refresh rate (host CPU permitting). `Max` runs flat out and still presents
-  at vsync. The default is set by `[emulation] warp_speed` (see
+  at vsync when enabled. With VSync off, the host's throughput determines
+  presentation frequency. The default is set by `[emulation] warp_speed` (see
   [Configuration](configuration.md)).
 
 ### Recording

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -403,6 +403,9 @@ pub struct Config {
     /// top-right of the display. The `Cmd+P` / `Alt+P` toggle flips it live
     /// without affecting this start-up value.
     pub perf_overlay: bool,
+    /// Synchronise desktop presentation to vblank (`[display] vsync`).
+    /// Enabled by default; independent of the emulator's real-time pacing.
+    pub vsync: bool,
     /// Screen tint applied to the window image: the phosphor colour of a
     /// monochrome monitor, or a sepia treatment. See [`Tint`].
     pub tint: Tint,
@@ -1632,20 +1635,21 @@ pub const WARP_MAX_FRAME_CAP: usize = 1024;
 
 /// Wall-clock budget (milliseconds) for one presented frame in `WarpSpeed::Max`.
 /// The event loop emulates frames back-to-back until this much host time has
-/// elapsed, then presents one frame at vsync. Kept under a 60 Hz refresh
-/// interval (16.6 ms) so input is still polled and a frame still presented every
-/// host refresh while the core runs flat out.
+/// elapsed, then presents one frame (at vsync when enabled). Kept under a
+/// 60 Hz refresh interval (16.6 ms) so input is still polled and a frame still
+/// presented every host refresh while the core runs flat out.
 pub const WARP_MAX_BUDGET_MS: u64 = 12;
 
 /// How fast the UI "Warp Speed" (turbo) mode runs when engaged.
 ///
-/// Presentation is gated to the host monitor's refresh rate (the wgpu surface
-/// presents with vsync), so emulating exactly one frame per presented frame
+/// With vsync enabled, presentation is gated to the host monitor's refresh
+/// rate, so emulating exactly one frame per presented frame
 /// caps warp at the monitor rate -- about 1.2x for a 50 Hz PAL machine on a
 /// 60 Hz display. To decouple emulation speed from the monitor, warp emulates
 /// several frames per *presented* frame (output frame skip): the intermediate
 /// frames are computed but never rendered or presented, so the effective speed
-/// is the level times the refresh rate, host CPU permitting.
+/// is the level times the refresh rate, host CPU permitting. Without vsync,
+/// presentation frequency depends on host throughput instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum WarpSpeed {
     /// Two emulated frames per presented frame.
@@ -1657,7 +1661,7 @@ pub enum WarpSpeed {
     /// Sixteen emulated frames per presented frame.
     X16,
     /// As many frames as fit in `WARP_MAX_BUDGET_MS` of host time per presented
-    /// frame (bounded by `WARP_MAX_FRAME_CAP`): run flat out, present at vsync.
+    /// frame (bounded by `WARP_MAX_FRAME_CAP`): run flat out, periodically present.
     #[default]
     Max,
 }
@@ -2678,6 +2682,7 @@ impl Default for Config {
             bezel: BezelStyle::None,
             bezel_stickers: None,
             perf_overlay: false,
+            vsync: true,
             tint: Tint::None,
             menu_scale: MenuScale::Normal,
             full_screen: false,

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -266,6 +266,7 @@ impl RawConfig {
             &overlay.display.pixel_aspect,
         );
         take(&mut self.display.scaling, &overlay.display.scaling);
+        take(&mut self.display.vsync, &overlay.display.vsync);
         take(&mut self.display.autocrop, &overlay.display.autocrop);
         take(&mut self.display.menu_scale, &overlay.display.menu_scale);
         take(&mut self.display.shader, &overlay.display.shader);
@@ -366,6 +367,9 @@ pub(crate) struct RawDisplay {
     /// Performance overlay in the top-right of the display (default false).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) perf_overlay: Option<bool>,
+    /// Synchronise desktop presentation to vblank (default true).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) vsync: Option<bool>,
     /// Screen tint: "none" (default), "bw", "green", "amber", or "sepia".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) tint: Option<String>,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -18,7 +18,7 @@ fn player_settings_overlay_field_by_field() -> Result<()> {
     base.set_display_defaults(Some("crt"), Some("1084"), Some(true));
 
     let overlay = RawConfig::parse(
-        "[display]\nshader = \"scanlines\"\nfull_screen = false\n\
+        "[display]\nshader = \"scanlines\"\nfull_screen = false\nvsync = false\n\
              [input]\nport2 = \"cd32\"\n",
     )?;
     base.merge_player_settings(&overlay);
@@ -26,6 +26,7 @@ fn player_settings_overlay_field_by_field() -> Result<()> {
     let cfg: Config = base.try_into()?;
     assert_eq!(cfg.shader, ShaderMode::Scanlines, "overlay wins");
     assert!(!cfg.full_screen, "overlay wins");
+    assert!(!cfg.vsync, "overlay wins");
     assert_eq!(cfg.bezel, BezelStyle::Model1084, "omitted keeps the base");
     assert_eq!(cfg.port_devices[1], crate::bus::PortDevice::Cd32Pad);
     assert_eq!(cfg.machine, Some(MachineModel::Cd32));
@@ -1279,6 +1280,20 @@ fn display_perf_overlay_parses_and_defaults_to_off() -> Result<()> {
     }
     .apply_to(&mut raw);
     assert_eq!(raw.display.perf_overlay, Some(true));
+    Ok(())
+}
+
+#[test]
+fn display_vsync_defaults_on_and_round_trips_both_choices() -> Result<()> {
+    assert!(parse_config("")?.vsync);
+    for enabled in [false, true] {
+        let mut raw = RawConfig::parse(&format!("[display]\nvsync = {enabled}\n"))?;
+        // An unrelated player preference must retain this display choice.
+        raw.merge_player_settings(&RawConfig::default());
+        let saved = raw.to_toml_string()?;
+        assert_eq!(parse_config(&saved)?.vsync, enabled);
+    }
+    assert!(parse_config("[display]\nvsync = \"off\"\n").is_err());
     Ok(())
 }
 

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -403,6 +403,7 @@ impl TryFrom<RawConfig> for Config {
             Some(p) => Some(PathBuf::from(p)),
         };
         let perf_overlay = raw.display.perf_overlay.unwrap_or(defaults.perf_overlay);
+        let vsync = raw.display.vsync.unwrap_or(defaults.vsync);
         let tint = match raw.display.tint.as_deref() {
             None => defaults.tint,
             Some(s) => parse_tint(s)?,
@@ -1441,6 +1442,7 @@ impl TryFrom<RawConfig> for Config {
             bezel,
             bezel_stickers,
             perf_overlay,
+            vsync,
             tint,
             menu_scale,
             full_screen,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1378,6 +1378,7 @@ fn main() -> Result<()> {
         config::resolve_bezel(cfg.bezel),
         config::resolve_bezel_stickers(cfg.bezel_stickers.clone()),
         config::resolve_perf_overlay(cfg.perf_overlay),
+        cfg.vsync,
         config::resolve_tint(cfg.tint),
         cfg.full_screen,
         !cfg.status_bar,
@@ -1553,6 +1554,7 @@ fn run_configuration_screen(raw_cfg: config::RawConfig) -> Result<()> {
         config::resolve_bezel(config::BezelStyle::None),
         config::resolve_bezel_stickers(None),
         config::resolve_perf_overlay(false),
+        true,
         config::resolve_tint(config::Tint::None),
         // The config-screen placeholder is always a normal windowed UI.
         false,

--- a/src/video/launcher.rs
+++ b/src/video/launcher.rs
@@ -911,6 +911,8 @@ pub struct MachineSetup {
     bezel_stickers: Option<PathBuf>,
     /// Performance overlay in the top-right ([display] perf_overlay).
     perf_overlay: bool,
+    /// Synchronise desktop presentation to vblank ([display] vsync).
+    vsync: bool,
     /// The MT-32's two ROM images, whether its front panel starts up, and
     /// how that panel's display is lit.
     mt32_control_rom: Option<PathBuf>,

--- a/src/video/launcher/fields.rs
+++ b/src/video/launcher/fields.rs
@@ -616,6 +616,7 @@ pub enum LauncherField {
     ShaderStrength,
     Bezel,
     PerfOverlay,
+    Vsync,
     MenuScale,
     StartFullscreen,
     ShowStatusBar,
@@ -1221,10 +1222,11 @@ pub(super) const VIDEO_ROWS: [Row; 10] = [
 ];
 
 // The host window and its furniture, as distinct from the picture inside it.
-pub(super) const DISPLAY_ROWS: [Row; 4] = [
+pub(super) const DISPLAY_ROWS: [Row; 5] = [
     row(F::StartFullscreen, "Start fullscreen", Cycle),
     row(F::ShowStatusBar, "Status bar", Cycle),
     row(F::PerfOverlay, "Perf overlay", Cycle),
+    row(F::Vsync, "VSync", Cycle),
     row(F::MenuScale, "Menu size", Cycle),
 ];
 pub(super) const AUDIO_ROWS: [Row; 6] = [

--- a/src/video/launcher/setup_config.rs
+++ b/src/video/launcher/setup_config.rs
@@ -314,6 +314,7 @@ impl MachineSetup {
             bezel: cfg.bezel,
             bezel_stickers: cfg.bezel_stickers.clone(),
             perf_overlay: cfg.perf_overlay,
+            vsync: cfg.vsync,
             mt32_control_rom: cfg.serial.mt32_control_rom.clone(),
             mt32_pcm_rom: cfg.serial.mt32_pcm_rom.clone(),
             mt32_panel: cfg.serial.mt32_panel,
@@ -798,6 +799,9 @@ impl MachineSetup {
         }
         if self.perf_overlay != base.perf_overlay {
             raw.display.perf_overlay = Some(self.perf_overlay);
+        }
+        if self.vsync != base.vsync {
+            raw.display.vsync = Some(self.vsync);
         }
         if self.tint != base.tint {
             raw.display.tint = Some(tint_name(self.tint).to_string());

--- a/src/video/launcher/tests.rs
+++ b/src/video/launcher/tests.rs
@@ -2384,6 +2384,23 @@ fn display_scaling_round_trips_through_raw() {
 }
 
 #[test]
+fn vsync_launcher_toggle_survives_save_and_reload() {
+    let mut setup = MachineSetup::default();
+    assert!(setup.toggle_value(LauncherField::Vsync));
+    assert!(setup.to_raw().display.vsync.is_none());
+
+    setup.cycle(LauncherField::Vsync, true);
+    assert!(!setup.build_config().unwrap().vsync);
+    let raw = setup.to_raw();
+    assert_eq!(raw.display.vsync, Some(false));
+    let mut reloaded = MachineSetup::from_raw(&raw).unwrap();
+    assert!(!reloaded.toggle_value(LauncherField::Vsync));
+    reloaded.cycle(LauncherField::Vsync, true);
+    assert!(reloaded.build_config().unwrap().vsync);
+    assert!(reloaded.to_raw().display.vsync.is_none());
+}
+
+#[test]
 fn cycling_chip_ram_walks_the_presets() {
     let mut s = MachineSetup::default();
     assert_eq!(s.chip_ram, 512 * 1024);

--- a/src/video/launcher/values.rs
+++ b/src/video/launcher/values.rs
@@ -40,6 +40,7 @@ boolean_settings! {
     Autocrop => autocrop,
     Deinterlace => deinterlace,
     PerfOverlay => perf_overlay,
+    Vsync => vsync,
     Mt32Panel => mt32_panel,
     #[cfg(feature = "midi")]
     SerialTelnet => serial_telnet,

--- a/src/video/menu.rs
+++ b/src/video/menu.rs
@@ -56,6 +56,7 @@ pub enum MenuAction {
     ToggleFullscreen,
     ToggleStatusBar,
     TogglePerfOverlay,
+    ToggleVsync,
 
     // Media.
     /// Pick a hard-disk image and push it into the PCMCIA slot as a CF
@@ -471,6 +472,7 @@ pub struct MenuState<'a> {
     /// Which monitor front the bezel pass is drawing, if any.
     pub bezel: BezelStyle,
     pub perf_overlay: bool,
+    pub vsync: bool,
     pub warp: bool,
     pub warp_speed: WarpSpeed,
     pub rewind: bool,
@@ -839,6 +841,7 @@ fn video_rows(s: &MenuState) -> Vec<MenuRow> {
         // category to fit the longest style name.
         MenuRow::submenu("Monitor Bezel", bezel_rows(s)),
         MenuRow::toggle("Performance", MenuAction::TogglePerfOverlay, s.perf_overlay),
+        MenuRow::toggle("VSync", MenuAction::ToggleVsync, s.vsync),
     ]
 }
 
@@ -856,6 +859,7 @@ fn player_video_rows(s: &MenuState) -> Vec<MenuRow> {
         shader_strength_row(s),
         MenuRow::submenu("Screen Tint", tint_rows(s)),
         MenuRow::toggle("Fullscreen", MenuAction::ToggleFullscreen, s.fullscreen),
+        MenuRow::toggle("VSync", MenuAction::ToggleVsync, s.vsync),
         MenuRow::submenu("Monitor Bezel", bezel_rows(s)),
     ]
 }
@@ -1385,6 +1389,7 @@ mod tests {
             status_bar_hidden: false,
             bezel: BezelStyle::None,
             perf_overlay: false,
+            vsync: true,
             warp: false,
             warp_speed: WarpSpeed::Max,
             rewind: false,
@@ -1735,7 +1740,7 @@ mod tests {
         assert!(!find(video, "Fullscreen").expect("fullscreen").closes_menu());
         // Every window toggle with a keyboard shortcut is reachable from
         // the menu too: the shortcut is the shortcut, not the only way.
-        for label in ["Status Bar", "Performance"] {
+        for label in ["Status Bar", "Performance", "VSync"] {
             let row = find(video, label).unwrap_or_else(|| panic!("{label} missing"));
             assert!(row.marks_state(), "{label} is not a toggle");
             assert!(!row.closes_menu(), "picking {label} closed the menu");
@@ -1876,6 +1881,7 @@ mod tests {
             "Shader Strength",
             "Monitor Bezel",
             "Fullscreen",
+            "VSync",
         ] {
             assert!(find(video, kept).is_some(), "missing {kept}");
         }

--- a/src/video/ui/tests.rs
+++ b/src/video/ui/tests.rs
@@ -3605,6 +3605,7 @@ fn panels_render_into_their_rects() {
         status_bar_hidden: false,
         bezel: crate::config::BezelStyle::None,
         perf_overlay: false,
+        vsync: true,
         warp: false,
         warp_speed: WarpSpeed::Max,
         rewind: false,

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1375,6 +1375,8 @@ pub struct App {
     /// a live emulation-performance readout in the top-right of the
     /// display. Presentation only, like the OSD: captures never include it.
     perf_overlay: bool,
+    /// Live desktop vsync preference, also used when recreating the surface.
+    vsync: bool,
     /// The overlay's formatted lines and sampling baseline.
     perf: PerfOverlay,
     /// Screen tint in effect ([display] tint). Presentation only, applied
@@ -1457,7 +1459,7 @@ pub struct App {
     sampler_stream: Option<cpal::Stream>,
     /// Output frame-skip level for warp/turbo mode: how many emulated frames
     /// are retired per presented frame while warp is engaged. Presentation is
-    /// vsync-gated, so this is what decouples warp speed from the host monitor
+    /// normally vsync-gated, so this decouples warp speed from the host monitor
     /// refresh rate. Adjustable from the Emulator menu and the keyboard.
     warp_speed: WarpSpeed,
     /// Rewind capture settings from `[emulation]`, kept so the Rewind menu
@@ -2100,6 +2102,7 @@ impl App {
         bezel: BezelStyle,
         bezel_stickers: Option<PathBuf>,
         perf_overlay: bool,
+        vsync: bool,
         tint: crate::config::Tint,
         start_fullscreen: bool,
         hide_status_bar: bool,
@@ -2333,6 +2336,7 @@ impl App {
             bezel_last: last_bezel_style(bezel),
             bezel_stickers_path: bezel_stickers,
             perf_overlay,
+            vsync,
             perf: PerfOverlay::default(),
             tint,
             tint_lut: tint_lut(tint),
@@ -3933,7 +3937,7 @@ impl ApplicationHandler for App {
         // Other platforms keep wgpu's default backend set (Metal on macOS,
         // DX12/Vulkan on Windows). cfg!() (not #[cfg]) keeps the Linux branch
         // type-checked on every host.
-        let pixels = match build_pixels_for_window(window.clone(), texture_scale, true) {
+        let pixels = match build_pixels_for_window(window.clone(), texture_scale, self.vsync) {
             Ok(p) => p,
             Err(e) => {
                 error!("pixels init failed: {e}");
@@ -5317,6 +5321,7 @@ impl ApplicationHandler for App {
         if self.render.is_none() {
             return;
         }
+        let host_poll_started = Instant::now();
         // Act on a completed drop before the OSD/control-flow computation
         // below, so a drop-raised OSD keeps the loop awake for its fade.
         if !self.pending_dropped_files.is_empty() {
@@ -5498,7 +5503,7 @@ impl ApplicationHandler for App {
             // If the live output device vanished (unplugged), reopen on the
             // current default so sound continues.
             self.recover_audio_if_device_lost();
-            // Presentation is vsync-gated, so emulating exactly one frame per
+            // With vsync enabled, emulating exactly one frame per
             // presented frame would cap warp at the host monitor refresh rate
             // (about 1.2x for 50 Hz PAL on a 60 Hz display). In warp, retire
             // several frames per presented frame (output frame skip): only the
@@ -5734,6 +5739,16 @@ impl ApplicationHandler for App {
         self.fire_auto_save_state();
         if self.fire_auto_shot() {
             event_loop.exit();
+        }
+        // Paused/off animations have no emulation-clock sleep. With vsync
+        // disabled they also lose the swapchain wait, so bound their polling
+        // to a UI frame. Credit any sleeps/work already done above.
+        if !self.vsync && !running && event_loop.control_flow() == ControlFlow::Poll {
+            let wait =
+                std::time::Duration::from_millis(16).saturating_sub(host_poll_started.elapsed());
+            if !wait.is_zero() {
+                std::thread::sleep(wait);
+            }
         }
     }
 }
@@ -6142,6 +6157,7 @@ impl App {
             return;
         };
         let mut raw = crate::config::RawConfig::default();
+        raw.display.vsync = Some(self.vsync);
         raw.display.pixel_aspect =
             Some(super::launcher::pixel_aspect_name(crate::video::pixel_aspect()).to_string());
         raw.display.scaling = Some(

--- a/src/video/window/app_display.rs
+++ b/src/video/window/app_display.rs
@@ -455,6 +455,24 @@ impl App {
         self.request_redraw();
     }
 
+    /// Change the host swapchain without restarting or changing guest pacing.
+    /// Keep the configuration screen in sync so Save retains the live choice.
+    pub(super) fn apply_vsync(&mut self, enabled: bool) {
+        if self.vsync == enabled {
+            return;
+        }
+        self.vsync = enabled;
+        self.machine_config.display.vsync = Some(enabled);
+        if let Some(render) = self.render.as_mut() {
+            render.pixels.set_present_mode(window_present_mode(enabled));
+            info!(
+                "window presentation: mode={:?}",
+                render.pixels.present_mode()
+            );
+        }
+        self.request_redraw();
+    }
+
     /// Follow a change of the canvas height that came from a presentation
     /// setting -- the pixel aspect, integer scaling under the tv aspect,
     /// the bezel (`video::present_height`): re-plan the main texture for

--- a/src/video/window/app_launcher.rs
+++ b/src/video/window/app_launcher.rs
@@ -1528,6 +1528,7 @@ impl App {
         // adopting them in this order moves the canvas at most once.
         self.apply_bezel_style(crate::config::resolve_bezel(cfg.bezel));
         self.apply_display_scaling(cfg.scaling);
+        self.apply_vsync(cfg.vsync);
         self.apply_autocrop(cfg.autocrop);
         // Apply the configured start-up window state; the runtime toggles
         // (Cmd+F, Cmd+Shift+F) take over from here. Reuse the toggles so the

--- a/src/video/window/app_menus.rs
+++ b/src/video/window/app_menus.rs
@@ -110,6 +110,7 @@ impl App {
             status_bar_hidden: crate::video::status_bar_hidden(),
             bezel: self.bezel,
             perf_overlay: self.perf_overlay,
+            vsync: self.vsync,
             warp: !self.emu.paced(),
             warp_speed: self.warp_speed,
             rewind: self.rewind_armed,
@@ -314,6 +315,14 @@ impl App {
             A::SetPixelAspect(aspect) => self.apply_pixel_aspect(aspect),
             A::SetDisplayScaling(scaling) => self.apply_display_scaling(scaling),
             A::ToggleAutocrop => self.apply_autocrop(!crate::video::autocrop()),
+            A::ToggleVsync => {
+                self.apply_vsync(!self.vsync);
+                self.show_osd(if self.vsync {
+                    "VSync: on"
+                } else {
+                    "VSync: off"
+                });
+            }
             A::StepTvCentre(dh, dv) => self.step_tv_centre(dh, dv),
             A::ResetTvCentre => {
                 self.tv_centre = crate::config::TvCentre::default();

--- a/src/video/window/app_session.rs
+++ b/src/video/window/app_session.rs
@@ -743,7 +743,7 @@ impl App {
     /// an optional wall-clock budget that bounds that burst. Warp's output frame
     /// skip applies only while warp is engaged and not doing headless capture;
     /// real-time pacing and headless capture both run one frame per presented
-    /// frame. The `Max` level returns a budget so the burst presents at vsync
+    /// frame. The `Max` level returns a budget so the burst presents regularly
     /// rather than spinning to its frame cap.
     pub(super) fn warp_burst_plan(
         &self,

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -913,6 +913,18 @@ pub(super) fn surface_resize_for_draw(
     ((inner.width, inner.height) != configured).then_some(inner)
 }
 
+pub(super) fn window_present_mode(vsync: bool) -> pixels::wgpu::PresentMode {
+    // pixels' enable_vsync(true) selects AutoVsync, which prefers
+    // FifoRelaxed where supported (including Vulkan on X11). That permits tearing
+    // whenever a frame arrives after vblank, including normal PAL output on
+    // a faster host display. FIFO keeps every swap on a vblank instead.
+    if vsync {
+        pixels::wgpu::PresentMode::Fifo
+    } else {
+        pixels::wgpu::PresentMode::AutoNoVsync
+    }
+}
+
 pub(super) fn build_pixels_for_window(
     window: Arc<Window>,
     texture_scale: usize,
@@ -925,7 +937,8 @@ pub(super) fn build_pixels_for_window(
         texture_height(texture_scale) as u32,
     );
     let surface_texture = SurfaceTexture::new(surface.0, surface.1, window);
-    let builder = PixelsBuilder::new(texture.0, texture.1, surface_texture).enable_vsync(vsync);
+    let builder = PixelsBuilder::new(texture.0, texture.1, surface_texture)
+        .present_mode(window_present_mode(vsync));
     let builder = if cfg!(target_os = "linux") {
         builder.wgpu_backend(
             pixels::wgpu::Backends::from_env().unwrap_or(pixels::wgpu::Backends::VULKAN),
@@ -934,6 +947,11 @@ pub(super) fn build_pixels_for_window(
         builder
     };
     let mut pixels = builder.build()?;
+    info!(
+        "window presentation: mode={:?}, supported={:?}",
+        pixels.present_mode(),
+        pixels.context().surface_capabilities.present_modes
+    );
     // The tool windows draw through the built-in Fill renderer (the
     // emulator window's own scaler pass ignores the mode). The scaling
     // matrix and clip rect stay the builder's defaults until a resize

--- a/src/video/window/tests.rs
+++ b/src/video/window/tests.rs
@@ -4293,6 +4293,7 @@ fn test_app_with_audio_cpu_and_program(
         crate::config::BezelStyle::None,
         None,
         false,
+        true,
         crate::config::Tint::None,
         false,
         false,
@@ -4319,6 +4320,42 @@ fn copperhf_temp_hardfile(name: &str) -> PathBuf {
     ));
     std::fs::write(&path, vec![0u8; 256 * 1024]).unwrap();
     path
+}
+
+#[test]
+fn vsync_menu_toggle_preserves_guest_pacing_and_configuration_choice() {
+    use crate::video::menu::MenuAction;
+    use pixels::wgpu::PresentMode;
+
+    let mut app = test_app();
+    app.emu.set_paced(true);
+    let frame = app.emu.bus().emulated_frames();
+    let pc = app.emu.machine.pc();
+    assert!(app.vsync);
+    assert_eq!(super::window_present_mode(app.vsync), PresentMode::Fifo);
+
+    app.run_menu_action(MenuAction::ToggleVsync, None);
+    assert!(!app.vsync);
+    assert_eq!(
+        super::window_present_mode(app.vsync),
+        PresentMode::AutoNoVsync
+    );
+    assert!(app.emu.paced());
+    assert_eq!(app.emu.bus().emulated_frames(), frame);
+    assert_eq!(app.emu.machine.pc(), pc);
+    app.open_launcher();
+    let saved = app.launcher_state().unwrap().setup.to_raw();
+    assert!(!crate::config::Config::try_from(saved).unwrap().vsync);
+
+    // Re-enabling while in warp must not turn normal emulation pacing on.
+    app.emu.set_paced(false);
+    app.run_menu_action(MenuAction::ToggleVsync, None);
+    assert!(app.vsync);
+    assert_eq!(super::window_present_mode(app.vsync), PresentMode::Fifo);
+    assert!(!app.emu.paced());
+    app.open_launcher();
+    let saved = app.launcher_state().unwrap().setup.to_raw();
+    assert!(crate::config::Config::try_from(saved).unwrap().vsync);
 }
 
 /// An interactive App around a real machine with one or more `[copperhf]`
@@ -4373,6 +4410,7 @@ fn test_app_with_copperhf_units(units: &[(usize, PathBuf)]) -> super::App {
         crate::config::BezelStyle::None,
         None,
         false,
+        true,
         crate::config::Tint::None,
         false,
         false,


### PR DESCRIPTION
Desktop VSync previously used `AutoVsync`, which can select `FifoRelaxed` on Vulkan/X11 and tear when frames arrive late. Default to strict FIFO and add **Video Settings > VSync** for immediate switching without restarting or changing normal emulation speed.

The setting defaults on, is saved as `[display] vsync`, appears in the configuration screen, and is retained by standalone player preferences. Off uses the backend's supported non-vsync fallback. Paused UI polling is bounded when VSync is off. The guide and example configuration explain the option and the remaining PAL/monitor refresh-rate mismatch.

Validation:
- Focused VSync/configuration/menu tests pass. Full library run: 3,839 passed, 42 ignored; three failures passed isolated reruns with host MIDI/network access (including the timing-sensitive mouse-convergence test).
- Locked all-target/all-feature Clippy, root/player formatting, standalone player check, and strict HTML/PDF manual builds pass.
- Optimized Linux build on an Intel Core Ultra Framework: Xwayland requests strict FIFO despite advertising FifoRelaxed; native Wayland starts successfully with On and Off; live On/Off/On menu switching exercised under Xvfb, with guest pacing retained.
- Headless On/Off runs produce byte-identical PNGs. Additional gameplay checks use the maintainer’s trainer-free Pinball Dreams ADFs and a scripted Ignition game: four 60-second runs at normal priority (original Xwayland default/strict FIFO and patched Wayland On/Off) each sustained about 49.9 fps with zero measured audio underruns or pacing slips. CPU use was similar within each pair; the original release build and patched optimized CI-profile build are not compared against each other.

The reported AMD/Ubuntu hardware was unavailable. This addresses presentation policy and provides a comparison switch; it does not claim to fix the reported audio glitches or remove PAL cadence judder.
