### PR TITLE
Coordinate Wayland redraws with compositor frame callbacks

### DIFF
--- a/.github/workflows/linux-present.yml
+++ b/.github/workflows/linux-present.yml
@@ -1,8 +1,9 @@
 name: Linux present
 
 # Verifies Copperline's presentation path initializes and renders frames on
-# Linux using software Vulkan (Mesa lavapipe) under a headless X server. Guards
-# the "Vulkan required on Linux" policy in src/video/window.rs: wgpu's GL
+# Linux using software Vulkan (Mesa lavapipe) under Xvfb and a headless Wayland
+# compositor. Guards the "Vulkan required on Linux" policy in
+# src/video/window.rs: wgpu's GL
 # fallback drops to an unusable surfaceless EGL platform, so a Vulkan adapter
 # (hardware or lavapipe) must be reachable for the window surface to come up.
 # GitHub runners have no GPU, so this exercises the lavapipe path -- the same
@@ -23,6 +24,7 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - ".github/workflows/linux-present.yml"
+      - "tools/check-wayland-present.py"
   pull_request:
     paths:
       - "src/video/**"
@@ -30,6 +32,7 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - ".github/workflows/linux-present.yml"
+      - "tools/check-wayland-present.py"
 
 concurrency:
   group: linux-present-${{ github.ref }}
@@ -49,15 +52,16 @@ jobs:
         # Build: ALSA (cpal) + udev (gilrs). Runtime: software Vulkan (Mesa
         # lavapipe) + a virtual X server, plus the X11/xkb client libraries
         # winit dlopens at startup (libxkbcommon-x11 in particular, which the
-        # runner image does not ship). CI runners have no GPU, so lavapipe is
-        # the only ICD present. Keep this list in sync with
+        # runner image does not ship). Weston supplies the isolated Wayland
+        # compositor. CI runners have no GPU, so lavapipe is
+        # the only ICD present. The X11 dependencies are also used by
         # packaging/test-linux-vulkan/Dockerfile.
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libasound2-dev libudev-dev \
             mesa-vulkan-drivers vulkan-tools \
-            xvfb xauth \
+            xvfb xauth weston \
             libxkbcommon0 libxkbcommon-x11-0 \
             libx11-6 libx11-xcb1 libxcb1 \
             libxcursor1 libxi6 libxrandr2 libxrender1 \
@@ -99,10 +103,17 @@ jobs:
             trap - EXIT
           '
           echo "present path OK ($(stat -c %s /tmp/present.png) bytes)"
+      - name: Native Wayland present smoke
+        run: |
+          python3 tools/check-wayland-present.py ./target/release/copperline \
+            --output-dir /tmp/wayland-present
       - name: Upload present screenshot
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: linux-present-screenshot
-          path: /tmp/present.png
+          path: |
+            /tmp/present.png
+            /tmp/wayland-present/*.png
+            /tmp/wayland-present/*.log
           if-no-files-found: ignore

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -13,6 +13,21 @@ or 120 Hz display as some Amiga frames stay on screen for an extra refresh.
 Vsync prevents tearing but does not make those refresh rates match or change
 the emulated machine's speed.
 
+On native Wayland, redraws also follow compositor frame callbacks. This
+allows the compositor to throttle a hidden window and schedule visible
+updates, including when VSync is off.
+
+For display diagnostics, launch with `RUST_LOG=info` to log the selected
+presentation mode, supported modes, GPU, graphics backend, and window
+system. The window-system field distinguishes native Wayland from an X11
+window running through XWayland. Add `COPPERLINE_PRESENT_PROFILE=1` to log
+each presentation attempt: its emulated frame number, interval since the
+previous attempt, time acquiring/uploading the surface, time recording draw
+commands, and time submitting/presenting. `submitted=false` means no frame
+was submitted; `-1` marks a stage that was not reached. These are host CPU
+timings, not GPU execution or physical display timestamps. They complement
+the performance overlay, whose FPS measures emulated frames.
+
 ## Keyboard shortcuts
 
 The app shortcut modifier is `Cmd` on macOS and `Alt` on Linux/Windows.
@@ -573,9 +588,9 @@ boot-time cards, SRAM cards, real card readers, and the fast-RAM rule.
   4x, 8x, 16x, or **Max** -- so warp retires that many emulated frames per
   presented frame, making the effective speed roughly the limit times the
   refresh rate (host CPU permitting). `Max` runs flat out and still presents
-  at vsync when enabled. With VSync off, the host's throughput determines
-  presentation frequency. The default is set by `[emulation] warp_speed` (see
-  [Configuration](configuration.md)).
+  at vsync when enabled. With VSync off, presentation frequency depends on
+  host throughput and compositor redraw scheduling. The default is set by
+  `[emulation] warp_speed` (see [Configuration](configuration.md)).
 
 ### Recording
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -193,6 +193,16 @@ The flow of a frame:
    wall-clock; for headless captures it does not. The emulated result is
    identical either way -- pacing only schedules host work.
 
+Window presentation goes through `window/presenter.rs`. After a successful
+draw callback, it calls winit's `pre_present_notify` before pixels submits
+and presents the buffer. Native Wayland uses that notification to request
+a compositor frame callback for subsequent redraws. A surface acquisition
+that times out or reports occlusion does not arm a callback, because no
+buffer will be committed. This schedules host redraws independently of the
+emulated clock. `COPPERLINE_PRESENT_PROFILE=1` enables per-attempt CPU
+timings for acquisition/upload, draw-command recording, and submission;
+these do not measure GPU completion or display scanout.
+
 The main presentation path uses the **main thread** (event loop, core,
 and pacer), the **`copperline-render` worker**, and the **cpal audio
 callback**. Rendering passes owned buffers and immutable shared snapshots;

--- a/src/video/window.rs
+++ b/src/video/window.rs
@@ -1688,6 +1688,7 @@ impl Drop for GifCaptureState {
 struct Render {
     window: Arc<Window>,
     pixels: Pixels<'static>,
+    presenter: presenter::Presenter,
     texture_scale: usize,
     debug_viewport: Option<(u32, u32, u32, u32)>,
     /// The pass that puts the composited buffer on the surface (see
@@ -3989,6 +3990,7 @@ impl ApplicationHandler for App {
         self.render = Some(Render {
             window,
             pixels,
+            presenter: presenter::Presenter::new(),
             texture_scale,
             scaler,
             rtg_texture,
@@ -5075,33 +5077,39 @@ impl ApplicationHandler for App {
                         // pixels rather than through the canvas texture the
                         // scaler pass letterboxed above.
                         let integer_scaling = integer_scaling_requested();
-                        r.pixels.render_with(|encoder, target, ctx| {
-                            scaler.render(
-                                &ctx.device,
-                                &ctx.queue,
-                                &ctx.texture,
-                                encoder,
-                                target,
-                                &present_draws,
-                            );
-                            let (cx, cy, cw, ch) = present_clip;
-                            let disp_h = if debug_layout {
-                                ch as f32
-                            } else {
-                                ch as f32 * present_height() as f32 / window_present_height() as f32
-                            };
-                            rtg.render(
-                                &ctx.queue,
-                                encoder,
-                                target,
-                                (cx as f32, cy as f32, cw as f32, disp_h),
-                                integer_scaling,
-                            );
-                            if let Some(ui) = inspector_ui {
-                                ui.paint_prepared(&ctx.device, &ctx.queue, encoder, target);
-                            }
-                            Ok(())
-                        })
+                        r.presenter.render(
+                            &r.pixels,
+                            &r.window,
+                            self.last_rendered_emulated_frame,
+                            |encoder, target, ctx| {
+                                scaler.render(
+                                    &ctx.device,
+                                    &ctx.queue,
+                                    &ctx.texture,
+                                    encoder,
+                                    target,
+                                    &present_draws,
+                                );
+                                let (cx, cy, cw, ch) = present_clip;
+                                let disp_h = if debug_layout {
+                                    ch as f32
+                                } else {
+                                    ch as f32 * present_height() as f32
+                                        / window_present_height() as f32
+                                };
+                                rtg.render(
+                                    &ctx.queue,
+                                    encoder,
+                                    target,
+                                    (cx as f32, cy as f32, cw as f32, disp_h),
+                                    integer_scaling,
+                                );
+                                if let Some(ui) = inspector_ui {
+                                    ui.paint_prepared(&ctx.device, &ctx.queue, encoder, target);
+                                }
+                                Ok(())
+                            },
+                        )
                     } else if crt_active || bezel_active {
                         // Draw the composited buffer, then re-draw the display
                         // rect. Bezel alone: one pass draws the frame with the
@@ -5157,104 +5165,118 @@ impl ApplicationHandler for App {
                         let crt = &mut r.crt_shader;
                         let bezel_shader = &mut r.bezel_shader;
                         let sticker_pass = &mut r.sticker_pass;
-                        r.pixels.render_with(|encoder, target, ctx| {
-                            scaler.render(
-                                &ctx.device,
-                                &ctx.queue,
-                                &ctx.texture,
-                                encoder,
-                                target,
-                                &present_draws,
-                            );
-                            let texture_extent =
-                                (ctx.texture_extent.width, ctx.texture_extent.height);
-                            let (uniforms, viewport) = match crt_crop {
-                                Some((dst, src, crop_scanlines)) => crt_shader::uniforms_for_rect(
-                                    kind,
-                                    strength,
-                                    dst,
-                                    src,
-                                    (FB_WIDTH, window_present_height()),
-                                    texture_extent,
-                                    crop_scanlines,
-                                ),
-                                None => crt_shader::uniforms_for(
-                                    kind,
-                                    strength,
-                                    present_clip,
-                                    present_height(),
-                                    window_present_height(),
-                                    texture_extent,
-                                    scanlines,
-                                ),
-                            };
-                            if bezel_active {
-                                let opening = bezel::opening_rect(bezel_style, viewport);
-                                if crt_active {
+                        r.presenter.render(
+                            &r.pixels,
+                            &r.window,
+                            self.last_rendered_emulated_frame,
+                            |encoder, target, ctx| {
+                                scaler.render(
+                                    &ctx.device,
+                                    &ctx.queue,
+                                    &ctx.texture,
+                                    encoder,
+                                    target,
+                                    &present_draws,
+                                );
+                                let texture_extent =
+                                    (ctx.texture_extent.width, ctx.texture_extent.height);
+                                let (uniforms, viewport) = match crt_crop {
+                                    Some((dst, src, crop_scanlines)) => {
+                                        crt_shader::uniforms_for_rect(
+                                            kind,
+                                            strength,
+                                            dst,
+                                            src,
+                                            (FB_WIDTH, window_present_height()),
+                                            texture_extent,
+                                            crop_scanlines,
+                                        )
+                                    }
+                                    None => crt_shader::uniforms_for(
+                                        kind,
+                                        strength,
+                                        present_clip,
+                                        present_height(),
+                                        window_present_height(),
+                                        texture_extent,
+                                        scanlines,
+                                    ),
+                                };
+                                if bezel_active {
+                                    let opening = bezel::opening_rect(bezel_style, viewport);
+                                    if crt_active {
+                                        crt.render(
+                                            &ctx.device,
+                                            &ctx.queue,
+                                            &ctx.texture,
+                                            encoder,
+                                            target,
+                                            opening,
+                                            kind,
+                                            uniforms.with_viewport(opening),
+                                        );
+                                    }
+                                    bezel_shader.render(
+                                        &ctx.device,
+                                        &ctx.queue,
+                                        &ctx.texture,
+                                        encoder,
+                                        target,
+                                        viewport,
+                                        bezel_style,
+                                        bezel::uniforms_from(
+                                            &uniforms, viewport, opening, crt_active,
+                                        ),
+                                    );
+                                    // Decals stick to the plastic, so they ride
+                                    // the bezel pass: suspended with it, never
+                                    // drawn over a bare picture.
+                                    sticker_pass.render(
+                                        &ctx.device,
+                                        &ctx.queue,
+                                        encoder,
+                                        target,
+                                        viewport,
+                                        opening,
+                                    );
+                                } else {
                                     crt.render(
                                         &ctx.device,
                                         &ctx.queue,
                                         &ctx.texture,
                                         encoder,
                                         target,
-                                        opening,
+                                        viewport,
                                         kind,
-                                        uniforms.with_viewport(opening),
+                                        uniforms,
                                     );
                                 }
-                                bezel_shader.render(
-                                    &ctx.device,
-                                    &ctx.queue,
-                                    &ctx.texture,
-                                    encoder,
-                                    target,
-                                    viewport,
-                                    bezel_style,
-                                    bezel::uniforms_from(&uniforms, viewport, opening, crt_active),
-                                );
-                                // Decals stick to the plastic, so they ride
-                                // the bezel pass: suspended with it, never
-                                // drawn over a bare picture.
-                                sticker_pass.render(
-                                    &ctx.device,
-                                    &ctx.queue,
-                                    encoder,
-                                    target,
-                                    viewport,
-                                    opening,
-                                );
-                            } else {
-                                crt.render(
-                                    &ctx.device,
-                                    &ctx.queue,
-                                    &ctx.texture,
-                                    encoder,
-                                    target,
-                                    viewport,
-                                    kind,
-                                    uniforms,
-                                );
-                            }
-                            if let Some(ui) = inspector_ui {
-                                ui.paint_prepared(&ctx.device, &ctx.queue, encoder, target);
-                            }
-                            Ok(())
-                        })
+                                if let Some(ui) = inspector_ui {
+                                    ui.paint_prepared(&ctx.device, &ctx.queue, encoder, target);
+                                }
+                                Ok(())
+                            },
+                        )
                     } else {
-                        r.pixels.render_with(|encoder, target, ctx| {
-                            scaler.render(
-                                &ctx.device,
-                                &ctx.queue,
-                                &ctx.texture,
-                                encoder,
-                                target,
-                                &present_draws,
-                            );
-                            if let Some(ui) = inspector_ui {
-                                ui.paint_prepared(&ctx.device, &ctx.queue, encoder, target);
-                            }
-                            Ok(())
-                        })
+                        r.presenter.render(
+                            &r.pixels,
+                            &r.window,
+                            self.last_rendered_emulated_frame,
+                            |encoder, target, ctx| {
+                                scaler.render(
+                                    &ctx.device,
+                                    &ctx.queue,
+                                    &ctx.texture,
+                                    encoder,
+                                    target,
+                                    &present_draws,
+                                );
+                                if let Some(ui) = inspector_ui {
+                                    ui.paint_prepared(&ctx.device, &ctx.queue, encoder, target);
+                                }
+                                Ok(())
+                            },
+                        )
                     };
                     if let Err(e) = render_result {
                         error!("pixels.render: {e}");
@@ -7003,6 +7025,7 @@ mod kbdpanel;
 #[cfg(feature = "mt32")]
 mod mt32panel;
 mod present;
+mod presenter;
 mod rtg_texture;
 mod scaler;
 pub(in crate::video) mod statusbar;

--- a/src/video/window/present.rs
+++ b/src/video/window/present.rs
@@ -8,6 +8,7 @@
 
 use super::*;
 use crate::config::{Tint, TvCentre};
+use pixels::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 // The pure post-render helpers live in `video/present_common.rs` so headless
 // consumers can present frames without the winit frontend; re-exported here so
@@ -936,7 +937,7 @@ pub(super) fn build_pixels_for_window(
         texture_width(texture_scale) as u32,
         texture_height(texture_scale) as u32,
     );
-    let surface_texture = SurfaceTexture::new(surface.0, surface.1, window);
+    let surface_texture = SurfaceTexture::new(surface.0, surface.1, Arc::clone(&window));
     let builder = PixelsBuilder::new(texture.0, texture.1, surface_texture)
         .present_mode(window_present_mode(vsync));
     let builder = if cfg!(target_os = "linux") {
@@ -947,10 +948,23 @@ pub(super) fn build_pixels_for_window(
         builder
     };
     let mut pixels = builder.build()?;
+    let adapter = pixels.adapter().get_info();
+    let window_system = match window.window_handle().map(|handle| handle.as_raw()) {
+        Ok(RawWindowHandle::Wayland(_)) => "Wayland",
+        Ok(RawWindowHandle::Xlib(_) | RawWindowHandle::Xcb(_)) => "X11",
+        Ok(RawWindowHandle::AppKit(_)) => "AppKit",
+        Ok(RawWindowHandle::Win32(_)) => "Win32",
+        _ => "other",
+    };
     info!(
-        "window presentation: mode={:?}, supported={:?}",
+        "window presentation: mode={:?}, supported={:?}, window_system={}, backend={:?}, adapter={:?}, driver={:?}, driver_info={:?}",
         pixels.present_mode(),
-        pixels.context().surface_capabilities.present_modes
+        pixels.context().surface_capabilities.present_modes,
+        window_system,
+        adapter.backend,
+        adapter.name,
+        adapter.driver,
+        adapter.driver_info,
     );
     // The tool windows draw through the built-in Fill renderer (the
     // emulator window's own scaler pass ignores the mode). The scaling

--- a/src/video/window/presenter.rs
+++ b/src/video/window/presenter.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Window-system notification and optional host presentation timings.
+
+use pixels::{wgpu, Pixels, PixelsContext};
+use std::time::Instant;
+use winit::window::Window;
+
+type DrawResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+pub(super) struct Presenter {
+    profile: bool,
+    previous: Option<Instant>,
+}
+
+impl Presenter {
+    pub(super) fn new() -> Self {
+        Self {
+            profile: crate::envcfg::flag("COPPERLINE_PRESENT_PROFILE"),
+            previous: None,
+        }
+    }
+
+    pub(super) fn render<F>(
+        &mut self,
+        pixels: &Pixels<'_>,
+        window: &Window,
+        emulated_frame: Option<u64>,
+        draw: F,
+    ) -> Result<(), pixels::Error>
+    where
+        F: FnOnce(&mut wgpu::CommandEncoder, &wgpu::TextureView, &PixelsContext) -> DrawResult,
+    {
+        let started = self.profile.then(Instant::now);
+        let mut acquired = None;
+        let mut drawn = None;
+        let result = pixels.render_with(|encoder, target, context| {
+            acquired = self.profile.then(Instant::now);
+            draw(encoder, target, context)?;
+            // pixels submits and presents immediately after this callback.
+            // Notify only once a surface was acquired and drawing succeeded:
+            // a timeout/occluded surface must not arm a callback for a buffer
+            // that will never be committed. On Wayland this lets winit align
+            // subsequent redraws with compositor frame callbacks.
+            window.pre_present_notify();
+            drawn = self.profile.then(Instant::now);
+            Ok(())
+        });
+        if let Some(started) = started {
+            let finished = Instant::now();
+            let interval_ms = self
+                .previous
+                .replace(started)
+                .map_or(0.0, |previous| millis(started, previous));
+            let acquire_upload_ms = acquired.map_or(-1.0, |at| millis(at, started));
+            let draw_ms = acquired.zip(drawn).map_or(-1.0, |(a, d)| millis(d, a));
+            let submit_present_ms = drawn.map_or(-1.0, |at| millis(finished, at));
+            log::info!(
+                "window frame: emulated_frame={emulated_frame:?} mode={:?} submitted={} interval_ms={interval_ms:.3} acquire_upload_ms={acquire_upload_ms:.3} draw_ms={draw_ms:.3} submit_present_ms={submit_present_ms:.3} total_ms={:.3}",
+                pixels.present_mode(),
+                drawn.is_some() && result.is_ok(),
+                millis(finished, started),
+            );
+        }
+        result
+    }
+}
+
+fn millis(later: Instant, earlier: Instant) -> f64 {
+    later.duration_since(earlier).as_secs_f64() * 1000.0
+}

--- a/tools/check-wayland-present.py
+++ b/tools/check-wayland-present.py
@@ -34,8 +34,7 @@ def wait_for_file(path, process, timeout=45):
 
 
 class Control:
-    def __init__(self, info):
-        endpoint = json.loads(info.read_text())
+    def __init__(self, endpoint):
         host, port = endpoint["listen"].rsplit(":", 1)
         self.connection = socket.create_connection((host, int(port)), timeout=15)
         self.stream = self.connection.makefile("rwb")
@@ -67,6 +66,22 @@ class Control:
                 if "error" in reply:
                     raise RuntimeError(reply["error"])
                 return reply.get("result")
+
+
+def wait_for_control_info(path, process, timeout=45):
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            return json.loads(path.read_text())
+        except (FileNotFoundError, json.JSONDecodeError):
+            # The server creates the file before writing its JSON. Existence
+            # alone is not readiness, particularly on a busy CI runner.
+            pass
+        if process.poll() is not None:
+            raise RuntimeError(f"process exited with {process.returncode} before control info")
+        if time.monotonic() >= deadline:
+            raise TimeoutError(f"waiting for complete JSON in {path.name}")
+        time.sleep(0.1)
 
 
 def submitted_frames(log):
@@ -140,10 +155,9 @@ def main():
                     ],
                     env=env, stdout=emulator_log, stderr=subprocess.STDOUT,
                 )
-                wait_for_file(info, emulator)
                 # Keep one connection: reconnecting repeatedly would keep
                 # showing the attachment OSD and prevent a truly idle window.
-                control = Control(info)
+                control = Control(wait_for_control_info(info, emulator))
                 control.rpc("hello", {"token": control.token})
                 before = control.rpc("status")
                 log_path = output / "copperline.log"

--- a/tools/check-wayland-present.py
+++ b/tools/check-wayland-present.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Exercise the real windowed Vulkan path on an isolated Wayland compositor."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import socket
+import subprocess
+import tempfile
+import time
+
+
+def stop(process):
+    if process is None or process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def wait_for_file(path, process, timeout=45):
+    deadline = time.monotonic() + timeout
+    while not path.exists():
+        if process.poll() is not None:
+            raise RuntimeError(f"process exited with {process.returncode} before {path.name}")
+        if time.monotonic() >= deadline:
+            raise TimeoutError(f"waiting for {path.name}")
+        time.sleep(0.1)
+
+
+class Control:
+    def __init__(self, info):
+        endpoint = json.loads(info.read_text())
+        host, port = endpoint["listen"].rsplit(":", 1)
+        self.connection = socket.create_connection((host, int(port)), timeout=15)
+        self.stream = self.connection.makefile("rwb")
+        self.ident = 0
+        self.token = endpoint["token"]
+
+    def close(self):
+        self.stream.close()
+        self.connection.close()
+
+    def send(self, method, params=None):
+        self.ident += 1
+        request = {
+            "jsonrpc": "2.0", "id": self.ident,
+            "method": method, "params": params or {},
+        }
+        self.stream.write((json.dumps(request) + "\n").encode())
+        self.stream.flush()
+        return self.ident
+
+    def rpc(self, method, params=None):
+        wanted = self.send(method, params)
+        while True:
+            line = self.stream.readline()
+            if not line:
+                raise RuntimeError("control connection closed")
+            reply = json.loads(line)
+            if reply.get("id") == wanted:
+                if "error" in reply:
+                    raise RuntimeError(reply["error"])
+                return reply.get("result")
+
+
+def submitted_frames(log):
+    return sum(
+        "window frame:" in line and "submitted=true" in line
+        for line in log.splitlines()
+    )
+
+
+def wait_for_frames(control, emulator, log_path, before_frame, before_submitted=0):
+    deadline = time.monotonic() + 30
+    while True:
+        time.sleep(0.5)
+        if emulator.poll() is not None:
+            raise RuntimeError(f"emulator exited with {emulator.returncode}")
+        after = control.rpc("status")
+        log = log_path.read_text()
+        submitted = submitted_frames(log)
+        if after["frame"] >= before_frame + 5 and submitted >= before_submitted + 5:
+            return submitted, log
+        if time.monotonic() >= deadline:
+            raise TimeoutError("Wayland window did not continue presenting")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("binary", type=Path)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    output = args.output_dir.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    compositor = None
+    emulator = None
+    control = None
+    with tempfile.TemporaryDirectory(prefix="wayland-", dir=output) as temporary:
+        runtime = Path(temporary)
+        runtime.chmod(0o700)
+        info = runtime / "control.json"
+        env = dict(os.environ)
+        # This test has its own display and a factory machine configuration.
+        for key in list(env):
+            if key.startswith("COPPERLINE_"):
+                del env[key]
+        for key in ("DISPLAY", "WINIT_UNIX_BACKEND", "MESA_VK_WSI_PRESENT_MODE"):
+            env.pop(key, None)
+        env.update(
+            XDG_RUNTIME_DIR=str(runtime),
+            WAYLAND_DISPLAY="wayland-present-test",
+            WAYLAND_DEBUG="client",
+            WGPU_BACKEND="vulkan",
+            RUST_LOG="info",
+            COPPERLINE_PRESENT_PROFILE="1",
+        )
+        with (output / "weston.log").open("w") as weston_log, (
+            output / "copperline.log"
+        ).open("w") as emulator_log:
+            try:
+                compositor = subprocess.Popen(
+                    [
+                        "weston", "--backend=headless-backend.so", "--use-pixman",
+                        "--socket=wayland-present-test", "--width=1280", "--height=720",
+                        "--idle-time=0", "--no-config", "--shell=kiosk-shell.so",
+                    ],
+                    env=env, stdout=weston_log, stderr=subprocess.STDOUT,
+                )
+                wait_for_file(runtime / env["WAYLAND_DISPLAY"], compositor)
+                emulator = subprocess.Popen(
+                    [
+                        str(args.binary.resolve()), "--factory", "--noaudio",
+                        "--control-gui", "127.0.0.1:0", "--control-info", str(info),
+                    ],
+                    env=env, stdout=emulator_log, stderr=subprocess.STDOUT,
+                )
+                wait_for_file(info, emulator)
+                # Keep one connection: reconnecting repeatedly would keep
+                # showing the attachment OSD and prevent a truly idle window.
+                control = Control(info)
+                control.rpc("hello", {"token": control.token})
+                before = control.rpc("status")
+                log_path = output / "copperline.log"
+                submitted, log = wait_for_frames(control, emulator, log_path, before["frame"])
+                if "window_system=Wayland" not in log or "backend=Vulkan" not in log:
+                    raise RuntimeError("test did not use native Wayland and Vulkan")
+                if not re.search(r"wl_surface[@#]\d+\.frame\(", log):
+                    raise RuntimeError("no compositor frame callback was requested")
+                # Let the event loop idle, then prove redraws resume as well as
+                # emulation. A status-only check would miss a frozen window.
+                control.rpc("pause")
+                time.sleep(4)  # Let the attachment OSD expire before resuming.
+                paused = control.rpc("status")
+                previous_submitted = submitted_frames(log_path.read_text())
+                # continue replies at the next stop; status remains available
+                # while it is pending on this same connection.
+                control.send("continue")
+                submitted, _ = wait_for_frames(
+                    control, emulator, log_path, paused["frame"], previous_submitted,
+                )
+                screenshot = output / "wayland-present.png"
+                control.rpc("capture.screenshot", {"path": str(screenshot)})
+                if not screenshot.is_file() or screenshot.stat().st_size == 0:
+                    raise RuntimeError("no screenshot produced")
+                control.rpc("shutdown")
+                emulator.wait(timeout=15)
+                if emulator.returncode != 0:
+                    raise RuntimeError(f"emulator exited with {emulator.returncode}")
+                print(f"Wayland/Vulkan: {submitted} submitted frames, pause/resume, screenshot and shutdown OK")
+            finally:
+                stop(emulator)
+                stop(compositor)
+                if control is not None:
+                    control.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Copperline never called winit's `pre_present_notify`, so native Wayland redraws were not coordinated with compositor frame callbacks. Route all three window presentation paths through a shared presenter that notifies after drawing succeeds and immediately before pixels submits/presents. Failed or occluded surface acquisitions do not arm a callback for an uncommitted buffer.

Log the actual window system, GPU/backend, driver and presentation modes at startup. Optional `COPPERLINE_PRESENT_PROFILE=1` logs CPU time spent acquiring/uploading, recording commands and submitting/presenting, with an explicit indication when no frame was submitted. The documentation distinguishes these timings from GPU completion, display scanout and the overlay's emulated FPS.

Add a Weston/lavapipe test to Linux present CI. It verifies native Wayland/Vulkan, actual frame submissions and compositor callback requests, presentation after an idle pause, a screenshot and clean shutdown.

This follows [winit's API contract](https://docs.rs/winit/0.30.13/winit/window/struct.Window.html#method.pre_present_notify), also used by PAL frontends such as [prisme_snes](https://github.com/stephanecot/prisme_snes/blob/a2a359e18eccca9125b034d63114b9033c9e5c6e/frontend/src/video.rs#L2003) and [TetaNES](https://github.com/lukexor/tetanes/blob/a0a6b17f8ba9c5ee451453fb2409753fd06e5a31/tetanes/src/nes/renderer.rs#L1203). It is not yet a confirmed fix for the Ryzen/Ubuntu horizontal split reported after #684. FIFO remains the default; a controlled Mailbox experiment gave no useful improvement on the available Intel hardware.

Validation:

- 338 window tests and 213 configuration tests passed; formatting, locked all-target/all-feature Clippy, strict HTML/link checks and PDF build passed.
- Native Wayland smoke passed with Weston and lavapipe, including pause/resume. Protocol tracing of the same-stack scrolling probe confirms compositor frame requests are present with the notification and absent without it.
- Actual Pinball Dreams Ignition gameplay uses clean ADFs and scripted ball launch/flipper input. On the Framework with Weston's normal desktop shell, a covered-window check confirmed the notification suppresses GPU submissions while emulation continues, then redraws resume on uncover. In the two-second observation, the same experimental binary without notification submitted 41 frames and advanced 48 guest frames; with notification it submitted none and advanced 100 guest frames. This exercises a headless Wayland output on the Intel GPU, not physical scanout or the reporter's tearing.
- Final-build visible gameplay on that desktop compositor sustained 49.93 emulated fps before and after, with zero underruns or pacing slips in both 60-second measurements at normal priority (optimized diagnostic profile).
- Intel Mac production release build: actual gameplay sustained 49.93 fps with sparse reverse-history capture, and 49.92 fps with normal reverse-debug recording; both measured minutes had zero underruns or pacing slips. The locked Metal surface was occluded, so this checks CPU/audio pacing rather than visible presentation.
- Paired headless gameplay produced identical PNG and WAV hashes and identical serialized machine chunks. The only save-file difference was the metadata save timestamp.

The gameplay measurements use one persistent control connection, normal scheduling priority and screenshots outside the measured interval. Notification-enabled experiments unset the presence-based disable flag. Both physical desktops were locked, so Linux presentation tests used isolated virtual outputs and Mac tests measured CPU/audio pacing with an occluded Metal surface. The reporter's AMD/Ubuntu horizontal split remains unreproduced on the available hardware.
